### PR TITLE
Fast equality test for `LLVMModule`

### DIFF
--- a/src/SAWScript/Crucible/LLVM/Boilerplate.hs
+++ b/src/SAWScript/Crucible/LLVM/Boilerplate.hs
@@ -400,13 +400,13 @@ bpFunToSpec (BPFun name setup ret as ls deps) = do
 
 llvm_boilerplate_info :: Some LLVMModule -> [Profile] -> TopLevel ()
 llvm_boilerplate_info m profs = liftIO $
-  (try . mapM (mapM typeToBPType) $ extractDefines (viewSome _modAST m) profs) >>=
+  (try . mapM (mapM typeToBPType) $ extractDefines (viewSome modAST m) profs) >>=
     \case Left (BPException e) -> liftIO . Text.IO.hPutStrLn stderr $ "[error] " <> e
           Right funs -> liftIO . Text.IO.putStrLn . Text.pack $ show funs
 
 llvm_boilerplate :: FilePath -> Some LLVMModule -> [Profile] -> TopLevel ()
 llvm_boilerplate path m profs = liftIO $
-  (try . mapM (mapM typeToBPType) $ extractDefines (viewSome _modAST m) profs) >>=
+  (try . mapM (mapM typeToBPType) $ extractDefines (viewSome modAST m) profs) >>=
   \case Left (BPException e) -> liftIO . Text.IO.hPutStrLn stderr $ "[error] " <> e
         Right funs -> liftIO . withFile path WriteMode $ \h -> do
           binds <- mconcat <$> mapM globalBinds globals
@@ -418,7 +418,7 @@ llvm_boilerplate path m profs = liftIO $
           mapM bpFunToSpec funs >>= Text.IO.hPutStrLn h . mconcat
   where
     globals :: [((LLVM.Type, Text, Bool), Text)]
-    globals = zip (extractGlobals $ viewSome _modAST m) $ globalName <$> [0, 1..]
+    globals = zip (extractGlobals $ viewSome modAST m) $ globalName <$> [0, 1..]
       where globalName :: Int -> Text
             globalName i = "global" <> Text.pack (show i)
     globalBinds :: MonadThrow m => ((LLVM.Type, Text, Bool), Text) -> m Text

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -296,8 +296,8 @@ createMethodSpec ::
   TopLevel (MS.CrucibleMethodSpecIR (LLVM arch))
 createMethodSpec verificationArgs asp bic opts lm@(LLVMModule _ _ mtrans) nm setup = do
   (nm', parent) <- resolveSpecName nm
-  let edef = findDefMaybeStatic (lm ^. modAST) nm'
-  let edecl = findDecl (lm ^. modAST) nm'
+  let edef = findDefMaybeStatic (modAST lm) nm'
+  let edecl = findDecl (modAST lm) nm'
   defOrDecls <- case (edef, edecl) of
     (Right defs, _) -> return (NE.map Left defs)
     (_, Right decl) -> return (Right decl NE.:| [])
@@ -343,7 +343,7 @@ createMethodSpec verificationArgs asp bic opts lm@(LLVMModule _ _ mtrans) nm set
 
             -- set up the LLVM memory with a pristine heap
             let globals = cc^.ccLLVMGlobals
-            let mvar = Crucible.llvmMemVar (cc^.ccLLVMContext)
+            let mvar = Crucible.llvmMemVar (ccLLVMContext cc)
             mem0 <- case Crucible.lookupGlobal mvar globals of
               Nothing   -> fail "internal error: LLVM Memory global not found"
               Just mem0 -> return mem0
@@ -354,7 +354,7 @@ createMethodSpec verificationArgs asp bic opts lm@(LLVMModule _ _ mtrans) nm set
                           (Crucible.memImplHeap mem0)
                         }
                       else mem0
-            let globals1 = Crucible.llvmGlobals (cc^.ccLLVMContext) mem
+            let globals1 = Crucible.llvmGlobals (ccLLVMContext cc) mem
 
             -- construct the initial state for verifications
             (args, assumes, env, globals2) <-
@@ -479,12 +479,12 @@ verifyPrestate ::
       Map AllocIndex (LLVMPtr (Crucible.ArchWidth arch)),
       Crucible.SymGlobalState Sym)
 verifyPrestate opts cc mspec globals = do
-  let ?lc = cc^.ccTypeCtx
+  let ?lc = ccTypeCtx cc
   let sym = cc^.ccBackend
   let prestateLoc = W4.mkProgramLoc "_SAW_verify_prestate" W4.InternalPos
   liftIO $ W4.setCurrentProgramLoc sym prestateLoc
 
-  let lvar = Crucible.llvmMemVar (cc^.ccLLVMContext)
+  let lvar = Crucible.llvmMemVar (ccLLVMContext cc)
   let Just mem = Crucible.lookupGlobal lvar globals
 
   -- Allocate LLVM memory for each 'crucible_alloc'
@@ -700,7 +700,7 @@ ppGlobalPair :: LLVMCrucibleContext arch
              -> Crucible.GlobalPair Sym a
              -> Doc
 ppGlobalPair cc gp =
-  let mvar = Crucible.llvmMemVar (cc^.ccLLVMContext)
+  let mvar = Crucible.llvmMemVar (ccLLVMContext cc)
       globals = gp ^. Crucible.gpGlobals in
   case Crucible.lookupGlobal mvar globals of
     Nothing -> text "LLVM Memory global variable not initialized"
@@ -722,7 +722,7 @@ registerOverride opts cc _ctx top_loc cs = do
   sc <- CrucibleSAW.saw_ctx <$> liftIO (readIORef (W4.sbStateManager sym))
   let fstr = (head cs)^.csName
       fsym = L.Symbol fstr
-      llvmctx = cc^.ccLLVMContext
+      llvmctx = ccLLVMContext cc
       matches (Crucible.LLVMHandleInfo _ h) =
         matchingStatics (L.Symbol (Text.unpack (W4.functionName (Crucible.handleName h)))) fsym
   liftIO $
@@ -787,7 +787,7 @@ withCfg
   -> IO a
 withCfg context name k = do
   let function_id = L.Symbol name
-  case Map.lookup function_id (Crucible.cfgMap (context^.ccLLVMModuleTrans)) of
+  case Map.lookup function_id (Crucible.cfgMap (ccLLVMModuleTrans context)) of
     Just (Crucible.AnyCFG cfg) -> k cfg
     Nothing -> fail $ "Unexpected function name: " ++ name
 
@@ -864,7 +864,7 @@ verifySimulate opts cc pfs mspec args assumes top_loc lemmas globals checkSat as
       (registerInvariantOverride opts cc top_loc (HashMap.fromList breakpoints))
       (groupOn (view csName) invLemmas)
 
-    additionalFeatures <- mapM (Crucible.arraySizeProfile (cc ^. ccLLVMContext))
+    additionalFeatures <- mapM (Crucible.arraySizeProfile (ccLLVMContext cc))
                           $ maybeToList asp
 
     let execFeatures = invariantExecFeatures ++
@@ -1160,9 +1160,9 @@ crucible_llvm_extract ::
   String ->
   TopLevel TypedTerm
 crucible_llvm_extract bic opts (Some lm) fn_name = do
-  let ctx = lm ^. modTrans . Crucible.transContext
+  let ctx = modTrans lm ^. Crucible.transContext
   let ?lc = ctx^.Crucible.llvmTypeCtx
-  let edef = findDefMaybeStatic (lm ^. modAST) fn_name
+  let edef = findDefMaybeStatic (modAST lm) fn_name
   case edef of
     Right defs -> do
       let defTypes = fold $
@@ -1174,7 +1174,7 @@ crucible_llvm_extract bic opts (Some lm) fn_name = do
         fail "Type aliases are not supported by `crucible_llvm_extract`."
     Left err -> fail (displayVerifExceptionOpts opts err)
   setupLLVMCrucibleContext bic opts lm $ \cc ->
-    case Map.lookup (fromString fn_name) (Crucible.cfgMap (cc^.ccLLVMModuleTrans)) of
+    case Map.lookup (fromString fn_name) (Crucible.cfgMap (ccLLVMModuleTrans cc)) of
       Nothing  -> fail $ unwords ["function", fn_name, "not found"]
       Just cfg -> io $ extractFromLLVMCFG opts (biSharedContext bic) cc cfg
 
@@ -1185,10 +1185,10 @@ crucible_llvm_cfg ::
   String ->
   TopLevel SAW_CFG
 crucible_llvm_cfg bic opts (Some lm) fn_name = do
-  let ctx = lm ^. modTrans . Crucible.transContext
+  let ctx = modTrans lm ^. Crucible.transContext
   let ?lc = ctx^.Crucible.llvmTypeCtx
   setupLLVMCrucibleContext bic opts lm $ \cc ->
-    case Map.lookup (fromString fn_name) (Crucible.cfgMap (cc^.ccLLVMModuleTrans)) of
+    case Map.lookup (fromString fn_name) (Crucible.cfgMap (ccLLVMModuleTrans cc)) of
       Nothing  -> fail $ unwords ["function", fn_name, "not found"]
       Just cfg -> return (LLVM_CFG cfg)
 
@@ -1332,10 +1332,10 @@ crucible_fresh_var ::
 crucible_fresh_var bic _opts name lty =
   LLVMCrucibleSetupM $
   do cctx <- getLLVMCrucibleContext
-     let ?lc = cctx ^. ccTypeCtx
+     let ?lc = ccTypeCtx cctx
      lty' <- memTypeForLLVMType bic lty
      let sc = biSharedContext bic
-     let dl = Crucible.llvmDataLayout (cctx^.ccTypeCtx)
+     let dl = Crucible.llvmDataLayout (ccTypeCtx cctx)
      case cryptolTypeOfActual dl lty' of
        Nothing -> fail $ "Unsupported type in crucible_fresh_var: " ++ show (L.ppType lty)
        Just cty -> Setup.freshVariable sc name cty
@@ -1354,7 +1354,7 @@ crucible_fresh_expanded_val ::
 crucible_fresh_expanded_val bic _opts lty = LLVMCrucibleSetupM $
   do let sc = biSharedContext bic
      cctx <- getLLVMCrucibleContext
-     let ?lc = cctx ^. ccTypeCtx
+     let ?lc = ccTypeCtx cctx
      lty' <- memTypeForLLVMType bic lty
      loc <- getW4Position "crucible_fresh_expanded_val"
      constructExpandedSetupValue cctx sc loc lty'
@@ -1436,7 +1436,7 @@ crucible_alloc_internal ::
   CrucibleSetup (Crucible.LLVM arch) (AllLLVM SetupValue)
 crucible_alloc_internal _bic _opt lty spec = do
   cctx <- getLLVMCrucibleContext
-  let ?lc = cctx ^. ccTypeCtx
+  let ?lc = ccTypeCtx cctx
   let ?dl = Crucible.llvmDataLayout ?lc
   n <- Setup.csVarCounter <<%= nextAllocIndex
   Setup.currentState . MS.csAllocs . at n ?= spec
@@ -1459,7 +1459,7 @@ crucible_alloc_with_mutability_and_size mut sz bic opts lty = LLVMCrucibleSetupM
   memTy <- memTypeForLLVMType bic lty
 
   let memTySize =
-        let ?lc = cctx ^. ccTypeCtx
+        let ?lc = ccTypeCtx cctx
             ?dl = Crucible.llvmDataLayout ?lc
         in Crucible.memTypeSize ?dl memTy
 
@@ -1537,7 +1537,7 @@ constructFreshPointer ::
   CrucibleSetup (LLVM arch) (AllLLVM SetupValue)
 constructFreshPointer mid loc memTy = do
   cctx <- getLLVMCrucibleContext
-  let ?lc = cctx ^. ccTypeCtx
+  let ?lc = ccTypeCtx cctx
   let ?dl = Crucible.llvmDataLayout ?lc
   n <- Setup.csVarCounter <<%= nextAllocIndex
   let sz = Crucible.memTypeSize ?dl memTy
@@ -1564,8 +1564,8 @@ crucible_points_to typed _bic _opt (getAllLLVM -> ptr) (getAllLLVM -> val) =
   LLVMCrucibleSetupM $
   do cc <- getLLVMCrucibleContext
      loc <- getW4Position "crucible_points_to"
-     Crucible.llvmPtrWidth (cc^.ccLLVMContext) $ \wptr -> Crucible.withPtrWidth wptr $
-       do let ?lc = cc^.ccTypeCtx
+     Crucible.llvmPtrWidth (ccLLVMContext cc) $ \wptr -> Crucible.withPtrWidth wptr $
+       do let ?lc = ccTypeCtx cc
           st <- get
           let rs = st ^. Setup.csResolvedState
           if st ^. Setup.csPrePost == PreState && MS.testResolved ptr [] rs

--- a/src/SAWScript/Crucible/LLVM/MethodSpecIR.hs
+++ b/src/SAWScript/Crucible/LLVM/MethodSpecIR.hs
@@ -29,7 +29,74 @@ Stability   : provisional
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 
-module SAWScript.Crucible.LLVM.MethodSpecIR where
+module SAWScript.Crucible.LLVM.MethodSpecIR
+  ( -- * LLVMMethodId
+    LLVMMethodId(..)
+  , llvmMethodParent
+  , llvmMethodName
+  , csName
+  , csParentName
+    -- * LLVMAllocSpec
+  , LLVMAllocSpec(..)
+  , allocSpecType
+  , allocSpecMut
+  , allocSpecLoc
+  , allocSpecBytes
+  , mutIso
+  , isMut
+    -- * LLVMModule
+  , LLVMModule -- abstract
+  , modFilePath
+  , modAST
+  , modTrans
+  , loadLLVMModule
+  , showLLVMModule
+    -- * CrucibleContext
+  , LLVMCrucibleContext(..)
+  , ccLLVMSimContext
+  , ccLLVMModule
+  , ccLLVMGlobals
+  , ccBasicSS
+  , ccBackend
+  , ccLLVMModuleAST
+  , ccLLVMModuleTrans
+  , ccLLVMContext
+  , ccTypeCtx
+    -- * PointsTo
+  , LLVMPointsTo(..)
+  , ppPointsTo
+    -- * AllocGlobal
+  , LLVMAllocGlobal(..)
+  , ppAllocGlobal
+    -- * Intrinsics
+  , intrinsics
+    -- * Initial CrucibleSetupMethodSpec
+  , SetupError(..)
+  , ppSetupError
+  , resolveArgs
+  , resolveRetTy
+  , initialDefCrucibleMethodSpecIR
+  , initialDeclCrucibleMethodSpecIR
+  , initialCrucibleSetupState
+  , initialCrucibleSetupStateDecl
+    -- * AllLLVM
+  , AllLLVM
+  , mkAllLLVM
+  , getAllLLVM
+  , anySetupTerm
+  , anySetupArray
+  , anySetupStruct
+  , anySetupElem
+  , anySetupField
+  , anySetupNull
+  , anySetupGlobal
+  , anySetupGlobalInitializer
+    -- * SomeLLVM
+  , SomeLLVM
+  , pattern SomeLLVM
+  , mkSomeLLVM
+  , getSomeLLVM
+  ) where
 
 import           Control.Lens
 import           Control.Monad (when)

--- a/src/SAWScript/Crucible/LLVM/MethodSpecIR.hs
+++ b/src/SAWScript/Crucible/LLVM/MethodSpecIR.hs
@@ -216,6 +216,11 @@ data LLVMModule arch =
   , _modAST :: L.Module
   , _modTrans :: CL.ModuleTranslation arch
   }
+-- NOTE: Type 'LLVMModule' is exported as an abstract type, and we
+-- maintain the invariant that the 'FilePath', 'Module', and
+-- 'ModuleTranslation' fields are all consistent with each other;
+-- 'loadLLVMModule' is the only function that is allowed to create
+-- values of type 'LLVMModule'.
 
 -- | The file path that the LLVM module was loaded from.
 modFilePath :: LLVMModule arch -> FilePath

--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -1251,7 +1251,7 @@ invalidateMutableAllocs opts sc cc cs = do
              ]
            )
         ) <$> Map.elems (Map.intersectionWith (,) sub mutableAllocs)
-      LLVMModule _ _ mtrans = cc ^. ccLLVMModule
+      mtrans = ccLLVMModuleTrans cc
       gimap = Crucible.globalInitMap mtrans
       mutableGlobals = cs ^. MS.csGlobalAllocs
 

--- a/src/SAWScript/Crucible/LLVM/ResolveSetupValue.hs
+++ b/src/SAWScript/Crucible/LLVM/ResolveSetupValue.hs
@@ -27,7 +27,6 @@ module SAWScript.Crucible.LLVM.ResolveSetupValue
 
 import Control.Lens
 import Control.Monad
-import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fail (MonadFail)
 import Control.Monad.State
 import Data.Foldable (toList)
@@ -91,7 +90,7 @@ resolveSetupValueInfo cc env nameEnv v =
     -- SetupGlobal g ->
     SetupVar i
       | Just alias <- Map.lookup i nameEnv
-      , let mdMap = Crucible.llvmMetadataMap (cc^.ccTypeCtx)
+      , let mdMap = Crucible.llvmMetadataMap (ccTypeCtx cc)
       -> L.Pointer (guessAliasInfo mdMap alias)
     SetupField () a n ->
        fromMaybe L.Unknown $
@@ -123,7 +122,7 @@ resolveSetupFieldIndex cc env nameEnv v n =
 
     _ -> Nothing
   where
-    lc = cc^.ccTypeCtx
+    lc = ccTypeCtx cc
 
 resolveSetupFieldIndexOrFail ::
   MonadFail m =>
@@ -156,7 +155,7 @@ typeOfSetupValue ::
   SetupValue (Crucible.LLVM arch) ->
   m Crucible.MemType
 typeOfSetupValue cc env nameEnv val =
-  do let ?lc = cc^.ccTypeCtx
+  do let ?lc = ccTypeCtx cc
      typeOfSetupValue' cc env nameEnv val
 
 typeOfSetupValue' :: forall m arch.
@@ -226,7 +225,7 @@ typeOfSetupValue' cc env nameEnv val =
       return (Crucible.PtrType Crucible.VoidType)
     -- A global and its initializer have the same type.
     SetupGlobal () name -> do
-      let m = cc ^. ccLLVMModuleAST
+      let m = ccLLVMModuleAST cc
           tys = [ (L.globalSym g, L.globalType g) | g <- L.modGlobals m ] ++
                 [ (L.decName d, L.decFunType d) | d <- L.modDeclares m ] ++
                 [ (L.defName d, L.defFunType d) | d <- L.modDefines m ]
@@ -240,7 +239,7 @@ typeOfSetupValue' cc env nameEnv val =
                                        ]
             Right symTy -> return (Crucible.PtrType symTy)
     SetupGlobalInitializer () name -> do
-      case Map.lookup (L.Symbol name) (Crucible.globalInitMap $ cc^.ccLLVMModuleTrans) of
+      case Map.lookup (L.Symbol name) (Crucible.globalInitMap $ ccLLVMModuleTrans cc) of
         Just (g, _) ->
           case let ?lc = lc in Crucible.liftMemType (L.globalType g) of
             Left err -> fail $ unlines [ "typeOfSetupValue: invalid type " ++ show (L.globalType g)
@@ -250,7 +249,7 @@ typeOfSetupValue' cc env nameEnv val =
             Right memTy -> return memTy
         Nothing             -> fail $ "resolveSetupVal: global not found: " ++ name
   where
-    lc = cc^.ccTypeCtx
+    lc = ccTypeCtx cc
     dl = Crucible.llvmDataLayout lc
 
 -- | Translate a SetupValue into a Crucible LLVM value, resolving
@@ -316,7 +315,7 @@ resolveSetupVal cc mem env tyenv nameEnv val = do
       Crucible.ptrToPtrVal <$> Crucible.doResolveGlobal sym mem (L.Symbol name)
     SetupGlobalInitializer () name ->
       case Map.lookup (L.Symbol name)
-                      (Crucible.globalInitMap $ cc^.ccLLVMModuleTrans) of
+                      (Crucible.globalInitMap $ ccLLVMModuleTrans cc) of
         -- There was an error in global -> constant translation
         Just (_, Left e) -> fail e
         Just (_, Right (_, Just v)) ->
@@ -328,7 +327,7 @@ resolveSetupVal cc mem env tyenv nameEnv val = do
           fail $ "resolveSetupVal: global not found: " ++ name
   where
     sym = cc^.ccBackend
-    lc = cc^.ccTypeCtx
+    lc = ccTypeCtx cc
     dl = Crucible.llvmDataLayout lc
 
 resolveTypedTerm ::
@@ -415,7 +414,7 @@ resolveSAWTerm cc tp tm =
         fail "resolveSAWTerm: invalid function type"
   where
     sym = cc^.ccBackend
-    dl = Crucible.llvmDataLayout (cc^.ccTypeCtx)
+    dl = Crucible.llvmDataLayout (ccTypeCtx cc)
 
 data ToLLVMTypeErr = NotYetSupported String | Impossible String
 
@@ -551,7 +550,7 @@ memArrayToSawCoreTerm ::
   IO Term
 memArrayToSawCoreTerm crucible_context endianess typed_term = do
   let sym = crucible_context ^. ccBackend
-  let data_layout = Crucible.llvmDataLayout $ crucible_context ^. ccTypeCtx
+  let data_layout = Crucible.llvmDataLayout $ ccTypeCtx crucible_context
   saw_context <- Crucible.saw_ctx <$> readIORef (W4.sbStateManager sym)
 
   let setBytes :: Cryptol.TValue -> Term -> Crucible.Bytes -> StateT (Vector Term) IO ()


### PR DESCRIPTION
The `TestEquality` instance for type `LLVMModule` now tests only equality between the `ModuleTranslation` components, which is itself fast because each `ModuleTranslation` gets a unique nonce upon creation.

To make this equality test sound, we enforce a datatype invariant for `LLVMModule`, which is that an `LLVMModule`'s internal components (the filename, the LLVM AST, and the translated module) must be consistent with each other. To preserve the invariant, we make `LLVMModule` an abstract type, and remove the lenses that gave access to the fields, replacing them with ordinary accessor functions.

Fixes #622.