### PR TITLE
More typechecking for ghost variables

### DIFF
--- a/intTests/test_ghost_types_00/test.saw
+++ b/intTests/test_ghost_types_00/test.saw
@@ -28,6 +28,6 @@ let main : TopLevel () = do {
   f_ov <- crucible_llvm_unsafe_assume_spec m "f" (f_spec x);
   // This spec should probably use a different variable, but doesn't:
   g_ov <- crucible_llvm_unsafe_assume_spec m "g" (g_spec x);
-  crucible_llvm_verify m "h" [f_ov, g_ov] false h_spec z3;
+  fails (crucible_llvm_verify m "h" [f_ov, g_ov] false h_spec z3);
   print "done";
 };

--- a/src/SAWScript/Crucible/JVM/Override.hs
+++ b/src/SAWScript/Crucible/JVM/Override.hs
@@ -616,6 +616,7 @@ valueToSC _sym loc failMsg _tval _val =
 
 ------------------------------------------------------------------------
 
+-- | NOTE: The two 'Term' arguments must have the same type.
 matchTerm ::
   SharedContext   {- ^ context for constructing SAW terms    -} ->
   JVMCrucibleContext {- ^ context for interacting with Crucible -} ->

--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -66,6 +66,7 @@ import qualified Text.LLVM.AST as L
 
 import qualified Cryptol.TypeCheck.AST as Cryptol (Schema(..))
 import qualified Cryptol.Eval.Type as Cryptol (TValue(..), evalType)
+import qualified Cryptol.Utils.PP as Cryptol (pp)
 
 import qualified Lang.Crucible.Backend as Crucible
 import qualified Lang.Crucible.Backend.SAWCore as Crucible
@@ -1025,6 +1026,7 @@ typeToSC sc t =
 
 ------------------------------------------------------------------------
 
+-- | NOTE: The two 'Term' arguments must have the same type.
 matchTerm ::
   SharedContext   {- ^ context for constructing SAW terms    -} ->
   LLVMCrucibleContext arch {- ^ context for interacting with Crucible -} ->
@@ -1086,6 +1088,11 @@ learnGhost ::
   OverrideMatcher (LLVM arch) md ()
 learnGhost sc cc loc prepost var expected =
   do actual <- readGlobal var
+     when (ttSchema actual /= ttSchema expected) $ fail $ unlines $
+       [ "Ghost variable had the wrong type:"
+       , "- Expected: " ++ show (Cryptol.pp (ttSchema expected))
+       , "- Actual:   " ++ show (Cryptol.pp (ttSchema actual))
+       ]
      matchTerm sc cc loc prepost (ttTerm actual) (ttTerm expected)
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #548 and #543 

Here's what it looks like on `test_ghost_branch_03`:
```
[16:59:17.110] Subgoal failed: h safety assertion: Attempted to mux ghost variables of different types:
Bit
[32]
```
And in the other case:
```
  Abort due to false assumption:
    Ghost variable had the wrong type:
    - Expected: [75][8]
    - Actual:   [45][8]
    in _ZN5folly3ssl11OpenSSLHash4Hmac10hash_finalENS_5RangeIPhEE at :123:30
```