### PR TITLE
Use panic package

### DIFF
--- a/saw-script.cabal
+++ b/saw-script.cabal
@@ -54,6 +54,7 @@ library
     , mtl >= 2.1
     , old-locale
     , old-time
+    , panic
     , parameterized-utils
     , parsec
     , pretty

--- a/src/SAWScript/CrucibleBuiltins.hs
+++ b/src/SAWScript/CrucibleBuiltins.hs
@@ -136,7 +136,6 @@ import SAWScript.CrucibleMethodSpecIR
 import SAWScript.CrucibleOverride
 import SAWScript.CrucibleResolveSetupValue
 
-
 type MemImpl = Crucible.MemImpl Sym
 
 show_cfg :: SAW_CFG -> String
@@ -191,7 +190,7 @@ crucible_llvm_verify bic opts lm nm lemmas checkSat setup tactic =
      let globals = cc^.ccLLVMGlobals
      let mvar = Crucible.llvmMemVar (cc^.ccLLVMContext)
      mem0 <- case Crucible.lookupGlobal mvar globals of
-       Nothing   -> fail "internal error: LLVM Memory global not found"
+       Nothing   -> panic "crucible_llvm_verify" ["LLVM Memory global not found"]
        Just mem0 -> return mem0
      let globals1 = Crucible.llvmGlobals (cc^.ccLLVMContext) mem0
 
@@ -730,9 +729,7 @@ setupCrucibleContext bic opts (LLVMModule _ llvm_mod (Some mtrans)) action = do
                                  }
               ]
             r -> panic "setupCrucibleContext" $
-              [ "Simulator initialization failed, for an unknown reason!"
-              , "This is always a bug, please report it."
-              ]
+              [ "Simulator initialization failed, for an unknown reason!" ]
 
       return CrucibleContext{ _ccLLVMModuleTrans = mtrans
                             , _ccLLVMModule      = llvm_mod

--- a/src/SAWScript/Panic.hs
+++ b/src/SAWScript/Panic.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE Trustworthy, TemplateHaskell #-}
+module SAWScript.Panic
+  (HasCallStack, SAWScript, Panic, panic) where
+
+import Panic hiding (panic)
+import qualified Panic as Panic
+
+data SAWScript = SAWScript
+
+panic :: HasCallStack => String -> [String] -> a
+panic = Panic.panic SAWScript
+
+instance PanicComponent SAWScript where
+  panicComponentName _ = "saw-script"
+  panicComponentIssues _ = "https://github.com/GaloisInc/saw-script/issues"
+  {-# Noinline panicComponentRevision #-}
+  panicComponentRevision = $useGitRevision


### PR DESCRIPTION
The `panic` package provides a convenient way to handle internal errors with a useful message. Using the `gitrev` package allows us to avoid a custom `Setup.hs`. Both packages are already part of the transitive dependency tree. 