### PR TITLE
Crucible/All: Split OverrideState into RO and RW components

### DIFF
--- a/src/SAWScript/Crucible/Common/Override.hs
+++ b/src/SAWScript/Crucible/Common/Override.hs
@@ -20,14 +20,13 @@ Stability   : provisional
 
 module SAWScript.Crucible.Common.Override
   ( Pointer
-  , OverrideState(..)
-  , osAsserts
-  , osArgAsserts
-  , osAssumes
-  , osFree
-  , osLocation
-  , overrideGlobals
-  , syminterface
+  , OverrideMatcherRW(..)
+  , omAsserts
+  , omArgAsserts
+  , omAssumes
+  , omFree
+  , omLocation
+  , omGlobals
   , setupValueSub
   , termSub
   --
@@ -52,13 +51,15 @@ module SAWScript.Crucible.Common.Override
 
 import qualified Control.Exception as X
 import           Control.Lens
-import           Control.Monad.Trans.State hiding (get, put)
-import           Control.Monad.State.Class (MonadState(..))
 import           Control.Monad.Error.Class (MonadError)
 import           Control.Monad.Fail (MonadFail)
-import           Control.Monad.Trans.Except
-import           Control.Monad.Trans.Class
 import           Control.Monad.IO.Class
+import           Control.Monad.Reader.Class (MonadReader(..))
+import           Control.Monad.State.Class (MonadState(..))
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.Except
+import           Control.Monad.Trans.Reader
+import           Control.Monad.Trans.State hiding (get, put)
 import           Data.Kind (Type)
 import           Data.Map (Map)
 import           Data.Set (Set)
@@ -86,13 +87,25 @@ import           SAWScript.Crucible.Common (Sym)
 import           SAWScript.Crucible.Common.MethodSpec as MS
 
 --------------------------------------------------------------------------------
--- ** OverrideState
+-- ** OverrideMatcherRW
 
 type LabeledPred sym = W4.LabeledPred (W4.Pred sym) Crucible.SimError
 
 type family Pointer ext :: Type
 
-data OverrideState ext = OverrideState
+-- | The read-only environment during override matching
+data OverrideMatcherRO = OverrideMatcherRO
+  { -- | Source location to associated with this override
+    _omLocation :: W4.ProgramLoc
+
+    -- | Symbolic simulation state
+  , omSymInterface :: Sym
+  }
+
+makeLenses ''OverrideMatcherRO
+
+-- | The mutable environment during override matching
+data OverrideMatcherRW ext = OverrideMatcherRW
   { -- | Substitution for memory allocations
     _setupValueSub :: Map AllocIndex (Pointer ext)
 
@@ -100,51 +113,41 @@ data OverrideState ext = OverrideState
   , _termSub :: Map VarIndex Term
 
     -- | Free variables available for unification
-  , _osFree :: Set VarIndex
+  , _omFree :: Set VarIndex
 
     -- | Accumulated assertions
-  , _osAsserts :: [LabeledPred Sym]
+  , _omAsserts :: [LabeledPred Sym]
 
     -- | Assertions about the values of function arguments
     --
     -- These come from @crucible_execute_func@.
-  , _osArgAsserts :: [[W4.LabeledPred (W4.Pred Sym) PP.Doc]]
+  , _omArgAsserts :: [[W4.LabeledPred (W4.Pred Sym) PP.Doc]]
 
     -- | Accumulated assumptions
-  , _osAssumes :: [W4.Pred Sym]
-
-    -- | Symbolic simulation state
-  , _syminterface :: Sym
+  , _omAssumes :: [W4.Pred Sym]
 
     -- | Global variables
-  , _overrideGlobals :: Crucible.SymGlobalState Sym
-
-    -- | Source location to associated with this override
-  , _osLocation :: W4.ProgramLoc
+  , _omGlobals :: Crucible.SymGlobalState Sym
   }
 
-makeLenses ''OverrideState
+makeLenses ''OverrideMatcherRW
 
 -- | The initial override matching state starts with an empty substitution
 -- and no assertions or assumptions.
 initialState ::
-  Sym                           {- ^ simulator                      -} ->
   Crucible.SymGlobalState Sym   {- ^ initial global variables       -} ->
   Map AllocIndex (Pointer ext) {- ^ initial allocation substituion -} ->
   Map VarIndex Term             {- ^ initial term substituion       -} ->
   Set VarIndex                  {- ^ initial free terms             -} ->
-  W4.ProgramLoc                 {- ^ location information for the override -} ->
-  OverrideState ext
-initialState sym globals allocs terms free loc = OverrideState
-  { _osAsserts       = []
-  , _osArgAsserts    = []
-  , _osAssumes       = []
-  , _syminterface    = sym
-  , _overrideGlobals = globals
+  OverrideMatcherRW ext
+initialState globals allocs terms free = OverrideMatcherRW
+  { _omAsserts       = []
+  , _omArgAsserts    = []
+  , _omAssumes       = []
+  , _omGlobals = globals
   , _termSub         = terms
-  , _osFree          = free
+  , _omFree          = free
   , _setupValueSub   = allocs
-  , _osLocation      = loc
   }
 
 --------------------------------------------------------------------------------
@@ -258,13 +261,16 @@ data RW
 -- the Crucible simulation in order to compute the variable substitution
 -- and side-conditions needed to proceed.
 newtype OverrideMatcher ext rorw a =
-  OM (StateT (OverrideState ext) (ExceptT (OverrideFailure ext) IO) a)
+  OM (ReaderT OverrideMatcherRO
+      (StateT (OverrideMatcherRW ext)
+       (ExceptT (OverrideFailure ext) IO)) a)
   deriving (Applicative, Functor, Generic, Generic1, Monad, MonadIO, MonadFail)
 
 instance Wrapped (OverrideMatcher ext rorw a) where
 
-deriving instance MonadState (OverrideState ext) (OverrideMatcher ext rorw)
 deriving instance MonadError (OverrideFailure ext) (OverrideMatcher ext rorw)
+deriving instance MonadReader OverrideMatcherRO (OverrideMatcher ext rorw)
+deriving instance MonadState (OverrideMatcherRW ext) (OverrideMatcher ext rorw)
 
 -- | "Run" function for OverrideMatcher. The final result and state
 -- are returned. The state will contain the updated globals and substitutions
@@ -276,27 +282,28 @@ runOverrideMatcher ::
    Set VarIndex                {- ^ initial free variables          -} ->
    W4.ProgramLoc               {- ^ override location information   -} ->
    OverrideMatcher ext md a   {- ^ matching action                 -} ->
-   IO (Either (OverrideFailure ext) (a, OverrideState ext))
+   IO (Either (OverrideFailure ext) (a, OverrideMatcherRW ext))
 runOverrideMatcher sym g a t free loc (OM m) =
-  runExceptT (runStateT m (initialState sym g a t free loc))
+  runExceptT (runStateT (runReaderT m initialRO) (initialState g a t free))
+  where initialRO = OverrideMatcherRO loc sym
 
 addAssert ::
   W4.Pred Sym       {- ^ property -} ->
   Crucible.SimError {- ^ reason   -} ->
   OverrideMatcher ext rorw ()
 addAssert p r =
-  OM (osAsserts %= cons (W4.LabeledPred p r))
+  OM (omAsserts %= cons (W4.LabeledPred p r))
 
 addAssume ::
   W4.Pred Sym       {- ^ property -} ->
   OverrideMatcher ext rorw ()
-addAssume p = OM (osAssumes %= cons p)
+addAssume p = OM (omAssumes %= cons p)
 
 readGlobal ::
   Crucible.GlobalVar tp ->
   OverrideMatcher ext rorw (Crucible.RegValue Sym tp)
 readGlobal k =
-  do mb <- OM (uses overrideGlobals (Crucible.lookupGlobal k))
+  do mb <- OM (uses omGlobals (Crucible.lookupGlobal k))
      case mb of
        Nothing -> fail ("No such global: " ++ show k)
        Just v  -> return v
@@ -305,7 +312,7 @@ writeGlobal ::
   Crucible.GlobalVar    tp ->
   Crucible.RegValue Sym tp ->
   OverrideMatcher ext RW ()
-writeGlobal k v = OM (overrideGlobals %= Crucible.insertGlobal k v)
+writeGlobal k v = OM (omGlobals %= Crucible.insertGlobal k v)
 
 -- | Abort the current computation by raising the given 'OverrideFailure'
 -- exception.
@@ -313,10 +320,10 @@ failure ::
   W4.ProgramLoc ->
   OverrideFailureReason ext ->
   OverrideMatcher ext md a
-failure loc e = OM (lift (throwE (OF loc e)))
+failure loc e = OM (lift (lift (throwE (OF loc e))))
 
 getSymInterface :: OverrideMatcher ext md Sym
-getSymInterface = OM (use syminterface)
+getSymInterface = OM (asks omSymInterface)
 
 ------------------------------------------------------------------------
 

--- a/src/SAWScript/Crucible/JVM/Builtins.hs
+++ b/src/SAWScript/Crucible/JVM/Builtins.hs
@@ -670,7 +670,7 @@ verifyPoststate opts sc cc mspec env0 globals ret =
      st <- case matchPost of
              Left err      -> fail (show err)
              Right (_, st) -> return st
-     io $ for_ (view osAsserts st) $ \assert -> Crucible.addAssertion sym assert
+     io $ for_ (view omAsserts st) $ \assert -> Crucible.addAssertion sym assert
 
      obligations <- io $ Crucible.getProofObligations sym
      io $ Crucible.clearProofObligations sym

--- a/src/SAWScript/Crucible/JVM/Override.hs
+++ b/src/SAWScript/Crucible/JVM/Override.hs
@@ -31,7 +31,7 @@ module SAWScript.Crucible.JVM.Override
   , runOverrideMatcher
 
   , setupValueSub
-  , osAsserts
+  , omAsserts
   , termSub
 
   , learnCond
@@ -200,7 +200,7 @@ methodSpecHandler opts sc cc top_loc css retTy = do
                     PPL.vcat (map (\x -> PPL.text "*" PPL.<> PPL.indent 2 (ppOverrideFailure x)) e)
                 (_, ss) -> liftIO $
                   forM ss $ \(cs,st) ->
-                    do precond <- W4.andAllOf sym (folded.labeledPred) (st^.osAsserts)
+                    do precond <- W4.andAllOf sym (folded.labeledPred) (st^.omAsserts)
                        return ( precond, cs, st )
 
   -- Now use crucible's symbolic branching machinery to select between the branches.
@@ -224,8 +224,8 @@ methodSpecHandler opts sc cc top_loc css retTy = do
                 res <- liftIO $ runOverrideMatcher sym g
                    (st^.setupValueSub)
                    (st^.termSub)
-                   (st^.osFree)
-                   (st^.osLocation)
+                   (st^.omFree)
+                   top_loc
                    (methodSpecHandler_poststate opts sc cc retTy cs)
                 case res of
                   Left (OF loc rsn)  ->
@@ -233,13 +233,13 @@ methodSpecHandler opts sc cc top_loc css retTy = do
                     liftIO $ Crucible.abortExecBecause
                       (Crucible.AssumedFalse (Crucible.AssumptionReason loc (show rsn)))
                   Right (ret,st') ->
-                    do liftIO $ forM_ (st'^.osAssumes) $ \asum ->
+                    do liftIO $ forM_ (st'^.omAssumes) $ \asum ->
                          Crucible.addAssumption (cc ^. jccBackend)
                             (Crucible.LabeledPred asum
-                              (Crucible.AssumptionReason (st^.osLocation) "override postcondition"))
-                       Crucible.writeGlobals (st'^.overrideGlobals)
+                              (Crucible.AssumptionReason top_loc "override postcondition"))
+                       Crucible.writeGlobals (st'^.omGlobals)
                        Crucible.overrideReturn' (Crucible.RegEntry retTy ret)
-           , Just (W4.plSourceLoc (cs ^. MS.csLoc))
+           , Just (W4.plSourceLoc top_loc)
            )
          | (precond, cs, st) <- branches
          ] ++
@@ -627,7 +627,7 @@ matchTerm ::
 
 matchTerm _ _ _ _ real expect | real == expect = return ()
 matchTerm sc cc loc prepost real expect =
-  do free <- OM (use osFree)
+  do free <- OM (use omFree)
      case unwrapTermF expect of
        FTermF (ExtCns ec)
          | Set.member (ecVarIndex ec) free ->
@@ -671,7 +671,7 @@ learnPointsTo opts sc cc spec prepost pt = do
   let tyenv = MS.csAllocations spec
   let nameEnv = MS.csTypeNames spec
   sym <- Ov.getSymInterface
-  globals <- OM (use overrideGlobals)
+  globals <- OM (use omGlobals)
   case pt of
 
     JVMPointsToField loc ptr fname val ->
@@ -749,12 +749,12 @@ executeAllocation opts cc (var, (loc, alloc)) =
      let jc = cc^.jccJVMContext
      let halloc = cc^.jccHandleAllocator
      sym <- Ov.getSymInterface
-     globals <- OM (use overrideGlobals)
+     globals <- OM (use omGlobals)
      (ptr, globals') <-
        case alloc of
          AllocObject cname -> liftIO $ CJ.doAllocateObject sym halloc jc cname globals
          AllocArray len elemTy -> liftIO $ CJ.doAllocateArray sym halloc jc len elemTy globals
-     OM (overrideGlobals .= globals')
+     OM (omGlobals .= globals')
      assignVar cc loc var ptr
 
 ------------------------------------------------------------------------
@@ -786,7 +786,7 @@ executePointsTo ::
   OverrideMatcher CJ.JVM w ()
 executePointsTo opts sc cc spec pt = do
   sym <- Ov.getSymInterface
-  globals <- OM (use overrideGlobals)
+  globals <- OM (use omGlobals)
   case pt of
 
     JVMPointsToField loc ptr fname val ->
@@ -795,7 +795,7 @@ executePointsTo opts sc cc spec pt = do
          rval <- asRVal loc ptr'
          let dyn = injectJVMVal sym val'
          globals' <- liftIO $ CJ.doFieldStore sym globals rval fname dyn
-         OM (overrideGlobals .= globals')
+         OM (omGlobals .= globals')
 
     JVMPointsToElem loc ptr idx val ->
       do (_, val') <- resolveSetupValueJVM opts cc sc spec val
@@ -803,7 +803,7 @@ executePointsTo opts sc cc spec pt = do
          rval <- asRVal loc ptr'
          let dyn = injectJVMVal sym val'
          globals' <- liftIO $ CJ.doArrayStore sym globals rval idx dyn
-         OM (overrideGlobals .= globals')
+         OM (omGlobals .= globals')
 
 ------------------------------------------------------------------------
 

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -877,8 +877,8 @@ verifyPoststate opts sc cc mspec env0 globals ret =
              Left err      -> fail (show err)
              Right (_, st) -> return st
 
-     io $ mapM_ (Crucible.addAssertion sym) (st ^. osAsserts)
-     when (not (null (st ^. osArgAsserts))) $ fail "verifyPoststate: impossible"
+     io $ mapM_ (Crucible.addAssertion sym) (st ^. omAsserts)
+     when (not (null (st ^. omArgAsserts))) $ fail "verifyPoststate: impossible"
 
      obligations <- io $ Crucible.getProofObligations sym
      io $ Crucible.clearProofObligations sym


### PR DESCRIPTION
Also make record field names more consistent