### PR TITLE
Revert "Replace use of Crucible's `loadRawWithCondition` with `loadRa…

### DIFF
--- a/src/SAWScript/CrucibleLLVM.hs
+++ b/src/SAWScript/CrucibleLLVM.hs
@@ -84,7 +84,7 @@ module SAWScript.CrucibleLLVM
   , doMalloc
   , doLoad
   , doStore
-  , loadRaw
+  , loadRawWithCondition
   , storeRaw
   , storeConstRaw
   , mallocRaw
@@ -165,7 +165,7 @@ import Lang.Crucible.LLVM.Translation
 import Lang.Crucible.LLVM.MemModel
   (Mem, MemImpl, doResolveGlobal, storeRaw, storeConstRaw, mallocRaw, mallocConstRaw,
    ppMem, packMemValue, unpackMemValue, buildDisjointRegionsAssertion,
-   doLoad, doStore, loadRaw, doPtrAddOffset, emptyMem, doMalloc,
+   doLoad, doStore, loadRawWithCondition, doPtrAddOffset, emptyMem, doMalloc,
    LLVMVal(..),
    LLVMPtr, HasPtrWidth, ptrToPtrVal, mkNullPointer, ptrIsNull, ppPtr, ptrEq,
    pattern LLVMPointerRepr, LLVMPointerType,


### PR DESCRIPTION
…w` (#356)"

This reverts commit c39504376a854f741cd4fcc9353ad4a65c763816.

The code in `CrucibleOverride` uses the `OverrideMatcher` monad and the `addAssert` function to collect all the assertions made by an override precondition.  Switching from `loadRawWithCondition` to `loadRaw` would require: catching the `IO` exception thrown by `Crucible.abortExecBecause`, and using `Crucible.pushAssumptionFrame`/`Crucible.popAssumptionFrame` in order to try each individual override precondition in isolation. The second change should be made throughout the entire override precondition matching process, and would replace the `OverrideMatcher` monad. I think that would be an improvement, but it would require considerable more work, so for now I'm just reverting this.

Fixes #374.