### PR TITLE
Use Recognizer library only with Maybe monad

### DIFF
--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -603,8 +603,7 @@ satExternal doCNF execName args = withFirstGoal $ \g -> do
   sc <- SV.getSharedContext
   SV.AIGProxy proxy <- SV.getProxy
   io $ do
-  let (vars, concl) = asPiList (unProp (goalProp g))
-  t0 <- scLambdaList sc vars =<< asEqTrue concl
+  t0 <- propToPredicate sc (goalProp g)
   t <- rewriteEqs sc t0
   let cnfName = goalType g ++ show (goalNum g) ++ ".cnf"
   (path, fh) <- openTempFile "." cnfName

--- a/src/SAWScript/JavaBuiltins.hs
+++ b/src/SAWScript/JavaBuiltins.hs
@@ -22,6 +22,7 @@ import Control.Lens
 import Control.Monad.State
 import Control.Monad.Trans.Except
 import Data.List (partition)
+import Data.Maybe (mapMaybe)
 import Data.IORef
 import qualified Data.Map as Map
 import Data.Time.Clock
@@ -177,7 +178,7 @@ extractJava bic opts cls mname setup = do
       liftIO $ do
         let sc = biSharedContext bic
         argBinds <- reverse <$> readIORef argsRef
-        exts <- mapM asExtCns argBinds
+        let exts = mapMaybe asExtCns argBinds
         -- TODO: group argBinds according to the declared types
         scAbstractExts jsc exts dt >>= mkTypedTerm sc
 

--- a/src/SAWScript/Proof.hs
+++ b/src/SAWScript/Proof.hs
@@ -83,8 +83,9 @@ predicateToProp sc quant env t =
 propToPredicate :: SharedContext -> Prop -> IO Term
 propToPredicate sc (Prop goal) =
   do let (args, t1) = asPiList goal
-     t2 <- asEqTrue t1
-     scLambdaList sc args t2
+     case asEqTrue t1 of
+       Just t2 -> scLambdaList sc args t2
+       Nothing -> fail "propToPredicate: expected EqTrue"
 
 -- | A ProofState represents a sequent, where the collection of goals
 -- implies the conclusion.

--- a/src/SAWScript/Prover/Exporter.hs
+++ b/src/SAWScript/Prover/Exporter.hs
@@ -63,7 +63,10 @@ adaptExporter ::
   (SharedContext -> FilePath -> Prop -> IO ())
 adaptExporter exporter sc path (Prop goal) =
   do let (args, concl) = asPiList goal
-     p <- asEqTrue concl
+     p <-
+       case asEqTrue concl of
+         Just p -> return p
+         Nothing -> fail "adaptExporter: expected EqTrue"
      p' <- scNot sc p -- is this right?
      t <- scLambdaList sc args p'
      exporter sc path t

--- a/src/SAWScript/Prover/MRSolver.hs
+++ b/src/SAWScript/Prover/MRSolver.hs
@@ -9,7 +9,6 @@ module SAWScript.Prover.MRSolver
   , SBV.z3, SBV.cvc4, SBV.yices, SBV.mathSAT, SBV.boolector
   ) where
 
-import Control.Monad.Fail (MonadFail)
 import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Except
@@ -331,13 +330,13 @@ compFunInputType (CompFunComp f _) = compFunInputType f
 compFunInputType (CompFunMark f _) = compFunInputType f
 
 -- | Match a term as a function name
-asFunName :: (MonadPlus m, MonadFail m) => Recognizer m Term FunName
+asFunName :: Term -> Maybe FunName
 asFunName t =
   (LocalName <$> LocalFunName <$> asExtCns t)
   `mplus` (GlobalName <$> asGlobalDef t)
 
 -- | Match a term as being of the form @CompM a@ for some @a@
-asCompMApp :: Monad m => Recognizer m Term Term
+asCompMApp :: Term -> Maybe Term
 asCompMApp (asApp -> Just (isGlobalDef "Prelude.CompM" -> Just (), tp)) =
   return tp
 asCompMApp _ = fail "not CompM app"


### PR DESCRIPTION
This PR prepares saw-script for some planned changes to the saw-core `Recognizer` library. Specifically, I plan to restrict `Recognizer` to work only with the `Maybe` monad, so that we can avoid the possibility of calling `fail` in an arbitrary monad.