### PR TITLE
Better line number reporting for monadic binds

### DIFF
--- a/saw-script.cabal
+++ b/saw-script.cabal
@@ -123,6 +123,7 @@ library
     SAWScript.Parser
     SAWScript.PathVC
     SAWScript.Proof
+    SAWScript.Position
     SAWScript.SBVParser
     SAWScript.SBVModel
     SAWScript.SAWCorePrimitives

--- a/saw/SAWScript/REPL/Command.hs
+++ b/saw/SAWScript/REPL/Command.hs
@@ -32,7 +32,7 @@ module SAWScript.REPL.Command (
 
 import SAWScript.REPL.Monad
 import SAWScript.REPL.Trie
-import SAWScript.Utils (getPos)
+import SAWScript.Position (getPos)
 
 import Cryptol.Parser (ParseError())
 import Cryptol.Utils.PP

--- a/src/SAWScript/AST.hs
+++ b/src/SAWScript/AST.hs
@@ -37,7 +37,7 @@ module SAWScript.AST
        ) where
 
 import SAWScript.Token
-import SAWScript.Utils
+import SAWScript.Position (Pos(..), Positioned(..), maxSpan)
 
 import Data.Map (Map)
 import qualified Data.Map as Map

--- a/src/SAWScript/AutoMatch.hs
+++ b/src/SAWScript/AutoMatch.hs
@@ -39,7 +39,7 @@ import qualified Cryptol.Parser.Position as Cryptol
 import qualified Cryptol.Utils.PP        as Cryptol
 import qualified Cryptol.Utils.Ident     as Cryptol (packIdent)
 import SAWScript.Builtins
---import SAWScript.Options
+import SAWScript.Position
 import SAWScript.Utils
 import SAWScript.TopLevel
 import SAWScript.Value

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -69,6 +69,8 @@ import Verifier.SAW.Rewriter
 import Verifier.SAW.Testing.Random (scRunTestsTFIO, scTestableType)
 import Verifier.SAW.TypedAST
 
+import SAWScript.Position
+
 -- cryptol-verifier
 import qualified Verifier.SAW.CryptolEnv as CEnv
 
@@ -115,7 +117,6 @@ import SAWScript.AST (getVal, pShow, Located(..))
 import SAWScript.Options as Opts
 import SAWScript.Proof
 import SAWScript.TopLevel
-import SAWScript.Utils
 import SAWScript.SAWCorePrimitives( bitblastPrimitives, sbvPrimitives, concretePrimitives )
 import qualified SAWScript.Value as SV
 import SAWScript.Value (ProofScript, printOutLnTop, AIGNetwork)

--- a/src/SAWScript/CrucibleBuiltins.hs
+++ b/src/SAWScript/CrucibleBuiltins.hs
@@ -134,7 +134,7 @@ import SAWScript.Prover.SolverStats
 import SAWScript.Prover.Versions
 import SAWScript.TopLevel
 import SAWScript.Value
-import SAWScript.Utils as SS
+import SAWScript.Position as SS
 import SAWScript.Options
 
 import SAWScript.CrucibleMethodSpecIR

--- a/src/SAWScript/Exceptions.hs
+++ b/src/SAWScript/Exceptions.hs
@@ -3,8 +3,8 @@ module SAWScript.Exceptions (TypeErrors(..), failTypecheck) where
 
 import Control.Exception
 
+import SAWScript.Position (Pos(..), Positioned(..))
 import SAWScript.Utils
-
 
 newtype TypeErrors = TypeErrors [(Pos, String)]
 

--- a/src/SAWScript/JVM/CrucibleBuiltins.hs
+++ b/src/SAWScript/JVM/CrucibleBuiltins.hs
@@ -111,6 +111,7 @@ import SAWScript.Prover.SolverStats
 import SAWScript.TopLevel
 import SAWScript.Value
 import SAWScript.Utils as SS
+import qualified SAWScript.Position as SS
 import SAWScript.Options
 import SAWScript.CrucibleBuiltinsJVM (prepareClassTopLevel)
 
@@ -507,7 +508,7 @@ registerOverride opts cc _ctx top_loc cs =
      let c0 = head cs
      let cname = c0^.csClassName
      let mname = c0^.csMethodName
-     let pos = PosInternal "registerOverride"
+     let pos = SS.PosInternal "registerOverride"
      sc <- Crucible.saw_ctx <$> liftIO (readIORef (W4.sbStateManager sym))
 
      (mcls, meth) <- liftIO $ findMethod cb pos mname =<< lookupClass cb pos cname
@@ -547,7 +548,7 @@ verifySimulate opts cc mspec args assumes top_loc lemmas globals checkSat =
      let mname = mspec^.csMethodName
      let verbosity = simVerbose opts
      let personality = Crucible.SAWCruciblePersonality
-     let pos = PosInternal "verifySimulate"
+     let pos = SS.PosInternal "verifySimulate"
      let halloc = cc^.ccHandleAllocator
 
      -- executeCrucibleJVM

--- a/src/SAWScript/JavaBuiltins.hs
+++ b/src/SAWScript/JavaBuiltins.hs
@@ -50,6 +50,7 @@ import SAWScript.JavaUtils
 
 import SAWScript.Builtins
 import SAWScript.Options
+import SAWScript.Position (Pos(..), renderDoc)
 import SAWScript.Proof
 import SAWScript.Utils
 import SAWScript.Value as SS

--- a/src/SAWScript/JavaExpr.hs
+++ b/src/SAWScript/JavaExpr.hs
@@ -79,6 +79,7 @@ import Verifier.SAW.Recognizer
 import Verifier.SAW.SharedTerm
 
 import qualified SAWScript.CongruenceClosure as CC
+import SAWScript.Position
 import SAWScript.Utils
 
 import qualified Cryptol.TypeCheck.AST as Cryptol

--- a/src/SAWScript/JavaMethodSpec.hs
+++ b/src/SAWScript/JavaMethodSpec.hs
@@ -65,6 +65,7 @@ import SAWScript.JavaMethodSpecIR
 import SAWScript.JavaMethodSpec.Evaluator
 import SAWScript.JavaUtils
 import SAWScript.PathVC
+import SAWScript.Position (Pos(..))
 import SAWScript.Value (TopLevel, TopLevelRW(rwPPOpts), getTopLevelRW, io, printOutTop, printOutLnTop)
 import SAWScript.VerificationCheck
 

--- a/src/SAWScript/JavaMethodSpecIR.hs
+++ b/src/SAWScript/JavaMethodSpecIR.hs
@@ -79,6 +79,7 @@ import Verifier.SAW.TypedAST (ppTerm, defaultPPOpts)
 import qualified SAWScript.CongruenceClosure as CC
 import SAWScript.CongruenceClosure (CCSet)
 import SAWScript.JavaExpr
+import SAWScript.Position (Pos(..), Positioned(..))
 import SAWScript.Utils
 
 -- ExprActualTypeMap {{{1

--- a/src/SAWScript/Lexer.x
+++ b/src/SAWScript/Lexer.x
@@ -14,6 +14,7 @@ module SAWScript.Lexer
   ) where
 
 import SAWScript.Token
+import SAWScript.Position
 import SAWScript.Utils
 
 import Numeric

--- a/src/SAWScript/MGU.hs
+++ b/src/SAWScript/MGU.hs
@@ -18,7 +18,7 @@ module SAWScript.MGU
        ) where
 
 import SAWScript.AST
-import SAWScript.Utils (Pos(..), Positioned(..))
+import SAWScript.Position (Pos(..), Positioned(..))
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative

--- a/src/SAWScript/Parser.y
+++ b/src/SAWScript/Parser.y
@@ -21,6 +21,7 @@ import Data.Text (pack)
 import SAWScript.Token
 import SAWScript.Lexer
 import SAWScript.AST
+import SAWScript.Position
 import SAWScript.Utils
 
 import qualified Cryptol.Parser.AST as P

--- a/src/SAWScript/Position.hs
+++ b/src/SAWScript/Position.hs
@@ -1,0 +1,117 @@
+{- |
+Module      : SAWScript.Position
+Description : Positions in source code
+Maintainer  : jhendrix, atomb
+Stability   : provisional
+-}
+
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module SAWScript.Position where
+
+import Control.Lens
+import Data.Data (Data)
+import Data.List (intercalate)
+import GHC.Generics (Generic)
+import System.Directory (makeRelativeToCurrentDirectory)
+import System.FilePath (makeRelative, isAbsolute, (</>), takeDirectory)
+import qualified Text.PrettyPrint.ANSI.Leijen as PP hiding ((</>), (<$>))
+
+-- Pos ------------------------------------------------------------------------
+
+data Pos = Range !FilePath -- file
+                 !Int !Int -- start line, col
+                 !Int !Int -- end line, col
+         | Unknown
+         | PosInternal String
+         | PosREPL
+  deriving (Data, Generic, Eq)
+
+renderDoc :: PP.Doc -> String
+renderDoc doc = PP.displayS (PP.renderPretty 0.8 80 doc) ""
+
+endPos :: FilePath -> Pos
+endPos f = Range f 0 0 0 0
+
+fmtPos :: Pos -> String -> String
+fmtPos p m = show p ++ ":\n" ++ m'
+  where m' = intercalate "\n" . map ("  " ++) . lines $ m
+
+spanPos :: Pos -> Pos -> Pos
+spanPos (PosInternal str) _ = PosInternal str
+spanPos PosREPL _ = PosREPL
+spanPos _ (PosInternal str) = PosInternal str
+spanPos _ PosREPL = PosREPL
+spanPos Unknown p = p
+spanPos p Unknown = p
+spanPos (Range f sl sc el ec) (Range _ sl' sc' el' ec') =  Range f l c l' c'
+  where
+    (l, c) = minPos sl sc sl' sc'
+    (l', c') = maxPos el ec el' ec'
+    minPos l1 c1 l2 c2 | l1 < l2   = (l1, c1)
+                       | l1 == l2  = (l1, min c1 c2)
+                       | otherwise = (l2, c2)
+    maxPos l1 c1 l2 c2 | l1 < l2   = (l2, c2)
+                       | l1 == l2  = (l1, max c1 c2)
+                       | otherwise = (l1, c1)
+
+fmtPoss :: [Pos] -> String -> String
+fmtPoss [] m = fmtPos (PosInternal "saw-script internal") m
+fmtPoss ps m = "[" ++ intercalate ",\n " (map show ps) ++ "]:\n" ++ m'
+  where m' = intercalate "\n" . map ("  " ++) . lines $ m
+
+posRelativeToCurrentDirectory :: Pos -> IO Pos
+posRelativeToCurrentDirectory (Range f sl sc el ec) = makeRelativeToCurrentDirectory f >>= \f' -> return (Range f' sl sc el ec)
+posRelativeToCurrentDirectory Unknown               = return Unknown
+posRelativeToCurrentDirectory (PosInternal s)       = return $ PosInternal s
+posRelativeToCurrentDirectory PosREPL               = return PosREPL
+
+posRelativeTo :: FilePath -> Pos -> Pos
+posRelativeTo d (Range f sl sc el ec) = Range (makeRelative d f) sl sc el ec
+posRelativeTo _ Unknown               = Unknown
+posRelativeTo _ (PosInternal s)       = PosInternal s
+posRelativeTo _ PosREPL               = PosREPL
+
+routePathThroughPos :: Pos -> FilePath -> FilePath
+routePathThroughPos (Range f _ _ _ _) fp
+  | isAbsolute fp = fp
+  | True          = takeDirectory f </> fp
+routePathThroughPos _ fp = fp
+
+instance Show Pos where
+  -- show (Pos f 0 0)           = f ++ ":end-of-file"
+  -- show (Pos f l c)           = f ++ ":" ++ show l ++ ":" ++ show c
+  show (Range f 0 0 0 0) = f ++ ":end-of-file"
+  show (Range f sl sc el ec) = f ++ ":" ++ show sl ++ ":" ++ show sc ++ "-" ++ show el ++ ":" ++ show ec
+  show Unknown               = "unknown"
+  show (PosInternal s)       = "[internal:" ++ s ++ "]"
+  show PosREPL               = "REPL"
+
+-- Positioned -----------------------------------------------------------------
+
+class Positioned a where
+  getPos :: a -> Pos
+
+instance Positioned Pos where
+  getPos p = p
+
+maxSpan :: (Functor t, Foldable t, Positioned a) => t a -> Pos
+maxSpan xs = foldr spanPos Unknown (fmap getPos xs)
+
+-- WithPos -----------------------------------------------------------------
+
+data WithPos a = WithPos { _wpPos :: Pos, _wpVal :: a }
+  deriving (Data, Eq, Functor, Foldable, Generic, Show, Traversable)
+
+wpPos :: Simple Lens (WithPos a) Pos
+wpPos = lens _wpPos (\s v -> s { _wpPos = v })
+
+wpVal :: Simple Lens (WithPos a) a
+wpVal = lens _wpVal (\s v -> s { _wpVal = v })
+
+instance Positioned (WithPos a) where
+  getPos = view wpPos

--- a/src/SAWScript/Token.hs
+++ b/src/SAWScript/Token.hs
@@ -8,7 +8,7 @@ Stability   : provisional
 {-# LANGUAGE DeriveFunctor #-}
 module SAWScript.Token where
 
-import SAWScript.Utils
+import SAWScript.Position (Positioned(..))
 
 data Token p = TVar      { tokPos :: p, tokStr :: String                               }
              | TQVar     { tokPos :: p, tokStr :: String, tokVars :: ([String],String) }

--- a/src/SAWScript/Utils.hs
+++ b/src/SAWScript/Utils.hs
@@ -20,7 +20,6 @@ import Control.Exception as CE
 import Control.Monad.State
 import Control.Monad.Trans.Except
 import Control.DeepSeq(rnf, NFData(..))
-import Data.List(intercalate)
 import Data.Char(isSpace)
 import Data.Data
 import Data.Map (Map)
@@ -28,8 +27,6 @@ import qualified Data.Map as Map
 import Data.Maybe
 import Data.Ratio
 import Data.Time.Clock
-import System.Directory(makeRelativeToCurrentDirectory)
-import System.FilePath(makeRelative, isAbsolute, (</>), takeDirectory)
 import System.Time(TimeDiff(..), getClockTime, diffClockTimes, normalizeTimeDiff, toCalendarTime, formatCalendarTime)
 import System.Locale(defaultTimeLocale)
 import qualified System.IO.Error as IOE
@@ -41,83 +38,7 @@ import Numeric(showFFloat)
 import qualified Verifier.Java.Codebase as JSS
 
 import SAWScript.Options
-
-data Pos = Range !FilePath -- file
-                 !Int !Int -- start line, col
-                 !Int !Int -- end line, col
-         | Unknown
-         | PosInternal String
-         | PosREPL
-  deriving (Eq)
-
-renderDoc :: Doc -> String
-renderDoc doc = displayS (renderPretty 0.8 80 doc) ""
-
-endPos :: FilePath -> Pos
-endPos f = Range f 0 0 0 0
-
-fmtPos :: Pos -> String -> String
-fmtPos p m = show p ++ ":\n" ++ m'
-  where m' = intercalate "\n" . map ("  " ++) . lines $ m
-
-spanPos :: Pos -> Pos -> Pos
-spanPos (PosInternal str) _ = PosInternal str
-spanPos PosREPL _ = PosREPL
-spanPos _ (PosInternal str) = PosInternal str
-spanPos _ PosREPL = PosREPL
-spanPos Unknown p = p
-spanPos p Unknown = p
-spanPos (Range f sl sc el ec) (Range _ sl' sc' el' ec') =  Range f l c l' c'
-  where
-    (l, c) = minPos sl sc sl' sc'
-    (l', c') = maxPos el ec el' ec'
-    minPos l1 c1 l2 c2 | l1 < l2   = (l1, c1)
-                       | l1 == l2  = (l1, min c1 c2)
-                       | otherwise = (l2, c2)
-    maxPos l1 c1 l2 c2 | l1 < l2   = (l2, c2)
-                       | l1 == l2  = (l1, max c1 c2)
-                       | otherwise = (l1, c1)
-
-fmtPoss :: [Pos] -> String -> String
-fmtPoss [] m = fmtPos (PosInternal "saw-script internal") m
-fmtPoss ps m = "[" ++ intercalate ",\n " (map show ps) ++ "]:\n" ++ m'
-  where m' = intercalate "\n" . map ("  " ++) . lines $ m
-
-posRelativeToCurrentDirectory :: Pos -> IO Pos
-posRelativeToCurrentDirectory (Range f sl sc el ec) = makeRelativeToCurrentDirectory f >>= \f' -> return (Range f' sl sc el ec)
-posRelativeToCurrentDirectory Unknown               = return Unknown
-posRelativeToCurrentDirectory (PosInternal s)       = return $ PosInternal s
-posRelativeToCurrentDirectory PosREPL               = return PosREPL
-
-posRelativeTo :: FilePath -> Pos -> Pos
-posRelativeTo d (Range f sl sc el ec) = Range (makeRelative d f) sl sc el ec
-posRelativeTo _ Unknown               = Unknown
-posRelativeTo _ (PosInternal s)       = PosInternal s
-posRelativeTo _ PosREPL               = PosREPL
-
-routePathThroughPos :: Pos -> FilePath -> FilePath
-routePathThroughPos (Range f _ _ _ _) fp
-  | isAbsolute fp = fp
-  | True          = takeDirectory f </> fp
-routePathThroughPos _ fp = fp
-
-instance Show Pos where
-  -- show (Pos f 0 0)           = f ++ ":end-of-file"
-  -- show (Pos f l c)           = f ++ ":" ++ show l ++ ":" ++ show c
-  show (Range f 0 0 0 0) = f ++ ":end-of-file"
-  show (Range f sl sc el ec) = f ++ ":" ++ show sl ++ ":" ++ show sc ++ "-" ++ show el ++ ":" ++ show ec
-  show Unknown               = "unknown"
-  show (PosInternal s)       = "[internal:" ++ s ++ "]"
-  show PosREPL               = "REPL"
-
-class Positioned a where
-  getPos :: a -> Pos
-
-instance Positioned Pos where
-  getPos p = p
-
-maxSpan :: (Functor t, Foldable t, Positioned a) => t a -> Pos
-maxSpan xs = foldr spanPos Unknown (fmap getPos xs)
+import SAWScript.Position
 
 data SSMode = Verify | Blif | CBlif deriving (Eq, Show, Data, Typeable)
 

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {- |
 Module      : SAWScript.Value
 Description : Value datatype for SAW-Script interpreter.
@@ -24,18 +27,22 @@ Stability   : provisional
 
 module SAWScript.Value where
 
+import Prelude hiding (fail)
+
 import Data.Semigroup ((<>))
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative (Applicative)
 #endif
 import Control.Monad.ST
-import Control.Monad.Fail (MonadFail)
+import Control.Monad.Fail (MonadFail(..))
+import Control.Monad.Except (ExceptT(..), MonadError)
+import Control.Monad.Reader (MonadReader)
 import qualified Control.Exception as X
 import qualified System.IO.Error as IOError
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader (ReaderT(..), ask, asks, local)
 import Control.Monad.State (StateT(..), get, gets, put)
-import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Class (MonadTrans(lift))
 import Data.List ( intersperse )
 import qualified Data.Map as M
 import Data.Map ( Map )
@@ -46,10 +53,12 @@ import qualified Text.PrettyPrint.HughesPJ as PP
 import qualified Text.PrettyPrint.ANSI.Leijen as PPL
 import Data.Parameterized.Some
 import Data.Typeable
+import GHC.Generics (Generic, Generic1)
 
 import qualified Data.AIG as AIG
 
 import qualified SAWScript.AST as SS
+import qualified SAWScript.Position as SS
 import qualified SAWScript.Utils as SS
 import qualified SAWScript.JavaMethodSpecIR as JIR
 import qualified SAWScript.CrucibleLLVM as Crucible


### PR DESCRIPTION
Progress on #415 

Example improved message:
```
Abort due to false assumption:
  All overrides failed during structural matching:
  *  Name: EVP_DigestUpdate
     Location: /build/fizz-hkdf/digest.saw:211:3
     Argument types: 
       %struct.env_md_ctx_st*
       i8*
       i64
     Return type: i32
     at /build/fizz-hkdf/sha256.saw:56:3
     error when loading through pointer that appeared in the override's points-to precondition(s):
     Precondition:
       Pointer: symbolic integer:  width = 64
       Pointee: symbolic integer:  width = 32
       Assertion made at: /build/fizz-hkdf/sha256.saw:56:3
     Failure reason: 
       When reading through pointer bvSum c@2346:bv 0x6c:[64]
       Tried to read something of size: 4
       And type: i32
       Found 0 possibly matching allocation(s):
```
Note that the precondition has a _different_ source location than the override definition site (as opposed to e.g. the message shown in #475). Yay!