### PR TITLE
Fix link from README to tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ languages such as C, Java, and Cryptol.
 
 ## Documentation
 
-The SAWScript tutorial, [doc/tutorial/]
-(https://github.com/GaloisInc/saw-script/raw/master/doc/tutorial),
-gives an introduction to using the SAWScript interpreter.
+The [SAWScript tutorial](https://saw.galois.com/tutorial.html) gives
+an introduction to using the SAWScript interpreter.
 
 ## Precompiled Binaries
 


### PR DESCRIPTION
This link wasn't showing up on github because of the linebreak between
the [] and () parts.  I also changed where the link points to since I
figured people reading the README would want to actually see the
rendered version of the tutorial rather than the source files for it.