### PR TITLE
Fix #207 - terminate w/ non-zero when `crucible_llvm_verify` fails

### DIFF
--- a/src/SAWScript/CrucibleBuiltins.hs
+++ b/src/SAWScript/CrucibleBuiltins.hs
@@ -184,7 +184,7 @@ verifyObligations cc mspec tactic assumes asserts = do
         io $ putStrLn $ unwords ["Subgoal failed:", nm, msg]
         io $ print stats
         io $ mapM_ print vals
-        return False
+        io $ fail "Proof failed." -- Mirroring behavior of llvm_verify
   let msg = if and r then "Proof succeeded!" else "Proof failed!"
   io $ putStrLn $ unwords [msg, nm]
 


### PR DESCRIPTION
Terminating the SAW binary seems a little harsh for the long run, but
for now there is no other way to programmatically determine the result
of a crucible verification short of parsing the stdout.  This change
also brings the behavior inline with `llvm_verify`.

I suggest we revert this patch once issue #208 is closed.

@atomb I'll leave the merging of this "Feature" up to you... unless it takes too long then I'll hit the button and let you shout if needed.