### PR TITLE
Feature/make verbosity more structured

### DIFF
--- a/saw/Main.hs
+++ b/saw/Main.hs
@@ -8,14 +8,15 @@ Stability   : provisional
 module Main where
 
 import Control.Exception
+import Control.Monad (when)
 import Data.List
 
-import System.Exit
 import System.IO
 import System.Console.GetOpt
 import System.Environment
 
 import SAWScript.Options
+import SAWScript.Utils
 import SAWScript.Interpreter (processFile)
 import qualified SAWScript.REPL as REPL
 import SAWScript.Version (shortVersionText)
@@ -32,12 +33,16 @@ main = do
       'SAWScript.ProcessFile', and a REPL, defined in 'SAWScript.REPL'. -}
       case files of
         _ | showVersion opts'' -> hPutStrLn stderr shortVersionText
-        _ | showHelp opts'' -> err (usageInfo header options)
+        _ | showHelp opts'' -> err opts'' (usageInfo header options)
         [] -> REPL.run opts''
         _ | runInteractively opts'' -> REPL.run opts''
         [file] -> processFile opts'' file `catch`
-                  (\(ErrorCall msg) -> err msg)
-        (_:_) -> err "Multiple files not yet supported."
-    (_, _, errs) -> err (concat errs ++ usageInfo header options)
+                  (\(ErrorCall msg) -> err opts'' msg)
+        (_:_) -> err opts'' "Multiple files not yet supported."
+    (_, _, errs) -> do hPutStrLn stderr (concat errs ++ usageInfo header options)
+                       exitProofUnknown
   where header = "Usage: saw [OPTION...] [-I | file]"
-        err msg = hPutStrLn stderr msg >> exitFailure
+        err opts msg = do
+               when (verbLevel opts >= Error)
+                    (hPutStrLn stderr msg)
+               exitProofUnknown

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -86,7 +86,7 @@ import SAWScript.TypedTerm
 import SAWScript.Utils
 import SAWScript.SAWCorePrimitives( bitblastPrimitives, sbvPrimitives, concretePrimitives )
 import qualified SAWScript.Value as SV
-import SAWScript.Value (ProofScript)
+import SAWScript.Value (ProofScript, printOutLnTop)
 
 import qualified Verifier.SAW.Cryptol.Prelude as CryptolSAW
 import qualified Verifier.SAW.Simulator.BitBlast as BBSim
@@ -152,12 +152,12 @@ readSBV path unintlst =
        opts <- getOptions
        pgm <- io $ SBV.loadSBV path
        let schema = C.Forall [] [] (toCType (SBV.typOf pgm))
-       trm <- io $ SBV.parseSBVPgm sc (\s _ -> Map.lookup s unintmap) pgm
+       trm <- io $ SBV.parseSBVPgm opts sc (\s _ -> Map.lookup s unintmap) pgm
        when (extraChecks opts) $ do
          tcr <- io $ scTypeCheck sc trm
          case tcr of
            Left err ->
-             io $ putStr $ unlines $
+             printOutLnTop Error $ unlines $
              ("Type error reading " ++ path ++ ":") : prettyTCError err
            Right _ -> return () -- TODO: check that it matches 'schema'?
        return (TypedTerm schema trm)
@@ -251,7 +251,8 @@ readAIGPrim f = do
   sc <- getSharedContext
   exists <- io $ doesFileExist f
   unless exists $ fail $ "AIG file " ++ f ++ " not found."
-  et <- io $ readAIG sc f
+  opts <- getOptions
+  et <- io $ readAIG opts sc f
   case et of
     Left err -> fail $ "Reading AIG failed: " ++ err
     Right t -> io $ mkTypedTerm sc t
@@ -306,16 +307,15 @@ hoistIfsPrim t = do
 
   return t{ ttTerm = t' }
 
-
-
 checkConvertiblePrim :: TypedTerm -> TypedTerm -> TopLevel ()
 checkConvertiblePrim x y = do
    sc <- getSharedContext
-   io $ do
+   str <- io $ do
      c <- scConvertible sc False (ttTerm x) (ttTerm y)
-     if c
-       then putStrLn "Convertible"
-       else putStrLn "Not convertible"
+     pure (if c
+            then "Convertible"
+            else "Not convertible")
+   printOutLnTop Info str
 
 -- | Write a @Term@ representing a theorem or an arbitrary
 -- function to an AIG file.
@@ -431,34 +431,36 @@ withFirstGoal f =
         Just g' -> return (x, ProofState (g' : gs) concl (stats <> stats'))
 
 quickcheckGoal :: SharedContext -> Integer -> ProofScript SV.SatResult
-quickcheckGoal sc n = withFirstGoal $ \goal -> io $ do
-  putStr $ "WARNING: using quickcheck to prove goal..."
-  hFlush stdout
-  let tm = goalTerm goal
-  ty <- scTypeOf sc tm
-  maybeInputs <- scTestableType sc ty
-  let stats = solverStats "quickcheck" (scSharedSize tm)
-  case maybeInputs of
-    Just inputs -> do
-      result <- scRunTestsTFIO sc n tm inputs
-      case result of
-        Nothing -> do
-          putStrLn $ "checked " ++ show n ++ " cases."
-          return (SV.Unsat stats, stats, Nothing)
-        -- TODO: use reasonable names here
-        Just cex -> return (SV.SatMulti stats (zip (repeat "_") (map toFirstOrderValue cex)), stats, Just goal)
-    Nothing -> fail $ "quickcheck:\n" ++
-      "term has non-testable type"
+quickcheckGoal sc n = do
+  opts <- Control.Monad.State.lift getOptions
+  withFirstGoal $ \goal -> io $ do
+    printOutLn opts Warn $ "WARNING: using quickcheck to prove goal..."
+    hFlush stdout
+    let tm = goalTerm goal
+    ty <- scTypeOf sc tm
+    maybeInputs <- scTestableType sc ty
+    let stats = solverStats "quickcheck" (scSharedSize tm)
+    case maybeInputs of
+      Just inputs -> do
+        result <- scRunTestsTFIO sc n tm inputs
+        case result of
+          Nothing -> do
+            printOutLn opts Info $ "checked " ++ show n ++ " cases."
+            return (SV.Unsat stats, stats, Nothing)
+          -- TODO: use reasonable names here
+          Just cex -> return (SV.SatMulti stats (zip (repeat "_") (map toFirstOrderValue cex)), stats, Just goal)
+      Nothing -> fail $ "quickcheck:\n" ++
+        "term has non-testable type"
 
 assumeValid :: ProofScript SV.ProofResult
 assumeValid = withFirstGoal $ \goal -> do
-  io $ putStrLn $ "WARNING: assuming goal " ++ goalName goal ++ " is valid"
+  printOutLnTop Warn $ "WARNING: assuming goal " ++ goalName goal ++ " is valid"
   let stats = solverStats "ADMITTED" (scSharedSize (goalTerm goal))
   return (SV.Valid stats, stats, Nothing)
 
 assumeUnsat :: ProofScript SV.SatResult
 assumeUnsat = withFirstGoal $ \goal -> do
-  io $ putStrLn $ "WARNING: assuming goal " ++ goalName goal ++ " is unsat"
+  printOutLnTop Warn $ "WARNING: assuming goal " ++ goalName goal ++ " is unsat"
   let stats = solverStats "ADMITTED" (scSharedSize (goalTerm goal))
   return (SV.Unsat stats, stats, Nothing)
 
@@ -505,37 +507,37 @@ show_term t = do
 print_term :: Term -> TopLevel ()
 print_term t = do
   opts <- getTopLevelPPOpts
-  io $ putStrLn (scPrettyTerm opts t)
+  printOutLnTop Info (scPrettyTerm opts t)
 
 print_term_depth :: Int -> Term -> TopLevel ()
 print_term_depth d t = do
   opts <- getTopLevelPPOpts
-  io $ print (ppTermDepth opts d t)
+  printOutLnTop Info $ show (ppTermDepth opts d t)
 
 print_goal :: ProofScript ()
 print_goal = withFirstGoal $ \goal -> do
   opts <- getTopLevelPPOpts
-  io $ putStrLn ("Goal " ++ goalName goal ++ ":")
-  io $ putStrLn (scPrettyTerm opts (goalTerm goal))
+  printOutLnTop Info ("Goal " ++ goalName goal ++ ":")
+  printOutLnTop Info (scPrettyTerm opts (goalTerm goal))
   return ((), mempty, Just goal)
 
 print_goal_depth :: Int -> ProofScript ()
 print_goal_depth n = withFirstGoal $ \goal -> do
   opts <- getTopLevelPPOpts
-  io $ putStrLn ("Goal " ++ goalName goal ++ ":")
-  io $ print (ppTermDepth opts n (goalTerm goal))
+  printOutLnTop Info ("Goal " ++ goalName goal ++ ":")
+  printOutLnTop Info $ show (ppTermDepth opts n (goalTerm goal))
   return ((), mempty, Just goal)
 
 printGoalConsts :: ProofScript ()
 printGoalConsts = withFirstGoal $ \goal -> do
-  io $ mapM_ putStrLn $ Map.keys (getConstantSet (goalTerm goal))
+  mapM_ (printOutLnTop Info) $ Map.keys (getConstantSet (goalTerm goal))
   return ((), mempty, Just goal)
 
 printGoalSize :: ProofScript ()
 printGoalSize = withFirstGoal $ \goal -> do
   let t = goalTerm goal
-  io $ putStrLn $ "Goal shared size: " ++ show (scSharedSize t)
-  io $ putStrLn $ "Goal unshared size: " ++ show (scTreeSize t)
+  printOutLnTop Info $ "Goal shared size: " ++ show (scSharedSize t)
+  printOutLnTop Info $ "Goal unshared size: " ++ show (scTreeSize t)
   return ((), mempty, Just goal)
 
 unfoldGoal :: [String] -> ProofScript ()
@@ -624,12 +626,10 @@ satABC sc = withFirstGoal $ \g -> io $ do
   tp <- scWhnf sc =<< scTypeOf sc t
   let (args, _) = asPiList tp
       argNames = map fst args
-  -- putStrLn "Simulating..."
   BBSim.withBitBlastedPred sawProxy sc bitblastPrimitives t $ \be lit0 shapes -> do
   let lit = case goalQuant g of
         Existential -> lit0
         Universal -> AIG.not lit0
-  -- putStrLn "Checking..."
   satRes <- AIG.checkSat be lit
   ft <- scApplyPrelude_False sc
   let stats = solverStats "ABC" (scSharedSize t0)
@@ -639,7 +639,6 @@ satABC sc = withFirstGoal $ \g -> io $ do
         Existential -> return (SV.Unsat stats, stats, Just (g { goalTerm = ft }))
         Universal -> return (SV.Unsat stats, stats, Nothing)
     AIG.Sat cex -> do
-      -- putStrLn "SAT"
       let r = liftCexBB shapes cex
       case r of
         Left err -> fail $ "Can't parse counterexample: " ++ err
@@ -736,13 +735,11 @@ satRME sc = withFirstGoal $ \g -> io $ do
   tp <- scWhnf sc =<< scTypeOf sc t
   let (args, _) = asPiList tp
       argNames = map fst args
-  -- putStrLn "Simulating..."
   RME.withBitBlastedPred sc Map.empty t $ \lit0 shapes -> do
   let lit = case goalQuant g of
         Existential -> lit0
         Universal -> RME.compl lit0
   let stats = solverStats "RME" (scSharedSize t0)
-  -- putStrLn "Checking..."
   case RME.sat lit of
     Nothing ->
       case goalQuant g of
@@ -750,7 +747,6 @@ satRME sc = withFirstGoal $ \g -> io $ do
                           return (SV.Unsat stats, stats, Just (g { goalTerm = ft }))
         Universal -> return (SV.Unsat stats, stats, Nothing)
     Just cex -> do
-      -- putStrLn "SAT"
       let m = Map.fromList cex
       let n = sum (map sizeFiniteType shapes)
       let bs = map (maybe False id . flip Map.lookup m) $ take n [0..]
@@ -943,7 +939,7 @@ provePrim script t = do
   (r, pstate) <- runStateT script (startProof (ProofGoal Universal "prove" (ttTerm t)))
   case finishProof pstate of
     (_stats, Just _)  -> return ()
-    (_stats, Nothing) -> io $ putStrLn $ "prove: " ++ show (length (psGoals pstate)) ++ " unsolved subgoal(s)"
+    (_stats, Nothing) -> printOutLnTop Info $ "prove: " ++ show (length (psGoals pstate)) ++ " unsolved subgoal(s)"
   return (SV.flipSatResult r)
 
 provePrintPrim :: ProofScript SV.SatResult
@@ -952,7 +948,7 @@ provePrintPrim script t = do
   (r, pstate) <- runStateT script (startProof (ProofGoal Universal "prove" (ttTerm t)))
   opts <- rwPPOpts <$> getTopLevelRW
   case finishProof pstate of
-    (_,Just thm) -> do io $ putStrLn "Valid"
+    (_,Just thm) -> do printOutLnTop Info "Valid"
                        return thm
     (_,Nothing) -> fail $ "prove: " ++ show (length (psGoals pstate)) ++ " unsolved subgoal(s)\n"
                      ++ SV.showsProofResult opts (SV.flipSatResult r) ""
@@ -968,12 +964,12 @@ satPrintPrim :: ProofScript SV.SatResult
 satPrintPrim script t = do
   result <- satPrim script t
   opts <- rwPPOpts <$> getTopLevelRW
-  io $ putStrLn (SV.showsSatResult opts result "")
+  printOutLnTop Info (SV.showsSatResult opts result "")
 
 -- | Quick check (random test) a term and print the result. The
 -- 'Integer' parameter is the number of random tests to run.
-quickCheckPrintPrim :: SharedContext -> Integer -> TypedTerm -> IO ()
-quickCheckPrintPrim sc numTests tt = do
+quickCheckPrintPrim :: Options -> SharedContext -> Integer -> TypedTerm -> IO ()
+quickCheckPrintPrim opts sc numTests tt = do
   let tm = ttTerm tt
   ty <- scTypeOf sc tm
   maybeInputs <- scTestableType sc ty
@@ -981,9 +977,9 @@ quickCheckPrintPrim sc numTests tt = do
     Just inputs -> do
       result <- scRunTestsTFIO sc numTests tm inputs
       case result of
-        Nothing -> putStrLn $ "All " ++ show numTests ++ " tests passed!"
-        Just counterExample -> putStrLn $
-          "At least one test failed! Counter example:\n" ++
+        Nothing -> printOutLn opts Info $ "All " ++ show numTests ++ " tests passed!"
+        Just counterExample -> printOutLn opts OnlyCounterExamples $
+          "----------Counterexample----------\n" ++
           showList counterExample ""
     Nothing -> fail $ "quickCheckPrintPrim:\n" ++
       "term has non-testable type:\n" ++
@@ -1062,14 +1058,14 @@ print_type t = do
   sc <- getSharedContext
   opts <- getTopLevelPPOpts
   ty <- io $ scTypeOf sc t
-  io $ putStrLn (scPrettyTerm opts ty)
+  printOutLnTop Info (scPrettyTerm opts ty)
 
 check_term :: Term -> TopLevel ()
 check_term t = do
   sc <- getSharedContext
   opts <- getTopLevelPPOpts
   ty <- io $ scTypeCheckError sc t
-  io $ putStrLn (scPrettyTerm opts ty)
+  printOutLnTop Info (scPrettyTerm opts ty)
 
 fixPos :: Pos
 fixPos = PosInternal "FIXME"
@@ -1170,8 +1166,9 @@ caseSatResultPrim sr vUnsat vSat = do
 envCmd :: TopLevel ()
 envCmd = do
   m <- rwTypes <$> getTopLevelRW
+  opts <- getOptions
   let showLName = getVal
-  io $ sequence_ [ putStrLn (showLName x ++ " : " ++ pShow v) | (x, v) <- Map.assocs m ]
+  io $ sequence_ [ printOutLn opts Info (showLName x ++ " : " ++ pShow v) | (x, v) <- Map.assocs m ]
 
 exitPrim :: Integer -> IO ()
 exitPrim code = Exit.exitWith exitCode
@@ -1195,12 +1192,10 @@ withTimePrim a = do
 timePrim :: TopLevel SV.Value -> TopLevel SV.Value
 timePrim a = do
   t1 <- liftIO $ getCurrentTime
-  --liftIO $ print t1
   r <- a
   t2 <- liftIO $ getCurrentTime
-  --liftIO $ print t2
   let diff = diffUTCTime t2 t1
-  liftIO $ printf "Time: %s\n" (show diff)
+  printOutLnTop Info $ printf "Time: %s\n" (show diff)
   return r
 
 eval_bool :: TypedTerm -> TopLevel Bool

--- a/src/SAWScript/CrucibleBuiltins.hs
+++ b/src/SAWScript/CrucibleBuiltins.hs
@@ -214,7 +214,8 @@ verifyObligations cc mspec tactic assumes asserts = do
       SatMulti stats vals -> do
         printOutLnTop Info $ unwords ["Subgoal failed:", nm, msg]
         printOutLnTop Info (show stats)
-        mapM_ (printOutLnTop Info . show) vals
+        printOutLnTop OnlyCounterExamples "----------Counterexample----------"
+        mapM_ (printOutLnTop OnlyCounterExamples . show) vals
         io $ fail "Proof failed." -- Mirroring behavior of llvm_verify
   printOutLnTop Info $ unwords ["Proof succeeded!", nm]
   return (mconcat stats)

--- a/src/SAWScript/CrucibleBuiltins.hs
+++ b/src/SAWScript/CrucibleBuiltins.hs
@@ -1089,7 +1089,8 @@ crucible_spec_size = solverStatsGoalSize . (view csSolverStats)
 
 crucible_setup_val_to_typed_term :: BuiltinContext -> Options -> SetupValue -> TopLevel TypedTerm
 crucible_setup_val_to_typed_term bic _opt sval = do
-  mtt <- io $ MaybeT.runMaybeT $ setupToTypedTerm (biSharedContext bic) sval
+  opts <- getOptions
+  mtt <- io $ MaybeT.runMaybeT $ setupToTypedTerm opts (biSharedContext bic) sval
   case mtt of
     Nothing -> fail $ "Could not convert a setup value to a term: " ++ show sval
     Just tt -> return tt

--- a/src/SAWScript/CrucibleBuiltins.hs
+++ b/src/SAWScript/CrucibleBuiltins.hs
@@ -16,7 +16,29 @@ License     : BSD3
 Maintainer  : atomb
 Stability   : provisional
 -}
-module SAWScript.CrucibleBuiltins where
+module SAWScript.CrucibleBuiltins
+    ( load_llvm_cfg
+    , show_cfg
+    , extract_crucible_llvm
+    , crucible_llvm_verify
+    , crucible_setup_val_to_typed_term
+    , crucible_spec_size
+    , crucible_spec_solvers
+    , crucible_ghost_value
+    , crucible_return
+    , crucible_declare_ghost_state
+    , crucible_execute_func
+    , crucible_postcond
+    , crucible_precond
+    , crucible_equal
+    , crucible_points_to
+    , crucible_fresh_pointer
+    , crucible_llvm_unsafe_assume_spec
+    , crucible_fresh_var
+    , crucible_alloc
+    , crucible_fresh_expanded_val
+    , match
+    ) where
 
 import           Control.Lens
 import           Control.Monad.ST
@@ -31,7 +53,6 @@ import           Data.Maybe (fromMaybe)
 import           Data.String
 import           Data.Map (Map)
 import qualified Data.Map as Map
-import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
@@ -68,7 +89,6 @@ import qualified Lang.Crucible.LLVM.MemType as Crucible
 import qualified Lang.Crucible.LLVM.LLVMContext as TyCtx
 import qualified Lang.Crucible.LLVM.Translation as Crucible
 import qualified Lang.Crucible.LLVM.MemModel as Crucible
-import qualified Lang.Crucible.LLVM.MemModel.Common as Crucible
 
 import Lang.Crucible.Utils.MonadST
 import qualified Data.Parameterized.TraversableFC as Ctx
@@ -333,42 +353,6 @@ assertEqualVals cc v1 v2 =
 
 --------------------------------------------------------------------------------
 
-asSAWType :: SharedContext
-          -> Crucible.Type
-          -> IO Term
-asSAWType sc t = case Crucible.typeF t of
-  Crucible.Bitvector bytes -> scBitvector sc (fromInteger (Crucible.bytesToBits bytes))
-  Crucible.Float           -> scGlobalDef sc (fromString "Prelude.Float")  -- FIXME??
-  Crucible.Double          -> scGlobalDef sc (fromString "Prelude.Double") -- FIXME??
-  Crucible.Array sz s ->
-    do s' <- asSAWType sc s
-       sz_tm <- scNat sc (fromIntegral sz)
-       scVecType sc sz_tm s'
-  Crucible.Struct flds ->
-    do flds' <- mapM (asSAWType sc . (^. Crucible.fieldVal)) $ V.toList flds
-       scTupleType sc flds'
-
-memTypeToType :: Crucible.MemType -> Maybe Crucible.Type
-memTypeToType mt = Crucible.mkType <$> go mt
-  where
-  go (Crucible.IntType w) = Just (Crucible.Bitvector (Crucible.bitsToBytes w))
-  -- Pointers can't be converted to SAWCore, so no need to translate
-  -- their types.
-  go (Crucible.PtrType _) = Nothing
-  go Crucible.FloatType = Just Crucible.Float
-  go Crucible.DoubleType = Just Crucible.Double
-  go (Crucible.ArrayType n et) = Crucible.Array (fromIntegral n) <$> memTypeToType et
-  go (Crucible.VecType n et) = Crucible.Array (fromIntegral n) <$> memTypeToType et
-  go (Crucible.StructType si) =
-    Crucible.Struct <$> mapM goField (Crucible.siFields si)
-  go Crucible.MetadataType  = Nothing
-  goField f =
-    Crucible.mkField (Crucible.toBytes (Crucible.fiOffset f)) <$>
-                     memTypeToType (Crucible.fiType f) <*>
-                     pure (Crucible.toBytes (Crucible.fiPadding f))
-
---------------------------------------------------------------------------------
-
 -- | Allocate space on the LLVM heap to store a value of the given
 -- type. Returns the pointer to the allocated memory.
 doAlloc ::
@@ -502,116 +486,6 @@ verifySimulate opts cc mspec args assumes lemmas globals checkSat =
            v <- Crucible.coerceAny sym tr a
            return (Crucible.RegEntry tr v))
       ctx
-
---------------------------------------------------------------------------------
-
-processPostconditions ::
-  (?lc :: TyCtx.LLVMContext) =>
-  CrucibleContext                 {- ^ simulator context         -} ->
-  Map AllocIndex Crucible.SymType {- ^ type env                  -} ->
-  Map AllocIndex LLVMPtr          {- ^ pointer environment       -} ->
-  Crucible.SymGlobalState Sym     {- ^ final global variables    -} ->
-  [SetupCondition]                {- ^ postconditions            -} ->
-  IO [(String, Term)]
-processPostconditions cc tyenv env globals = traverse verifyPostCond
-  where
-    verifyPostCond :: SetupCondition -> IO (String, Term)
-    verifyPostCond (SetupCond_Equal val1 val2) =
-      do val1' <- resolveSetupVal cc env tyenv val1
-         val2' <- resolveSetupVal cc env tyenv val2
-         g <- assertEqualVals cc val1' val2'
-         return ("equality assertion", g)
-    verifyPostCond (SetupCond_Pred tm) =
-      return ("predicate assertion", ttTerm tm)
-    verifyPostCond (SetupCond_Ghost var val) =
-      do sc <- Crucible.saw_ctx <$> readIORef (Crucible.sbStateManager (ccBackend cc))
-         v  <- case Crucible.lookupGlobal var globals of
-                 Nothing   -> scBool sc False
-                 Just term -> scEq sc (ttTerm term) (ttTerm val)
-         return ("ghost assertion", v)
-
-
-------------------------------------------------------------------------
-
--- | For each points-to statement from the postcondition section of a
--- function spec, read the memory value through the given pointer
--- (lhs) and match the value against the given pattern (rhs).
--- Statements are processed in dependency order: a points-to statement
--- cannot be executed until bindings for any/all lhs variables exist.
-processPostPointsTos ::
-  (?lc :: TyCtx.LLVMContext) =>
-  SharedContext                   {- ^ term construction context -} ->
-  CrucibleContext                 {- ^ simulator context         -} ->
-  Map AllocIndex Crucible.SymType {- ^ type env                  -} ->
-  Map AllocIndex LLVMPtr          {- ^ pointer environment       -} ->
-  MemImpl                         {- ^ LLVM heap                 -} ->
-  [PointsTo]                      {- ^ points-to postconditions  -} ->
-  IO [(String, Term)]             {- ^ equality constraints      -}
-processPostPointsTos sc cc tyenv env0 mem conds0 =
-  evalStateT (go False [] conds0) env0
-  where
-    sym = ccBackend cc
-
-    go ::
-      Bool       {- progress indicator -} ->
-      [PointsTo] {- delayed conditions -} ->
-      [PointsTo] {- queued conditions  -} ->
-      StateT (Map AllocIndex LLVMPtr) IO [(String, Term)]
-
-    -- all conditions processed, success
-    go _ [] [] = return []
-
-    -- not all conditions processed, no progress, failure
-    go False _delayed [] = fail "processPostconditions: unprocessed conditions"
-
-    -- not all conditions processed, progress made, resume delayed conditions
-    go True delayed [] = go False [] delayed
-
-    -- progress the next precondition in the work queue
-    go progress delayed (c:cs) =
-      do ready <- checkPointsTo c
-         if ready then
-           do goals1 <- verifyPostCond c
-              goals2 <- go True delayed cs
-              return (goals1 ++ goals2)
-           else go progress (c:delayed) cs
-
-    -- determine if a precondition is ready to be checked
-    checkPointsTo :: PointsTo -> StateT (Map AllocIndex LLVMPtr) IO Bool
-    checkPointsTo (PointsTo p _) = checkSetupValue p
-
-    checkSetupValue :: SetupValue -> StateT (Map AllocIndex LLVMPtr) IO Bool
-    checkSetupValue v =
-      do m <- get
-         return (all (`Map.member` m) (setupVars v))
-
-    -- Compute the set of variable identifiers in a 'SetupValue'
-    setupVars :: SetupValue -> Set AllocIndex
-    setupVars v =
-      case v of
-        SetupVar    i  -> Set.singleton i
-        SetupStruct xs -> foldMap setupVars xs
-        SetupArray  xs -> foldMap setupVars xs
-        SetupElem x _  -> setupVars x
-        SetupField x _ -> setupVars x
-        SetupTerm   _  -> Set.empty
-        SetupNull      -> Set.empty
-        SetupGlobal _  -> Set.empty
-
-    verifyPostCond :: PointsTo -> StateT (Map AllocIndex LLVMPtr) IO [(String, Term)]
-    verifyPostCond (PointsTo lhs val) =
-      do env <- get
-         lhs' <- liftIO $ resolveSetupVal cc env tyenv lhs
-         ptr <- case lhs' of
-           Crucible.LLVMValPtr blk end off -> return (Crucible.LLVMPtr blk end off)
-           _ -> fail "Non-pointer value found in points-to assertion"
-         -- In case the types are different (from crucible_points_to_untyped)
-         -- then the load type should be determined by the rhs.
-         memTy <- liftIO $ typeOfSetupValue cc tyenv val
-         storTy <- Crucible.toStorableType memTy
-         x <- liftIO $ Crucible.loadRaw sym mem ptr storTy
-         gs <- match sc cc tyenv x val
-         return [ ("points-to assertion", g) | g <- gs ]
 
 --------------------------------------------------------------------------------
 
@@ -1196,7 +1070,6 @@ crucible_declare_ghost_state _bic _opt name =
                                   (Crucible.IntrinsicRepr
                                      (Crucible.knownSymbol :: Crucible.SymbolRepr GhostValue))))
      return (VGhostVar global)
-
 
 crucible_ghost_value ::
   BuiltinContext                      ->

--- a/src/SAWScript/CrucibleOverride.hs
+++ b/src/SAWScript/CrucibleOverride.hs
@@ -29,7 +29,7 @@ module SAWScript.CrucibleOverride
   ) where
 
 import           Control.Lens
-import           Control.Exception
+import           Control.Exception as X
 import           Control.Monad.Trans.State
 import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Class
@@ -81,6 +81,7 @@ import           SAWScript.CrucibleMethodSpecIR
 import           SAWScript.CrucibleResolveSetupValue
 import           SAWScript.TypedTerm
 import           SAWScript.Options
+import           SAWScript.Utils (handleException)
 
 -- | The 'OverrideMatcher' type provides the operations that are needed
 -- to match a specification's arguments with the arguments provided by
@@ -321,23 +322,24 @@ methodSpecHandler1 opts sc cc args retTy cs =
 
        sequence_ [ matchArg sc cc PreState x y z | (x, y, z) <- xs]
 
-       learnCond sc cc cs PreState (cs^.csPreState)
+       learnCond opts sc cc cs PreState (cs^.csPreState)
 
        executeCond opts sc cc cs (cs^.csPostState)
 
-       computeReturnValue cc sc cs retTy (cs^.csRetValue)
+       computeReturnValue opts cc sc cs retTy (cs^.csRetValue)
 
 -- learn pre/post condition
 learnCond :: (?lc :: TyCtx.LLVMContext)
-          => SharedContext
+          => Options
+          -> SharedContext
           -> CrucibleContext
           -> CrucibleMethodSpecIR
           -> PrePost
           -> StateSpec
           -> OverrideMatcher ()
-learnCond sc cc cs prepost ss = do
-  matchPointsTos sc cc cs prepost (ss^.csPointsTos)
-  traverse_ (learnSetupCondition sc cc cs prepost) (ss^.csConditions)
+learnCond opts sc cc cs prepost ss = do
+  matchPointsTos opts sc cc cs prepost (ss^.csPointsTos)
+  traverse_ (learnSetupCondition opts sc cc cs prepost) (ss^.csConditions)
   enforceDisjointness cc ss
   enforceCompleteSubstitution ss
 
@@ -385,8 +387,8 @@ executeCond opts sc cc cs ss = do
   OM (setupValueSub %= Map.union ptrs)
 
   traverse_ (executeAllocation opts cc) (Map.assocs (ss^.csAllocs))
-  traverse_ (executePointsTo sc cc cs) (ss^.csPointsTos)
-  traverse_ (executeSetupCondition sc cc cs) (ss^.csConditions)
+  traverse_ (executePointsTo opts sc cc cs) (ss^.csPointsTos)
+  traverse_ (executeSetupCondition opts sc cc cs) (ss^.csConditions)
 
 
 -- | Allocate fresh variables for all of the "fresh" vars
@@ -454,13 +456,14 @@ enforceDisjointness cc ss =
 -- variables exist.
 matchPointsTos ::
   (?lc :: TyCtx.LLVMContext) =>
+  Options          {- ^ saw script print out opts -} ->
   SharedContext    {- ^ term construction context -} ->
   CrucibleContext  {- ^ simulator context         -} ->
   CrucibleMethodSpecIR                               ->
   PrePost                                            ->
   [PointsTo]       {- ^ points-tos                -} ->
   OverrideMatcher ()
-matchPointsTos sc cc spec prepost = go False []
+matchPointsTos opts sc cc spec prepost = go False []
   where
     go ::
       Bool       {- progress indicator -} ->
@@ -481,7 +484,7 @@ matchPointsTos sc cc spec prepost = go False []
     go progress delayed (c:cs) =
       do ready <- checkPointsTo c
          if ready then
-           do learnPointsTo sc cc spec prepost c
+           do learnPointsTo opts sc cc spec prepost c
               go True delayed cs
          else
            do go progress (c:delayed) cs
@@ -526,6 +529,7 @@ resolveMemType ty =
 
 computeReturnValue ::
   (?lc :: TyCtx.LLVMContext) =>
+  Options               {- ^ saw script debug and print options     -} ->
   CrucibleContext       {- ^ context of the crucible simulation     -} ->
   SharedContext         {- ^ context for generating saw terms       -} ->
   CrucibleMethodSpecIR  {- ^ method specification                   -} ->
@@ -534,13 +538,13 @@ computeReturnValue ::
   OverrideMatcher (Crucible.RegValue Sym ret)
                         {- ^ concrete return value                  -}
 
-computeReturnValue _ _ _ ty Nothing =
+computeReturnValue _ _ _ _ ty Nothing =
   case ty of
     Crucible.UnitRepr -> return ()
     _ -> failure BadReturnSpecification
 
-computeReturnValue cc sc spec ty (Just val) =
-  do (_memTy, Crucible.AnyValue xty xval) <- resolveSetupValue cc sc spec val
+computeReturnValue opts cc sc spec ty (Just val) =
+  do (_memTy, Crucible.AnyValue xty xval) <- resolveSetupValue opts cc sc spec val
      case Crucible.testEquality ty xty of
        Just Crucible.Refl -> return xval
        Nothing -> failure BadReturnSpecification
@@ -745,15 +749,16 @@ matchTerm sc cc prepost real expect =
 -- preconditions for a procedure specification.
 learnSetupCondition ::
   (?lc :: TyCtx.LLVMContext) =>
+  Options                    ->
   SharedContext              ->
   CrucibleContext            ->
   CrucibleMethodSpecIR       ->
   PrePost                    ->
   SetupCondition             ->
   OverrideMatcher ()
-learnSetupCondition sc cc spec prepost (SetupCond_Equal val1 val2)  = learnEqual sc cc spec prepost val1 val2
-learnSetupCondition sc cc _    prepost (SetupCond_Pred tm)          = learnPred sc cc prepost (ttTerm tm)
-learnSetupCondition sc cc _    prepost (SetupCond_Ghost var val)    = learnGhost sc cc prepost var val
+learnSetupCondition opts sc cc spec prepost (SetupCond_Equal val1 val2)  = learnEqual opts sc cc spec prepost val1 val2
+learnSetupCondition _opts sc cc _    prepost (SetupCond_Pred tm)         = learnPred sc cc prepost (ttTerm tm)
+learnSetupCondition _opts sc cc _    prepost (SetupCond_Ghost var val)   = learnGhost sc cc prepost var val
 
 
 ------------------------------------------------------------------------
@@ -776,16 +781,17 @@ learnGhost sc cc prepost var expected =
 -- indicated by 'ptr', and then match it against the pattern 'val'.
 learnPointsTo ::
   (?lc :: TyCtx.LLVMContext) =>
+  Options                    ->
   SharedContext              ->
   CrucibleContext            ->
   CrucibleMethodSpecIR       ->
   PrePost                    ->
   PointsTo                   ->
   OverrideMatcher ()
-learnPointsTo sc cc spec prepost (PointsTo ptr val) =
+learnPointsTo opts sc cc spec prepost (PointsTo ptr val) =
   do let tyenv = csAllocations spec
      memTy <- liftIO $ typeOfSetupValue cc tyenv val
-     (_memTy, ptr1) <- asPointer =<< resolveSetupValue cc sc spec ptr
+     (_memTy, ptr1) <- asPointer =<< resolveSetupValue opts cc sc spec ptr
      -- In case the types are different (from crucible_points_to_untyped)
      -- then the load type should be determined by the rhs.
      storTy <- Crucible.toStorableType memTy
@@ -812,6 +818,7 @@ stateCond PostState = "postcondition"
 -- | Process a "crucible_equal" statement from the precondition
 -- section of the CrucibleSetup block.
 learnEqual ::
+  Options                                          ->
   SharedContext                                    ->
   CrucibleContext                                  ->
   CrucibleMethodSpecIR                             ->
@@ -819,9 +826,9 @@ learnEqual ::
   SetupValue       {- ^ first value to compare  -} ->
   SetupValue       {- ^ second value to compare -} ->
   OverrideMatcher ()
-learnEqual sc cc spec prepost v1 v2 = do
-  (_, val1) <- resolveSetupValueLLVM cc sc spec v1
-  (_, val2) <- resolveSetupValueLLVM cc sc spec v2
+learnEqual opts sc cc spec prepost v1 v2 = do
+  (_, val1) <- resolveSetupValueLLVM opts cc sc spec v1
+  (_, val2) <- resolveSetupValueLLVM opts cc sc spec v2
   p         <- liftIO (equalValsPred cc val1 val2)
   let name = "equality " ++ stateCond prepost
   addAssert p (Crucible.AssertFailureSimError name)
@@ -871,14 +878,15 @@ executeAllocation opts cc (var, symTy) =
 -- procedure specification.
 executeSetupCondition ::
   (?lc :: TyCtx.LLVMContext) =>
+  Options                    ->
   SharedContext              ->
   CrucibleContext            ->
   CrucibleMethodSpecIR       ->
   SetupCondition             ->
   OverrideMatcher ()
-executeSetupCondition sc cc spec (SetupCond_Equal val1 val2) = executeEqual sc cc spec val1 val2
-executeSetupCondition sc cc _    (SetupCond_Pred tm)         = executePred sc cc tm
-executeSetupCondition sc _  _    (SetupCond_Ghost var val)   = executeGhost sc var val
+executeSetupCondition opts sc cc spec (SetupCond_Equal val1 val2) = executeEqual opts sc cc spec val1 val2
+executeSetupCondition _opts sc cc _    (SetupCond_Pred tm)        = executePred sc cc tm
+executeSetupCondition _opts sc _  _    (SetupCond_Ghost var val)  = executeGhost sc var val
 
 ------------------------------------------------------------------------
 
@@ -899,18 +907,19 @@ executeGhost sc var val =
 -- 'val', and then write it to the address indicated by 'ptr'.
 executePointsTo ::
   (?lc :: TyCtx.LLVMContext) =>
+  Options                    ->
   SharedContext              ->
   CrucibleContext            ->
   CrucibleMethodSpecIR       ->
   PointsTo                   ->
   OverrideMatcher ()
-executePointsTo sc cc spec (PointsTo ptr val) =
-  do (_, ptr1) <- asPointer =<< resolveSetupValue cc sc spec ptr
+executePointsTo opts sc cc spec (PointsTo ptr val) =
+  do (_, ptr1) <- asPointer =<< resolveSetupValue opts cc sc spec ptr
      sym    <- getSymInterface
 
      -- In case the types are different (from crucible_points_to_untyped)
      -- then the load type should be determined by the rhs.
-     (memTy1, val1) <- resolveSetupValue cc sc spec val
+     (memTy1, val1) <- resolveSetupValue opts cc sc spec val
      storTy <- Crucible.toStorableType memTy1
 
      let memVar = Crucible.llvmMemVar $ Crucible.memModelOps $ ccLLVMContext cc
@@ -925,15 +934,16 @@ executePointsTo sc cc spec (PointsTo ptr val) =
 -- | Process a "crucible_equal" statement from the postcondition
 -- section of the CrucibleSetup block.
 executeEqual ::
+  Options                                          ->
   SharedContext                                    ->
   CrucibleContext                                  ->
   CrucibleMethodSpecIR                             ->
   SetupValue       {- ^ first value to compare  -} ->
   SetupValue       {- ^ second value to compare -} ->
   OverrideMatcher ()
-executeEqual sc cc spec v1 v2 = do
-  (_, val1) <- resolveSetupValueLLVM cc sc spec v1
-  (_, val2) <- resolveSetupValueLLVM cc sc spec v2
+executeEqual opts sc cc spec v1 v2 = do
+  (_, val1) <- resolveSetupValueLLVM opts cc sc spec v1
+  (_, val2) <- resolveSetupValueLLVM opts cc sc spec v2
   p         <- liftIO (equalValsPred cc val1 val2)
   addAssume p
 
@@ -991,28 +1001,30 @@ instantiateSetupValue sc s v =
 ------------------------------------------------------------------------
 
 resolveSetupValueLLVM ::
+  Options              ->
   CrucibleContext      ->
   SharedContext        ->
   CrucibleMethodSpecIR ->
   SetupValue           ->
   OverrideMatcher (Crucible.MemType, LLVMVal)
-resolveSetupValueLLVM cc sc spec sval =
+resolveSetupValueLLVM opts cc sc spec sval =
   do m <- OM (use setupValueSub)
      s <- OM (use termSub)
      let tyenv = csAllocations spec :: Map AllocIndex Crucible.SymType
      memTy <- liftIO $ typeOfSetupValue cc tyenv sval
      sval' <- liftIO $ instantiateSetupValue sc s sval
-     lval  <- liftIO $ resolveSetupVal cc m tyenv sval'
+     lval  <- liftIO $ resolveSetupVal cc m tyenv sval' `X.catch` handleException opts
      return (memTy, lval)
 
 resolveSetupValue ::
+  Options              ->
   CrucibleContext      ->
   SharedContext        ->
   CrucibleMethodSpecIR ->
   SetupValue           ->
   OverrideMatcher (Crucible.MemType, Crucible.AnyValue Sym)
-resolveSetupValue cc sc spec sval =
-  do (memTy, lval) <- resolveSetupValueLLVM cc sc spec sval
+resolveSetupValue opts cc sc spec sval =
+  do (memTy, lval) <- resolveSetupValueLLVM opts cc sc spec sval
      sym <- getSymInterface
      aval <- liftIO $ Crucible.unpackMemValue sym lval
      return (memTy, aval)

--- a/src/SAWScript/CryptolEnv.hs
+++ b/src/SAWScript/CryptolEnv.hs
@@ -440,12 +440,10 @@ parseDecls sc env input = do
 
 parseSchema :: CryptolEnv -> Located String -> IO T.Schema
 parseSchema env input = do
-  --putStrLn $ "parseSchema: " ++ show input
   let modEnv = eModuleEnv env
 
   -- Parse
   pschema <- ioParseSchema input
-  --putStrLn $ "ioParseSchema: " ++ show pschema
 
   fmap fst $ liftModuleM modEnv $ do
 

--- a/src/SAWScript/Import.hs
+++ b/src/SAWScript/Import.hs
@@ -12,7 +12,6 @@ module SAWScript.Import
   , findAndLoadFile
   ) where
 
-import Control.Monad (when)
 
 import SAWScript.AST
 import SAWScript.Lexer (lexSAW)
@@ -23,7 +22,7 @@ import System.Directory
 
 loadFile :: Options -> FilePath -> IO [Stmt]
 loadFile opts fname = do
-  when (verbLevel opts > 0) $ putStrLn $ "Loading file " ++ show fname
+  printOutLn opts Info $ "Loading file " ++ show fname
   ftext <- readFile fname
   either fail return (parseFile fname ftext)
 

--- a/src/SAWScript/ImportAIG.hs
+++ b/src/SAWScript/ImportAIG.hs
@@ -12,8 +12,7 @@ Maintainer  : huffman
 Stability   : provisional
 -}
 module SAWScript.ImportAIG
-  ( readAIGexpect
-  , readAIG
+  ( readAIG
   , loadAIG
   , verifyAIGCompatible
   , AIGNetwork
@@ -36,6 +35,7 @@ import qualified Data.ABC.GIA as ABC
 import Verifier.SAW.Prelude
 import Verifier.SAW.Recognizer
 import Verifier.SAW.SharedTerm hiding (scNot, scAnd, scOr)
+import SAWScript.Options
 
 type TypeParser = StateT (V.Vector Term) (ExceptT String IO)
 
@@ -146,14 +146,15 @@ withReadAiger path action = do
       Right ntk -> action ntk
 
 translateNetwork :: AIG.IsAIG l g
-                 => SharedContext    -- ^ Context to build in term.
+                 => Options          -- ^ Options to control user feedback
+                 -> SharedContext    -- ^ Context to build in term.
                  -> g x              -- ^ Network to bitblast
                  -> [l x]            -- ^ Outputs for network.
                  -> [(String, Term)] -- ^ Expected types
                  -> Term             -- ^ Expected output type.
                  -> ExceptT String IO Term
-translateNetwork sc ntk outputLits args resultType = do
-  --lift $ putStrLn "inputTerms"
+translateNetwork opts sc ntk outputLits args resultType = do
+  lift $ printOutLn opts Debug "inputTerms"
   inputTerms <- bitblastVarsAsInputLits sc (snd <$> args)
   -- Check number of inputs to network matches expected inputs.
   do let expectedInputCount = V.length inputTerms
@@ -162,28 +163,16 @@ translateNetwork sc ntk outputLits args resultType = do
        throwE $ "AIG has " ++ show aigCount
                   ++ " inputs, while expected type has "
                   ++ show expectedInputCount ++ " inputs."
-  --lift $ putStrLn "Output vars"
+  lift $ printOutLn opts Debug "Output vars"
   -- Get outputs as SAWCore terms.
   outputVars <- liftIO $
     networkAsSharedTerms ntk sc inputTerms (V.fromList outputLits)
-  --lift $ putStrLn "Type parser"
+  lift $ printOutLn opts Debug "Type parser"
    -- Join output lits into result type.
   (res,rargs) <- runTypeParser outputVars $ parseAIGResultType sc resultType
   unless (V.null rargs) $
     throwE "AIG contains more outputs than expected."
   lift $ scLambdaList sc args res
-
-readAIGexpect
-        :: SharedContext -- ^ Context to build in term.
-        -> FilePath      -- ^ Path to AIG
-        -> Term          -- ^ Expected type of term.
-        -> IO (Either String Term)
-readAIGexpect sc path aigType =
-  withReadAiger path $ \(AIG.Network ntk outputLits) -> do
-    --putStrLn "Network outputs"
-    let (args,resultType) = asPiList aigType
-    runExceptT $
-      translateNetwork sc ntk outputLits args resultType
 
 loadAIG :: FilePath -> IO (Either String AIGNetwork)
 loadAIG f = do
@@ -192,8 +181,8 @@ loadAIG f = do
       Left e -> return (Left (show (e :: IOException)))
       Right ntk -> return $ Right ntk
 
-readAIG :: SharedContext -> FilePath -> IO (Either String Term)
-readAIG sc f =
+readAIG :: Options -> SharedContext -> FilePath -> IO (Either String Term)
+readAIG opts sc f =
   withReadAiger f $ \(AIG.Network ntk outputLits) -> do
     inputs <- AIG.inputCount ntk
     inLen <- scNat sc (fromIntegral inputs)
@@ -202,7 +191,7 @@ readAIG sc f =
     inType <- scVecType sc inLen boolType
     outType <- scVecType sc outLen boolType
     runExceptT $
-      translateNetwork sc ntk outputLits [("x", inType)] outType
+      translateNetwork opts sc ntk outputLits [("x", inType)] outType
 
 -- | Check that the input and output counts of the given
 --   AIGNetworks are equal.

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -290,12 +290,12 @@ processStmtBind printBinds pat _mc expr = do -- mx mt
   -- Print non-unit result if it was not bound to a variable
   case pat of
     SS.PWild _ | printBinds && not (isVUnit result) ->
-      io $ putStrLn (showsPrecValue opts 0 result "")
+      printOutLnTop Info (showsPrecValue opts 0 result "")
     _ -> return ()
 
   -- Print function type if result was a function
   case ty of
-    SS.TyCon SS.FunCon _ -> io $ putStrLn $ getVal lname ++ " : " ++ SS.pShow ty
+    SS.TyCon SS.FunCon _ -> printOutLnTop Info $ getVal lname ++ " : " ++ SS.pShow ty
     _ -> return ()
 
   rw' <- getTopLevelRW
@@ -427,7 +427,7 @@ set_base b = do
   putTopLevelRW rw { rwPPOpts = (rwPPOpts rw) { ppOptsBase = b } }
 
 print_value :: Value -> TopLevel ()
-print_value (VString s) = io $ putStrLn s
+print_value (VString s) = printOutLnTop Info s
 print_value (VTerm t) = do
   sc <- getSharedContext
   cenv <- fmap rwCryptol getTopLevelRW
@@ -443,7 +443,7 @@ print_value (VTerm t) = do
   io (rethrowEvalError $ print $ doc)
 print_value v = do
   opts <- fmap rwPPOpts getTopLevelRW
-  io $ putStrLn (showsPrecValue opts 0 v "")
+  printOutLnTop Info (showsPrecValue opts 0 v "")
 
 cryptol_load :: FilePath -> TopLevel CryptolModule
 cryptol_load path = do
@@ -779,7 +779,7 @@ primitives = Map.fromList
     ]
 
   , prim "qc_print"            "Int -> Term -> TopLevel ()"
-    (scVal quickCheckPrintPrim)
+    (\a -> scVal (quickCheckPrintPrim a) a)
     [ "Quick Check a term by applying it to a sequence of random inputs"
     , "and print the results. The 'Int' arg specifies how many tests to run."
     ]

--- a/src/SAWScript/JavaBuiltins.hs
+++ b/src/SAWScript/JavaBuiltins.hs
@@ -193,7 +193,6 @@ runJavaSetup :: Pos -> Codebase -> Class -> String
 runJavaSetup pos cb cls mname setup = do
   sc <- getSharedContext
   ms <- io $ initMethodSpec pos cb cls mname
-  --putStrLn "Created MethodSpec"
   let setupState = JavaSetupState {
                      jsSpec = ms
                    , jsContext = sc
@@ -214,7 +213,6 @@ verifyJava bic opts cls mname overrides setup = do
       bsc = biSharedContext bic
       jsc = bsc
   setupRes <- runJavaSetup pos cb cls mname setup
-  --putStrLn "Done running setup"
   let ms = jsSpec setupRes
       vp = VerifyParams {
              vpCode = cb
@@ -224,8 +222,7 @@ verifyJava bic opts cls mname overrides setup = do
            , vpOver = overrides
            }
   when (jsSimulate setupRes) $ do
-    let verb = simVerbose opts
-        overrideText =
+    let overrideText =
           case overrides of
             [] -> ""
             irs -> " (overriding " ++ show (map renderName irs) ++ ")"
@@ -238,14 +235,12 @@ verifyJava bic opts cls mname overrides setup = do
         fl = defaultSimFlags { alwaysBitBlastBranchTerms = True
                              , satAtBranches = jsSatBranches setupRes
                              }
-    when (verb >= 2) $ io $ putStrLn $ "Starting verification of " ++ specName ms
+    printOutLnTop Info $ "Starting verification of " ++ specName ms
     ro <- getTopLevelRO
     rw <- getTopLevelRW
-    -- io $ print (length configs)
     forM_ configs $ \(bs,cl) -> withSAWBackend Nothing $ \sbe -> io $ do
       liftIO $ bsCheckAliasTypes pos bs
-      when (verb >= 2) $ do
-        putStrLn $ "Executing " ++ specName ms ++
+      liftIO $ printOutLn opts Info $ "Executing " ++ specName ms ++
                    " at PC " ++ show (bsLoc bs) ++ "."
       -- runDefSimulator cb sbe $ do
       runSimulator cb sbe defaultSEH (Just fl) $ do
@@ -256,70 +251,67 @@ verifyJava bic opts cls mname overrides setup = do
               io $ doExtraChecks opts bsc glam
               r <- evalStateT script (startProof (ProofGoal Universal (vsVCName vs) glam))
               case r of
-                SS.Unsat _ -> when (verb >= 3) $ io $ putStrLn "Valid."
-                SS.SatMulti _ vals -> io $ showCexResults jsc (rwPPOpts rw) ms vs exts vals
+                SS.Unsat _ -> liftIO $ printOutLn opts Info "Valid."
+                SS.SatMulti _ vals ->
+                       io $ showCexResults opts jsc (rwPPOpts rw) ms vs exts vals
         let ovds = vpOver vp
         initPS <- initializeVerification' jsc ms bs cl
-        when (verb >= 2) $ liftIO $
-          putStrLn $ "Overriding: " ++ show (map specName ovds)
+        liftIO $ printOutLn opts Info $ "Overriding: " ++ show (map specName ovds)
         mapM_ (overrideFromSpec jsc (specPos ms)) ovds
-        when (verb >= 2) $ liftIO $
-          putStrLn $ "Running method: " ++ specName ms
+        liftIO $ printOutLn opts Info $ "Running method: " ++ specName ms
         -- Execute code.
         run
-        when (verb >= 2) $ liftIO $
-          putStrLn $ "Checking final state"
+        liftIO $ printOutLn opts Info $ "Checking final state"
         pvc <- checkFinalState jsc ms bs cl initPS
         let pvcs = [pvc] -- Only one for now, but that might change
-        when (verb >= 5) $ liftIO $ do
-          putStrLn "Verifying the following:"
-          mapM_ (print . ppPathVC) pvcs
+        liftIO $ printOutLn opts Debug "Verifying the following:"
+        liftIO $ mapM_ (printOutLn opts Debug . show . ppPathVC) pvcs
         let validator script = runValidation (prover script) vp jsc pvcs
         case jsTactic setupRes of
-          Skip -> liftIO $ putStrLn $
-            "WARNING: skipping verification of " ++ specName ms
+          Skip -> liftIO $ printOutLn opts Warn $
+                    "WARNING: skipping verification of " ++ specName ms
           RunVerify script ->
             liftIO $ fmap fst $ runTopLevel (validator script) ro rw
     endTime <- io $ getCurrentTime
-    io $ putStrLn $ "Successfully verified " ++ specName ms ++ overrideText ++
+    printOutLnTop Info $ "Successfully verified " ++ specName ms ++ overrideText ++
                     " (" ++ showDuration (diffUTCTime endTime startTime) ++ ")"
-  unless (jsSimulate setupRes) $ io $ putStrLn $
+  unless (jsSimulate setupRes) $ printOutLnTop Warn $
     "WARNING: skipping simulation of " ++ specName ms
   return ms
 
 doExtraChecks :: Options -> SharedContext -> Term -> IO ()
 doExtraChecks opts bsc t = do
-  let verb = simVerbose opts
   when (extraChecks opts) $ do
-    when (verb >= 2) $ putStrLn "Type checking goal..."
+    printOutLn opts Info "Type checking goal..."
     tcr <- scTypeCheck bsc t
     case tcr of
-      Left e -> putStr $ unlines $
+      Left e -> printOutLn opts Warn $ unlines $
                 "Ill-typed goal constructed." : prettyTCError e
-      Right _ -> when (verb >= 2) $ putStrLn "Done."
-  when (verb >= 6) $ putStrLn $ "Trying to prove: " ++ show t
+      Right _ -> printOutLn opts Info "Done."
+  printOutLn opts Debug $ "Trying to prove: " ++ show t
 
-showCexResults :: SharedContext
+showCexResults :: Options
+               -> SharedContext
                -> SS.PPOpts
                -> JavaMethodSpecIR
                -> VerifyState
                -> [ExtCns Term]
                -> [(String, FirstOrderValue)]
                -> IO ()
-showCexResults sc opts ms vs exts vals = do
-  putStrLn $ "When verifying " ++ specName ms ++ ":"
-  putStrLn $ "Proof of " ++ vsVCName vs ++ " failed."
-  putStrLn $ "Counterexample:"
+showCexResults vpopts sc opts ms vs exts vals = do
+  printOutLn vpopts Info $ "When verifying " ++ specName ms ++ ":"
+  printOutLn vpopts Info $ "Proof of " ++ vsVCName vs ++ " failed."
+  printOutLn vpopts Info $ "Counterexample:"
   let showVal v = show <$> (Cryptol.runEval SS.quietEvalOpts (Cryptol.ppValue (cryptolPPOpts opts) (exportFirstOrderValue v)))
   mapM_ (\(n, v) -> do vdoc <- showVal v
-                       putStrLn ("  " ++ n ++ ": " ++ vdoc)) vals
+                       printOutLn vpopts Info ("  " ++ n ++ ": " ++ vdoc)) vals
   if (length exts == length vals)
     then do let cexEval = cexEvalFn sc (zip exts (map snd vals))
             doc <- vsCounterexampleFn vs cexEval
-            putStrLn (renderDoc doc)
-    else do putStrLn $ "ERROR: Can't show result, wrong number of values"
-            putStrLn $ "Constants: " ++ show (map ecName exts)
-            putStrLn $ "Value names: " ++ show (map fst vals)
+            printOutLn vpopts Info (renderDoc doc)
+    else do printOutLn vpopts Info $ "ERROR: Can't show result, wrong number of values"
+            printOutLn vpopts Info $ "Constants: " ++ show (map ecName exts)
+            printOutLn vpopts Info $ "Value names: " ++ show (map fst vals)
   fail "Proof failed."
 
 mkMixedExpr :: Term -> JavaSetup MixedExpr
@@ -453,7 +445,6 @@ javaClassVar bic _ name t = do
 javaVar :: BuiltinContext -> Options -> String -> JavaType
         -> JavaSetup TypedTerm
 javaVar bic _ name t = do
-  --liftIO $ putStrLn "javaVar"
   (expr, aty) <- typeJavaExpr bic name t
   case aty of
     ClassInstance _ -> fail "Can't use `java_var` with variable of class type."
@@ -475,7 +466,6 @@ javaMayAlias exprs = do
 
 javaAssert :: TypedTerm -> JavaSetup ()
 javaAssert (TypedTerm schema v) = do
-  --liftIO $ putStrLn "javaAssert"
   unless (schemaNoUser schema == Cryptol.Forall [] [] Cryptol.tBit) $
     fail $ "java_assert passed expression of non-boolean type: " ++ show schema
   me <- mkMixedExpr v
@@ -485,7 +475,6 @@ javaAssert (TypedTerm schema v) = do
 
 javaAssertEq :: BuiltinContext -> Options -> String -> TypedTerm -> JavaSetup ()
 javaAssertEq bic _ name (TypedTerm schema t) = do
-  --liftIO $ putStrLn "javaAssertEq"
   (expr, aty) <- (getJavaExpr "java_assert_eq") name
   checkCompatibleType (biSharedContext bic) "java_assert_eq" aty schema
   me <- mkMixedExpr t
@@ -493,16 +482,13 @@ javaAssertEq bic _ name (TypedTerm schema t) = do
 
 javaEnsureEq :: BuiltinContext -> Options -> String -> TypedTerm -> JavaSetup ()
 javaEnsureEq bic _ name (TypedTerm schema t) = do
-  --liftIO $ putStrLn "javaEnsureEq"
   ms <- gets jsSpec
   (expr, aty) <- (getJavaExpr "java_ensure_eq") name
-  --liftIO $ putStrLn "Making MixedExpr"
   when (isArg (specMethod ms) expr && isScalarExpr expr) $ fail $
     "The `java_ensure_eq` function cannot be used " ++
     "to set the value of a scalar argument."
   checkCompatibleType (biSharedContext bic) "java_ensure_eq" aty schema
   me <- mkMixedExpr t
-  --liftIO $ putStrLn "Done making MixedExpr"
   cmd <- case (CC.unTerm expr, aty) of
     (_, ArrayInstance _ _) -> return (EnsureArray fixPos expr me)
     (InstanceField r f, _) -> return (EnsureInstanceField fixPos r f me)
@@ -512,7 +498,6 @@ javaEnsureEq bic _ name (TypedTerm schema t) = do
 
 javaModify :: String -> JavaSetup ()
 javaModify name = do
-  --liftIO $ putStrLn "javaModify"
   ms <- gets jsSpec
   (expr, aty) <- (getJavaExpr "java_modify") name
   when (isArg (specMethod ms) expr && isScalarExpr expr) $ fail $
@@ -527,7 +512,6 @@ javaModify name = do
 
 javaReturn :: TypedTerm -> JavaSetup ()
 javaReturn (TypedTerm _ t) = do
-  --liftIO $ putStrLn "javaReturn"
   ms <- gets jsSpec
   let meth = specMethod ms
   case methodReturnType meth of

--- a/src/SAWScript/JavaMethodSpec.hs
+++ b/src/SAWScript/JavaMethodSpec.hs
@@ -58,14 +58,15 @@ import qualified Text.PrettyPrint.HughesPJ as PP
 import Language.JVM.Common (ppFldId)
 import qualified SAWScript.CongruenceClosure as CC
 import SAWScript.JavaExpr as TC
-import SAWScript.Options
+import SAWScript.Options hiding (Verbosity)
+import qualified SAWScript.Options as Opts
 import SAWScript.Utils
 import SAWScript.JavaMethodSpecIR
 import SAWScript.JavaMethodSpec.Evaluator
 import SAWScript.JavaUtils
 import SAWScript.PathVC
 import SAWScript.TypedTerm
-import SAWScript.Value (TopLevel, TopLevelRW(rwPPOpts), getTopLevelRW, io)
+import SAWScript.Value (TopLevel, TopLevelRW(rwPPOpts), getTopLevelRW, io, printOutTop, printOutLnTop)
 import SAWScript.VerificationCheck
 
 import Data.JVM.Symbolic.AST (entryBlock)
@@ -436,13 +437,19 @@ type Prover =
 runValidation :: Prover -> VerifyParams -> SymbolicRunHandler
 runValidation prover params sc results = do
   let ir = vpSpec params
-      verb = verbLevel (vpOpts params)
+      printLn      = printOutLnTop
   opts <- fmap rwPPOpts getTopLevelRW
   forM_ results $ \pvc -> do
     let mkVState nm cfn =
           VState { vsVCName = nm
                  , vsMethodSpec = ir
-                 , vsVerbosity = verb
+                 , vsVerbosity = case Opts.verbLevel (vpOpts params) of
+                                    Opts.Silent              -> 0
+                                    Opts.OnlyCounterExamples -> 0
+                                    Opts.Error               -> 1
+                                    Opts.Warn                -> 2
+                                    Opts.Info                -> 3
+                                    _                        -> 4
                  , vsCounterexampleFn = cfn
                  , vsStaticErrors = pvcStaticErrors pvc
                  }
@@ -450,21 +457,18 @@ runValidation prover params sc results = do
      forM_ (pvcChecks pvc) $ \vc -> do
        let vs = mkVState (vcName vc) (vcCounterexample sc opts vc)
        g <- io $ scImplies sc (pvcAssumptions pvc) =<< vcGoal sc vc
-       when (verb >= 2) $ io $ do
-         putStr $ "Checking " ++ vcName vc
-         when (verb >= 5) $ putStr $ " (" ++ scPrettyTerm defaultPPOpts g ++ ")"
-         putStrLn ""
+       printOutTop Info $ "Checking " ++ vcName vc
+       printOutTop Debug $ " (" ++ scPrettyTerm defaultPPOpts g ++ ")"
+       printLn Info ""
        prover vs g
     else do
       let vsName = "an invalid path"
       let vs = mkVState vsName (\_ -> return $ vcat (pvcStaticErrors pvc))
       false <- io $ scBool sc False
       g <- io $ scImplies sc (pvcAssumptions pvc) false
-      when (verb >= 2) $ io $ do
-        putStrLn $ "Checking " ++ vsName
-        print $ pvcStaticErrors pvc
-      when (verb >= 5) $ io $ do
-        putStrLn $ "Calling prover to disprove " ++
+      printLn Info $ "Checking " ++ vsName
+      printLn Info $ show $ pvcStaticErrors pvc
+      printLn Debug $ "Calling prover to disprove " ++
                  scPrettyTerm defaultPPOpts (pvcAssumptions pvc)
       prover vs g
 

--- a/src/SAWScript/LLVMBuiltins.hs
+++ b/src/SAWScript/LLVMBuiltins.hs
@@ -62,7 +62,7 @@ import SAWScript.LLVMExpr
 import SAWScript.LLVMMethodSpecIR
 import SAWScript.LLVMMethodSpec
 import SAWScript.LLVMUtils
-import SAWScript.Options
+import SAWScript.Options as Opt
 import SAWScript.Proof
 import SAWScript.SolverStats
 import SAWScript.TypedTerm
@@ -88,7 +88,8 @@ llvm_load_module file =
 
 type Assign = (LLVMExpr, TypedTerm)
 
-startSimulator :: SharedContext
+startSimulator :: Options
+               -> SharedContext
                -> LSSOpts
                -> LLVMModule
                -> Symbol
@@ -99,11 +100,11 @@ startSimulator :: SharedContext
                    -> SymDefine Term
                    -> Simulator SAWBackend IO a)
                -> IO a
-startSimulator sc lopts (LLVMModule file mdl) sym body = do
+startSimulator opts sc lopts (LLVMModule file mdl) sym body = do
   let dl = parseDataLayout $ modDataLayout mdl
   (sbe, mem, scLLVM) <- createSAWBackend' sawProxy dl sc
   (warnings, cb) <- mkCodebase sbe dl mdl
-  forM_ warnings $ putStrLn . ("WARNING: " ++) . show
+  forM_ warnings $ printOutLn opts Warn . ("WARNING: " ++) . show
   case lookupDefine sym cb of
     Nothing -> fail $ missingSymMsg file sym
     Just md -> runSimulator cb sbe mem (Just lopts) $
@@ -125,9 +126,8 @@ llvm_symexec bic opts lmod fname allocs inputs outputs doSat =
                       , optsSatAtBranches = doSat
                       , optsSimplifyAddrs = False
                       }
-  in startSimulator sc lopts lmod sym $ \scLLVM sbe cb dl md -> do
+  in startSimulator opts sc lopts lmod sym $ \scLLVM sbe cb dl md -> do
         setVerbosity (simVerbose opts)
-        let verb = simVerbose opts
         let mkAssign (s, tm, n) = do
               e <- failLeft $ runExceptT $ parseLLVMExpr lmod cb sym s
               return (e, tm, n)
@@ -135,10 +135,10 @@ llvm_symexec bic opts lmod fname allocs inputs outputs doSat =
               e <- failLeft $ runExceptT $ parseLLVMExpr lmod cb sym s
               case resolveType cb (lssTypeOfLLVMExpr e) of
                 PtrType (MemType ty) -> do
-                  when (verb >= 2) $ liftIO $ putStrLn $
+                  liftIO $ printOutLn opts Info $
                     "Allocating " ++ show n ++ " elements of type " ++ show (ppActualType ty)
                   tm <- allocSome sbe dl n ty
-                  when (verb >= 2) $ liftIO $ putStrLn $
+                  liftIO $ printOutLn opts Info $
                     "Allocated address: " ++ show tm
                   return (e, tm, 1)
                 ty -> fail $ "Allocation parameter " ++ s ++
@@ -167,9 +167,9 @@ llvm_symexec bic opts lmod fname allocs inputs outputs doSat =
         _ <- callDefine' False sym retReg args
         -- TODO: the following line is generating memory errors
         mapM_ (writeLLVMTerm Nothing argVals) otherAssigns
-        when (verb >= 2) $ liftIO $ putStrLn $ "Running " ++ fname
+        liftIO $ printOutLn opts Info $ "Running " ++ fname
         run
-        when (verb >= 2) $ liftIO $ putStrLn $ "Finished running " ++ fname
+        liftIO $ printOutLn opts Info $ "Finished running " ++ fname
         outtms <- forM outputs $ \(ostr, n) -> do
           case ostr of
             "$safety" -> do
@@ -203,7 +203,7 @@ llvm_extract bic opts lmod func _setup =
                       , optsSatAtBranches = True
                       , optsSimplifyAddrs = False
                       }
-  in startSimulator sc lopts lmod sym $ \scLLVM _sbe _cb _dl md -> do
+  in startSimulator opts sc lopts lmod sym $ \scLLVM _sbe _cb _dl md -> do
     setVerbosity (simVerbose opts)
     args <- mapM freshLLVMArg (sdArgs md)
     exts <- mapM (asExtCns . snd) args
@@ -229,7 +229,7 @@ llvm_verify bic opts lmod@(LLVMModule file mdl) funcname overrides setup =
   in do
     (sbe, mem, scLLVM) <- io $ createSAWBackend' sawProxy dl sc
     (warnings, cb) <- io $ mkCodebase sbe dl mdl
-    io $ forM_ warnings $ putStrLn . ("WARNING: " ++) . show
+    forM_ warnings $ printOutLnTop Warn . ("WARNING: " ++) . show
     let ms0 = initLLVMMethodSpec pos sbe cb (fromString funcname)
         lsctx0 = LLVMSetupState {
                     lsSpec = ms0
@@ -248,21 +248,20 @@ llvm_verify bic opts lmod@(LLVMModule file mdl) funcname overrides setup =
                           , vpSpec = ms
                           , vpOver = overrides
                           }
-    let verb = verbLevel opts
     let overrideText =
           case overrides of
             [] -> ""
             irs -> " (overriding " ++ show (map specFunction irs) ++ ")"
-    when (verb >= 2) $ io $ putStrLn $ "Starting verification of " ++ show (specName ms)
+    printOutLnTop Info $ "Starting verification of " ++ show (specName ms)
     let lopts = LSSOpts { optsErrorPathDetails = True
                         , optsSatAtBranches = lsSatBranches lsctx
                         , optsSimplifyAddrs = lsSimplifyAddrs lsctx
                         }
     ro <- getTopLevelRO
     rw <- getTopLevelRW
+    vpopts <- getOptions
     if lsSimulate lsctx then io $ do
-      when (verb >= 3) $ do
-        putStrLn $ "Executing " ++ show (specName ms)
+      liftIO $ printOutLn vpopts Info $ "Executing " ++ show (specName ms)
       ms' <- runSimulator cb sbe mem (Just lopts) $ do
         setVerbosity (simVerbose opts)
         (initPS, otherPtrs, args) <- initializeVerification' scLLVM file ms
@@ -270,27 +269,26 @@ llvm_verify bic opts lmod@(LLVMModule file mdl) funcname overrides setup =
         let ovdsByFunction = groupBy ((==) `on` specFunction) $
                              sortBy (compare `on` specFunction) $
                              vpOver vp
-        mapM_ (overrideFromSpec scLLVM (specPos ms)) ovdsByFunction
+        mapM_ (overrideFromSpec (vpOpts vp) scLLVM (specPos ms)) ovdsByFunction
         run
         dumpMem 4 "llvm_verify post" Nothing
         res <- checkFinalState scLLVM ms initPS otherPtrs args
-        when (verb >= 3) $ liftIO $ do
-          putStrLn "Verifying the following:"
-          print (ppPathVC res)
+        liftIO $ printOutFn vpopts Info "Verifying the following:"
+        liftIO $ printOutLn vpopts Info $ show (ppPathVC res)
         case lsTactic lsctx of
              Skip -> do
-                liftIO $ putStrLn $
+                liftIO $ printOutLn vpopts Warn $
                    "WARNING: skipping verification of " ++ show (specName ms)
                 return ms
              RunVerify script -> do
                 let prv = prover opts scLLVM ms script
                 stats <- liftIO $ fmap fst $ runTopLevel (runValidation prv vp scLLVM [res]) ro rw
                 return ms { specSolverStats = stats }
-      putStrLn $ "Successfully verified " ++
+      printOutLn vpopts Info $ "Successfully verified " ++
                    show (specName ms) ++ overrideText
       return ms'
     else do
-      io $ putStrLn $ "WARNING: skipping simulation of " ++ show (specName ms)
+      printOutLnTop Warn $ "WARNING: skipping simulation of " ++ show (specName ms)
       return ms
 
 prover :: Options
@@ -300,38 +298,39 @@ prover :: Options
        -> VerifyState
        -> Term
        -> TopLevel SolverStats
-prover opts sc ms script vs g = do
+prover vpopts sc ms script vs g = do
   let exts = getAllExts g
-      verb = verbLevel opts
   ppopts <- fmap rwPPOpts getTopLevelRW
   tt <- io (scAbstractExts sc exts g)
   r <- evalStateT script (startProof (ProofGoal Universal (vsVCName vs) tt))
   case r of
     SV.Unsat stats -> do
-        when (verb >= 3) $ io $ putStrLn "Valid."
+        printOutLnTop Info "Valid."
         return stats
     SV.SatMulti _stats vals -> do
-        io $ showCexResults sc ppopts ms vs exts vals
+        io $ showCexResults vpopts sc ppopts ms vs exts vals
         return mempty
 
-showCexResults :: SharedContext
+showCexResults :: Options
+               -> SharedContext
                -> SV.PPOpts
                -> LLVMMethodSpecIR
                -> VerifyState
                -> [ExtCns Term]
                -> [(String, FirstOrderValue)]
                -> IO ()
-showCexResults sc opts ms vs exts vals = do
-  putStrLn $ "When verifying " ++ show (specName ms) ++ ":"
-  putStrLn $ "Proof of " ++ vsVCName vs ++ " failed."
-  putStrLn $ "Counterexample:"
+showCexResults vpopts sc opts ms vs exts vals = do
+  printOutLn vpopts Info $ "When verifying " ++ show (specName ms) ++ ":"
+  printOutLn vpopts Info $ "Proof of " ++ vsVCName vs ++ " failed."
+  printOutLn vpopts OnlyCounterExamples $ "----------Counterexample----------"
   let showVal v = show <$> (Cryptol.runEval SV.quietEvalOpts (Cryptol.ppValue (cryptolPPOpts opts) (exportFirstOrderValue v)))
   mapM_ (\(n, v) -> do vdoc <- showVal v
-                       putStrLn ("  " ++ n ++ ": " ++ vdoc)) vals
+                       printOutLn vpopts OnlyCounterExamples ("  " ++ n ++ ": " ++ vdoc)) vals
   if (length exts == length vals)
-    then vsCounterexampleFn vs (cexEvalFn sc (zip exts (map snd vals))) >>= print
-    else putStrLn "ERROR: Can't show result, wrong number of values"
-  fail "Proof failed."
+    then vsCounterexampleFn vs (cexEvalFn sc (zip exts (map snd vals))) >>= printOutLn vpopts OnlyCounterExamples . show
+    else printOutLn vpopts Opt.Error "ERROR: Can't show result, wrong number of values"
+  printOutLn vpopts Opt.Error "Proof failed."
+  exitProofFalse
 
 llvm_pure :: LLVMSetup ()
 llvm_pure = return ()

--- a/src/SAWScript/LLVMMethodSpec.hs
+++ b/src/SAWScript/LLVMMethodSpec.hs
@@ -52,14 +52,15 @@ import Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
 import qualified SAWScript.CongruenceClosure as CC
 import qualified SAWScript.LLVMExpr as TC
-import SAWScript.Options
+import SAWScript.Options hiding (Verbosity)
+import qualified SAWScript.Options as Opts
 import SAWScript.Utils
 import Verifier.SAW.Prelude
 import SAWScript.LLVMMethodSpecIR
 import SAWScript.LLVMUtils
 import SAWScript.PathVC
 import SAWScript.SolverStats
-import SAWScript.Value (TopLevel, TopLevelRW(rwPPOpts), getTopLevelRW, io)
+import SAWScript.Value (TopLevel, TopLevelRW(rwPPOpts), getTopLevelRW, io, printOutLnTop)
 import SAWScript.VerificationCheck
 
 import Verifier.LLVM.Simulator hiding (State)
@@ -372,19 +373,19 @@ execBehavior bsl ec ps = do
        -- Execute statements.
        mapM_ ocStep (bsCommands bs)
 
-execOverride :: (MonadIO m, Functor m) =>
-                SharedContext
+execOverride :: (MonadIO m, Functor m)
+             => Options
+             -> SharedContext
              -> Pos
              -> [LLVMMethodSpecIR]
              -> [(MemType, SpecLLVMValue)]
              -> Simulator SpecBackend m (Maybe Term)
-execOverride _ _ [] _ = fail "Empty list of overrides passed to execOverride."
-execOverride sc _pos irs@(ir:_) args = do
+execOverride _ _ _ [] _ = fail "Empty list of overrides passed to execOverride."
+execOverride vpopts sc _pos irs@(ir:_) args = do
   initPS <- fromMaybe (error "no path during override") <$> getPath
   let bsl = map specBehavior irs
       cb = specCodebase ir
   sbe <- gets symBE
-  --liftIO $ putStrLn $ "Executing override for " ++ show func
   gm <- use globalTerms
   opts <- gets lssOpts
   let ec = EvalContext { ecContext = sc
@@ -397,12 +398,12 @@ execOverride sc _pos irs@(ir:_) args = do
                        , ecLLVMExprs = specLLVMExprNames ir
                        , ecFunction = specFunction ir
                        }
-  --liftIO $ putStrLn $ "Executing behavior"
+  liftIO $ printOutLn vpopts Debug $ "Executing behavior"
   res <- execBehavior bsl ec initPS
   case [ (ps, mval) | (ps, _, Right mval) <- res ] of
     -- One or more successful result: use the first.
     (ps, mval):rest -> do
-      unless (null rest) $ liftIO $ print $ hcat
+      unless (null rest) $ liftIO $ printOutLn vpopts Warn $ show $ hcat
         [ text "WARNING: More than one successful path returned from override "
         , text "execution for " , specName ir
         ]
@@ -424,14 +425,15 @@ execOverride sc _pos irs@(ir:_) args = do
 
 -- | Add a method override for the given method to the simulator.
 overrideFromSpec :: (MonadIO m, Functor m) =>
-                    SharedContext
+                    Options
+                 -> SharedContext
                  -> Pos
                  -> [LLVMMethodSpecIR]
                  -> Simulator SpecBackend m ()
-overrideFromSpec _ _ [] =
+overrideFromSpec _ _ _ [] =
   fail "Called overrideFromSpec with empty list."
-overrideFromSpec sc pos irs@(ir:_) = do
-  let ovd = Override (\_ _ -> execOverride sc pos irs)
+overrideFromSpec vpopts sc pos irs@(ir:_) = do
+  let ovd = Override (\_ _ -> execOverride vpopts sc pos irs)
   -- TODO: check argument types?
   tryRegisterOverride (specFunction ir) (const (Just ovd))
 
@@ -662,7 +664,13 @@ type Prover = VerifyState -> Term -> TopLevel SolverStats
 runValidation :: Prover -> VerifyParams -> SymbolicRunHandler
 runValidation prover params sc results = do
   let ir = vpSpec params
-      verb = verbLevel (vpOpts params)
+      verb = case Opts.verbLevel (vpOpts params) of
+                Opts.Silent              -> 0
+                Opts.OnlyCounterExamples -> 0
+                Opts.Error               -> 1
+                Opts.Warn                -> 2
+                Opts.Info                -> 3
+                _                        -> 5
   opts <- fmap rwPPOpts getTopLevelRW
   mconcat <$> (forM results $ \pvc -> do
     let mkVState nm cfn =
@@ -676,20 +684,18 @@ runValidation prover params sc results = do
       mconcat <$> (forM (pvcChecks pvc) $ \vc -> do
         let vs = mkVState (vcName vc) (vcCounterexample sc opts vc)
         g <- io (scImplies sc (pvcAssumptions pvc) =<< vcGoal sc vc)
-        when (verb >= 3) $ io $ do
-          putStr $ "Checking " ++ vcName vc
-          when (verb >= 4) $ putStr $ " (" ++ show g ++ ")"
-          putStrLn ""
+        io $ printOutLn (vpOpts params) Info $ "Checking " ++ vcName vc
+        io $ printOutLn (vpOpts params) Debug $ " (" ++ show g ++ ")"
+        io $ printOutLn (vpOpts params) Info "\n"
         prover vs g)
     else do
       let vsName = "an invalid path"
       let vs = mkVState vsName (\_ -> return $ vcat (pvcStaticErrors pvc))
       false <- io $ scBool sc False
       g <- io $ scImplies sc (pvcAssumptions pvc) false
-      when (verb >= 4) $ io $ do
-        putStrLn $ "Checking " ++ vsName
-        print $ pvcStaticErrors pvc
-        putStrLn $ "Calling prover to disprove " ++
+      printOutLnTop Info $ "Checking " ++ vsName
+      printOutLnTop Info $ show (pvcStaticErrors pvc)
+      printOutLnTop Info $ "Calling prover to disprove " ++
                  scPrettyTerm defaultPPOpts (pvcAssumptions pvc)
       prover vs g)
 

--- a/src/SAWScript/Options.hs
+++ b/src/SAWScript/Options.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 {- |
 Module      : $Header$
@@ -9,21 +10,30 @@ Stability   : provisional
 -}
 module SAWScript.Options where
 
+import Data.Char (toLower)
 import System.Console.GetOpt
 import System.Environment
 import System.FilePath
+import Text.Read (readMaybe)
+import Text.Show.Functions ()
 
 data Options = Options
   { importPath       :: [FilePath]
   , classPath        :: [FilePath]
   , jarList          :: [FilePath]
-  , verbLevel        :: Int
+  , verbLevel        :: Verbosity
   , simVerbose       :: Int
   , extraChecks      :: Bool
   , runInteractively :: Bool
   , showHelp         :: Bool
   , showVersion      :: Bool
+  , printOutFn       :: Verbosity -> String -> IO ()
   } deriving (Show)
+
+-- | Verbosity is currently a linear setting (vs a mask or tree).  Any given
+-- level includes the outputs of all lower levels.
+data Verbosity = Silent | OnlyCounterExamples | Error | Warn | Info | Debug
+    deriving (Show,Eq,Ord)
 
 defaultOptions :: Options
 defaultOptions
@@ -31,13 +41,22 @@ defaultOptions
       importPath = ["."]
     , classPath = ["."]
     , jarList = []
-    , verbLevel = 1
+    , verbLevel = Info
+    , printOutFn = printOutWith Info
     , simVerbose = 1
     , extraChecks = False
     , runInteractively = False
     , showHelp = False
     , showVersion = False
     }
+
+printOutWith :: Verbosity -> Verbosity -> String -> IO ()
+printOutWith setting level msg
+    | setting >= level = putStr msg
+    | otherwise        = return ()
+
+printOutLn :: Options -> Verbosity -> String -> IO ()
+printOutLn o v s = printOutFn o v (s ++ "\n")
 
 options :: [OptDescr (Options -> Options)]
 options =
@@ -81,11 +100,35 @@ options =
     "Set simulator verbosity level"
   , Option "v" ["verbose"]
     (ReqArg
-     (\v opts -> opts { verbLevel = read v })
-     "num"
+     (\v opts -> let verb = readVerbosity v
+                 in opts { verbLevel = verb
+                         , printOutFn = printOutWith verb } )
+     "<num 0-5 | 'silent' | 'counterexamples' | 'error' | 'warn' | 'info' | 'debug'>"
     )
     "Set verbosity level"
   ]
+
+-- Try to read verbosity as either a string or number and default to 'Debug'.
+readVerbosity :: String -> Verbosity
+readVerbosity s | Just (n::Integer) <- readMaybe s =
+     case n of
+         0 -> Silent
+         1 -> OnlyCounterExamples
+         2 -> Error
+         3 -> Warn
+         4 -> Info
+         _ -> Debug
+readVerbosity s =
+    case map toLower s of
+        "silent"              -> Silent
+        "counterexamples"     -> OnlyCounterExamples
+        "onlycounterexamples" -> OnlyCounterExamples
+        "error"               -> Error
+        "warn"                -> Warn
+        "warning"             -> Warn
+        "info"                -> Info
+        "debug"               -> Debug
+        _                     -> Debug
 
 processEnv :: Options -> IO Options
 processEnv opts = do

--- a/src/SAWScript/SBVParser.hs
+++ b/src/SAWScript/SBVParser.hs
@@ -28,6 +28,7 @@ import Data.Traversable (mapM)
 import Verifier.SAW.TypedAST
 import Verifier.SAW.SharedTerm
 import qualified SAWScript.SBVModel as SBV
+import SAWScript.Options
 
 type NodeCache = Map SBV.NodeId Term
 
@@ -42,11 +43,11 @@ parseSBV _ nodes (SBV.SBV size (Right nodeid)) =
 
 type UnintMap = String -> Typ -> Maybe Term
 
-parseSBVExpr :: SharedContext -> UnintMap -> NodeCache ->
+parseSBVExpr :: Options -> SharedContext -> UnintMap -> NodeCache ->
                 Nat -> SBV.SBVExpr -> IO Term
-parseSBVExpr sc _unint nodes _size (SBV.SBVAtom sbv) =
+parseSBVExpr _opts sc _unint nodes _size (SBV.SBVAtom sbv) =
     liftM snd $ parseSBV sc nodes sbv
-parseSBVExpr sc unint nodes size (SBV.SBVApp operator sbvs) =
+parseSBVExpr opts sc unint nodes size (SBV.SBVApp operator sbvs) =
     case operator of
       SBV.BVAdd -> binop scBvAdd sbvs
       SBV.BVSub -> binop scBvSub sbvs
@@ -113,7 +114,6 @@ parseSBVExpr sc unint nodes size (SBV.SBVApp operator sbvs) =
             _ -> fail "parseSBVExpr: wrong number of arguments for append"
       SBV.BVLkUp indexSize resultSize ->
           do (size1 : inSizes, arg1 : args) <- liftM unzip $ mapM (parseSBV sc nodes) sbvs
-             -- unless (2 ^ indexSize == length args) $ putStrLn "parseSBVExpr BVLkUp: list size not a power of 2"
              unless (size1 == fromInteger indexSize && all (== (fromInteger resultSize)) inSizes)
                         (fail $ "parseSBVExpr BVLkUp: size mismatch")
              e <- scBitvector sc (fromInteger resultSize)
@@ -123,14 +123,14 @@ parseSBVExpr sc unint nodes size (SBV.SBVApp operator sbvs) =
              t <- case unint name typ of
                Just t -> return t
                Nothing ->
-                   do putStrLn ("WARNING: unknown uninterpreted function " ++ show (name, typ, size))
-                      putStrLn ("Using Prelude." ++ name)
+                   do printOutLn opts Warn ("WARNING: unknown uninterpreted function " ++ show (name, typ, size))
+                      printOutLn opts Info ("Using Prelude." ++ name)
                       scGlobalDef sc (mkIdent preludeName name)
              args <- mapM (parseSBV sc nodes) sbvs
              let inSizes = map fst args
                  (TFun inTyp outTyp) = typ
              unless (sum (typSizes inTyp) == sum (map fromIntegral inSizes)) $ do
-               putStrLn ("ERROR parseSBVPgm: input size mismatch in " ++ name)
+               printOutLn opts Error ("ERROR parseSBVPgm: input size mismatch in " ++ name)
                print inTyp
                print inSizes
              argument <- combineOutputs sc inTyp args
@@ -196,9 +196,9 @@ partitionSBVCommands = foldr select ([], [], [])
                 (assigns, inputs, sbv : outputs)
 
 -- TODO: Should I use a state monad transformer?
-parseSBVAssign :: SharedContext -> UnintMap -> NodeCache -> SBVAssign -> IO NodeCache
-parseSBVAssign sc unint nodes (SBVAssign size nodeid expr) =
-    do term <- parseSBVExpr sc unint nodes (fromInteger size) expr
+parseSBVAssign :: Options -> SharedContext -> UnintMap -> NodeCache -> SBVAssign -> IO NodeCache
+parseSBVAssign opts sc unint nodes (SBVAssign size nodeid expr) =
+    do term <- parseSBVExpr opts sc unint nodes (fromInteger size) expr
        return (Map.insert nodeid term nodes)
 
 ----------------------------------------------------------------------
@@ -329,24 +329,19 @@ combineOutputs sc ty xs0 =
 
 ----------------------------------------------------------------------
 
-parseSBVPgm :: SharedContext -> UnintMap -> SBV.SBVPgm -> IO Term
-parseSBVPgm sc unint (SBV.SBVPgm (_version, irtype, revcmds, _vcs, _warnings, _uninterps)) =
+parseSBVPgm :: Options -> SharedContext -> UnintMap -> SBV.SBVPgm -> IO Term
+parseSBVPgm opts sc unint (SBV.SBVPgm (_version, irtype, revcmds, _vcs, _warnings, _uninterps)) =
     do let (TFun inTyp outTyp) = parseIRType irtype
        let cmds = reverse revcmds
        let (assigns, inputs, outputs) = partitionSBVCommands cmds
        let inSizes = [ size | SBVInput size _ <- inputs ]
        let inNodes = [ node | SBVInput _ node <- inputs ]
-       -- putStrLn ("inTyp: " ++ show inTyp)
-       --putStrLn ("outTyp: " ++ show outTyp)
-       --putStrLn ("inSizes: " ++ show inSizes)
        unless (typSizes inTyp == inSizes) (fail "parseSBVPgm: input size mismatch")
        inputType <- scTyp sc inTyp
        inputVar <- scLocalVar sc 0
        inputTerms <- splitInputs sc inTyp inputVar
-       --putStrLn "processing..."
        let nodes0 = Map.fromList (zip inNodes inputTerms)
-       nodes <- foldM (parseSBVAssign sc unint) nodes0 assigns
-       --putStrLn "collecting output..."
+       nodes <- foldM (parseSBVAssign opts sc unint) nodes0 assigns
        outputTerms <- mapM (parseSBV sc nodes) outputs
        outputTerm <- combineOutputs sc outTyp outputTerms
        scLambda sc "x" inputType outputTerm

--- a/src/SAWScript/SBVParser.hs
+++ b/src/SAWScript/SBVParser.hs
@@ -131,8 +131,8 @@ parseSBVExpr opts sc unint nodes size (SBV.SBVApp operator sbvs) =
                  (TFun inTyp outTyp) = typ
              unless (sum (typSizes inTyp) == sum (map fromIntegral inSizes)) $ do
                printOutLn opts Error ("ERROR parseSBVPgm: input size mismatch in " ++ name)
-               print inTyp
-               print inSizes
+               printOutFn opts Error (show inTyp)
+               printOutFn opts Error (show inSizes)
              argument <- combineOutputs sc inTyp args
              result <- scApply sc t argument
              results <- splitInputs sc outTyp result

--- a/src/SAWScript/Utils.hs
+++ b/src/SAWScript/Utils.hs
@@ -31,6 +31,7 @@ import System.Directory(makeRelativeToCurrentDirectory)
 import System.FilePath(makeRelative, isAbsolute, (</>), takeDirectory)
 import System.Time(TimeDiff(..), getClockTime, diffClockTimes, normalizeTimeDiff, toCalendarTime, formatCalendarTime)
 import System.Locale(defaultTimeLocale)
+import System.Exit
 import Text.PrettyPrint.ANSI.Leijen hiding ((</>), (<$>))
 import Text.Printf
 import Numeric(showFFloat)
@@ -250,3 +251,8 @@ ordinal n | n < 0 = error "Only non-negative cardinals are supported."
              3 -> "rd"
              _ -> "th"
     inTens = (n `mod` 100) `div` 10 == 1
+
+exitProofFalse,exitProofUnknown,exitProofSuccess :: IO a
+exitProofFalse = exitWith (ExitFailure 1)
+exitProofUnknown = exitWith (ExitFailure 2)
+exitProofSuccess = exitSuccess

--- a/src/SAWScript/Utils.hs
+++ b/src/SAWScript/Utils.hs
@@ -38,6 +38,7 @@ import Numeric(showFFloat)
 
 import qualified Verifier.Java.Codebase as JSS
 
+import SAWScript.Options
 import Verifier.SAW.Conversion
 import Verifier.SAW.Rewriter
 import Verifier.SAW.SharedTerm
@@ -251,6 +252,9 @@ ordinal n | n < 0 = error "Only non-negative cardinals are supported."
              3 -> "rd"
              _ -> "th"
     inTens = (n `mod` 100) `div` 10 == 1
+
+handleException :: Options -> CE.SomeException -> IO a
+handleException opts e = printOutLn opts Error (show e) >> exitProofUnknown
 
 exitProofFalse,exitProofUnknown,exitProofSuccess :: IO a
 exitProofFalse = exitWith (ExitFailure 1)

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -45,7 +45,7 @@ import qualified Text.LLVM.AST as LLVM (Type)
 import qualified Text.LLVM.PP as LLVM (ppType)
 import SAWScript.JavaExpr (JavaType(..))
 import SAWScript.JavaPretty (prettyClass)
-import SAWScript.Options (Options)
+import SAWScript.Options (Options(printOutFn),printOutLn,Verbosity)
 import SAWScript.Proof
 import SAWScript.TypedTerm
 import SAWScript.ImportAIG
@@ -354,6 +354,16 @@ getJavaCodebase = TopLevel (asks roJavaCodebase)
 
 getOptions :: TopLevel Options
 getOptions = TopLevel (asks roOptions)
+
+printOutLnTop :: Verbosity -> String -> TopLevel ()
+printOutLnTop v s =
+    do opts <- getOptions
+       io $ printOutLn opts v s
+
+printOutTop :: Verbosity -> String -> TopLevel ()
+printOutTop v s =
+    do opts <- getOptions
+       io $ printOutFn opts v s
 
 getHandleAlloc :: TopLevel (Crucible.HandleAllocator RealWorld)
 getHandleAlloc = TopLevel (asks roHandleAlloc)


### PR DESCRIPTION
This version of SAW behaves more or less how I'd like for my IRAD and I believe the patches are in a form that is acceptable for merge.

Changes:

- Enumerated a list of verbosity values as an ADT.  This is set by the `-v` flag.
- added a print out function to the options which is used throughout saw-script
- Plumb the `Options` around much more so we have said function in needed contexts. A later clean-up could likely fold either the entire `Options` or just the print function into state carried by other monads.
- Translated `putStr*` and `print` calls and verbosity guards, if present, into this new print out method trying to match up the levels as best I could
- Exit codes!
    - If the proof is successful we return 0
    - If the proof fails with a counterexample we return 1
    - If there is the proof failed and its validity is unknown we return 2
-  Counterexamples are now tagged with `----------Counterexample----------` and followed by `(String,Value)` tuple(s)
- Some dead code has been eliminated and one or two modules have explicit export lists. Far from necessary, just a side-effect.