### PR TITLE
Crucible/LLVM: Assert and assume that allocations happen at the right alignment

### DIFF
--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -460,7 +460,7 @@ verifyPrestate opts cc mspec globals = do
 
   -- Allocate LLVM memory for each 'crucible_alloc'
   (env1, mem') <- runStateT
-    (traverse (doAlloc cc)  $ mspec ^. MS.csPreState . MS.csAllocs)
+    (traverse (doAlloc' cc) $ mspec ^. MS.csPreState . MS.csAllocs)
     mem
 
   env2 <- Map.traverseWithKey
@@ -474,6 +474,8 @@ verifyPrestate opts cc mspec globals = do
   args <- resolveArguments cc mspec env
 
   return (args, cs, env, globals2)
+
+  where doAlloc' cc_ allocSpec = StateT $ liftIO . doAlloc cc_ allocSpec
 
 -- | Check two MemTypes for register compatiblity.  This is a stricter
 --   check than the memory compatiblity check that is done for points-to
@@ -592,23 +594,6 @@ assertEqualVals ::
   IO Term
 assertEqualVals cc v1 v2 =
   CrucibleSAW.toSC (cc^.ccBackend) =<< equalValsPred cc v1 v2
-
---------------------------------------------------------------------------------
-
--- TODO(langston): combine with/move to executeAllocation
-doAlloc ::
-  (?lc :: Crucible.TypeContext, Crucible.HasPtrWidth (Crucible.ArchWidth arch)) =>
-  LLVMCrucibleContext arch       ->
-  LLVMAllocSpec ->
-  StateT MemImpl IO (LLVMPtr (Crucible.ArchWidth arch))
-doAlloc cc (LLVMAllocSpec mut _memTy sz loc) = StateT $ \mem ->
-  do let sym = cc^.ccBackend
-     let dl = Crucible.llvmDataLayout ?lc
-     sz' <- W4.bvLit sym Crucible.PtrWidth $ Crucible.bytesToInteger sz
-     let alignment = Crucible.maxAlignment dl -- Use the maximum alignment required for any primitive type (FIXME?)
-     let l = show (W4.plSourceLoc loc)
-     liftIO $
-       Crucible.doMalloc sym Crucible.HeapAlloc mut l mem sz' alignment
 
 --------------------------------------------------------------------------------
 

--- a/src/SAWScript/Crucible/LLVM/CrucibleLLVM.hs
+++ b/src/SAWScript/Crucible/LLVM/CrucibleLLVM.hs
@@ -42,6 +42,7 @@ module SAWScript.Crucible.LLVM.CrucibleLLVM
     -- * Re-exports from "Lang.Crucible.LLVM.MemType"
   , SymType(MemType, Alias, VoidType)
   , MemType(..)
+  , memTypeAlign
   , memTypeSize
   , fiOffset
   , fiType
@@ -148,7 +149,7 @@ import Lang.Crucible.LLVM.Intrinsics
 import Lang.Crucible.LLVM.MemType
   (SymType(MemType, Alias, VoidType),
    MemType(..),
-   Ident, memTypeSize, fiOffset, fiType,
+   Ident, memTypeAlign, memTypeSize, fiOffset, fiType,
    siFields, siFieldInfo, siFieldOffset, siFieldTypes, siIsPacked,
    mkStructInfo, ppMemType)
 

--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -38,6 +38,7 @@ module SAWScript.Crucible.LLVM.Override
   , osArgAsserts
   , termSub
 
+  , doAlloc
   , learnCond
   , matchArg
   , methodSpecHandler
@@ -1218,29 +1219,32 @@ learnPred sc cc loc prepost t =
 
 ------------------------------------------------------------------------
 
--- | Perform an allocation as indicated by a 'crucible_alloc'
--- statement from the postcondition section.
+-- | Perform an allocation as indicated by a 'crucible_alloc' statement
+doAlloc ::
+  (?lc :: Crucible.TypeContext, Crucible.HasPtrWidth (Crucible.ArchWidth arch)) =>
+  LLVMCrucibleContext arch       ->
+  LLVMAllocSpec ->
+  Crucible.MemImpl Sym ->
+  IO (LLVMPtr (Crucible.ArchWidth arch), Crucible.MemImpl Sym)
+doAlloc cc (LLVMAllocSpec mut _memTy sz loc) mem =
+  do let sym = cc^.ccBackend
+     sz' <- W4.bvLit sym Crucible.PtrWidth $ Crucible.bytesToInteger sz
+     let alignment = Crucible.noAlignment -- FIXME? max alignment?
+     let l = show (W4.plSourceLoc loc)
+     Crucible.doMalloc sym Crucible.HeapAlloc mut l mem sz' alignment
+
+-- | Perform an allocation as indicated by a 'crucible_alloc' statement
 executeAllocation ::
   (?lc :: Crucible.TypeContext, Crucible.HasPtrWidth (Crucible.ArchWidth arch)) =>
   Options                        ->
   LLVMCrucibleContext arch          ->
   (AllocIndex, LLVMAllocSpec) ->
   OverrideMatcher (LLVM arch) RW ()
-executeAllocation opts cc (var, LLVMAllocSpec mut memTy sz loc) =
-  do let sym = cc^.ccBackend
-     {-
-     memTy <- case Crucible.asMemType symTy of
-                Just memTy -> return memTy
-                Nothing    -> fail "executAllocation: failed to resolve type"
-                -}
-     liftIO $ printOutLn opts Debug $ unwords ["executeAllocation:", show var, show memTy]
+executeAllocation opts cc (var, spec@(LLVMAllocSpec _mut memTy _sz loc)) =
+  do liftIO $ printOutLn opts Debug $ unwords ["executeAllocation:", show var, show memTy]
      let memVar = Crucible.llvmMemVar $ (cc^.ccLLVMContext)
      mem <- readGlobal memVar
-     sz' <- liftIO $ W4.bvLit sym Crucible.PtrWidth (Crucible.bytesToInteger sz)
-     let alignment = Crucible.noAlignment -- default to byte alignment (FIXME)
-     let l = show (W4.plSourceLoc loc) ++ " (Poststate)"
-     (ptr, mem') <- liftIO $
-       Crucible.doMalloc sym Crucible.HeapAlloc mut l mem sz' alignment
+     (ptr, mem') <- liftIO $ doAlloc cc spec mem
      writeGlobal memVar mem'
      assignVar cc loc var ptr
 

--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -1128,7 +1128,8 @@ learnPointsTo opts sc cc spec prepost (LLVMPointsTo loc ptr val) =
      mem    <- readGlobal $ Crucible.llvmMemVar
                           $ (cc^.ccLLVMContext)
 
-     let alignment = Crucible.noAlignment -- default to byte alignment (FIXME)
+     let ?lc = cc^.ccTypeCtx
+     let alignment = Crucible.memTypeAlign (Crucible.llvmDataLayout ?lc) memTy
      res <- liftIO $ Crucible.loadRaw sym mem ptr1 storTy alignment
      let summarizeBadLoad =
           let dataLayout = Crucible.llvmDataLayout (cc^.ccTypeCtx)
@@ -1226,10 +1227,10 @@ doAlloc ::
   LLVMAllocSpec ->
   Crucible.MemImpl Sym ->
   IO (LLVMPtr (Crucible.ArchWidth arch), Crucible.MemImpl Sym)
-doAlloc cc (LLVMAllocSpec mut _memTy sz loc) mem =
+doAlloc cc (LLVMAllocSpec mut memTy sz loc) mem =
   do let sym = cc^.ccBackend
      sz' <- W4.bvLit sym Crucible.PtrWidth $ Crucible.bytesToInteger sz
-     let alignment = Crucible.noAlignment -- FIXME? max alignment?
+     let alignment = Crucible.memTypeAlign (Crucible.llvmDataLayout ?lc) memTy
      let l = show (W4.plSourceLoc loc)
      Crucible.doMalloc sym Crucible.HeapAlloc mut l mem sz' alignment
 
@@ -1323,9 +1324,10 @@ storePointsToValue ::
 storePointsToValue opts cc env tyenv nameEnv mem ptr val = do
   let sym = cc ^. ccBackend
 
-  let alignment = Crucible.noAlignment -- default to byte alignment (FIXME)
   memTy <- typeOfSetupValue cc tyenv nameEnv val
   storTy <- Crucible.toStorableType memTy
+  let ?lc = cc^.ccTypeCtx
+  let alignment = Crucible.memTypeAlign (Crucible.llvmDataLayout ?lc) memTy
 
   smt_array_memory_model_enabled <- W4.getOpt
     =<< W4.getOptionSetting enableSMTArrayMemoryModel (W4.getConfiguration sym)


### PR DESCRIPTION
Fix a few `FIXME`s