### PR TITLE
Add an option to print an ASCII logo without color

### DIFF
--- a/saw/SAWScript/REPL.hs
+++ b/saw/SAWScript/REPL.hs
@@ -7,12 +7,12 @@ Stability   : provisional
 -}
 module SAWScript.REPL (run) where
 
-import SAWScript.Options (Options)
+import SAWScript.Options (Options(..))
 import SAWScript.REPL.Logo (displayLogo)
 import SAWScript.REPL.Haskeline (repl)
 
 -- | Main function
 run :: Options -> IO ()
 run opts = do
-  displayLogo True
+  displayLogo $ useColor opts
   repl Nothing opts (return ())

--- a/saw/SAWScript/REPL/Logo.hs
+++ b/saw/SAWScript/REPL/Logo.hs
@@ -26,7 +26,7 @@ logo useColor =
   ver = sgr [SetColor Foreground Dull White]
         ++ replicate (lineLen - 20 - length versionText) ' '
         ++ versionText
-  ls = logo2 ver
+  ls = (if useColor then logo2 else logo1) ver
   lineLen   = length (head ls)
   slen      = length ls `div` 3
   (ws,rest) = splitAt slen ls

--- a/src/SAWScript/Options.hs
+++ b/src/SAWScript/Options.hs
@@ -124,7 +124,7 @@ options =
      "<num 0-5 | 'silent' | 'counterexamples' | 'error' | 'warn' | 'info' | 'debug'>"
     )
     "Set verbosity level"
-  , Option "C" ["no-color"]
+  , Option [] ["no-color"]
     (NoArg (\opts -> opts { useColor = False }))
     "Disable ANSI color and Unicode output"
   ]

--- a/src/SAWScript/Options.hs
+++ b/src/SAWScript/Options.hs
@@ -29,6 +29,7 @@ data Options = Options
   , showHelp         :: Bool
   , showVersion      :: Bool
   , printShowPos     :: Bool
+  , useColor         :: Bool
   , printOutFn       :: Verbosity -> String -> IO ()
   } deriving (Show)
 
@@ -58,6 +59,7 @@ defaultOptions
     , runInteractively = False
     , showHelp = False
     , showVersion = False
+    , useColor = True
     }
 
 printOutWith :: Verbosity -> Verbosity -> String -> IO ()
@@ -122,6 +124,9 @@ options =
      "<num 0-5 | 'silent' | 'counterexamples' | 'error' | 'warn' | 'info' | 'debug'>"
     )
     "Set verbosity level"
+  , Option "C" ["no-color"]
+    (NoArg (\opts -> opts { useColor = False }))
+    "Disable ANSI color and Unicode output"
   ]
 
 -- Try to read verbosity as either a string or number and default to 'Debug'.


### PR DESCRIPTION
Closes #592.

```
$ saw --no-color
   ___  __ _ _ _ _
  / __|/ _' | | | |
  \__ \ (_| | | | |
  |___/\__,_|\_,_/ version 0.4.0.99 (11bd94ba-dirty)

sawscript> 
```