### PR TITLE
saw-script.el: define a comment syntax

### DIFF
--- a/saw-script.el
+++ b/saw-script.el
@@ -400,6 +400,10 @@ See URL `http://saw.galois.com' for more information."
   (add-to-list 'compilation-error-regexp-alist 'cryptol-warning)
   (add-to-list 'compilation-error-regexp-alist 'cryptol-error)
 
+  ;; Comment syntax
+  (setq-local comment-start "// ")
+  (setq-local comment-end "")
+
   ;; Setup code for output viewing
   (make-variable-buffer-local 'saw-script-output)
 


### PR DESCRIPTION
cc @david-christiansen 

Comments tested and working, I think my Emacs doesn't use tabs already so I'm not sure how to test that. 