### PR TITLE
explicit-float-modes

### DIFF
--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -46,6 +46,8 @@ import System.Process (callCommand, readProcessWithExitCode)
 import Text.Printf (printf)
 import Text.Read (readMaybe)
 
+import What4.Expr(FloatModeRepr(..))
+
 import qualified Verifier.SAW.Cryptol as Cryptol
 import qualified Verifier.SAW.Cryptol.Simpset as Cryptol
 
@@ -472,7 +474,7 @@ goal_eval unints =
   do sc <- getSharedContext
      t0 <- liftIO $ propToPredicate sc (goalTerm goal)
      let gen = globalNonceGenerator
-     sym <- liftIO $ Crucible.newSAWCoreBackend sc gen
+     sym <- liftIO $ Crucible.newSAWCoreBackend FloatRealRepr sc gen
      (_names, (_mlabels, p)) <- liftIO $ W4Sim.w4Eval sym sc Map.empty unints t0
      t1 <- liftIO $ Crucible.toSC sym p
      t2 <- liftIO $ scEqTrue sc t1

--- a/src/SAWScript/Crucible/JVM/Builtins.hs
+++ b/src/SAWScript/Crucible/JVM/Builtins.hs
@@ -705,7 +705,7 @@ setupCrucibleContext bic opts jclass =
      cb <- getJavaCodebase
      let sc  = biSharedContext bic
      let gen = globalNonceGenerator
-     sym <- io $ Crucible.newSAWCoreBackend sc gen
+     sym <- io $ Crucible.newSAWCoreBackend W4.FloatRealRepr sc gen
      io $ CJ.setSimulatorVerbosity (simVerbose opts) sym
      return JVMCrucibleContext { _jccJVMClass = jclass
                                , _jccCodebase = cb

--- a/src/SAWScript/Crucible/JVM/BuiltinsJVM.hs
+++ b/src/SAWScript/Crucible/JVM/BuiltinsJVM.hs
@@ -151,7 +151,7 @@ crucible_java_extract bic opts c mname = do
   ctx <- getJVMTrans
 
   io $ do -- only the IO monad, nothing else
-          sym <- CrucibleSAW.newSAWCoreBackend sc gen
+          sym <- CrucibleSAW.newSAWCoreBackend W4.FloatRealRepr sc gen
           CJ.setSimulatorVerbosity verbosity sym
 
           (CJ.JVMHandleInfo _m2 h) <- CJ.findMethodHandle ctx mcls meth

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -991,7 +991,7 @@ setupLLVMCrucibleContext bic opts lm@(LLVMModule _ llvm_mod mtrans) action = do
       let gen = globalNonceGenerator
       let sc  = biSharedContext bic
       let verbosity = simVerbose opts
-      sym <- CrucibleSAW.newSAWCoreBackend sc gen
+      sym <- CrucibleSAW.newSAWCoreBackend W4.FloatRealRepr sc gen
 
       let cfg = W4.getConfiguration sym
       verbSetting <- W4.getOptionSetting W4.verbosity cfg

--- a/src/SAWScript/Prover/What4.hs
+++ b/src/SAWScript/Prover/What4.hs
@@ -48,7 +48,7 @@ satWhat4_sym :: SolverAdapter St
              -> IO (Maybe [(String, FirstOrderValue)], SolverStats)
 satWhat4_sym solver un sc t = do
   -- TODO: get rid of GlobalNonceGenerator ???
-  sym <- B.newExprBuilder St globalNonceGenerator
+  sym <- B.newExprBuilder B.FloatRealRepr St globalNonceGenerator
   satWhat4_solver solver sym un sc t
 
 

--- a/src/SAWScript/X86.hs
+++ b/src/SAWScript/X86.hs
@@ -42,6 +42,7 @@ import Data.Parameterized.Nonce(globalNonceGenerator)
 
 -- What4
 import What4.Interface(asNat,asUnsignedBV)
+import What4.Expr(FloatModeRepr(..))
 import qualified What4.Interface as W4
 import qualified What4.Config as W4
 import What4.FunctionName(functionNameFromText)
@@ -188,7 +189,7 @@ proof archi file mbCry globs fun =
      halloc  <- newHandleAllocator
      scLoadPreludeModule sc
      scLoadCryptolModule sc
-     sym <- newSAWCoreBackend sc globalNonceGenerator
+     sym <- newSAWCoreBackend FloatRealRepr sc globalNonceGenerator
      cenv <- loadCry sym mbCry
      mvar <- mkMemVar halloc
      proofWithOptions Options

--- a/stack.ghc-8.4.yaml
+++ b/stack.ghc-8.4.yaml
@@ -30,6 +30,7 @@ packages:
   - deps/macaw/x86_symbolic
   - .
 extra-deps:
+  - zenc-0.1.1@sha256:e4be3e5e9fe1a1ade05910909c6e5b5a8eff72e697868b03955c9781b0443947
   - IfElse-0.85
   - fgl-visualize-0.1.0.1
   - dotgen-0.4.2

--- a/stack.ghc-8.6.yaml
+++ b/stack.ghc-8.6.yaml
@@ -30,6 +30,7 @@ packages:
   - deps/macaw/x86_symbolic
   - .
 extra-deps:
+  - zenc-0.1.1@sha256:e4be3e5e9fe1a1ade05910909c6e5b5a8eff72e697868b03955c9781b0443947
   - IfElse-0.85
   - fgl-visualize-0.1.0.1
   - dotgen-0.4.2


### PR DESCRIPTION
WIP, updates for upcoming crucible changes (see GaloisInc/crucible#329).

Side note/question: Does `what4`'s version need to be bumped and thus the `what4` version constraint in the cabal file here need to be bumped?