### PR TITLE
Fail more gracefully when solver executables are missing

### DIFF
--- a/saw/Main.hs
+++ b/saw/Main.hs
@@ -15,6 +15,7 @@ import Data.List
 import System.IO
 import System.Console.GetOpt
 import System.Environment
+import System.Directory
 
 import SAWScript.Options
 import SAWScript.Utils
@@ -22,7 +23,6 @@ import SAWScript.Interpreter (processFile)
 import qualified SAWScript.REPL as REPL
 import SAWScript.Version (shortVersionText)
 import SAWScript.Value (AIGProxy(..))
-import SAWScript.Prover.Versions (getZ3Version)
 import qualified Data.ABC.GIA as GIA
 
 main :: IO ()
@@ -48,8 +48,8 @@ main = do
                        exitProofUnknown
   where header = "Usage: saw [OPTION...] [-I | file]"
         checkZ3Version opts = do
-          z3 <- getZ3Version
-          unless (isJust z3)
+          p <- findExecutable "z3"
+          unless (isJust p)
             $ err opts "Error: z3 is required to run SAW, but it was not found on the system path."
         err opts msg = do
           when (verbLevel opts >= Error)

--- a/saw/Main.hs
+++ b/saw/Main.hs
@@ -38,16 +38,16 @@ main = do
       case files of
         _ | showVersion opts'' -> hPutStrLn stderr shortVersionText
         _ | showHelp opts'' -> err opts'' (usageInfo header options)
-        [] -> checkZ3Version opts'' *> REPL.run opts''
-        _ | runInteractively opts'' -> checkZ3Version opts'' *> REPL.run opts''
-        [file] -> checkZ3Version opts'' *>
+        [] -> checkZ3 opts'' *> REPL.run opts''
+        _ | runInteractively opts'' -> checkZ3 opts'' *> REPL.run opts''
+        [file] -> checkZ3 opts'' *>
           processFile (AIGProxy GIA.proxy) opts'' file `catch`
           (\(ErrorCall msg) -> err opts'' msg)
         (_:_) -> err opts'' "Multiple files not yet supported."
     (_, _, errs) -> do hPutStrLn stderr (concat errs ++ usageInfo header options)
                        exitProofUnknown
   where header = "Usage: saw [OPTION...] [-I | file]"
-        checkZ3Version opts = do
+        checkZ3 opts = do
           p <- findExecutable "z3"
           unless (isJust p)
             $ err opts "Error: z3 is required to run SAW, but it was not found on the system path."


### PR DESCRIPTION
Closes #286, and also prints a more informative error when `z3` is missing at startup.