### PR TITLE
Bump crucible and pass the ?laxArith implicit parameter to Crucible.translateModule.

### DIFF
--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -472,6 +472,7 @@ buildTopLevelEnv proxy opts =
                    , rwPrimsAvail = primsAvail
                    , rwSMTArrayMemoryModel = False
                    , rwProfilingFile = Nothing
+                   , rwLaxArith = False
                    }
        return (bic, ro0, rw0)
 
@@ -510,6 +511,11 @@ enable_crucible_profiling :: FilePath -> TopLevel ()
 enable_crucible_profiling f = do
   rw <- getTopLevelRW
   putTopLevelRW rw { rwProfilingFile = Just f }
+
+enable_lax_arithmetic :: TopLevel ()
+enable_lax_arithmetic = do
+  rw <- getTopLevelRW
+  putTopLevelRW rw { rwLaxArith = True }
 
 disable_crucible_profiling :: TopLevel ()
 disable_crucible_profiling = do
@@ -673,6 +679,11 @@ primitives = Map.fromList
     (pureVal enable_smt_array_memory_model)
     Current
     [ "Enable the SMT array memory model." ]
+
+  , prim "enable_lax_arithmetic" "TopLevel ()"
+    (pureVal enable_lax_arithmetic)
+    Current
+    [ "Enable lax rules for arithmetic overflow in Crucible." ]
 
   , prim "env"                 "TopLevel ()"
     (pureVal envCmd)

--- a/src/SAWScript/LLVMBuiltins.hs
+++ b/src/SAWScript/LLVMBuiltins.hs
@@ -24,6 +24,7 @@ import Control.Applicative hiding (many)
 #endif
 import Data.String
 import Data.Parameterized.Some
+import Control.Monad.State (gets)
 
 import qualified Text.LLVM.AST as LLVM
 import qualified Data.LLVM.BitCode as LLVM
@@ -35,7 +36,9 @@ import qualified SAWScript.Crucible.LLVM.CrucibleLLVM as Crucible (translateModu
 import qualified SAWScript.Crucible.LLVM.MethodSpecIR as CMS (LLVMModule(..))
 
 llvm_load_module :: FilePath -> TopLevel (Some CMS.LLVMModule)
-llvm_load_module file =
+llvm_load_module file = do
+  laxArith <- gets rwLaxArith
+  let ?laxArith = laxArith
   io (LLVM.parseBitCodeFromFile file) >>= \case
     Left err -> fail (LLVM.formatError err)
     Right llvm_mod -> do

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -388,6 +388,7 @@ data TopLevelRW =
   , rwPrimsAvail :: Set PrimitiveLifecycle
   , rwSMTArrayMemoryModel :: Bool
   , rwProfilingFile :: Maybe FilePath
+  , rwLaxArith :: Bool
   }
 
 newtype TopLevel a =


### PR DESCRIPTION
`?laxArith` is false by default, but the top-level command `enable_lax_arithmetic` sets it to true.