### PR TITLE
Track and check alignment for memory regions in llvm overrides

### DIFF
--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -1483,8 +1483,9 @@ crucible_alloc_with_mutability_and_size mut sz alignment bic opts lty =
          Just a -> do
            when (a < memTyAlign) $ fail $ unlines
              [ "User error: manually-specified alignment was less than needed"
-             , "Needed for this type: " ++ show memTyAlign
-             , "Specified: " ++ show a
+             , "Allocation type: " ++ show memTy
+             , "Minimum alignment for type: " ++ show (Crucible.fromAlignment memTyAlign) ++ "-byte"
+             , "Specified alignment: " ++ show (Crucible.fromAlignment a) ++ "-byte"
              ]
            pure a
          Nothing -> pure memTyAlign

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -44,6 +44,7 @@ module SAWScript.Crucible.LLVM.Builtins
     , crucible_llvm_unsafe_assume_spec
     , crucible_fresh_var
     , crucible_alloc
+    , crucible_alloc_aligned
     , crucible_alloc_readonly
     , crucible_alloc_with_size
     , crucible_alloc_global
@@ -1505,6 +1506,26 @@ crucible_alloc ::
   LLVMCrucibleSetupM (AllLLVM SetupValue)
 crucible_alloc =
   crucible_alloc_with_mutability_and_size Crucible.Mutable Nothing Nothing
+
+crucible_alloc_aligned ::
+  BuiltinContext ->
+  Options        ->
+  Int            ->
+  L.Type         ->
+  LLVMCrucibleSetupM (AllLLVM SetupValue)
+crucible_alloc_aligned bic opts n lty =
+  case Crucible.toAlignment (Crucible.toBytes n) of
+    Nothing ->
+      LLVMCrucibleSetupM $ fail $
+      "crucible_alloc_aligned: invalid non-power-of-2 alignment: " ++ show n
+    Just alignment ->
+      crucible_alloc_with_mutability_and_size
+        Crucible.Mutable
+        Nothing
+        (Just alignment)
+        bic
+        opts
+        lty
 
 crucible_alloc_readonly ::
   BuiltinContext ->

--- a/src/SAWScript/Crucible/LLVM/CrucibleLLVM.hs
+++ b/src/SAWScript/Crucible/LLVM/CrucibleLLVM.hs
@@ -31,6 +31,7 @@ module SAWScript.Crucible.LLVM.CrucibleLLVM
   , ptrBitwidth
   , integerAlignment
   , floatAlignment
+  , fromAlignment
   , EndianForm(..)
     -- * Re-exports from "Lang.Crucible.LLVM.Extension"
   , ArchWidth
@@ -137,7 +138,7 @@ import Lang.Crucible.LLVM.Bytes
 
 import Lang.Crucible.LLVM.DataLayout
   (Alignment, noAlignment, padToAlignment, DataLayout, EndianForm(..),
-   integerAlignment, floatAlignment, intWidthSize, ptrBitwidth)
+   integerAlignment, floatAlignment, fromAlignment, intWidthSize, ptrBitwidth)
 
 import Lang.Crucible.LLVM.Extension
   (ArchWidth)

--- a/src/SAWScript/Crucible/LLVM/MethodSpecIR.hs
+++ b/src/SAWScript/Crucible/LLVM/MethodSpecIR.hs
@@ -39,6 +39,7 @@ module SAWScript.Crucible.LLVM.MethodSpecIR
     -- * LLVMAllocSpec
   , LLVMAllocSpec(..)
   , allocSpecType
+  , allocSpecAlign
   , allocSpecMut
   , allocSpecLoc
   , allocSpecBytes
@@ -183,6 +184,7 @@ data LLVMAllocSpec =
   LLVMAllocSpec
     { _allocSpecMut   :: CL.Mutability
     , _allocSpecType  :: CL.MemType
+    , _allocSpecAlign :: CL.Alignment
     , _allocSpecBytes :: CL.Bytes
     , _allocSpecLoc   :: ProgramLoc
     }

--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -612,12 +612,12 @@ learnCond :: (?lc :: Crucible.TypeContext, Crucible.HasPtrWidth (Crucible.ArchWi
           -> PrePost
           -> MS.StateSpec (LLVM arch)
           -> OverrideMatcher (LLVM arch) md ()
-learnCond opts sc cc cs prepost ss = do
-  let loc = cs ^. MS.csLoc
-  matchPointsTos opts sc cc cs prepost (ss ^. MS.csPointsTos)
-  traverse_ (learnSetupCondition opts sc cc cs prepost) (ss ^. MS.csConditions)
-  enforceDisjointness loc ss
-  enforceCompleteSubstitution loc ss
+learnCond opts sc cc cs prepost ss =
+  do let loc = cs ^. MS.csLoc
+     matchPointsTos opts sc cc cs prepost (ss ^. MS.csPointsTos)
+     traverse_ (learnSetupCondition opts sc cc cs prepost) (ss ^. MS.csConditions)
+     enforceDisjointness loc ss
+     enforceCompleteSubstitution loc ss
 
 
 -- | Verify that all of the fresh variables for the given
@@ -1078,9 +1078,11 @@ learnSetupCondition ::
   PrePost                    ->
   MS.SetupCondition (LLVM arch) ->
   OverrideMatcher (LLVM arch) md ()
-learnSetupCondition opts sc cc spec prepost (MS.SetupCond_Equal loc val1 val2)  = learnEqual opts sc cc spec loc prepost val1 val2
-learnSetupCondition _opts sc cc _    prepost (MS.SetupCond_Pred loc tm)         = learnPred sc cc loc prepost (ttTerm tm)
-learnSetupCondition _opts sc cc _    prepost (MS.SetupCond_Ghost () loc var val)   = learnGhost sc cc loc prepost var val
+learnSetupCondition opts sc cc spec prepost cond =
+  case cond of
+    MS.SetupCond_Equal loc val1 val2  -> learnEqual opts sc cc spec loc prepost val1 val2
+    MS.SetupCond_Pred loc tm          -> learnPred sc cc loc prepost (ttTerm tm)
+    MS.SetupCond_Ghost () loc var val -> learnGhost sc cc loc prepost var val
 
 
 ------------------------------------------------------------------------

--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -724,8 +724,8 @@ enforceDisjointness loc ss =
              addAssert c $ Crucible.SimError loc $
                Crucible.AssertFailureSimError msg ""
 
-        | (LLVMAllocSpec _mut _pty psz ploc, p) : ps <- tails memsRW
-        , (LLVMAllocSpec _mut _qty qsz qloc, q) <- ps ++ memsRO
+        | (LLVMAllocSpec _mut _pty _align psz ploc, p) : ps <- tails memsRW
+        , (LLVMAllocSpec _mut _qty _align qsz qloc, q) <- ps ++ memsRO
         ]
 
 ------------------------------------------------------------------------
@@ -1306,7 +1306,7 @@ executeAllocation ::
   LLVMCrucibleContext arch          ->
   (AllocIndex, LLVMAllocSpec) ->
   OverrideMatcher (LLVM arch) RW ()
-executeAllocation opts cc (var, LLVMAllocSpec mut memTy sz loc) =
+executeAllocation opts cc (var, LLVMAllocSpec mut memTy alignment sz loc) =
   do let sym = cc^.ccBackend
      {-
      memTy <- case Crucible.asMemType symTy of
@@ -1317,7 +1317,6 @@ executeAllocation opts cc (var, LLVMAllocSpec mut memTy sz loc) =
      let memVar = Crucible.llvmMemVar (ccLLVMContext cc)
      mem <- readGlobal memVar
      sz' <- liftIO $ W4.bvLit sym Crucible.PtrWidth (Crucible.bytesToInteger sz)
-     let alignment = Crucible.noAlignment -- default to byte alignment (FIXME)
      let l = show (W4.plSourceLoc loc) ++ " (Poststate)"
      (ptr, mem') <- liftIO $
        Crucible.doMalloc sym Crucible.HeapAlloc mut l mem sz' alignment

--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -707,7 +707,7 @@ enforceAlignment loc ss =
              let msg =
                    "Memory region not aligned: "
                    ++ "(base=" ++ show (Crucible.ppPtr ptr)
-                   ++ ", required alignment=" ++ show alignment ++ ")"
+                   ++ ", required alignment=" ++ show (Crucible.fromAlignment alignment) ++ "-byte)"
              addAssert c $ Crucible.SimError loc $
                Crucible.AssertFailureSimError msg ""
 

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1797,6 +1797,16 @@ primitives = Map.fromList
     , "verified is expected to perform the allocation."
     ]
 
+  , prim "crucible_alloc_aligned" "Int -> LLVMType -> CrucibleSetup SetupValue"
+    (bicVal crucible_alloc_aligned)
+    Current
+    [ "Declare that a memory region of the given type should be allocated in"
+    , "a Crucible specification, and also specify that the start of the region"
+    , "should be aligned to a multiple of the specified number of bytes (which"
+    , "must be a power of 2). The specified alignment must be no less than the"
+    , "minimum required by the LLVM type."
+    ]
+
   , prim "crucible_alloc_readonly" "LLVMType -> CrucibleSetup SetupValue"
     (bicVal crucible_alloc_readonly)
     Current


### PR DESCRIPTION
This contains a fix for #635. I'm making a PR now for the automated tests, but I want to also implement a fix for #633 on this branch before it's ready to merge.