### PR TITLE
Add new saw-script command "check_goal".

### DIFF
--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -938,6 +938,15 @@ check_term t = do
   ty <- io $ scTypeCheckError sc t
   printOutLnTop Info (scPrettyTerm opts ty)
 
+check_goal :: ProofScript ()
+check_goal =
+  StateT $ \(ProofState goals concl stats timeout) ->
+  case goals of
+    [] -> fail "ProofScript failed: no subgoal"
+    (ProofGoal _num _ty _name prop) : gs ->
+      do check_term prop
+         return ((), ProofState goals concl stats timeout)
+
 fixPos :: Pos
 fixPos = PosInternal "FIXME"
 

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -743,6 +743,11 @@ primitives = Map.fromList
     Current
     [ "Type-check the given term, printing an error message if ill-typed." ]
 
+  , prim "check_goal"          "ProofScript ()"
+    (pureVal check_goal)
+    Current
+    [ "Type-check the current proof goal, printing an error message if ill-typed." ]
+
   , prim "term_size"           "Term -> Int"
     (pureVal scSharedSize)
     Current


### PR DESCRIPTION
"Type-check the current proof goal, printing an error message
if ill-typed."