### PR TITLE
Update runtests.sh to properly handle SIGINT, cleanup for ShellCheck

### DIFF
--- a/intTests/runtests.sh
+++ b/intTests/runtests.sh
@@ -166,8 +166,3 @@ echo "<?xml version='1.0'?>" > $XML_FILE
 rm $XML_TEMP
 
 finish;
-
-# Local Variables:
-# sh-basic-offset: 2
-# indent-tabs-mode: nil
-# End:


### PR DESCRIPTION
Closes #612 

```
$ ./runtests.sh
test0001: FAIL (0s)
test0002: OK (12s)
test0003: OK (1s)
test0003_w4: OK (0s)
test0004: OK (5s)
test0004_w4: OK (5s)
^C
tests passed: 5 / 65
failed: test0001
interrupted: test0005
```