### PR TITLE
Avoid generating 1-tuple Cryptol types from 1-field LLVM struct types.

### DIFF
--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -1314,7 +1314,9 @@ cryptolTypeOfActual dl mt =
     Crucible.StructType si ->
       do let memtypes = V.toList (Crucible.siFieldTypes si)
          ctys <- traverse (cryptolTypeOfActual dl) memtypes
-         return $ Cryptol.tTuple ctys
+         case ctys of
+           [cty] -> return cty
+           _ -> return $ Cryptol.tTuple ctys
     _ ->
       Nothing
 


### PR DESCRIPTION
Fixes #583.