### PR TITLE
Fix crucible_llvm_extract

### DIFF
--- a/src/SAWScript/CrucibleBuiltins.hs
+++ b/src/SAWScript/CrucibleBuiltins.hs
@@ -913,26 +913,36 @@ setupCrucibleContext bic opts (LLVMModule _ llvm_mod (Some mtrans)) action = do
 
 --------------------------------------------------------------------------------
 
-setupArg :: SharedContext
+setupArg :: forall tp. SharedContext
          -> Sym
          -> IORef (Seq (ExtCns Term))
          -> Crucible.TypeRepr tp
          -> IO (Crucible.RegEntry Sym tp)
 setupArg sc sym ecRef tp =
-  case Crucible.asBaseType tp of
-    Crucible.AsBaseType btp -> do
+  case (Crucible.asBaseType tp, tp) of
+    (Crucible.AsBaseType btp, _) -> do
        sc_tp <- CrucibleSAW.baseSCType sym sc btp
-       i     <- scFreshGlobalVar sc
-       ecs   <- readIORef ecRef
-       let len = Seq.length ecs
-       let ec = EC i ("arg_"++show len) sc_tp
-       writeIORef ecRef (ecs Seq.|> ec)
-       t     <- scFlatTermF sc (ExtCns ec)
+       t     <- freshGlobal sc_tp
        elt   <- CrucibleSAW.bindSAWTerm sym btp t
        return (Crucible.RegEntry tp elt)
 
-    Crucible.NotBaseType ->
+    (Crucible.NotBaseType, Crucible.LLVMPointerRepr w) -> do
+       sc_tp <- scBitvector sc (natValue w)
+       t     <- freshGlobal sc_tp
+       elt   <- CrucibleSAW.bindSAWTerm sym (Crucible.BaseBVRepr w) t
+       elt'  <- Crucible.llvmPointer_bv sym elt
+       return (Crucible.RegEntry tp elt')
+
+    (Crucible.NotBaseType, _) ->
       fail $ unwords ["Crucible extraction currently only supports Crucible base types", show tp]
+  where
+    freshGlobal sc_tp = do
+      i     <- scFreshGlobalVar sc
+      ecs   <- readIORef ecRef
+      let len = Seq.length ecs
+      let ec = EC i ("arg_"++show len) sc_tp
+      writeIORef ecRef (ecs Seq.|> ec)
+      scFlatTermF sc (ExtCns ec)
 
 setupArgs :: SharedContext
           -> Sym
@@ -972,7 +982,6 @@ runCFG simCtx globals h cfg args = do
                  (Crucible.regValue <$> (Crucible.callCFG cfg args))
   Crucible.executeCrucible [] initExecState
 
-
 extractFromLLVMCFG :: Crucible.HasPtrWidth (Crucible.ArchWidth arch) =>
    Options -> SharedContext -> CrucibleContext arch -> Crucible.AnyCFG (Crucible.LLVM arch) -> IO TypedTerm
 extractFromLLVMCFG opts sc cc (Crucible.AnyCFG cfg) =
@@ -985,10 +994,15 @@ extractFromLLVMCFG opts sc cc (Crucible.AnyCFG cfg) =
       case res of
         Crucible.FinishedResult _ pr -> do
             gp <- getGlobalPair opts pr
-            t <- Crucible.asSymExpr
-                   (gp^.Crucible.gpValue)
-                   (CrucibleSAW.toSC sym)
-                   (fail $ unwords ["Unexpected return type:", show (Crucible.regType (gp^.Crucible.gpValue))])
+            let regv = gp^.Crucible.gpValue
+                rt = Crucible.regType regv
+                rv = Crucible.regValue regv
+            t <- case rt of
+                   Crucible.LLVMPointerRepr _ -> do
+                     bv <- Crucible.projectLLVM_bv sym rv
+                     CrucibleSAW.toSC sym bv
+                   Crucible.BVRepr _ -> CrucibleSAW.toSC sym rv
+                   _ -> fail $ unwords ["Unexpected return type:", show rt]
             t' <- scAbstractExts sc (toList ecs) t
             mkTypedTerm sc t'
         Crucible.AbortedResult _ ar -> do


### PR DESCRIPTION
Now it understands the new merged representation of pointers and bit
vectors.

Fixes #362.