### PR TITLE
Replace pointers with names of globals when printing LLVMVals

### DIFF
--- a/src/SAWScript/CrucibleResolveSetupValue.hs
+++ b/src/SAWScript/CrucibleResolveSetupValue.hs
@@ -17,7 +17,6 @@ module SAWScript.CrucibleResolveSetupValue
 
 import Control.Lens
 import Control.Monad (zipWithM, foldM)
-import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fail (MonadFail)
 import Data.Foldable (toList)
 import Data.Maybe (fromMaybe, listToMaybe, fromJust)


### PR DESCRIPTION
Use the new `Crucible.ppLLVMValWithGlobals` function to traverse the `LLVMVal` and replace pointers to globals with the names of globals when pretty-printing. Here's an example:
```

  No override specification applies for EVP_DigestInit_ex.
  The following overrides had some preconditions that failed concretely:
  - Name: EVP_DigestInit_ex
    Location: /build/fizz-hkdf/digest.saw:149:3
    Argument types: 
      %struct.env_md_ctx_st*
      %struct.env_md_st*
      %struct.engine_st*
    Return type: i32
    * Equality precondition
      Expected value (as a SAW value): 
      global_initializer(sha256_md)
      Expected value (as a Crucible value): 
      {literal integer: unsigned value = 672, signed value =  672, width = 32
      ;literal integer: unsigned value = 668, signed value =  668, width = 32
      ;literal integer: unsigned value = 32, signed value =  32, width = 32
      ;literal integer: unsigned value = 12, signed value =  12, width = 64
      ;@init256
      ;@update256
      ;@final256
      ;<zero : bitvectorType 8>
      ;<zero : bitvectorType 8>
      ;@RSA_sign
      ;@RSA_verify
      ;[literal integer: unsigned value = 6, signed value =  6, width = 32
       ,literal integer: unsigned value = 19, signed value =  19, width = 32
       ,<zero : bitvectorType 4>
       ,<zero : bitvectorType 4>
       ,<zero : bitvectorType 4>]
      ;literal integer: unsigned value = 64, signed value =  64, width = 32
      ;literal integer: unsigned value = 120, signed value =  120, width = 32
      ;<zero : bitvectorType 8>}
      Actual value: 
      {literal integer: unsigned value = 672, signed value =  672, width = 32
      ;literal integer: unsigned value = 668, signed value =  668, width = 32
      ;literal integer: unsigned value = 32, signed value =  32, width = 32
      ;literal integer: unsigned value = 12, signed value =  12, width = 64
      ;@init256
      ;@update256
      ;@final256
      ;<zero : bitvectorType 8>
      ;<zero : bitvectorType 8>
      ;@RSA_sign
      ;@RSA_verify
      ;[literal integer: unsigned value = 6, signed value =  6, width = 32
       ,literal integer: unsigned value = 19, signed value =  19, width = 32
       ,<zero : bitvectorType 4>
       ,<zero : bitvectorType 4>
       ,<zero : bitvectorType 4>]
      ;literal integer: unsigned value = 64, signed value =  64, width = 32
      ;literal integer: unsigned value = 120, signed value =  120, width = 32
      ;<zero : bitvectorType 8>}
      in _SAW_verify_prestate at /build/fizz-hkdf/digest.saw:149:3
```