### PR TITLE
Skip call to `scGeneralizeExts` in crucible verify commands.

### DIFF
--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -350,12 +350,12 @@ quickcheckGoal sc n = do
   withFirstGoal $ \goal -> io $ do
     printOutLn opts Warn $ "WARNING: using quickcheck to prove goal..."
     hFlush stdout
-    let Prop tm = goalProp goal
+    tm0 <- propToPredicate sc (goalProp goal)
+    tm <- scAbstractExts sc (getAllExts tm0) tm0
     ty <- scTypeOf sc tm
     maybeInputs <- scTestableType sc ty
-    maybeInputs' <- scTestableType sc tm
     let stats = solverStats "quickcheck" (scSharedSize tm)
-    case msum [maybeInputs, maybeInputs'] of
+    case maybeInputs of
       Just inputs -> do
         result <- scRunTestsTFIO sc n tm inputs
         case result of

--- a/src/SAWScript/Crucible/JVM/Builtins.hs
+++ b/src/SAWScript/Crucible/JVM/Builtins.hs
@@ -273,7 +273,7 @@ verifyObligations cc mspec tactic assumes asserts =
      let nm = mspec ^. csMethodName
      stats <- forM (zip [(0::Int)..] asserts) $ \(n, (msg, assert)) -> do
        goal   <- io $ scImplies sc assume assert
-       goal'  <- io $ scGeneralizeExts sc (getAllExts goal) =<< scEqTrue sc goal
+       goal'  <- io $ scEqTrue sc goal
        let goalname = concat [nm, " (", takeWhile (/= '\n') msg, ")"]
            proofgoal = ProofGoal n "vc" goalname (Prop goal')
        r      <- evalStateT tactic (startProof proofgoal)

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -400,7 +400,7 @@ verifyObligations cc mspec tactic assumes asserts = do
   let nm  = mspec ^. csName
   stats <- forM (zip [(0::Int)..] asserts) $ \(n, (msg, assert)) -> do
     goal   <- io $ scImplies sc assume assert
-    goal'  <- io $ scGeneralizeExts sc (getAllExts goal) =<< scEqTrue sc goal
+    goal'  <- io $ scEqTrue sc goal
     let goalname = concat [nm, " (", takeWhile (/= '\n') msg, ")"]
         proofgoal = ProofGoal n "vc" goalname (Prop goal')
     r <- evalStateT tactic (startProof proofgoal)


### PR DESCRIPTION
There is no need to convert from external constants to local variables; the proof backends can handle external constants just as well.

Fixes #626.