### PR TITLE
Simplify ProofGoal representation; fix negation convention in backends.

### DIFF
--- a/src/SAWScript/CrucibleBuiltins.hs
+++ b/src/SAWScript/CrucibleBuiltins.hs
@@ -253,8 +253,8 @@ verifyObligations cc mspec tactic assumes asserts = do
     goal   <- io $ scImplies sc assume assert
     goal'  <- io $ scGeneralizeExts sc (getAllExts goal) =<< scEqTrue sc goal
     let goalname = concat [nm, " (", takeWhile (/= '\n') msg, ")"]
-        proofgoal = ProofGoal Universal n "vc" goalname goal'
-    r      <- evalStateT tactic (startProof proofgoal)
+        proofgoal = ProofGoal n "vc" goalname goal'
+    r <- evalStateT tactic (startProof proofgoal)
     case r of
       Unsat stats -> return stats
       SatMulti stats vals -> do

--- a/src/SAWScript/JVM/CrucibleBuiltins.hs
+++ b/src/SAWScript/JVM/CrucibleBuiltins.hs
@@ -266,7 +266,7 @@ verifyObligations cc mspec tactic assumes asserts =
        goal   <- io $ scImplies sc assume assert
        goal'  <- io $ scGeneralizeExts sc (getAllExts goal) =<< scEqTrue sc goal
        let goalname = concat [nm, " (", takeWhile (/= '\n') msg, ")"]
-           proofgoal = ProofGoal Universal n "vc" goalname goal'
+           proofgoal = ProofGoal n "vc" goalname goal'
        r      <- evalStateT tactic (startProof proofgoal)
        case r of
          Unsat stats -> return stats

--- a/src/SAWScript/JavaBuiltins.hs
+++ b/src/SAWScript/JavaBuiltins.hs
@@ -250,7 +250,7 @@ verifyJava bic opts cls mname overrides setup = do
               let exts = getAllExts g
               gprop <- io $ scGeneralizeExts jsc exts =<< scEqTrue jsc g
               io $ doExtraChecks opts bsc gprop
-              let goal = ProofGoal Universal n "vc" (vsVCName vs) gprop
+              let goal = ProofGoal n "vc" (vsVCName vs) gprop
               r <- evalStateT script (startProof goal)
               case r of
                 SS.Unsat _ -> liftIO $ printOutLn opts Debug "Valid."

--- a/src/SAWScript/LLVMBuiltins.hs
+++ b/src/SAWScript/LLVMBuiltins.hs
@@ -314,7 +314,7 @@ prover vpopts sc ms script vs n g = do
   let exts = getAllExts g
   ppopts <- fmap rwPPOpts getTopLevelRW
   tt <- io $ scGeneralizeExts sc exts =<< scEqTrue sc g
-  let goal = ProofGoal Universal n "vc" (vsVCName vs) tt
+  let goal = ProofGoal n "vc" (vsVCName vs) tt
   r <- evalStateT script (startProof goal)
   case r of
     SV.Unsat stats -> do

--- a/src/SAWScript/Proof.hs
+++ b/src/SAWScript/Proof.hs
@@ -15,26 +15,25 @@ import SAWScript.Prover.SolverStats
 -- or more lambdas which are interpreted as universal quantifiers.
 data Theorem = Theorem { thmTerm :: Term }
 
-data Quantification = Existential | Universal
-  deriving Eq
-
 -- | A ProofGoal is a term of type @sort n@, or a pi type of any arity
 -- with a @sort n@ result type. The abstracted arguments are treated
--- as either universally quantified. If the 'goalQuant' field is set
--- to 'Existential', then the entire goal is considered to be
--- logically negated, so it is as if the quantifiers are existential.
+-- as universally quantified.
 data ProofGoal =
   ProofGoal
-  { goalQuant :: Quantification
-  , goalNum  :: Int
+  { goalNum  :: Int
   , goalType :: String
   , goalName :: String
   , goalTerm :: Term
   }
 
+data Quantification = Existential | Universal
+  deriving Eq
+
 -- | Construct a 'ProofGoal' from a term of type @Bool@, or a function
 -- of any arity with a boolean result type. Any function arguments are
--- treated as quantified variables.
+-- treated as quantified variables. If the 'Quantification' argument
+-- is 'Existential', then the predicate is negated and turned into a
+-- universally-quantified goal.
 makeProofGoal ::
   SharedContext ->
   Quantification ->
@@ -45,7 +44,7 @@ makeProofGoal ::
   IO ProofGoal
 makeProofGoal sc quant gnum gtype gname t =
   do t' <- predicateToProp sc quant [] t
-     return (ProofGoal quant gnum gtype gname t')
+     return (ProofGoal gnum gtype gname t')
 
 -- | Convert a term with a function type of any arity into a pi type.
 -- Negate the term if the result type is @Bool@ and the quantification

--- a/src/SAWScript/Prover/Exporter.hs
+++ b/src/SAWScript/Prover/Exporter.hs
@@ -163,7 +163,8 @@ write_smtlib2 sc f (TypedTerm schema t) = do
 writeUnintSMTLib2 :: [String] -> SharedContext -> FilePath -> Term -> IO ()
 writeUnintSMTLib2 unints sc f t = do
   (_, _, l) <- prepSBV sc unints t
-  txt <- SBV.generateSMTBenchmark True l
+  let isSat = False -- term is a proof goal with universally-quantified variables
+  txt <- SBV.generateSMTBenchmark isSat l
   writeFile f txt
 
 writeCore :: FilePath -> Term -> IO ()


### PR DESCRIPTION
As of this commit, we now treat every ProofGoal as having universally-
quantified variables. The `sat` command creates a universally-quantified
goal by logically negating the given predicate. As a result the solver
backends don't need to know whether the current proof goal came from a
`prove` or a `sat` command; they should behave the same in either case.

Fixes #322.