### PR TITLE
Update to accommodate macaw-symbolic changes

### DIFF
--- a/src/SAWScript/Crucible/LLVM/CrucibleLLVM.hs
+++ b/src/SAWScript/Crucible/LLVM/CrucibleLLVM.hs
@@ -120,6 +120,7 @@ module SAWScript.Crucible.LLVM.CrucibleLLVM
   , mkNullPointer
   , ptrIsNull
   , ptrEq
+  , muxLLVMPtr
   , pattern PtrWidth
   , llvmPointerView
   , llvmPointer_bv
@@ -175,6 +176,7 @@ import Lang.Crucible.LLVM.MemModel
    pattern LLVMPointerRepr, LLVMPointerType,
    pattern PtrWidth, llvmPointer_bv, withPtrWidth, pattern LLVMPointer, pattern PtrRepr,
    llvmPointerView, projectLLVM_bv,
+   muxLLVMPtr,
    storageTypeF, StorageType, StorageTypeF(..),
    storageTypeSize, toStorableType, fieldVal, bitvectorType, fieldPad, arrayType,
    mkStructType, AllocType(HeapAlloc, GlobalAlloc), Mutability(..))

--- a/src/SAWScript/Crucible/LLVM/X86.hs
+++ b/src/SAWScript/Crucible/LLVM/X86.hs
@@ -156,6 +156,9 @@ crucible_llvm_verify_x86 bic opts (Some (llvmModule :: LLVMModule x)) path nm gl
         liftIO $ initialMemory sym elf cc maxAddr globsyms methodSpec
 
       let
+        funcLookup = Macaw.LookupFunctionHandle $ \_ _ _ ->
+          fail "Attempted to call a function during x86 verification"
+        noExtraValidityPred _ _ _ _ = return Nothing
         ctx :: C.SimContext (Macaw.MacawSimulatorState Sym) Sym (Macaw.MacawExt Macaw.X86_64)
         ctx = C.SimContext
               { C._ctxSymInterface = sym
@@ -164,9 +167,7 @@ crucible_llvm_verify_x86 bic opts (Some (llvmModule :: LLVMModule x)) path nm gl
               , C.simHandleAllocator = halloc
               , C.printHandle = stdout
               , C.extensionImpl =
-                Macaw.macawExtensions (Macaw.x86_64MacawEvalFn sfs) mvar globs
-                $ Macaw.LookupFunctionHandle $ \_ _ _ ->
-                  fail "Attempted to call a function during x86 verification"
+                Macaw.macawExtensions (Macaw.x86_64MacawEvalFn sfs) mvar globs funcLookup noExtraValidityPred
               , C._functionBindings =
                 C.insertHandleMap (C.cfgHandle cfg) (C.UseCFG cfg $ C.postdomInfo cfg) C.emptyHandleMap
               , C._cruciblePersonality = Macaw.MacawSimulatorState

--- a/src/SAWScript/X86.hs
+++ b/src/SAWScript/X86.hs
@@ -451,13 +451,20 @@ doSim opts elf sfs name (globs,overs) st checkPost =
      execResult <- statusBlock "  Simulating... " $ do
        let crucRegTypes = crucArchRegTypes x86
        let macawStructRepr = StructRepr crucRegTypes
+       -- The global pointer validity predicate is required if your memory
+       -- representation has gaps that are not supposed to be mapped and you
+       -- want to verify that no memory accesses touch unmapped regions.
+       --
+       -- The memory setup for this verifier does not have that problem, and
+       -- thus does not need any additional validity predicates.
+       let noExtraValidityPred _ _ _ _ = return Nothing
        let ctx :: SimContext (MacawSimulatorState Sym) Sym (MacawExt X86_64)
            ctx = SimContext { _ctxSymInterface = sym
                               , ctxSolverProof = \a -> a
                               , ctxIntrinsicTypes = llvmIntrinsicTypes
                               , simHandleAllocator = allocator opts
                               , printHandle = stdout
-                              , extensionImpl = macawExtensions (x86_64MacawEvalFn sfs) mvar globs (callHandler overs sym)
+                              , extensionImpl = macawExtensions (x86_64MacawEvalFn sfs) mvar globs (callHandler overs sym) noExtraValidityPred
                               , _functionBindings =
                                    insertHandleMap (cfgHandle cfg) (UseCFG cfg (postdomInfo cfg)) $
                                    emptyHandleMap


### PR DESCRIPTION
The machine code memory model API changed a bit.  This commit should fix the breakage.