### PR TITLE
Don't exit '2' due to ExitCode exceptions.

### DIFF
--- a/src/SAWScript/Utils.hs
+++ b/src/SAWScript/Utils.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {- |
 Module      : $Header$
 Description : Miscellaneous utilities.
@@ -317,7 +318,9 @@ ordinal n | n < 0 = error "Only non-negative cardinals are supported."
     inTens = (n `mod` 100) `div` 10 == 1
 
 handleException :: Options -> CE.SomeException -> IO a
-handleException opts e = printOutLn opts Error (show e) >> exitProofUnknown
+handleException opts e
+    | Just (_ :: ExitCode) <- CE.fromException e = CE.throw e
+    | otherwise = printOutLn opts Error (CE.displayException e) >> exitProofUnknown
 
 exitProofFalse,exitProofUnknown,exitProofSuccess :: IO a
 exitProofFalse = exitWith (ExitFailure 1)


### PR DESCRIPTION
Grumble grumble, some post-test-pre-commit change broke intended operations, grumble.

It seems we're catching the ExitCode exception and interpreting all exceptions to mean "result unknown" when, in fact, some times ExitSuccess is thrown when a proof succeeds.  Now it might not be a good design to throw exit success but so long as we're doing that we certainly should not rewrite the exit code on the way out.