### PR TITLE
Crucible/LLVM: Print both errors when both symbolic branches abort

### DIFF
--- a/src/SAWScript/CrucibleBuiltins.hs
+++ b/src/SAWScript/CrucibleBuiltins.hs
@@ -182,8 +182,14 @@ ppAbortedResult _ (Crucible.AbortedExec Crucible.InfeasibleBranch _) =
   text "Infeasible branch"
 ppAbortedResult cc (Crucible.AbortedExec abt gp) = do
   Crucible.ppAbortExecReason abt <$$> ppGlobalPair cc gp
-ppAbortedResult _ (Crucible.AbortedBranch _ _ _) =
-  text "Aborted branch"
+ppAbortedResult cc (Crucible.AbortedBranch _pred trueBranch falseBranch) =
+  vcat
+    [ text "Both branches aborted after a symbolic branch"
+    , text "Message from the true branch:"
+    , indent 4 (ppAbortedResult cc trueBranch)
+    , text "Message from the false branch:"
+    , indent 4 (ppAbortedResult cc falseBranch)
+    ]
 ppAbortedResult _ (Crucible.AbortedExit ec) =
   text "Branch exited:" <+> text (show ec)
 


### PR DESCRIPTION
This is verbose, but otherwise this error is completely un-debuggable. 