### PR TITLE
Use ppTermDepth in matchTerm.

### DIFF
--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -1060,9 +1060,7 @@ matchTerm sc cc loc prepost real expect =
               , "Expected term: " ++ prettyTerm expect
               , "Actual term:   " ++ prettyTerm real
               ]
-  where prettyTerm term =
-          let pretty_ = show (ppTerm defaultPPOpts term)
-          in if length pretty_ < 200 then pretty_ else "<term omitted due to size>"
+  where prettyTerm = show . ppTermDepth 20
 
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
Currently, the code uses `ppTerm` to build the entire string, and
then doesn't use it if it is longer than 200 characters. This
approach can use large amounts of memory without using the result.
Switch to `ppTermDepth`.