### PR TITLE
Crucible/LLVM: More detailed messages on StrucutralMismatch

### DIFF
--- a/src/SAWScript/CrucibleOverride.hs
+++ b/src/SAWScript/CrucibleOverride.hs
@@ -210,13 +210,13 @@ ppOverrideFailureReason rsn = case rsn of
     PP.text "Precondition:" PP.<+> ppPointsTo pointsTo PP.<$$>
     PP.text "Failure reason: " PP.<$$> msg -- this can be long
   StructuralMismatch llvmval setupval setupvalTy ty ->
-    PP.text "could not match the following terms with expected type:" PP.<$$>
+    PP.text "could not match specified value with actual value:" PP.<$$>
     PP.vcat (map (PP.indent 2) $
-              [ PP.text "expected type:" PP.<+> Crucible.ppMemType ty
-              , PP.text "simulator value:" PP.<+>
+              [ PP.text "actual (simulator) value:" PP.<+>
                   either (PP.text . show) id llvmval
               , PP.text "specified value:" PP.<+>
                   either ppSetupValue id setupval
+              , PP.text "type of actual value:" PP.<+> Crucible.ppMemType ty
               ] ++ let msg memty =
                          [PP.text "type of specified value:"
                           PP.<+> Crucible.ppMemType memty]

--- a/src/SAWScript/CrucibleOverride.hs
+++ b/src/SAWScript/CrucibleOverride.hs
@@ -214,9 +214,9 @@ ppOverrideFailureReason rsn = case rsn of
     PP.vcat (map (PP.indent 2) $
               [ PP.text "actual (simulator) value:" PP.<+>
                   either (PP.text . show) id llvmval
-              , PP.text "specified value:" PP.<+>
+              , PP.text "specified value:         " PP.<+>
                   either ppSetupValue id setupval
-              , PP.text "type of actual value:" PP.<+> Crucible.ppMemType ty
+              , PP.text "type of actual value:   " PP.<+> Crucible.ppMemType ty
               ] ++ let msg memty =
                          [PP.text "type of specified value:"
                           PP.<+> Crucible.ppMemType memty]


### PR DESCRIPTION
Also, use the relatively new pretty-printing of `LLVMVal`.

Previously:
```
could not match the following terms
  <ptr 64>
  (@AllocIndex 1).6
with type
  i32(%struct.env_md_ctx_st*, i8*)**
```
now:
```
could not match the following terms with expected type:
  expected type: i32(%struct.env_md_ctx_st*, i8*)**
  simulator value: concrete pointer: allocation = 552, offset = 0
  specified value: (concrete pointer: allocation = 646, offset = 0).6
  type of specified value: i32(%struct.env_md_ctx_st*, i8*)**
```
This message has the following advantages:
- It makes it clear that at least the specified value has the correct type. If I get a printout of the simulator memory, I can also look at the allocation and see if I can debug the problem. 
- It uses explicit pointers for both the expected and simulated values, rather than `AllocIndex`, which the user won't be familiar with
- It shows the structure of the simulator value, instead of leaving it opaque