### PR TITLE
First cut at model counting commands

### DIFF
--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -2103,6 +2103,22 @@ primitives = Map.fromList
     Experimental
     [ "Call the monadic-recursive solver (that's MR. Solver to you)"
     , " to ask if two monadic terms are equal" ]
+
+    ---------------------------------------------------------------------
+
+  , prim "sharpSAT"  "Term -> TopLevel Integer"
+    (pureVal sharpSAT)
+    Current
+    [ "Use the sharpSAT solver to count the number of solutions to the CNF"
+    , "representation of the given Term."
+    ]
+
+  , prim "approxmc"  "Term -> TopLevel String"
+    (pureVal approxmc)
+    Current
+    [ "Use the approxmc solver to approximate the number of solutions to the"
+    , "CNF representation of the given Term."
+    ]
   ]
 
   where


### PR DESCRIPTION
The two new commands, `approxmc` and `sharpSAT`, use the command-line
programs of the same names to calculate the approximate and exact number
of solutions to a Term, respectively. The number of solutions is
relative to the CNF encoding, and is always larger than the number of
inputs to the SAWCore function itself.