### PR TITLE
Crucible: Better error message on type mismatch

### DIFF
--- a/src/SAWScript/CrucibleBuiltins.hs
+++ b/src/SAWScript/CrucibleBuiltins.hs
@@ -352,6 +352,10 @@ resolveArguments cc mspec env = mapM resolveArg [0..(nArgs-1)]
            fail $ unlines [ "Type mismatch in argument " ++ show i ++ " when veriyfing " ++ show nm
                           , "Argument is declared with type: " ++ show mt
                           , "but provided argument has incompatible type: " ++ show mt'
+                          , "Note: this may be because the signature of your " ++
+                            "function changed during compilation. If using " ++
+                            "Clang, check the signature in the disassembled " ++
+                            ".ll file."
                           ]
     resolveArg i =
       case Map.lookup i (mspec^.csArgBindings) of


### PR DESCRIPTION
Clang can change the signatures of functions in the generated bytecode, which can yield a confusing error where the user is passing an argument which has a type that agrees with the C code, but disagrees with the LLVM IR. This will help the user find out if that's what happened.