### PR TITLE
Save source locations from parser and plumb through type checker

### DIFF
--- a/saw-script.cabal
+++ b/saw-script.cabal
@@ -88,6 +88,7 @@ library
     SAWScript.CrucibleResolveSetupValue
     SAWScript.CrucibleMethodSpecIR
     SAWScript.CryptolEnv
+    SAWScript.Exceptions
     SAWScript.Import
     SAWScript.ImportAIG
     SAWScript.Interpreter

--- a/saw-script.el
+++ b/saw-script.el
@@ -209,6 +209,24 @@
     map)
   "Keymap for SAWScript mode.")
 
+;;; Flycheck support
+(with-eval-after-load 'flycheck
+  (flycheck-define-checker saw-script
+    "A checker for SAWScript.
+
+See URL `http://saw.galois.com' for more information."
+    :command ("saw" source-inplace)
+    :error-patterns ((error line-start (file-name) ":" line ":" column "-" (1+ digit) ":" (1+ digit) ":"
+                            (message) line-end)
+                     (error (seq line-start "[error] at " (file-name (1+ (not (any ?\:)))) ":" line ":" column
+                                 "--" (group (1+ digit)) ":" (group (1+ digit)) ":"
+                                 (message (1+ (seq "\n " (1+ (not (any ?\n))))))))
+                     (warning (seq line-start "[warning] at " (file-name (1+ (not (any ?\:)))) ":" line ":" column
+                                   "--" (group (1+ digit)) ":" (group (1+ digit)) ":"
+                                   (message (1+ (seq "\n " (1+ (not (any ?\n)))))))))
+    :modes (saw-script-mode))
+  (add-to-list 'flycheck-checkers 'saw-script))
+
 ;;; The mode itself
 
 ;;;###autoload

--- a/saw-script.el
+++ b/saw-script.el
@@ -216,13 +216,22 @@
   "A major mode for editing SAWScript files."
   (setq font-lock-defaults saw-script-font-lock-defaults)
   (setq font-lock-multiline t)
+
   ;; Compilation mode highlighting
-  (let ((compilation-regexp '("$\\([^:]+\\):\\([0-9]+\\):\\(0-9\\)-\\([0-9]+\\):\\(0-9\\): "
-                              1 (2 . 4) (3 . 5) nil 0)))
-    (if (assoc 'saw-script compilation-error-regexp-alist-alist)
-        (setf (assoc 'saw-script compilation-error-regexp-alist-alist) compilation-regexp)
-      (add-to-list 'compilation-error-regexp-alist-alist (cons 'saw-script compilation-regexp))))
+  (add-to-list 'compilation-error-regexp-alist-alist
+               '(saw-script "$\\([^:]+\\):\\([0-9]+\\):\\(0-9\\)-\\([0-9]+\\):\\(0-9\\): "
+                            1 (2 . 4) (3 . 5) nil 0))
+  (add-to-list 'compilation-error-regexp-alist-alist
+               '(cryptol-warning
+                 "\\[warning\\] at \\([^:]+\\):\\([0-9]+\\):\\([0-9]+\\)--\\([0-9]+\\):\\([0-9+]\\)"
+                 1 (2 . 4) (3 . 5) 1))
+  (add-to-list 'compilation-error-regexp-alist-alist
+               '(cryptol-error
+                 "\\[error\\] at \\([^:]+\\):\\([0-9]+\\):\\([0-9]+\\)--\\([0-9]+\\):\\([0-9+]\\)"
+                 1 (2 . 4) (3 . 5) 1))
   (add-to-list 'compilation-error-regexp-alist 'saw-script)
+  (add-to-list 'compilation-error-regexp-alist 'cryptol-warning)
+  (add-to-list 'compilation-error-regexp-alist 'cryptol-error)
   )
 
 ;;;###autoload

--- a/saw-script.el
+++ b/saw-script.el
@@ -177,7 +177,7 @@
   (interactive "fFile to run in saw: ")
   (let* ((dir (file-name-directory filename))
          (file (file-name-nondirectory filename))
-         (command (concat saw-script-command " " file))
+         (command (concat saw-script-command " --output-locations " file))
          ;; Special variables that configure compilation mode
          (compilation-buffer-name-function
           'saw-script--compilation-buffer-name-function)
@@ -215,8 +215,9 @@
     "A checker for SAWScript.
 
 See URL `http://saw.galois.com' for more information."
-    :command ("saw" source-inplace)
-    :error-patterns ((error line-start (file-name) ":" line ":" column "-" (1+ digit) ":" (1+ digit) ":"
+    :command ("saw" "--output-locations" source-inplace)
+    :error-patterns ((info line-start "[output] at " (file-name (1+ (not (any ?\:)))) ":" line ":" column "-" (1+ digit) ":" (1+ digit) ": " (message))
+                     (error line-start (file-name) ":" line ":" column "-" (1+ digit) ":" (1+ digit) ":"
                             (message) line-end)
                      (error (seq line-start "[error] at " (file-name (1+ (not (any ?\:)))) ":" line ":" column
                                  "--" (group (1+ digit)) ":" (group (1+ digit)) ":"

--- a/saw-script.el
+++ b/saw-script.el
@@ -165,6 +165,7 @@
     (font-lock-extend-after-change-region-function . saw-script--extend-after-change-region-function))
   "Highlighting instructions for SAWScript.")
 
+
 ;;; Running SAWScript
 
 (defun saw-script--compilation-buffer-name-function (_mode)
@@ -214,7 +215,15 @@
 (define-derived-mode saw-script-mode prog-mode "SAWScript"
   "A major mode for editing SAWScript files."
   (setq font-lock-defaults saw-script-font-lock-defaults)
-  (setq font-lock-multiline t))
+  (setq font-lock-multiline t)
+  ;; Compilation mode highlighting
+  (let ((compilation-regexp '("$\\([^:]+\\):\\([0-9]+\\):\\(0-9\\)-\\([0-9]+\\):\\(0-9\\): "
+                              1 (2 . 4) (3 . 5) nil 0)))
+    (if (assoc 'saw-script compilation-error-regexp-alist-alist)
+        (setf (assoc 'saw-script compilation-error-regexp-alist-alist) compilation-regexp)
+      (add-to-list 'compilation-error-regexp-alist-alist (cons 'saw-script compilation-regexp))))
+  (add-to-list 'compilation-error-regexp-alist 'saw-script)
+  )
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.saw$" . saw-script-mode))

--- a/saw/SAWScript/REPL/Monad.hs
+++ b/saw/SAWScript/REPL/Monad.hs
@@ -18,6 +18,7 @@ module SAWScript.REPL.Monad (
   , catch
   , catchIO
   , catchFail
+  , catchTypeErrors
 
     -- ** Errors
   , REPLException(..)
@@ -74,6 +75,7 @@ import Verifier.SAW.SharedTerm (Term)
 
 import SAWScript.AST (Located(getVal))
 import SAWScript.CryptolEnv
+import SAWScript.Exceptions
 import SAWScript.Interpreter (buildTopLevelEnv)
 import SAWScript.Options (Options)
 import SAWScript.TopLevel (TopLevelRO(..), TopLevelRW(..))
@@ -193,6 +195,10 @@ catchEx m k = REPL (\ ref -> unREPL m ref `X.catch` \ e -> unREPL (k e) ref)
 -- | Handle 'IOError' exceptions in 'REPL' actions.
 catchIO :: REPL a -> (IOError -> REPL a) -> REPL a
 catchIO = catchEx
+
+-- | Handle SAWScript type error exceptions in 'REPL' actions.
+catchTypeErrors :: REPL a -> (TypeErrors -> REPL a) -> REPL a
+catchTypeErrors = catchEx
 
 -- | Handle 'REPLException' exceptions in 'REPL' actions.
 catch :: REPL a -> (REPLException -> REPL a) -> REPL a

--- a/src/SAWScript/AutoMatch.hs
+++ b/src/SAWScript/AutoMatch.hs
@@ -353,17 +353,17 @@ processResults (TaggedSourceFile leftLang  leftFile) (TaggedSourceFile rightLang
          returning boundName . tell $
             case lang of
                Cryptol ->
-                  [SAWScript.StmtBind (SAWScript.PVar boundName Nothing) Nothing
+                  [SAWScript.StmtBind Unknown (SAWScript.PVar boundName Nothing) Nothing
                      (SAWScript.Application
                         (SAWScript.Var . locate $ "cryptol_load")
                         (SAWScript.String file))]
                LLVM ->
-                  [SAWScript.StmtBind (SAWScript.PVar boundName Nothing) Nothing
+                  [SAWScript.StmtBind Unknown (SAWScript.PVar boundName Nothing) Nothing
                      (SAWScript.Application
                         (SAWScript.Var . locate $ "llvm_load_module")
                         (SAWScript.String file))]
                JVM ->
-                  [SAWScript.StmtBind (SAWScript.PVar boundName Nothing) Nothing
+                  [SAWScript.StmtBind Unknown (SAWScript.PVar boundName Nothing) Nothing
                      (SAWScript.Application
                         (SAWScript.Var . locate $ "java_load_class")
                         (SAWScript.String $ dropExtension file))]
@@ -374,14 +374,14 @@ processResults (TaggedSourceFile leftLang  leftFile) (TaggedSourceFile rightLang
          returning boundName . tell $
             case lang of
                Cryptol ->
-                  [SAWScript.StmtBind (SAWScript.PVar boundName Nothing) Nothing
+                  [SAWScript.StmtBind Unknown (SAWScript.PVar boundName Nothing) Nothing
                      (SAWScript.Application
                         (SAWScript.Application
                            (SAWScript.Var . locate $ "cryptol_extract")
                            (SAWScript.Var loadedModule))
                         (SAWScript.String function))]
                LLVM ->
-                  [SAWScript.StmtBind (SAWScript.PVar boundName Nothing) Nothing
+                  [SAWScript.StmtBind Unknown (SAWScript.PVar boundName Nothing) Nothing
                      (SAWScript.Application
                         (SAWScript.Application
                            (SAWScript.Application
@@ -390,7 +390,7 @@ processResults (TaggedSourceFile leftLang  leftFile) (TaggedSourceFile rightLang
                            (SAWScript.String function))
                         (SAWScript.Var . locate $ "llvm_pure"))]
                JVM ->
-                  [SAWScript.StmtBind (SAWScript.PVar boundName Nothing) Nothing
+                  [SAWScript.StmtBind Unknown (SAWScript.PVar boundName Nothing) Nothing
                      (SAWScript.Application
                         (SAWScript.Application
                            (SAWScript.Application
@@ -409,7 +409,7 @@ processResults (TaggedSourceFile leftLang  leftFile) (TaggedSourceFile rightLang
                   name <- newNameWith (nameCenter (leftName ++ "_" ++ rightName))
                   return ((leftIndex, name), (rightIndex, name))
          returning theoremName . tell $
-            [SAWScript.StmtBind (SAWScript.PVar theoremName Nothing) Nothing .
+            [SAWScript.StmtBind Unknown (SAWScript.PVar theoremName Nothing) Nothing .
                 SAWScript.Code . locate .
                    show . Cryptol.ppPrec 0 .
                       cryptolAbstractNamesSAW leftArgs .
@@ -435,7 +435,7 @@ processResults (TaggedSourceFile leftLang  leftFile) (TaggedSourceFile rightLang
 
       prove :: SAWScript.LName -> ScriptWriter ()
       prove theorem = tell $
-         [SAWScript.StmtBind (SAWScript.PWild Nothing) Nothing
+         [SAWScript.StmtBind Unknown (SAWScript.PWild Nothing) Nothing
              (SAWScript.Application
                 (SAWScript.Application
                    (SAWScript.Var . locate $ "prove_print")
@@ -444,7 +444,7 @@ processResults (TaggedSourceFile leftLang  leftFile) (TaggedSourceFile rightLang
 
       printString :: String -> ScriptWriter ()
       printString string = tell $
-         [SAWScript.StmtBind (SAWScript.PWild Nothing) Nothing
+         [SAWScript.StmtBind Unknown (SAWScript.PWild Nothing) Nothing
              (SAWScript.Application
                 (SAWScript.Var . locate $ "print")
                 (SAWScript.String string))]

--- a/src/SAWScript/CryptolEnv.hs
+++ b/src/SAWScript/CryptolEnv.hs
@@ -78,7 +78,7 @@ import Cryptol.Utils.Logger (quietLogger)
 --import SAWScript.REPL.Monad (REPLException(..))
 import SAWScript.TypedTerm
 import SAWScript.Utils (Pos(..))
-import SAWScript.AST (Located(getVal, getPos), Import(..))
+import SAWScript.AST (Located(getVal, locatedPos), Import(..))
 
 --------------------------------------------------------------------------------
 
@@ -147,10 +147,11 @@ ioParseGeneric :: (P.Config -> Text -> Either P.ParseError a) -> Located String 
 ioParseGeneric parse lstr = ioParseResult (parse cfg (pack str))
   where
     (file, line, col) =
-      case getPos lstr of
-        Pos f l c     -> (f, l, c)
+      case locatedPos lstr of
+        Range f sl sc _el _ec -> (f, sl, sc) -- TODO: take span into account
         PosInternal s -> (s, 1, 1)
         PosREPL       -> ("<interactive>", 1, 1)
+        Unknown       -> ("Unknown", 1, 1)
     cfg = P.defaultConfig { P.cfgSource = file }
     str = concat [ replicate (line - 1) '\n'
                  , replicate (col - 1 + 2) ' ' -- add 2 to compensate for dropped "{{"

--- a/src/SAWScript/Exceptions.hs
+++ b/src/SAWScript/Exceptions.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module SAWScript.Exceptions (TypeErrors(..), failTypecheck) where
+
+import Control.Exception
+
+import SAWScript.Utils
+
+
+newtype TypeErrors = TypeErrors [(Pos, String)]
+
+instance Show TypeErrors where
+  show (TypeErrors []) = "Unspecified type error"
+  show (TypeErrors [(pos, msg)]) = show pos ++ ": " ++ msg
+  show (TypeErrors errs) = "Type errors:\n" ++ showErrs errs
+    where showErrs = unlines . map showErr
+          showErr (pos, msg) = "  " ++ show pos ++ ": " ++ msg
+
+instance Exception TypeErrors where
+
+failTypecheck :: [(Pos, String)] -> a
+failTypecheck = throw . TypeErrors
+

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -340,11 +340,13 @@ interpretFile file = do
   stmts <- io $ SAWScript.Import.loadFile opts file
   mapM_ stmtWithPrint stmts
   where
-    stmtWithPrint s = do let p = getPos s
+    stmtWithPrint s = do let withPos str = unlines $
+                                           ("[output] at " ++ show (getPos s) ++ ": ") :
+                                             map (\l -> "\t"  ++ l) (lines str)
                          showLoc <- printShowPos <$> getOptions
                          if showLoc
                            then localOptions (\o -> o { printOutFn = \lvl str ->
-                                                          printOutFn o lvl ("[output] at " ++ show p ++ ": " ++ str) })
+                                                          printOutFn o lvl (withPos str) })
                                   (interpretStmt False s)
                            else interpretStmt False s
 

--- a/src/SAWScript/Lexer.x
+++ b/src/SAWScript/Lexer.x
@@ -93,8 +93,15 @@ via  c g p s = c p s (g s)
 via' c g p s = c p (g s)
 
 lexSAW :: FilePath -> String -> [Token Pos]
-lexSAW f = dropComments . map (fmap fixPos) . alexScanTokens
-  where fixPos (AlexPn _ l c) = Pos f l c
+lexSAW f = dropComments . map fixPos . alexScanTokens
+  where fixPos tok =
+          let (AlexPn _ sl sc) = tokPos tok
+              pos = case lines (tokStr tok) of
+                      [] -> Range f sl sc sl sc
+                      [l] -> Range f sl sc sl (sc + length l)
+                      (l:ls) -> Range f sl sc (sl + length ls) (length (last (l:ls)))
+          in tok { tokPos = pos }
+
 
 readCode :: String -> String
 readCode = reverse . drop 2 . reverse . drop 2

--- a/src/SAWScript/MGU.hs
+++ b/src/SAWScript/MGU.hs
@@ -18,7 +18,7 @@ module SAWScript.MGU
        ) where
 
 import SAWScript.AST
-import SAWScript.Utils (Pos(..))
+import SAWScript.Utils (Pos(..), Positioned(..))
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
@@ -145,17 +145,18 @@ instance NamedVars Schema where
 -- TI Monad {{{
 
 newtype TI a = TI { unTI :: ReaderT RO (StateT RW Identity) a }
-                        deriving (Functor,Applicative,Monad)
+                        deriving (Functor,Applicative,Monad,MonadReader RO)
 
 data RO = RO
   { typeEnv :: M.Map (Located Name) Schema
   , typedefEnv :: M.Map Name Type
+  , currentExprPos :: Pos
   }
 
 data RW = RW
   { nameGen :: TypeIndex
   , subst   :: Subst
-  , errors  :: [String]
+  , errors  :: [(Pos, String)]
   }
 
 emptyRW :: RW
@@ -170,6 +171,9 @@ newTypeIndex = do
 newType :: TI Type
 newType = TyUnifyVar <$> newTypeIndex
 
+withExprPos :: Pos -> TI a -> TI a
+withExprPos p = local (\e -> e { currentExprPos = p })
+
 newTypePattern :: Pattern -> TI (Type, Pattern)
 newTypePattern pat =
   case pat of
@@ -179,6 +183,7 @@ newTypePattern pat =
                     return (t, PVar x (Just t))
     PTuple ps -> do (ts, ps') <- unzip <$> mapM newTypePattern ps
                     return (tTuple ts, PTuple ps')
+    LPattern pos pat' -> withExprPos pos (newTypePattern pat')
 
 appSubstM :: AppSubst t => t -> TI t
 appSubstM t = do
@@ -186,8 +191,9 @@ appSubstM t = do
   return $ appSubst s t
 
 recordError :: String -> TI ()
-recordError err = TI $ modify $ \rw ->
-  rw { errors = err : errors rw }
+recordError err = do pos <- currentExprPos <$> ask
+                     TI $ modify $ \rw ->
+                       rw { errors = (pos, err) : errors rw }
 
 unify :: LName -> Type -> Type -> TI ()
 unify m t1 t2 = do
@@ -209,8 +215,8 @@ bindSchemas :: [(Located Name, Schema)] -> TI a -> TI a
 bindSchemas bs m = foldr (uncurry bindSchema) m bs
 
 bindDecl :: Decl -> TI a -> TI a
-bindDecl (Decl _ Nothing _) m = m
-bindDecl (Decl p (Just s) _) m = bindPatternSchema p s m
+bindDecl (Decl _ _ Nothing _) m = m
+bindDecl (Decl _ p (Just s) _) m = bindPatternSchema p s m
 
 bindDeclGroup :: DeclGroup -> TI a -> TI a
 bindDeclGroup (NonRecursive d) m = bindDecl d m
@@ -226,6 +232,7 @@ patternBindings pat =
     PWild _mt -> []
     PVar x mt -> [(x, mt)]
     PTuple ps -> concatMap patternBindings ps
+    LPattern _ pat' -> patternBindings pat'
 
 bindPatternSchema :: Pattern -> Schema -> TI a -> TI a
 bindPatternSchema pat s@(Forall vs t) m =
@@ -237,6 +244,7 @@ bindPatternSchema pat s@(Forall vs t) m =
         TyCon (TupleCon _) ts -> foldr ($) m
           [ bindPatternSchema p (Forall vs t') | (p, t') <- zip ps ts ]
         _ -> m
+    LPattern pos pat' -> withExprPos pos (bindPatternSchema pat' s m)
 
 bindTypedef :: LName -> Type -> TI a -> TI a
 bindTypedef n t m =
@@ -308,12 +316,14 @@ instance AppSubst Expr where
     Application f v    -> Application (appSubst s f) (appSubst s v)
     Let dg e           -> Let (appSubst s dg) (appSubst s e)
     IfThenElse e e2 e3 -> IfThenElse (appSubst s e) (appSubst s e2) (appSubst s e3)
+    LExpr p e          -> LExpr p (appSubst s e)
 
 instance AppSubst Pattern where
   appSubst s pat = case pat of
     PWild mt  -> PWild (appSubst s mt)
     PVar x mt -> PVar x (appSubst s mt)
     PTuple ps -> PTuple (appSubst s ps)
+    LPattern _ pat' -> appSubst s pat'
 
 instance (Ord k, AppSubst a) => AppSubst (M.Map k a) where
   appSubst s = fmap (appSubst s)
@@ -331,7 +341,7 @@ instance AppSubst DeclGroup where
   appSubst s (NonRecursive d) = NonRecursive (appSubst s d)
 
 instance AppSubst Decl where
-  appSubst s (Decl p mt e) = Decl (appSubst s p) (appSubst s mt) (appSubst s e)
+  appSubst s (Decl pos p mt e) = Decl pos (appSubst s p) (appSubst s mt) (appSubst s e)
 
 -- }}}
 
@@ -483,6 +493,9 @@ inferE (ln, expr) = case expr of
        e3' <- checkE ln e3 t
        return (IfThenElse e1' e2' e3', t)
 
+  LExpr p e ->
+    withExprPos p (inferE (ln, e))
+
 
 checkE :: LName -> Expr -> Type -> TI OutExpr
 checkE m e t = do
@@ -562,6 +575,7 @@ patternLNames pat =
     PWild _ -> []
     PVar n _ -> [n]
     PTuple ps -> concatMap patternLNames ps
+    LPattern _ pat' -> patternLNames pat'
 
 patternLName :: Pattern -> LName
 patternLName pat =
@@ -585,14 +599,15 @@ constrainTypeWithPattern ln t pat =
                [ "type mismatch: " ++ pShow (TupleCon (genericLength ps)) ++ " and " ++ pShow t
                , " at " ++ show ln
                ]
+    LPattern pos pat' -> withExprPos pos (constrainTypeWithPattern ln t pat')
 
 inferDecl :: Decl -> TI Decl
-inferDecl (Decl pat _ e) = do
+inferDecl (Decl pos pat _ e) = withExprPos pos $ do
   let n = patternLName pat
   (e',t) <- inferE (n, e)
   constrainTypeWithPattern n t pat
   [(e1,s)] <- generalize [e'] [t]
-  return (Decl pat (Just s) e1)
+  return (Decl pos pat (Just s) e1)
 
 inferRecDecls :: [Decl] -> TI [Decl]
 inferRecDecls ds =
@@ -600,10 +615,14 @@ inferRecDecls ds =
      (_ts, pats') <- unzip <$> mapM newTypePattern pats
      (es, ts) <- fmap unzip
                  $ flip (foldr bindPattern) pats'
-                 $ sequence [ inferE (patternLName p, e) | Decl p _ e <- ds ]
+                 $ sequence [ withExprPos pos $ inferE (patternLName p, e)
+                            | Decl pos p _ e <- ds
+                            ]
      sequence_ $ zipWith (constrainTypeWithPattern (error "FIXME")) ts pats'
      ess <- generalize es ts
-     return [ Decl p (Just s) e1 | (p, (e1, s)) <- zip pats ess ]
+     return [ Decl pos p (Just s) e1
+            | (pos, p, (e1, s)) <- zip3 (map getPos ds) pats ess
+            ]
 
 generalize :: [OutExpr] -> [Type] -> TI [(OutExpr,Schema)]
 generalize es0 ts0 =
@@ -628,30 +647,31 @@ checkKind = return
 
 -- }}}
 
+
 -- Main interface {{{
 
-checkDeclGroup :: Map LName Schema -> Map Name Type -> DeclGroup -> Either String DeclGroup
+checkDeclGroup :: Map LName Schema -> Map Name Type -> DeclGroup -> Either [(Pos, String)] DeclGroup
 checkDeclGroup env tenv dg =
-  case evalTIWithEnv env tenv (inferDeclGroup dg) of
-    Left errs -> Left ("Error\n" ++ unlines (map ("  " ++) errs))
+  case evalTIWithEnv env tenv (getPos dg) (inferDeclGroup dg) of
+    Left errs -> Left errs
     Right dg' -> Right dg'
 
-checkDecl :: Map LName Schema -> Map Name Type -> Decl -> Either String Decl
+checkDecl :: Map LName Schema -> Map Name Type -> Decl -> Either [(Pos, String)] Decl
 checkDecl env tenv decl =
-  case evalTIWithEnv env tenv (inferDecl decl) of
-    Left errs -> Left ("Error\n" ++ unlines (map ("  " ++) errs))
+  case evalTIWithEnv env tenv (getPos decl) (inferDecl decl) of
+    Left errs -> Left errs
     Right decl' -> Right decl'
 
-evalTIWithEnv :: Map LName Schema -> Map Name Type -> TI a -> Either [String] a
-evalTIWithEnv env tenv m =
-  case runTIWithEnv env tenv m of
+evalTIWithEnv :: Map LName Schema -> Map Name Type -> Pos -> TI a -> Either [(Pos, String)] a
+evalTIWithEnv env tenv pos m =
+  case runTIWithEnv env tenv pos m of
     (res, _, []) -> Right res
     (_, _, errs) -> Left errs
 
-runTIWithEnv :: Map LName Schema -> Map Name Type -> TI a -> (a, Subst, [String])
-runTIWithEnv env tenv m = (a, subst rw, errors rw)
+runTIWithEnv :: Map LName Schema -> Map Name Type -> Pos -> TI a -> (a, Subst, [(Pos, String)])
+runTIWithEnv env tenv pos m = (a, subst rw, errors rw)
   where
-  m' = runReaderT (unTI m) (RO env tenv)
+  m' = runReaderT (unTI m) (RO env tenv pos)
   (a,rw) = runState m' emptyRW
 
 -- }}}

--- a/src/SAWScript/Options.hs
+++ b/src/SAWScript/Options.hs
@@ -27,6 +27,7 @@ data Options = Options
   , runInteractively :: Bool
   , showHelp         :: Bool
   , showVersion      :: Bool
+  , printShowPos     :: Bool
   , printOutFn       :: Verbosity -> String -> IO ()
   } deriving (Show)
 
@@ -42,6 +43,7 @@ defaultOptions
     , classPath = ["."]
     , jarList = []
     , verbLevel = Info
+    , printShowPos = False
     , printOutFn = printOutWith Info
     , simVerbose = 1
     , extraChecks = False
@@ -92,6 +94,10 @@ options =
      "path"
     )
     pathDesc
+  , Option [] ["output-locations"]
+    (NoArg
+     (\opts -> opts { printShowPos = True }))
+     "Show the source locations that are responsible for output."
   , Option "d" ["sim-verbose"]
     (ReqArg
      (\v opts -> opts { simVerbose = read v })

--- a/src/SAWScript/Token.hs
+++ b/src/SAWScript/Token.hs
@@ -8,6 +8,8 @@ Stability   : provisional
 {-# LANGUAGE DeriveFunctor #-}
 module SAWScript.Token where
 
+import SAWScript.Utils
+
 data Token p = TVar      { tokPos :: p, tokStr :: String                               }
              | TQVar     { tokPos :: p, tokStr :: String, tokVars :: ([String],String) }
              | TLit      { tokPos :: p, tokStr :: String                               }
@@ -22,3 +24,6 @@ data Token p = TVar      { tokPos :: p, tokStr :: String                        
              | TCmntE    { tokPos :: p, tokStr :: String                               }
              | TEOF      { tokPos :: p, tokStr :: String                               }
              deriving (Show, Functor)
+
+instance Positioned p => Positioned (Token p) where
+  getPos = getPos . tokPos

--- a/src/SAWScript/TopLevel.hs
+++ b/src/SAWScript/TopLevel.hs
@@ -17,6 +17,7 @@ module SAWScript.TopLevel
   , getHandleAlloc
   , getTopLevelRO
   , getTopLevelRW
+  , localOptions
   , putTopLevelRW
   ) where
 

--- a/src/SAWScript/Utils.hs
+++ b/src/SAWScript/Utils.hs
@@ -44,9 +44,10 @@ import Verifier.SAW.Rewriter
 import Verifier.SAW.SharedTerm
 import Verifier.SAW.TypedAST
 
-data Pos = Pos !FilePath -- file
-               !Int      -- line
-               !Int      -- col
+data Pos = Range !FilePath -- file
+                 !Int !Int -- start line, col
+                 !Int !Int -- end line, col
+         | Unknown
          | PosInternal String
          | PosREPL
   deriving (Eq)
@@ -55,11 +56,29 @@ renderDoc :: Doc -> String
 renderDoc doc = displayS (renderPretty 0.8 80 doc) ""
 
 endPos :: FilePath -> Pos
-endPos f = Pos f 0 0
+endPos f = Range f 0 0 0 0
 
 fmtPos :: Pos -> String -> String
 fmtPos p m = show p ++ ":\n" ++ m'
   where m' = intercalate "\n" . map ("  " ++) . lines $ m
+
+spanPos :: Pos -> Pos -> Pos
+spanPos (PosInternal str) _ = PosInternal str
+spanPos PosREPL _ = PosREPL
+spanPos _ (PosInternal str) = PosInternal str
+spanPos _ PosREPL = PosREPL
+spanPos Unknown p = p
+spanPos p Unknown = p
+spanPos (Range f sl sc el ec) (Range _ sl' sc' el' ec') =  Range f l c l' c'
+  where
+    (l, c) = minPos sl sc sl' sc'
+    (l', c') = maxPos el ec el' ec'
+    minPos l1 c1 l2 c2 | l1 < l2   = (l1, c1)
+                       | l1 == l2  = (l1, min c1 c2)
+                       | otherwise = (l2, c2)
+    maxPos l1 c1 l2 c2 | l1 < l2   = (l2, c2)
+                       | l1 == l2  = (l1, max c1 c2)
+                       | otherwise = (l1, c1)
 
 fmtPoss :: [Pos] -> String -> String
 fmtPoss [] m = fmtPos (PosInternal "saw-script internal") m
@@ -67,26 +86,40 @@ fmtPoss ps m = "[" ++ intercalate ",\n " (map show ps) ++ "]:\n" ++ m'
   where m' = intercalate "\n" . map ("  " ++) . lines $ m
 
 posRelativeToCurrentDirectory :: Pos -> IO Pos
-posRelativeToCurrentDirectory (Pos f l c)     = makeRelativeToCurrentDirectory f >>= \f' -> return (Pos f' l c)
-posRelativeToCurrentDirectory (PosInternal s) = return $ PosInternal s
-posRelativeToCurrentDirectory PosREPL = return PosREPL
+posRelativeToCurrentDirectory (Range f sl sc el ec) = makeRelativeToCurrentDirectory f >>= \f' -> return (Range f' sl sc el ec)
+posRelativeToCurrentDirectory Unknown               = return Unknown
+posRelativeToCurrentDirectory (PosInternal s)       = return $ PosInternal s
+posRelativeToCurrentDirectory PosREPL               = return PosREPL
 
 posRelativeTo :: FilePath -> Pos -> Pos
-posRelativeTo d (Pos f l c)     = Pos (makeRelative d f) l c
-posRelativeTo _ (PosInternal s) = PosInternal s
-posRelativeTo _ PosREPL = PosREPL
+posRelativeTo d (Range f sl sc el ec) = Range (makeRelative d f) sl sc el ec
+posRelativeTo _ Unknown               = Unknown
+posRelativeTo _ (PosInternal s)       = PosInternal s
+posRelativeTo _ PosREPL               = PosREPL
 
 routePathThroughPos :: Pos -> FilePath -> FilePath
-routePathThroughPos (Pos f _ _) fp
+routePathThroughPos (Range f _ _ _ _) fp
   | isAbsolute fp = fp
   | True          = takeDirectory f </> fp
 routePathThroughPos _ fp = fp
 
 instance Show Pos where
-  show (Pos f 0 0)     = f ++ ":end-of-file"
-  show (Pos f l c)     = f ++ ":" ++ show l ++ ":" ++ show c
-  show (PosInternal s) = "[internal:" ++ s ++ "]"
-  show PosREPL = "REPL"
+  -- show (Pos f 0 0)           = f ++ ":end-of-file"
+  -- show (Pos f l c)           = f ++ ":" ++ show l ++ ":" ++ show c
+  show (Range f 0 0 0 0) = f ++ ":end-of-file"
+  show (Range f sl sc el ec) = f ++ ":" ++ show sl ++ ":" ++ show sc ++ "-" ++ show el ++ ":" ++ show ec
+  show Unknown               = "unknown"
+  show (PosInternal s)       = "[internal:" ++ s ++ "]"
+  show PosREPL               = "REPL"
+
+class Positioned a where
+  getPos :: a -> Pos
+
+instance Positioned Pos where
+  getPos p = p
+
+maxSpan :: (Functor t, Foldable t, Positioned a) => t a -> Pos
+maxSpan xs = foldr spanPos Unknown (fmap getPos xs)
 
 data SSMode = Verify | Blif | CBlif deriving (Eq, Show, Data, Typeable)
 
@@ -115,11 +148,11 @@ instance Exception ExecException
 
 -- | Throw exec exception in a MonadIO.
 throwIOExecException :: MonadIO m => Pos -> Doc -> String -> m a
-throwIOExecException pos errorMsg resolution = liftIO $ throwIO (ExecException pos errorMsg resolution)
+throwIOExecException site errorMsg resolution = liftIO $ throwIO (ExecException site errorMsg resolution)
 
 -- | Throw exec exception in a MonadIO.
 throwExecException :: Pos -> Doc -> String -> m a
-throwExecException pos errorMsg resolution = throw (ExecException pos errorMsg resolution)
+throwExecException site errorMsg resolution = throw (ExecException site errorMsg resolution)
 
 -- Timing {{{1
 
@@ -152,19 +185,19 @@ showDuration n = printf "%02d:%s" m (show s)
 -- | Atempt to find class with given name, or throw ExecException if no class
 -- with that name exists. Class name should be in slash-separated form.
 lookupClass :: JSS.Codebase -> Pos -> String -> IO JSS.Class
-lookupClass cb pos nm = do
+lookupClass cb site nm = do
   maybeCl <- JSS.tryLookupClass cb nm
   case maybeCl of
     Nothing -> do
      let msg = ftext ("The Java class " ++ JSS.slashesToDots nm ++ " could not be found.")
          res = "Please check that the --classpath and --jars options are set correctly."
-      in throwIOExecException pos msg res
+      in throwIOExecException site msg res
     Just cl -> return cl
 
 -- | Returns method with given name in this class or one of its subclasses.
 -- Throws an ExecException if method could not be found or is ambiguous.
 findMethod :: JSS.Codebase -> Pos -> String -> JSS.Class -> IO (JSS.Class, JSS.Method)
-findMethod cb pos nm initClass = impl initClass
+findMethod cb site nm initClass = impl initClass
   where javaClassName = JSS.slashesToDots (JSS.className initClass)
         methodMatches m = JSS.methodName m == nm && not (JSS.methodIsAbstract m)
         impl cl =
@@ -175,15 +208,15 @@ findMethod cb pos nm initClass = impl initClass
                   let msg = ftext $ "Could not find method " ++ nm
                               ++ " in class " ++ javaClassName ++ "."
                       res = "Please check that the class and method are correct."
-                   in throwIOExecException pos msg res
+                   in throwIOExecException site msg res
                 Just superName ->
-                  impl =<< lookupClass cb pos superName
+                  impl =<< lookupClass cb site superName
             [method] -> return (cl,method)
             _ -> let msg = "The method " ++ nm ++ " in class " ++ javaClassName
                              ++ " is ambiguous.  SAWScript currently requires that "
                              ++ "method names are unique."
                      res = "Please rename the Java method so that it is unique."
-                  in throwIOExecException pos (ftext msg) res
+                  in throwIOExecException site (ftext msg) res
 
 throwFieldNotFound :: JSS.Type -> String -> ExceptT String IO a
 throwFieldNotFound tp fieldName = throwE msg
@@ -194,14 +227,14 @@ throwFieldNotFound tp fieldName = throwE msg
 
 findField :: JSS.Codebase -> Pos -> JSS.Type -> String -> ExceptT String IO JSS.FieldId
 findField _  _ tp@(JSS.ArrayType _) nm = throwFieldNotFound tp nm
-findField cb pos tp@(JSS.ClassType clName) nm = impl =<< lift (lookupClass cb pos clName)
+findField cb site tp@(JSS.ClassType clName) nm = impl =<< lift (lookupClass cb site clName)
   where
     impl cl =
       case filter (\f -> JSS.fieldName f == nm) $ JSS.classFields cl of
         [] -> do
           case JSS.superClass cl of
             Nothing -> throwFieldNotFound tp nm
-            Just superName -> impl =<< lift (lookupClass cb pos superName)
+            Just superName -> impl =<< lift (lookupClass cb site superName)
         [f] -> return $ JSS.FieldId (JSS.className cl) nm (JSS.fieldType f)
         _ -> throwE $
              "internal: Found multiple fields with the same name: " ++ nm

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -29,7 +29,7 @@ import Control.Monad.ST
 import qualified Control.Exception as X
 import qualified System.IO.Error as IOError
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Reader (ReaderT(..), ask, asks)
+import Control.Monad.Reader (ReaderT(..), ask, asks, local)
 import Control.Monad.State (StateT(..), get, put)
 import Control.Monad.Trans.Class (lift)
 import Data.List ( intersperse )
@@ -370,6 +370,9 @@ getJavaCodebase = TopLevel (asks roJavaCodebase)
 
 getOptions :: TopLevel Options
 getOptions = TopLevel (asks roOptions)
+
+localOptions :: (Options -> Options) -> TopLevel a -> TopLevel a
+localOptions f (TopLevel m) = TopLevel (local (\x -> x {roOptions = f (roOptions x)}) m)
 
 printOutLnTop :: Verbosity -> String -> TopLevel ()
 printOutLnTop v s =


### PR DESCRIPTION
Type errors now give much more specific locations. This was implemented as follows:
 1. Add specific constructors for source location annotations
 2. Update lexer to save source spans rather than points, and use spans generally throughout the code
 3. IO exceptions are used to throw type errors, and there's an exception and handler for that now

The end result is that type errors in expressions are now easier to track down, and the "user error" badge has been removed from the top. Because this is my first substantive contribution, I'd appreciate a once-over.

Thanks!

