### PR TITLE
Crucible/LLVM: Group argument equality assertions in override matching

### DIFF
--- a/src/SAWScript/Crucible/Common/Override.hs
+++ b/src/SAWScript/Crucible/Common/Override.hs
@@ -108,7 +108,7 @@ data OverrideState ext = OverrideState
     -- | Assertions about the values of function arguments
     --
     -- These come from @crucible_execute_func@.
-  , _osArgAsserts :: [[LabeledPred Sym]]
+  , _osArgAsserts :: [[W4.LabeledPred (W4.Pred Sym) PP.Doc]]
 
     -- | Accumulated assumptions
   , _osAssumes :: [W4.Pred Sym]

--- a/src/SAWScript/Crucible/Common/Override.hs
+++ b/src/SAWScript/Crucible/Common/Override.hs
@@ -22,6 +22,7 @@ module SAWScript.Crucible.Common.Override
   ( Pointer
   , OverrideState(..)
   , osAsserts
+  , osArgAsserts
   , osAssumes
   , osFree
   , osLocation
@@ -104,6 +105,11 @@ data OverrideState ext = OverrideState
     -- | Accumulated assertions
   , _osAsserts :: [LabeledPred Sym]
 
+    -- | Assertions about the values of function arguments
+    --
+    -- These come from @crucible_execute_func@.
+  , _osArgAsserts :: [[LabeledPred Sym]]
+
     -- | Accumulated assumptions
   , _osAssumes :: [W4.Pred Sym]
 
@@ -131,6 +137,7 @@ initialState ::
   OverrideState ext
 initialState sym globals allocs terms free loc = OverrideState
   { _osAsserts       = []
+  , _osArgAsserts    = []
   , _osAssumes       = []
   , _syminterface    = sym
   , _overrideGlobals = globals

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -878,14 +878,8 @@ verifyPoststate opts sc cc mspec env0 globals ret =
              Right (_, st) -> return st
 
      -- Assert that the arguments got the values specified in execute_func
-     io $ forM_ (zip ([1..] :: [Int]) (view osArgAsserts st)) $ \(n, asserts) ->
-       forM_ asserts $ Crucible.addAssertion sym .
-          labelWithSimError poststateLoc (\doc ->
-            unlines [ "In argument #" ++ show n ++
-                      "to a crucible_execute_func statement:"
-                    , show doc
-                    ])
-
+     io $ mapM_ (Crucible.addAssertion sym)
+                (labelWithArgNum poststateLoc $ view osArgAsserts st)
      io $ mapM_ (Crucible.addAssertion sym) (view osAsserts st)
 
      obligations <- io $ Crucible.getProofObligations sym

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -877,10 +877,7 @@ verifyPoststate opts sc cc mspec env0 globals ret =
              Left err      -> fail (show err)
              Right (_, st) -> return st
 
-     -- Assert that the arguments got the values specified in execute_func
-     io $ mapM_ (Crucible.addAssertion sym)
-                (labelWithArgNum poststateLoc $ view osArgAsserts st)
-     io $ mapM_ (Crucible.addAssertion sym) (view osAsserts st)
+     io $ mapM_ (Crucible.addAssertion sym) (st ^. osAsserts)
 
      obligations <- io $ Crucible.getProofObligations sym
      io $ Crucible.clearProofObligations sym

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -63,7 +63,7 @@ import           Control.Monad.State hiding (fail)
 import           Control.Monad.Fail (MonadFail(..))
 import qualified Data.Bimap as Bimap
 import           Data.Char (isDigit)
-import           Data.Foldable (for_, toList, find)
+import           Data.Foldable (toList, find)
 import           Data.Function
 import           Data.IORef
 import           Data.List
@@ -98,7 +98,6 @@ import           Data.Parameterized.Some
 import qualified What4.Concrete as W4
 import qualified What4.Config as W4
 import qualified What4.FunctionName as W4
-import qualified What4.LabeledPred as W4
 import qualified What4.ProgramLoc as W4
 import qualified What4.Interface as W4
 import qualified What4.Expr.Builder as W4
@@ -863,14 +862,20 @@ verifyPoststate opts sc cc mspec env0 globals ret =
                                     (view (MS.csPostState . MS.csFreshVars) mspec))
      matchPost <- io $
           runOverrideMatcher sym globals env0 terms0 initialFree poststateLoc $
-           do matchResult
+           do -- Assert that the function returned the correct value
+              retAsserts <- matchResult
+              liftIO $ mapM_ (Crucible.addAssertion sym) retAsserts
+              -- Assert other post-state conditions (equalities, points-to)
               learnCond opts sc cc mspec PostState (mspec ^. MS.csPostState)
 
      st <- case matchPost of
              Left err      -> fail (show err)
              Right (_, st) -> return st
-     io $ for_ (view osAsserts st) $ \(W4.LabeledPred p r) ->
-       Crucible.addAssertion sym (Crucible.LabeledPred p r)
+
+     -- TODO: Use the fact that we know that these are assertions about arguments
+     -- from `crucible_execute_func` to provide better error messages
+     io $ mapM_ (mapM_ (Crucible.addAssertion sym)) (view osArgAsserts st)
+     io $ mapM_ (Crucible.addAssertion sym) (view osAsserts st)
 
      obligations <- io $ Crucible.getProofObligations sym
      io $ Crucible.clearProofObligations sym
@@ -890,7 +895,7 @@ verifyPoststate opts sc cc mspec env0 globals ret =
         (Just (rty,r), Just expect) -> matchArg opts sc cc mspec PostState r rty expect
         (Nothing     , Just _ )     ->
           fail "verifyPoststate: unexpected crucible_return specification"
-        _ -> return ()
+        _ -> return []
 
 --------------------------------------------------------------------------------
 

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -878,6 +878,7 @@ verifyPoststate opts sc cc mspec env0 globals ret =
              Right (_, st) -> return st
 
      io $ mapM_ (Crucible.addAssertion sym) (st ^. osAsserts)
+     when (not (null (st ^. osArgAsserts))) $ fail "verifyPoststate: impossible"
 
      obligations <- io $ Crucible.getProofObligations sym
      io $ Crucible.clearProofObligations sym

--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -136,7 +136,7 @@ labelWithArgNum loc asserts =
   foldMap (\(n, as) -> map (helper n) as) (zip [1..] asserts)
   where helper :: Int -> LabeledPred' Sym -> LabeledPred Sym
         helper n = labelWithSimError loc $ \doc -> unlines
-          ["In argument #" ++ show n ++ "to crucible_execute_func:", show doc]
+          ["In argument #" ++ show n ++ " to crucible_execute_func:", show doc]
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #522 

Currently, Crucible/LLVM override matching is a very sequential, stateful
process. We iterate over the constructions in the method specification
(`crucible_points_to`, `crucible_equal`), accumulating relevant symbolic
predicates in a big list along the way.

This MR begins the process of making this process more declarative, while improving
debugability. It ties the symbolic assertions more closely to the spec.

Next steps: refactor the rest of `learnCond` to return lists of labeled
predicates, get rid of assertions stored in `OverrideState` and pass them
explicitly instead.
