### PR TITLE
Add a SAWscript position to calls to Crucible's malloc

### DIFF
--- a/src/SAWScript/CrucibleBuiltins.hs
+++ b/src/SAWScript/CrucibleBuiltins.hs
@@ -587,7 +587,7 @@ doAllocWithMutability mut cc (loc, tp) = StateT $ \mem ->
      let dl = Crucible.llvmDataLayout ?lc
      sz <- W4.bvLit sym Crucible.PtrWidth (Crucible.bytesToInteger (Crucible.memTypeSize dl tp))
      let alignment = Crucible.maxAlignment dl -- Use the maximum alignment required for any primitive type (FIXME?)
-     let l = show loc
+     let l = show (W4.plSourceLoc loc)
      liftIO $
        Crucible.doMalloc sym Crucible.HeapAlloc Crucible.Mutable l mem sz alignment
 

--- a/src/SAWScript/CrucibleOverride.hs
+++ b/src/SAWScript/CrucibleOverride.hs
@@ -1368,7 +1368,7 @@ executeAllocation opts cc (var, (loc, memTy)) =
      mem <- readGlobal memVar
      sz <- liftIO $ W4.bvLit sym Crucible.PtrWidth (Crucible.bytesToInteger w)
      let alignment = Crucible.noAlignment -- default to byte alignment (FIXME)
-     let l = show loc ++ " (Poststate)"
+     let l = show (W4.plSourceLoc loc) ++ " (Poststate)"
      (ptr, mem') <- liftIO $
        Crucible.doMalloc sym Crucible.HeapAlloc Crucible.Mutable l mem sz alignment
      writeGlobal memVar mem'

--- a/src/SAWScript/CrucibleOverride.hs
+++ b/src/SAWScript/CrucibleOverride.hs
@@ -1368,7 +1368,9 @@ executeAllocation opts cc (var, (loc, memTy)) =
      mem <- readGlobal memVar
      sz <- liftIO $ W4.bvLit sym Crucible.PtrWidth (Crucible.bytesToInteger w)
      let alignment = Crucible.noAlignment -- default to byte alignment (FIXME)
-     (ptr, mem') <- liftIO (Crucible.mallocRaw sym mem sz alignment)
+     let l = show loc ++ " (Poststate)"
+     (ptr, mem') <- liftIO $
+       Crucible.doMalloc sym Crucible.HeapAlloc Crucible.Mutable l mem sz alignment
      writeGlobal memVar mem'
      assignVar cc loc var ptr
 


### PR DESCRIPTION
So when users get a Crucible memory dump, they can tell that this allocation was made in a SAW override, rather than in their C/LLVM code.

It would also be good to do this in `doAlloc` and `doAllocConst`. 

Example (right below `Found 1 possibly matching allocation(s)`):
```
Abort due to false assumption:
  All overrides failed during structural matching:
  *  Name: EVP_DigestInit_ex
     Location: /build/fizz-hkdf/digest.saw:198:3
     Argument types: 
     - %struct.env_md_ctx_st*
     - %struct.env_md_st*
     - %struct.engine_st*
     Return type: i32
     at /build/fizz-hkdf/digest.saw:104:3
     error when loading through pointer that appeared in the override's points-to precondition(s):
     Precondition:
       Pointer: concrete pointer: allocation = 645, offset = 72
       Pointee: literal integer: unsigned value = 0, signed value =  0, width = 64
       Assertion made at: /build/fizz-hkdf/digest.saw:104:3
     Failure reason: 
       When reading through pointer (645, 0x48:[64])
       Tried to read something of size: 8
       And type: i64
       Found 1 possibly matching allocation(s):
       - HeapAlloc 645 0x120:[64] Mutable /build/fizz-hkdf/hmac.saw:143:14
```