### PR TITLE
Introduce `Prop` newtype wrapper for `Term`s representing propositions as types

### DIFF
--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -350,7 +350,7 @@ quickcheckGoal sc n = do
   withFirstGoal $ \goal -> io $ do
     printOutLn opts Warn $ "WARNING: using quickcheck to prove goal..."
     hFlush stdout
-    let tm = goalTerm goal
+    let Prop tm = goalProp goal
     ty <- scTypeOf sc tm
     maybeInputs <- scTestableType sc ty
     maybeInputs' <- scTestableType sc tm
@@ -369,21 +369,24 @@ quickcheckGoal sc n = do
         showTerm ty ++ ", for term: " ++ showTerm tm
 
 assumeValid :: ProofScript SV.ProofResult
-assumeValid = withFirstGoal $ \goal -> do
-  printOutLnTop Warn $ "WARNING: assuming goal " ++ goalName goal ++ " is valid"
-  let stats = solverStats "ADMITTED" (scSharedSize (goalTerm goal))
-  return (SV.Valid stats, stats, Nothing)
+assumeValid =
+  withFirstGoal $ \goal ->
+  do printOutLnTop Warn $ "WARNING: assuming goal " ++ goalName goal ++ " is valid"
+     let stats = solverStats "ADMITTED" (scSharedSize (unProp (goalProp goal)))
+     return (SV.Valid stats, stats, Nothing)
 
 assumeUnsat :: ProofScript SV.SatResult
-assumeUnsat = withFirstGoal $ \goal -> do
-  printOutLnTop Warn $ "WARNING: assuming goal " ++ goalName goal ++ " is unsat"
-  let stats = solverStats "ADMITTED" (scSharedSize (goalTerm goal))
-  return (SV.Unsat stats, stats, Nothing)
+assumeUnsat =
+  withFirstGoal $ \goal ->
+  do printOutLnTop Warn $ "WARNING: assuming goal " ++ goalName goal ++ " is unsat"
+     let stats = solverStats "ADMITTED" (scSharedSize (unProp (goalProp goal)))
+     return (SV.Unsat stats, stats, Nothing)
 
 trivial :: ProofScript SV.SatResult
-trivial = withFirstGoal $ \goal -> do
-  checkTrue (goalTerm goal)
-  return (SV.Unsat mempty, mempty, Nothing)
+trivial =
+  withFirstGoal $ \goal ->
+  do checkTrue (unProp (goalProp goal))
+     return (SV.Unsat mempty, mempty, Nothing)
   where
     checkTrue :: Term -> TopLevel ()
     checkTrue (asPiList -> (_, asEqTrue -> Just (asBool -> Just True))) = return ()
@@ -394,16 +397,16 @@ split_goal =
   StateT $ \(ProofState goals concl stats timeout) ->
   case goals of
     [] -> fail "ProofScript failed: no subgoal"
-    (ProofGoal num ty name prop) : gs ->
-      let (vars, body) = asLambdaList prop in
-      case (isGlobalDef "Prelude.and" <@> return <@> return) body of
+    (ProofGoal num ty name (Prop prop)) : gs ->
+      let (vars, body) = asPiList prop in
+      case (isGlobalDef "Prelude.and" <@> return <@> return) =<< asEqTrue body of
         Nothing -> fail "split_goal: goal not of form 'Prelude.and _ _'"
         Just (_ :*: p1 :*: p2) ->
           do sc <- getSharedContext
-             t1 <- io $ scLambdaList sc vars p1
-             t2 <- io $ scLambdaList sc vars p2
-             let g1 = ProofGoal num (ty ++ ".left") name t1
-             let g2 = ProofGoal num (ty ++ ".right") name t2
+             t1 <- io $ scPiList sc vars =<< scEqTrue sc p1
+             t2 <- io $ scPiList sc vars =<< scEqTrue sc p2
+             let g1 = ProofGoal num (ty ++ ".left") name (Prop t1)
+             let g2 = ProofGoal num (ty ++ ".right") name (Prop t2)
              return ((), ProofState (g1 : g2 : gs) concl stats timeout)
 
 getTopLevelPPOpts :: TopLevel PPOpts
@@ -428,67 +431,74 @@ print_term_depth d t = do
   printOutLnTop Info $ show (scPrettyTerm opts' t)
 
 print_goal :: ProofScript ()
-print_goal = withFirstGoal $ \goal -> do
-  opts <- getTopLevelPPOpts
-  printOutLnTop Info ("Goal " ++ goalName goal ++ ":")
-  printOutLnTop Info (scPrettyTerm opts (goalTerm goal))
-  return ((), mempty, Just goal)
+print_goal =
+  withFirstGoal $ \goal ->
+  do opts <- getTopLevelPPOpts
+     printOutLnTop Info ("Goal " ++ goalName goal ++ ":")
+     printOutLnTop Info (scPrettyTerm opts (unProp (goalProp goal)))
+     return ((), mempty, Just goal)
 
 print_goal_depth :: Int -> ProofScript ()
-print_goal_depth n = withFirstGoal $ \goal -> do
-  opts <- getTopLevelPPOpts
-  let opts' = opts { ppMaxDepth = Just n }
-  printOutLnTop Info ("Goal " ++ goalName goal ++ ":")
-  printOutLnTop Info $ scPrettyTerm opts' (goalTerm goal)
-  return ((), mempty, Just goal)
+print_goal_depth n =
+  withFirstGoal $ \goal ->
+  do opts <- getTopLevelPPOpts
+     let opts' = opts { ppMaxDepth = Just n }
+     printOutLnTop Info ("Goal " ++ goalName goal ++ ":")
+     printOutLnTop Info $ scPrettyTerm opts' (unProp (goalProp goal))
+     return ((), mempty, Just goal)
 
 printGoalConsts :: ProofScript ()
-printGoalConsts = withFirstGoal $ \goal -> do
-  mapM_ (printOutLnTop Info) $ Map.keys (getConstantSet (goalTerm goal))
-  return ((), mempty, Just goal)
+printGoalConsts =
+  withFirstGoal $ \goal ->
+  do mapM_ (printOutLnTop Info) $ Map.keys (getConstantSet (unProp (goalProp goal)))
+     return ((), mempty, Just goal)
 
 printGoalSize :: ProofScript ()
-printGoalSize = withFirstGoal $ \goal -> do
-  let t = goalTerm goal
-  printOutLnTop Info $ "Goal shared size: " ++ show (scSharedSize t)
-  printOutLnTop Info $ "Goal unshared size: " ++ show (scTreeSize t)
-  return ((), mempty, Just goal)
+printGoalSize =
+  withFirstGoal $ \goal ->
+  do let Prop t = goalProp goal
+     printOutLnTop Info $ "Goal shared size: " ++ show (scSharedSize t)
+     printOutLnTop Info $ "Goal unshared size: " ++ show (scTreeSize t)
+     return ((), mempty, Just goal)
 
 unfoldGoal :: [String] -> ProofScript ()
-unfoldGoal names = withFirstGoal $ \goal -> do
-  sc <- getSharedContext
-  let trm = goalTerm goal
-  trm' <- io $ scUnfoldConstants sc names trm
-  return ((), mempty, Just (goal { goalTerm = trm' }))
+unfoldGoal names =
+  withFirstGoal $ \goal ->
+  do sc <- getSharedContext
+     let Prop trm = goalProp goal
+     trm' <- io $ scUnfoldConstants sc names trm
+     return ((), mempty, Just (goal { goalProp = Prop trm' }))
 
 simplifyGoal :: Simpset -> ProofScript ()
-simplifyGoal ss = withFirstGoal $ \goal -> do
-  sc <- getSharedContext
-  let trm = goalTerm goal
-  trm' <- io $ rewriteSharedTerm sc ss trm
-  return ((), mempty, Just (goal { goalTerm = trm' }))
+simplifyGoal ss =
+  withFirstGoal $ \goal ->
+  do sc <- getSharedContext
+     let Prop trm = goalProp goal
+     trm' <- io $ rewriteSharedTerm sc ss trm
+     return ((), mempty, Just (goal { goalProp = Prop trm' }))
 
 goal_eval :: [String] -> ProofScript ()
 goal_eval unints =
   withFirstGoal $ \goal ->
   do sc <- getSharedContext
-     t0 <- liftIO $ propToPredicate sc (goalTerm goal)
+     t0 <- liftIO $ propToPredicate sc (goalProp goal)
      let gen = globalNonceGenerator
      sym <- liftIO $ Crucible.newSAWCoreBackend FloatRealRepr sc gen
      (_names, (_mlabels, p)) <- liftIO $ W4Sim.w4Eval sym sc Map.empty unints t0
      t1 <- liftIO $ Crucible.toSC sym p
      t2 <- liftIO $ scEqTrue sc t1
-     return ((), mempty, Just (goal { goalTerm = t2 }))
+     return ((), mempty, Just (goal { goalProp = Prop t2 }))
 
 beta_reduce_goal :: ProofScript ()
-beta_reduce_goal = withFirstGoal $ \goal -> do
-  sc <- getSharedContext
-  let trm = goalTerm goal
-  trm' <- io $ betaNormalize sc trm
-  return ((), mempty, Just (goal { goalTerm = trm' }))
+beta_reduce_goal =
+  withFirstGoal $ \goal ->
+  do sc <- getSharedContext
+     let Prop trm = goalProp goal
+     trm' <- io $ betaNormalize sc trm
+     return ((), mempty, Just (goal { goalProp = Prop trm' }))
 
 goal_apply :: Theorem -> ProofScript ()
-goal_apply (Theorem rule) =
+goal_apply (Theorem (Prop rule)) =
   StateT $ \(ProofState goals concl stats timeout) ->
   case goals of
     [] -> fail "goal_apply failed: no subgoal"
@@ -496,7 +506,7 @@ goal_apply (Theorem rule) =
       do sc <- getSharedContext
          let applyFirst [] = fail "goal_apply failed: no match"
              applyFirst ((ruleArgs, ruleConcl) : rest) =
-               do result <- io $ scMatch sc ruleConcl (goalTerm goal)
+               do result <- io $ scMatch sc ruleConcl (unProp (goalProp goal))
                   case result of
                     Nothing -> applyFirst rest
                     Just inst ->
@@ -505,12 +515,12 @@ goal_apply (Theorem rule) =
                          let mkNewGoals (Nothing : mts) ((_, prop) : args) =
                                do c0 <- instantiateVarList sc 0 (map (fromMaybe dummy) mts) prop
                                   cs <- mkNewGoals mts args
-                                  return (c0 : cs)
+                                  return (Prop c0 : cs)
                              mkNewGoals (Just _ : mts) (_ : args) =
                                mkNewGoals mts args
                              mkNewGoals _ _ = return []
                          newgoalterms <- io $ mkNewGoals inst' (reverse ruleArgs)
-                         let newgoals = reverse [ goal { goalTerm = t } | t <- newgoalterms ]
+                         let newgoals = reverse [ goal { goalProp = t } | t <- newgoalterms ]
                          return ((), ProofState (newgoals ++ goals') concl stats timeout)
          applyFirst (asPiLists rule)
   where
@@ -527,13 +537,13 @@ goal_assume =
   case goals of
     [] -> fail "goal_assume failed: no subgoal"
     goal : goals' ->
-      case asPi (goalTerm goal) of
+      case asPi (unProp (goalProp goal)) of
         Nothing -> fail "goal_assume failed: not a pi type"
         Just (_nm, tp, body)
           | looseVars body /= emptyBitSet -> fail "goal_assume failed: dependent pi type"
           | otherwise ->
-            let goal' = goal { goalTerm = body } in
-            return (Theorem tp, ProofState (goal' : goals') concl stats timeout)
+            let goal' = goal { goalProp = Prop body } in
+            return (Theorem (Prop tp), ProofState (goal' : goals') concl stats timeout)
 
 goal_intro :: String -> ProofScript TypedTerm
 goal_intro s =
@@ -541,7 +551,7 @@ goal_intro s =
   case goals of
     [] -> fail "goal_intro failed: no subgoal"
     goal : goals' ->
-      case asPi (goalTerm goal) of
+      case asPi (unProp (goalProp goal)) of
         Nothing -> fail "goal_intro failed: not a pi type"
         Just (nm, tp, body) ->
           do let name = if null s then nm else s
@@ -549,18 +559,18 @@ goal_intro s =
              x <- io $ scFreshGlobal sc name tp
              tt <- io $ mkTypedTerm sc x
              body' <- io $ instantiateVar sc 0 x body
-             let goal' = goal { goalTerm = body' }
+             let goal' = goal { goalProp = Prop body' }
              return (tt, ProofState (goal' : goals') concl stats timeout)
 
 goal_insert :: Theorem -> ProofScript ()
-goal_insert (Theorem t) =
+goal_insert (Theorem (Prop t)) =
   StateT $ \(ProofState goals concl stats timeout) ->
   case goals of
     [] -> fail "goal_insert failed: no subgoal"
     goal : goals' ->
       do sc <- SV.getSharedContext
-         body' <- io $ scFun sc t (goalTerm goal)
-         let goal' = goal { goalTerm = body' }
+         body' <- io $ scFun sc t (unProp (goalProp goal))
+         let goal' = goal { goalProp = Prop body' }
          return ((), ProofState (goal' : goals') concl stats timeout)
 
 goal_when :: String -> ProofScript () -> ProofScript ()
@@ -593,7 +603,7 @@ satExternal doCNF execName args = withFirstGoal $ \g -> do
   sc <- SV.getSharedContext
   SV.AIGProxy proxy <- SV.getProxy
   io $ do
-  let (vars, concl) = asPiList (goalTerm g)
+  let (vars, concl) = asPiList (unProp (goalProp g))
   t0 <- scLambdaList sc vars =<< asEqTrue concl
   t <- rewriteEqs sc t0
   let cnfName = goalType g ++ show (goalNum g) ++ ".cnf"
@@ -613,7 +623,7 @@ satExternal doCNF execName args = withFirstGoal $ \g -> do
   let ls = lines out
       sls = filter ("s " `isPrefixOf`) ls
       vls = filter ("v " `isPrefixOf`) ls
-  ft <- scEqTrue sc =<< scApplyPrelude_False sc
+  ft <- Prop <$> (scEqTrue sc =<< scApplyPrelude_False sc)
   let stats = solverStats ("external SAT:" ++ execName) (scSharedSize t)
   case (sls, vls) of
     (["s SATISFIABLE"], _) -> do
@@ -625,7 +635,7 @@ satExternal doCNF execName args = withFirstGoal $ \g -> do
         Right vs
           | length argNames == length vs -> do
             let r' = SV.SatMulti stats (zip argNames (map toFirstOrderValue vs))
-            return (r', stats, Just (g { goalTerm = ft }))
+            return (r', stats, Just (g { goalProp = ft }))
           | otherwise -> fail $ unwords ["external SAT results do not match expected arguments", show argNames, show vs]
     (["s UNSATISFIABLE"], []) ->
       return (SV.Unsat stats, stats, Nothing)
@@ -682,16 +692,16 @@ proveUnintSBV conf unints =
 
 wrapProver ::
   ( SharedContext ->
-    Term -> IO (Maybe [(String, FirstOrderValue)], SolverStats)) ->
+    Prop -> IO (Maybe [(String, FirstOrderValue)], SolverStats)) ->
   ProofScript SV.SatResult
 wrapProver f = do
   sc <- lift $ SV.getSharedContext
   withFirstGoal $ \g -> do
 
-  (mb, stats) <- io $ f sc (goalTerm g)
+  (mb, stats) <- io $ f sc (goalProp g)
 
   let nope r = do ft <- io $ scEqTrue sc =<< scApplyPrelude_False sc
-                  return (r, stats, Just g { goalTerm = ft })
+                  return (r, stats, Just g { goalProp = Prop ft })
 
   case mb of
     Nothing -> return (SV.Unsat stats, stats, Nothing)
@@ -755,18 +765,16 @@ w4_unint_yices :: [String] -> ProofScript SV.SatResult
 w4_unint_yices = wrapProver . Prover.proveWhat4_yices
 
 proveWithExporter ::
-  (SharedContext -> FilePath -> Term -> IO ()) ->
+  (SharedContext -> FilePath -> Prop -> IO ()) ->
   String ->
   String ->
   ProofScript SV.SatResult
 proveWithExporter exporter path ext =
-  withFirstGoal $ \g -> do
-    let file = path ++ "." ++ goalType g ++ show (goalNum g) ++ ext
-
-    sc <- SV.getSharedContext
-    stats <- io $ Prover.proveWithExporter exporter file sc (goalTerm g)
-
-    return (SV.Unsat stats, stats, Nothing)
+  withFirstGoal $ \g ->
+  do let file = path ++ "." ++ goalType g ++ show (goalNum g) ++ ext
+     sc <- SV.getSharedContext
+     stats <- io $ Prover.proveWithExporter exporter file sc (goalProp g)
+     return (SV.Unsat stats, stats, Nothing)
 
 offline_aig :: FilePath -> ProofScript SV.SatResult
 offline_aig path = do
@@ -779,7 +787,7 @@ offline_cnf path = do
   proveWithExporter (Prover.adaptExporter (Prover.writeCNF proxy)) path ".cnf"
 
 offline_extcore :: FilePath -> ProofScript SV.SatResult
-offline_extcore path = proveWithExporter (const Prover.writeCore) path ".extcore"
+offline_extcore path = proveWithExporter (const Prover.writeCoreProp) path ".extcore"
 
 offline_smtlib2 :: FilePath -> ProofScript SV.SatResult
 offline_smtlib2 path = proveWithExporter Prover.writeSMTLib2 path ".smt2"
@@ -911,14 +919,13 @@ beta_reduce_term (TypedTerm schema t) = do
   return (TypedTerm schema t')
 
 addsimp :: Theorem -> Simpset -> Simpset
-addsimp (Theorem t) ss = addRule (ruleOfProp t) ss
+addsimp (Theorem (Prop t)) ss = addRule (ruleOfProp t) ss
 
 addsimp' :: Term -> Simpset -> Simpset
 addsimp' t ss = addRule (ruleOfProp t) ss
 
 addsimps :: [Theorem] -> Simpset -> Simpset
-addsimps thms ss =
-  foldr (\thm -> addRule (ruleOfProp (thmTerm thm))) ss thms
+addsimps thms ss = foldr addsimp ss thms
 
 addsimps' :: [Term] -> Simpset -> Simpset
 addsimps' ts ss = foldr (\t -> addRule (ruleOfProp t)) ss ts
@@ -942,7 +949,7 @@ check_goal =
   StateT $ \(ProofState goals concl stats timeout) ->
   case goals of
     [] -> fail "ProofScript failed: no subgoal"
-    (ProofGoal _num _ty _name prop) : _ ->
+    (ProofGoal _num _ty _name (Prop prop)) : _ ->
       do check_term prop
          return ((), ProofState goals concl stats timeout)
 
@@ -1237,27 +1244,27 @@ parse_core input = do
   io $ mkTypedTerm sc t
 
 prove_core :: ProofScript SV.SatResult -> String -> TopLevel Theorem
-prove_core script input = do
-  t <- parseCore input
-  (r', pstate) <- runStateT script (startProof (ProofGoal 0 "prove" "prove" t))
-  let r = SV.flipSatResult r'
-  opts <- rwPPOpts <$> getTopLevelRW
-  case finishProof pstate of
-    (_,Just thm) -> return thm
-    (_,Nothing)  -> fail $ "prove_core: " ++ show (length (psGoals pstate)) ++ " unsolved subgoal(s)\n"
-                      ++ SV.showsProofResult opts r ""
+prove_core script input =
+  do t <- parseCore input
+     (r', pstate) <- runStateT script (startProof (ProofGoal 0 "prove" "prove" (Prop t)))
+     let r = SV.flipSatResult r'
+     opts <- rwPPOpts <$> getTopLevelRW
+     case finishProof pstate of
+       (_,Just thm) -> return thm
+       (_,Nothing)  -> fail $ "prove_core: " ++ show (length (psGoals pstate)) ++ " unsolved subgoal(s)\n"
+                         ++ SV.showsProofResult opts r ""
 
 core_axiom :: String -> TopLevel Theorem
-core_axiom input = do
-  t <- parseCore input
-  return (Theorem t)
+core_axiom input =
+  do t <- parseCore input
+     return (Theorem (Prop t))
 
 core_thm :: String -> TopLevel Theorem
 core_thm input =
   do t <- parseCore input
      sc <- getSharedContext
      ty <- io $ scTypeOf sc t
-     return (Theorem ty)
+     return (Theorem (Prop ty))
 
 get_opt :: Int -> TopLevel String
 get_opt n = do

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -942,7 +942,7 @@ check_goal =
   StateT $ \(ProofState goals concl stats timeout) ->
   case goals of
     [] -> fail "ProofScript failed: no subgoal"
-    (ProofGoal _num _ty _name prop) : gs ->
+    (ProofGoal _num _ty _name prop) : _ ->
       do check_term prop
          return ((), ProofState goals concl stats timeout)
 

--- a/src/SAWScript/Crucible/JVM/Builtins.hs
+++ b/src/SAWScript/Crucible/JVM/Builtins.hs
@@ -275,7 +275,7 @@ verifyObligations cc mspec tactic assumes asserts =
        goal   <- io $ scImplies sc assume assert
        goal'  <- io $ scGeneralizeExts sc (getAllExts goal) =<< scEqTrue sc goal
        let goalname = concat [nm, " (", takeWhile (/= '\n') msg, ")"]
-           proofgoal = ProofGoal n "vc" goalname goal'
+           proofgoal = ProofGoal n "vc" goalname (Prop goal')
        r      <- evalStateT tactic (startProof proofgoal)
        case r of
          Unsat stats -> return stats

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -401,7 +401,7 @@ verifyObligations cc mspec tactic assumes asserts = do
     goal   <- io $ scImplies sc assume assert
     goal'  <- io $ scGeneralizeExts sc (getAllExts goal) =<< scEqTrue sc goal
     let goalname = concat [nm, " (", takeWhile (/= '\n') msg, ")"]
-        proofgoal = ProofGoal n "vc" goalname goal'
+        proofgoal = ProofGoal n "vc" goalname (Prop goal')
     r <- evalStateT tactic (startProof proofgoal)
     case r of
       Unsat stats -> return stats

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1099,78 +1099,78 @@ primitives = Map.fromList
     ]
 
   , prim "abc"                 "ProofScript SatResult"
-    (pureVal satABC)
+    (pureVal proveABC)
     Current
     [ "Use the ABC theorem prover to prove the current goal." ]
 
   , prim "boolector"           "ProofScript SatResult"
-    (pureVal satBoolector)
+    (pureVal proveBoolector)
     Current
     [ "Use the Boolector theorem prover to prove the current goal." ]
 
   , prim "cvc4"                "ProofScript SatResult"
-    (pureVal satCVC4)
+    (pureVal proveCVC4)
     Current
     [ "Use the CVC4 theorem prover to prove the current goal." ]
 
   , prim "z3"                  "ProofScript SatResult"
-    (pureVal satZ3)
+    (pureVal proveZ3)
     Current
     [ "Use the Z3 theorem prover to prove the current goal." ]
 
   , prim "mathsat"             "ProofScript SatResult"
-    (pureVal satMathSAT)
+    (pureVal proveMathSAT)
     Current
     [ "Use the MathSAT theorem prover to prove the current goal." ]
 
   , prim "yices"               "ProofScript SatResult"
-    (pureVal satYices)
+    (pureVal proveYices)
     Current
     [ "Use the Yices theorem prover to prove the current goal." ]
 
   , prim "unint_z3"            "[String] -> ProofScript SatResult"
-    (pureVal satUnintZ3)
+    (pureVal proveUnintZ3)
     Current
     [ "Use the Z3 theorem prover to prove the current goal. Leave the"
     , "given list of names, as defined with 'define', as uninterpreted."
     ]
 
   , prim "unint_cvc4"            "[String] -> ProofScript SatResult"
-    (pureVal satUnintCVC4)
+    (pureVal proveUnintCVC4)
     Current
     [ "Use the CVC4 theorem prover to prove the current goal. Leave the"
     , "given list of names, as defined with 'define', as uninterpreted."
     ]
 
   , prim "unint_yices"           "[String] -> ProofScript SatResult"
-    (pureVal satUnintYices)
+    (pureVal proveUnintYices)
     Current
     [ "Use the Yices theorem prover to prove the current goal. Leave the"
     , "given list of names, as defined with 'define', as uninterpreted."
     ]
 
   , prim "offline_aig"         "String -> ProofScript SatResult"
-    (pureVal satAIG)
+    (pureVal offline_aig)
     Current
     [ "Write the current goal to the given file in AIGER format." ]
 
   , prim "offline_cnf"         "String -> ProofScript SatResult"
-    (pureVal satCNF)
+    (pureVal offline_cnf)
     Current
     [ "Write the current goal to the given file in CNF format." ]
 
   , prim "offline_extcore"     "String -> ProofScript SatResult"
-    (pureVal satExtCore)
+    (pureVal offline_extcore)
     Current
     [ "Write the current goal to the given file in SAWCore format." ]
 
   , prim "offline_smtlib2"     "String -> ProofScript SatResult"
-    (pureVal satSMTLib2)
+    (pureVal offline_smtlib2)
     Current
     [ "Write the current goal to the given file in SMT-Lib2 format." ]
 
   , prim "offline_unint_smtlib2"  "[String] -> String -> ProofScript SatResult"
-    (pureVal satUnintSMTLib2)
+    (pureVal offline_unint_smtlib2)
     Current
     [ "Write the current goal to the given file in SMT-Lib2 format,"
     , "leaving the listed functions uninterpreted."
@@ -1195,7 +1195,7 @@ primitives = Map.fromList
     , "temporary file holding the AIG version of the formula."]
 
   , prim "rme"                 "ProofScript SatResult"
-    (pureVal satRME)
+    (pureVal proveRME)
     Current
     [ "Prove the current goal by expansion to Reed-Muller Normal Form." ]
 
@@ -1205,26 +1205,26 @@ primitives = Map.fromList
     [ "Succeed only if the proof goal is a literal 'True'." ]
 
   , prim "w4"                  "ProofScript SatResult"
-    (pureVal satWhat4_Z3)
+    (pureVal w4_z3)
     Current
     [ "Prove the current goal using What4 (Z3 backend)." ]
 
   , prim "w4_unint_z3"         "[String] -> ProofScript SatResult"
-    (pureVal satWhat4_UnintZ3)
+    (pureVal w4_unint_z3)
     Current
     [ "Prove the current goal using What4 (Z3 backend). Leave the"
     , "given list of names, as defined with 'define', as uninterpreted."
     ]
 
   , prim "w4_unint_yices"         "[String] -> ProofScript SatResult"
-    (pureVal satWhat4_UnintYices)
+    (pureVal w4_unint_yices)
     Current
     [ "Prove the current goal using What4 (Yices backend). Leave the"
     , "given list of names, as defined with 'define', as uninterpreted."
     ]
 
   , prim "w4_unint_cvc4"         "[String] -> ProofScript SatResult"
-    (pureVal satWhat4_UnintCVC4)
+    (pureVal w4_unint_cvc4)
     Current
     [ "Prove the current goal using What4 (CVC4 backend). Leave the"
     , "given list of names, as defined with 'define', as uninterpreted."

--- a/src/SAWScript/JavaBuiltins.hs
+++ b/src/SAWScript/JavaBuiltins.hs
@@ -251,7 +251,7 @@ verifyJava bic opts cls mname overrides setup = do
               let exts = getAllExts g
               gprop <- io $ scGeneralizeExts jsc exts =<< scEqTrue jsc g
               io $ doExtraChecks opts bsc gprop
-              let goal = ProofGoal n "vc" (vsVCName vs) gprop
+              let goal = ProofGoal n "vc" (vsVCName vs) (Prop gprop)
               r <- evalStateT script (startProof goal)
               case r of
                 SS.Unsat _ -> liftIO $ printOutLn opts Debug "Valid."

--- a/src/SAWScript/Proof.hs
+++ b/src/SAWScript/Proof.hs
@@ -11,19 +11,24 @@ import Verifier.SAW.Recognizer
 import Verifier.SAW.SharedTerm
 import SAWScript.Prover.SolverStats
 
--- | A theorem must contain a boolean term, possibly surrounded by one
--- or more lambdas which are interpreted as universal quantifiers.
-data Theorem = Theorem { thmTerm :: Term }
+-- | A proposition is a saw-core type (i.e. a term of type @sort n@
+-- for some @n@). In particular, this includes any pi type whose
+-- result type is a proposition. The argument of a pi type represents
+-- a universally quantified variable.
+newtype Prop = Prop { unProp :: Term }
 
--- | A ProofGoal is a term of type @sort n@, or a pi type of any arity
--- with a @sort n@ result type. The abstracted arguments are treated
--- as universally quantified.
+-- | A theorem is a proposition which has been wrapped in a
+-- constructor indicating that it has already been proved.
+data Theorem = Theorem { thmProp :: Prop }
+
+-- | A @ProofGoal@ contains a proposition to be proved, along with
+-- some metadata.
 data ProofGoal =
   ProofGoal
   { goalNum  :: Int
   , goalType :: String
   , goalName :: String
-  , goalTerm :: Term
+  , goalProp :: Prop
   }
 
 data Quantification = Existential | Universal
@@ -49,12 +54,12 @@ makeProofGoal sc quant gnum gtype gname t =
 -- | Convert a term with a function type of any arity into a pi type.
 -- Negate the term if the result type is @Bool@ and the quantification
 -- is 'Existential'.
-predicateToProp :: SharedContext -> Quantification -> [Term] -> Term -> IO Term
+predicateToProp :: SharedContext -> Quantification -> [Term] -> Term -> IO Prop
 predicateToProp sc quant env t =
   case asLambda t of
     Just (x, ty, body) ->
-      do body' <- predicateToProp sc quant (ty : env) body
-         scPi sc x ty body'
+      do Prop body' <- predicateToProp sc quant (ty : env) body
+         Prop <$> scPi sc x ty body'
     Nothing ->
       do (argTs, resT) <- asPiList <$> scTypeOf' sc env t
          let toPi [] t0 =
@@ -69,14 +74,14 @@ predicateToProp sc quant env t =
                   t2 <- scApply sc t1 =<< scLocalVar sc 0
                   t3 <- toPi tys t2
                   scPi sc x xT t3
-         toPi argTs t
+         Prop <$> toPi argTs t
 
 -- | Turn a pi type with an @EqTrue@ result into a lambda term with a
 -- boolean result type. This function exists to interface the new
 -- pi-type proof goals with older proof tactic implementations that
 -- expect the old lambda-term representation.
-propToPredicate :: SharedContext -> Term -> IO Term
-propToPredicate sc goal =
+propToPredicate :: SharedContext -> Prop -> IO Term
+propToPredicate sc (Prop goal) =
   do let (args, t1) = asPiList goal
      t2 <- asEqTrue t1
      scLambdaList sc args t2
@@ -97,5 +102,5 @@ startProof g = ProofState [g] g mempty Nothing
 finishProof :: ProofState -> (SolverStats, Maybe Theorem)
 finishProof (ProofState gs concl stats _) =
   case gs of
-    []    -> (stats, Just (Theorem (goalTerm concl)))
+    []    -> (stats, Just (Theorem (goalProp concl)))
     _ : _ -> (stats, Nothing)

--- a/src/SAWScript/Prover/ABC.hs
+++ b/src/SAWScript/Prover/ABC.hs
@@ -1,4 +1,4 @@
-module SAWScript.Prover.ABC (satABC) where
+module SAWScript.Prover.ABC (proveABC) where
 
 
 import qualified Data.AIG as AIG
@@ -15,15 +15,14 @@ import SAWScript.SAWCorePrimitives( bitblastPrimitives )
 import SAWScript.Prover.Util
          (liftCexBB, bindAllExts, checkBooleanSchema)
 
--- | Bit-blast a @Term@ representing a theorem and check its
--- satisfiability using ABC.
-satABC ::
+-- | Bit-blast a proposition and check its validity using ABC.
+proveABC ::
   (AIG.IsAIG l g) =>
   AIG.Proxy l g ->
   SharedContext ->
   Term ->
   IO (Maybe [(String,FirstOrderValue)], SolverStats)
-satABC proxy sc goal =
+proveABC proxy sc goal =
   do t0 <- propToPredicate sc goal
      TypedTerm schema t <-
         (bindAllExts sc t0 >>= rewriteEqs sc >>= mkTypedTerm sc)

--- a/src/SAWScript/Prover/ABC.hs
+++ b/src/SAWScript/Prover/ABC.hs
@@ -8,7 +8,7 @@ import           Verifier.SAW.TypedTerm
 import           Verifier.SAW.FiniteValue
 import qualified Verifier.SAW.Simulator.BitBlast as BBSim
 
-import SAWScript.Proof(propToPredicate)
+import SAWScript.Proof(Prop, propToPredicate)
 import SAWScript.Prover.SolverStats (SolverStats, solverStats)
 import SAWScript.Prover.Rewrite(rewriteEqs)
 import SAWScript.SAWCorePrimitives( bitblastPrimitives )
@@ -20,8 +20,8 @@ proveABC ::
   (AIG.IsAIG l g) =>
   AIG.Proxy l g ->
   SharedContext ->
-  Term ->
-  IO (Maybe [(String,FirstOrderValue)], SolverStats)
+  Prop ->
+  IO (Maybe [(String, FirstOrderValue)], SolverStats)
 proveABC proxy sc goal =
   do t0 <- propToPredicate sc goal
      TypedTerm schema t <-

--- a/src/SAWScript/Prover/Exporter.hs
+++ b/src/SAWScript/Prover/Exporter.hs
@@ -14,6 +14,7 @@ module SAWScript.Prover.Exporter
   , write_smtlib2
   , writeUnintSMTLib2
   , writeCore
+  , writeCoreProp
 
     -- * Misc
   , bitblastPrim
@@ -36,7 +37,7 @@ import qualified Verifier.SAW.Simulator.BitBlast as BBSim
 
 
 import SAWScript.SAWCorePrimitives( bitblastPrimitives )
-import SAWScript.Proof (predicateToProp, Quantification(..))
+import SAWScript.Proof (Prop(..), predicateToProp, Quantification(..))
 import SAWScript.Prover.SolverStats
 import SAWScript.Prover.Rewrite
 import SAWScript.Prover.Util
@@ -45,25 +46,25 @@ import SAWScript.Value
 
 
 proveWithExporter ::
-  (SharedContext -> FilePath -> Term -> IO ()) ->
+  (SharedContext -> FilePath -> Prop -> IO ()) ->
   String ->
   SharedContext ->
-  Term ->
+  Prop ->
   IO SolverStats
 proveWithExporter exporter path sc goal =
   do exporter sc path goal
-     let stats = solverStats ("offline: "++ path) (scSharedSize goal)
+     let stats = solverStats ("offline: "++ path) (scSharedSize (unProp goal))
      return stats
 
 -- | Converts an old-style exporter (which expects to take a predicate
 -- as an argument) into a new-style one (which takes a pi-type proposition).
 adaptExporter ::
   (SharedContext -> FilePath -> Term -> IO ()) ->
-  (SharedContext -> FilePath -> Term -> IO ())
-adaptExporter exporter sc path goal =
+  (SharedContext -> FilePath -> Prop -> IO ())
+adaptExporter exporter sc path (Prop goal) =
   do let (args, concl) = asPiList goal
      p <- asEqTrue concl
-     p' <- scNot sc p
+     p' <- scNot sc p -- is this right?
      t <- scLambdaList sc args p'
      exporter sc path t
 
@@ -148,9 +149,9 @@ write_cnf sc f (TypedTerm schema t) = do
   AIGProxy proxy <- getProxy
   io $ writeCNF proxy sc f t
 
--- | Write a @Term@ representing a theorem to an SMT-Lib version
--- 2 file.
-writeSMTLib2 :: SharedContext -> FilePath -> Term -> IO ()
+-- | Write a proposition to an SMT-Lib version 2 file.
+-- TODO: say something about convention for negation
+writeSMTLib2 :: SharedContext -> FilePath -> Prop -> IO ()
 writeSMTLib2 sc f t = writeUnintSMTLib2 [] sc f t
 
 -- | Write a @Term@ representing a predicate (i.e. a monomorphic
@@ -161,17 +162,20 @@ write_smtlib2 sc f (TypedTerm schema t) = do
   p <- predicateToProp sc Universal [] t
   writeSMTLib2 sc f p
 
--- | Write a @Term@ representing a theorem to an SMT-Lib version
--- 2 file, treating some constants as uninterpreted.
-writeUnintSMTLib2 :: [String] -> SharedContext -> FilePath -> Term -> IO ()
-writeUnintSMTLib2 unints sc f t = do
-  (_, _, l) <- prepSBV sc unints t
-  let isSat = False -- term is a proof goal with universally-quantified variables
-  txt <- SBV.generateSMTBenchmark isSat l
-  writeFile f txt
+-- | Write a proposition to an SMT-Lib version 2 file, treating some
+-- constants as uninterpreted.
+writeUnintSMTLib2 :: [String] -> SharedContext -> FilePath -> Prop -> IO ()
+writeUnintSMTLib2 unints sc f t =
+  do (_, _, l) <- prepSBV sc unints t
+     let isSat = False -- term is a proof goal with universally-quantified variables
+     txt <- SBV.generateSMTBenchmark isSat l
+     writeFile f txt
 
 writeCore :: FilePath -> Term -> IO ()
 writeCore path t = writeFile path (scWriteExternal t)
+
+writeCoreProp :: FilePath -> Prop -> IO ()
+writeCoreProp path (Prop t) = writeFile path (scWriteExternal t)
 
 
 -- | Tranlsate a SAWCore term into an AIG
@@ -186,5 +190,3 @@ bitblastPrim proxy sc t = do
 -}
   BBSim.withBitBlastedTerm proxy sc bitblastPrimitives t' $ \be ls -> do
     return (AIG.Network be (toList ls))
-
-

--- a/src/SAWScript/Prover/Exporter.hs
+++ b/src/SAWScript/Prover/Exporter.hs
@@ -1,6 +1,6 @@
 {-# Language ViewPatterns #-}
 module SAWScript.Prover.Exporter
-  ( satWithExporter
+  ( proveWithExporter
   , adaptExporter
 
     -- * External formats
@@ -44,13 +44,13 @@ import SAWScript.Prover.SBV(prepSBV)
 import SAWScript.Value
 
 
-satWithExporter ::
+proveWithExporter ::
   (SharedContext -> FilePath -> Term -> IO ()) ->
   String ->
   SharedContext ->
   Term ->
   IO SolverStats
-satWithExporter exporter path sc goal =
+proveWithExporter exporter path sc goal =
   do exporter sc path goal
      let stats = solverStats ("offline: "++ path) (scSharedSize goal)
      return stats

--- a/src/SAWScript/Prover/Exporter.hs
+++ b/src/SAWScript/Prover/Exporter.hs
@@ -41,7 +41,7 @@ import SAWScript.Proof (Prop(..), predicateToProp, Quantification(..))
 import SAWScript.Prover.SolverStats
 import SAWScript.Prover.Rewrite
 import SAWScript.Prover.Util
-import SAWScript.Prover.SBV(prepSBV)
+import SAWScript.Prover.SBV (prepNegatedSBV)
 import SAWScript.Value
 
 
@@ -166,8 +166,8 @@ write_smtlib2 sc f (TypedTerm schema t) = do
 -- constants as uninterpreted.
 writeUnintSMTLib2 :: [String] -> SharedContext -> FilePath -> Prop -> IO ()
 writeUnintSMTLib2 unints sc f t =
-  do (_, _, l) <- prepSBV sc unints t
-     let isSat = False -- term is a proof goal with universally-quantified variables
+  do (_, _, l) <- prepNegatedSBV sc unints t
+     let isSat = True -- l is encoded as an existential formula
      txt <- SBV.generateSMTBenchmark isSat l
      writeFile f txt
 

--- a/src/SAWScript/Prover/MRSolver.hs
+++ b/src/SAWScript/Prover/MRSolver.hs
@@ -21,6 +21,7 @@ import Verifier.SAW.Term.Functor
 import Verifier.SAW.SharedTerm
 import Verifier.SAW.Recognizer
 
+import SAWScript.Proof (Prop(..))
 import qualified SAWScript.Prover.SBV as SBV
 
 import Prelude
@@ -268,7 +269,7 @@ liftSC1 f a = (mrSC <$> get) >>= \sc -> liftIO (f sc a)
 liftSC2 :: (SharedContext -> a -> b -> IO c) -> a -> b -> MRM c
 liftSC2 f a b = (mrSC <$> get) >>= \sc -> liftIO (f sc a b)
 
--- | Lift a trinary SharedTerm computation into 'MRM'
+-- | Lift a ternary SharedTerm computation into 'MRM'
 liftSC3 :: (SharedContext -> a -> b -> c -> IO d) -> a -> b -> c -> MRM d
 liftSC3 f a b c = (mrSC <$> get) >>= \sc -> liftIO (f sc a b c)
 
@@ -280,7 +281,7 @@ mrProvable bool_prop =
      path_prop <- mrPathCondition <$> get
      bool_prop' <- liftSC2 scImplies path_prop bool_prop
      prop <- liftSC1 scEqTrue bool_prop'
-     (smt_res, _) <- liftSC1 (SBV.proveUnintSBV smt_conf [] timeout) prop
+     (smt_res, _) <- liftSC1 (SBV.proveUnintSBV smt_conf [] timeout) (Prop prop)
      case smt_res of
        Just _ -> return False
        Nothing -> return True

--- a/src/SAWScript/Prover/MRSolver.hs
+++ b/src/SAWScript/Prover/MRSolver.hs
@@ -280,7 +280,7 @@ mrProvable bool_prop =
      path_prop <- mrPathCondition <$> get
      bool_prop' <- liftSC2 scImplies path_prop bool_prop
      prop <- liftSC1 scEqTrue bool_prop'
-     (smt_res, _) <- liftSC1 (SBV.satUnintSBV smt_conf [] timeout) prop
+     (smt_res, _) <- liftSC1 (SBV.proveUnintSBV smt_conf [] timeout) prop
      case smt_res of
        Just _ -> return False
        Nothing -> return True

--- a/src/SAWScript/Prover/RME.hs
+++ b/src/SAWScript/Prover/RME.hs
@@ -15,11 +15,12 @@ import SAWScript.Prover.Rewrite(rewriteEqs)
 import SAWScript.Prover.SolverStats
 import SAWScript.Prover.Util
 
-satRME ::
+-- | Bit-blast a proposition and check its validity using RME.
+proveRME ::
   SharedContext {- ^ Context for working with terms -} ->
   Term          {- ^ A boolean term to be proved/checked. -} ->
   IO (Maybe [(String,FirstOrderValue)], SolverStats)
-satRME sc goal =
+proveRME sc goal =
   do t0 <- propToPredicate sc goal
      TypedTerm schema t <-
         bindAllExts sc t0 >>= rewriteEqs sc >>= mkTypedTerm sc

--- a/src/SAWScript/Prover/RME.hs
+++ b/src/SAWScript/Prover/RME.hs
@@ -10,7 +10,7 @@ import qualified Verifier.SAW.Simulator.RME.Base as RME
 import Verifier.SAW.TypedTerm(TypedTerm(..), mkTypedTerm)
 import Verifier.SAW.Recognizer(asPiList)
 
-import SAWScript.Proof(propToPredicate)
+import SAWScript.Proof(Prop, propToPredicate)
 import SAWScript.Prover.Rewrite(rewriteEqs)
 import SAWScript.Prover.SolverStats
 import SAWScript.Prover.Util
@@ -18,8 +18,8 @@ import SAWScript.Prover.Util
 -- | Bit-blast a proposition and check its validity using RME.
 proveRME ::
   SharedContext {- ^ Context for working with terms -} ->
-  Term          {- ^ A boolean term to be proved/checked. -} ->
-  IO (Maybe [(String,FirstOrderValue)], SolverStats)
+  Prop          {- ^ A proposition to be proved -} ->
+  IO (Maybe [(String, FirstOrderValue)], SolverStats)
 proveRME sc goal =
   do t0 <- propToPredicate sc goal
      TypedTerm schema t <-

--- a/src/SAWScript/Prover/SBV.hs
+++ b/src/SAWScript/Prover/SBV.hs
@@ -23,7 +23,7 @@ import Verifier.SAW.Recognizer(asPi, asPiList)
 import Verifier.SAW.Cryptol.Prims (sbvPrims)
 
 
-import SAWScript.Proof(propToPredicate)
+import SAWScript.Proof(Prop, propToPredicate)
 import SAWScript.Prover.SolverStats
 import SAWScript.Prover.Rewrite(rewriteEqs)
 import SAWScript.Prover.Util(checkBooleanSchema)
@@ -38,8 +38,8 @@ proveUnintSBV ::
   [String]      {- ^ Uninterpreted functions -} ->
   Maybe Integer {- ^ Timeout in milliseconds -} ->
   SharedContext {- ^ Context for working with terms -} ->
-  Term          {- ^ A proposition to be proved/checked. -} ->
-  IO (Maybe [(String,FirstOrderValue)], SolverStats)
+  Prop          {- ^ A proposition to be proved -} ->
+  IO (Maybe [(String, FirstOrderValue)], SolverStats)
     -- ^ (example/counter-example, solver statistics)
 proveUnintSBV conf unints timeout sc term =
   do (t', mlabels, lit0) <- prepSBV sc unints term
@@ -74,7 +74,7 @@ proveUnintSBV conf unints timeout sc term =
 
 
 prepSBV ::
-  SharedContext -> [String] -> Term ->
+  SharedContext -> [String] -> Prop ->
   IO (Term, [Maybe SBVSim.Labeler], SBV.Symbolic SBV.SVal)
 prepSBV sc unints goal =
   do t0 <- propToPredicate sc goal

--- a/src/SAWScript/Prover/SBV.hs
+++ b/src/SAWScript/Prover/SBV.hs
@@ -1,5 +1,5 @@
 module SAWScript.Prover.SBV
-  ( satUnintSBV
+  ( proveUnintSBV
   , SBV.SMTConfig
   , SBV.z3, SBV.cvc4, SBV.yices, SBV.mathSAT, SBV.boolector
   , prepSBV
@@ -30,10 +30,10 @@ import SAWScript.Prover.Util(checkBooleanSchema)
 
 
 
--- | Bit-blast a @Term@ representing a theorem and check its
--- satisfiability using SBV.
--- Constants with names in @unints@ are kept as uninterpreted functions.
-satUnintSBV ::
+-- | Bit-blast a proposition and check its validity using SBV.
+-- Constants with names in @unints@ are kept as uninterpreted
+-- functions.
+proveUnintSBV ::
   SBV.SMTConfig {- ^ SBV configuration -} ->
   [String]      {- ^ Uninterpreted functions -} ->
   Maybe Integer {- ^ Timeout in milliseconds -} ->
@@ -41,7 +41,7 @@ satUnintSBV ::
   Term          {- ^ A proposition to be proved/checked. -} ->
   IO (Maybe [(String,FirstOrderValue)], SolverStats)
     -- ^ (example/counter-example, solver statistics)
-satUnintSBV conf unints timeout sc term =
+proveUnintSBV conf unints timeout sc term =
   do (t', mlabels, lit0) <- prepSBV sc unints term
 
      let lit = liftM SBV.svNot lit0

--- a/src/SAWScript/Prover/What4.hs
+++ b/src/SAWScript/Prover/What4.hs
@@ -41,36 +41,37 @@ import qualified What4.Expr.Builder as B
 -- trivial state
 data St t = St
 
-satWhat4_sym :: SolverAdapter St
-             -> [String]
-             -> SharedContext
-             -> Term
-             -> IO (Maybe [(String, FirstOrderValue)], SolverStats)
-satWhat4_sym solver un sc t = do
-  -- TODO: get rid of GlobalNonceGenerator ???
-  sym <- B.newExprBuilder B.FloatRealRepr St globalNonceGenerator
-  satWhat4_solver solver sym un sc t
+proveWhat4_sym ::
+  SolverAdapter St ->
+  [String] ->
+  SharedContext ->
+  Term ->
+  IO (Maybe [(String, FirstOrderValue)], SolverStats)
+proveWhat4_sym solver un sc t =
+  do -- TODO: get rid of GlobalNonceGenerator ???
+     sym <- B.newExprBuilder B.FloatRealRepr St globalNonceGenerator
+     proveWhat4_solver solver sym un sc t
 
 
-satWhat4_z3, satWhat4_boolector, satWhat4_cvc4,
-  satWhat4_dreal, satWhat4_stp, satWhat4_yices ::
+proveWhat4_z3, proveWhat4_boolector, proveWhat4_cvc4,
+  proveWhat4_dreal, proveWhat4_stp, proveWhat4_yices ::
   [String]      {- ^ Uninterpreted functions -} ->
   SharedContext {- ^ Context for working with terms -} ->
   Term          {- ^ A boolean term to be proved/checked. -} ->
   IO (Maybe [(String,FirstOrderValue)], SolverStats)
 
-satWhat4_z3        = satWhat4_sym z3Adapter
-satWhat4_boolector = satWhat4_sym boolectorAdapter
-satWhat4_cvc4      = satWhat4_sym cvc4Adapter
-satWhat4_dreal     = satWhat4_sym drealAdapter
-satWhat4_stp       = satWhat4_sym stpAdapter
-satWhat4_yices     = satWhat4_sym yicesAdapter
+proveWhat4_z3        = proveWhat4_sym z3Adapter
+proveWhat4_boolector = proveWhat4_sym boolectorAdapter
+proveWhat4_cvc4      = proveWhat4_sym cvc4Adapter
+proveWhat4_dreal     = proveWhat4_sym drealAdapter
+proveWhat4_stp       = proveWhat4_sym stpAdapter
+proveWhat4_yices     = proveWhat4_sym yicesAdapter
 
 
 
 
--- | Check the satisfiability of a theorem using What4.
-satWhat4_solver :: forall st t ff.
+-- | Check the validity of a proposition using What4.
+proveWhat4_solver :: forall st t ff.
   SolverAdapter st   {- ^ Which solver to use -} ->
   B.ExprBuilder t st ff {- ^ The glorious sym -}  ->
   [String]           {- ^ Uninterpreted functions -} ->
@@ -78,7 +79,7 @@ satWhat4_solver :: forall st t ff.
   Term               {- ^ A proposition to be proved/checked. -} ->
   IO (Maybe [(String,FirstOrderValue)], SolverStats)
   -- ^ (example/counter-example, solver statistics)
-satWhat4_solver solver sym unints sc goal =
+proveWhat4_solver solver sym unints sc goal =
 
   do
      -- convert goal to lambda term

--- a/src/SAWScript/Prover/What4.hs
+++ b/src/SAWScript/Prover/What4.hs
@@ -16,7 +16,7 @@ import Verifier.SAW.FiniteValue
 import Verifier.SAW.TypedTerm(TypedTerm(..), mkTypedTerm)
 import Verifier.SAW.Recognizer(asPi)
 
-import           SAWScript.Proof(propToPredicate)
+import           SAWScript.Proof(Prop, propToPredicate)
 import           SAWScript.Prover.Rewrite(rewriteEqs)
 import           SAWScript.Prover.SolverStats
 import           SAWScript.Prover.Util
@@ -45,7 +45,7 @@ proveWhat4_sym ::
   SolverAdapter St ->
   [String] ->
   SharedContext ->
-  Term ->
+  Prop ->
   IO (Maybe [(String, FirstOrderValue)], SolverStats)
 proveWhat4_sym solver un sc t =
   do -- TODO: get rid of GlobalNonceGenerator ???
@@ -57,8 +57,8 @@ proveWhat4_z3, proveWhat4_boolector, proveWhat4_cvc4,
   proveWhat4_dreal, proveWhat4_stp, proveWhat4_yices ::
   [String]      {- ^ Uninterpreted functions -} ->
   SharedContext {- ^ Context for working with terms -} ->
-  Term          {- ^ A boolean term to be proved/checked. -} ->
-  IO (Maybe [(String,FirstOrderValue)], SolverStats)
+  Prop          {- ^ A proposition to be proved -} ->
+  IO (Maybe [(String, FirstOrderValue)], SolverStats)
 
 proveWhat4_z3        = proveWhat4_sym z3Adapter
 proveWhat4_boolector = proveWhat4_sym boolectorAdapter
@@ -76,8 +76,8 @@ proveWhat4_solver :: forall st t ff.
   B.ExprBuilder t st ff {- ^ The glorious sym -}  ->
   [String]           {- ^ Uninterpreted functions -} ->
   SharedContext      {- ^ Context for working with terms -} ->
-  Term               {- ^ A proposition to be proved/checked. -} ->
-  IO (Maybe [(String,FirstOrderValue)], SolverStats)
+  Prop               {- ^ A proposition to be proved/checked. -} ->
+  IO (Maybe [(String, FirstOrderValue)], SolverStats)
   -- ^ (example/counter-example, solver statistics)
 proveWhat4_solver solver sym unints sc goal =
 

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -274,7 +274,7 @@ showsPrecValue opts p v =
     VTopLevel {} -> showString "<<TopLevel>>"
     VSimpset ss -> showString (showSimpset opts ss)
     VProofScript {} -> showString "<<proof script>>"
-    VTheorem (Theorem t) ->
+    VTheorem (Theorem (Prop t)) ->
       showString "Theorem " .
       showParen True (showString (SAWCorePP.scPrettyTerm opts' t))
     VJavaSetup {} -> showString "<<Java Setup>>"

--- a/src/SAWScript/X86.hs
+++ b/src/SAWScript/X86.hs
@@ -124,8 +124,8 @@ import Verifier.SAW.CryptolEnv(CryptolEnv,initCryptolEnv,loadCryptolModule)
 import Verifier.SAW.Cryptol.Prelude(scLoadPreludeModule,scLoadCryptolModule)
 
 -- SAWScript
-import SAWScript.X86Spec
-import SAWScript.Proof(predicateToProp, Quantification(Universal))
+import SAWScript.X86Spec hiding (Prop)
+import SAWScript.Proof(predicateToProp, Quantification(Universal), Prop)
 
 
 
@@ -514,8 +514,8 @@ data Goal = Goal
   , gMessage :: SimErrorReason        -- ^ We should say this if the proof fails
   }
 
--- | The boolean term that needs proving (i.e., assumptions imply conclusion)
-gGoal :: SharedContext -> Goal -> IO Term
+-- | The proposition that needs proving (i.e., assumptions imply conclusion)
+gGoal :: SharedContext -> Goal -> IO Prop
 gGoal sc g0 = predicateToProp sc Universal [] =<< go (gAssumes g)
   where
   g = g0 { gAssumes = mapMaybe skip (gAssumes g0) }


### PR DESCRIPTION
This branch attempts to clean up some of the unclear conventions about how various functions expect `Term` arguments to encode logical propositions. Now we can use type `Prop` to unambiguously indicate that we will encode universal quantification with Pi types, and `EqTrue` to lift booleans to type `sort 0`.

This branch also includes a fix for #613, which is one of those bugs caused by disagreement between conventions for variable quantification and logical negation for prove vs sat.