### PR TITLE
Fix `resolveSetupVal` error introduced in #593.

### DIFF
--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -665,9 +665,8 @@ executeCond opts sc cc cs ss = do
             (ss ^. MS.csFreshPointers)
   OM (setupValueSub %= Map.union ptrs)
 
-  invalidateMutableAllocs opts sc cc cs
-
   traverse_ (executeAllocation opts cc) (Map.assocs (ss ^. MS.csAllocs))
+  invalidateMutableAllocs opts sc cc cs
   traverse_ (executePointsTo opts sc cc cs) (ss ^. MS.csPointsTos)
   traverse_ (executeSetupCondition opts sc cc cs) (ss ^. MS.csConditions)
 


### PR DESCRIPTION
In `invalidateMutableAllocs`, `resolveSetupValue` fails if any of the pointers in the postcondition are not resolved. In order to resolve those pointers, now `executeAllocation` runs before `invalidateMutableAllocs`.