### PR TITLE
Loosen Crucible/LLVM override return type check

### DIFF
--- a/src/SAWScript/CrucibleBuiltins.hs
+++ b/src/SAWScript/CrucibleBuiltins.hs
@@ -380,8 +380,9 @@ checkSpecReturnType cc mspec =
           (csAllocations mspec) -- map allocation indices to allocations
           (mspec^.csPreState.csVarTypeNames) -- map alloc indices to var names
           sv
-      -- The following check is even more strict than checkRegisterCompatibility
-      unless (retTy == retTy') $ fail $ unlines
+      -- This check is too lax, see saw-script#443
+      b <- checkRegisterCompatibility retTy retTy'
+      unless b $ fail $ unlines
         [ "Incompatible types for return value when verifying " ++ mspec^.csName
         , "Expected: " ++ show retTy
         , "but given value of type: " ++ show retTy'


### PR DESCRIPTION
This is a spot fix. The check we have right now is too strict, it won't even let you specify that a function returns `crucible_null`.

See #443, which we should leave open until we implement the proper check described there.