### PR TITLE
Crucible/LLVM: Show a list of available field names for structs

### DIFF
--- a/src/SAWScript/CrucibleResolveSetupValue.hs
+++ b/src/SAWScript/CrucibleResolveSetupValue.hs
@@ -121,6 +121,7 @@ resolveSetupFieldIndexOrFail ::
   m Int                           {- ^ field index       -}
 resolveSetupFieldIndexOrFail cc env nameEnv v n =
   case resolveSetupFieldIndex cc env nameEnv v n of
+    Just i  -> pure i
     Nothing ->
       let msg = "Unable to resolve field name: " ++ show n
       in

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -29,6 +29,7 @@ import Data.Semigroup ((<>))
 import Control.Applicative (Applicative)
 #endif
 import Control.Monad.ST
+import Control.Monad.Fail (MonadFail)
 import qualified Control.Exception as X
 import qualified System.IO.Error as IOError
 import Control.Monad.IO.Class (MonadIO, liftIO)
@@ -404,7 +405,7 @@ data TopLevelRW =
   }
 
 newtype TopLevel a = TopLevel (ReaderT TopLevelRO (StateT TopLevelRW IO) a)
-  deriving (Functor, Applicative, Monad, MonadIO)
+  deriving (Functor, Applicative, Monad, MonadIO, MonadFail)
 
 runTopLevel :: TopLevel a -> TopLevelRO -> TopLevelRW -> IO (a, TopLevelRW)
 runTopLevel (TopLevel m) = runStateT . runReaderT m


### PR DESCRIPTION
This is helpful in quickly debugging the issue, it shows me which one of the following situations I'm in:
- I typed a field name incorrectly (I'll see the correct spelling in the message)
- I gave a value of an incorrect struct type (I'll see unexpected field names)
- There were no field names available, and I should switch to `crucible_elem`