### PR TITLE
Switch llvm-pretty back to GaloisInc fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	url = https://github.com/GaloisInc/jvm-verifier.git
 [submodule "deps/llvm-pretty"]
 	path = deps/llvm-pretty
-	url = https://github.com/elliottt/llvm-pretty.git
+	url = https://github.com/GaloisInc/llvm-pretty.git
 [submodule "deps/llvm-pretty-bc-parser"]
 	path = deps/llvm-pretty-bc-parser
 	url = https://github.com/GaloisInc/llvm-pretty-bc-parser.git


### PR DESCRIPTION
Recommend swtiching GaloisInc/saw-script back to referencing its own fork of llvm-pretty. To do this, we'll need to merge the changes from elliottt.

This is desirable as it keeps all dependencies for SAW in one place. This makes it easier to manage the mirror of the Galois github that we have recently set up.