### PR TITLE
Fix SMT-Lib export negation issues

### DIFF
--- a/intTests/test_smtlib/test.saw
+++ b/intTests/test_smtlib/test.saw
@@ -1,0 +1,5 @@
+// `offline_smtlib2` takes a formula to prove universally
+prove (offline_smtlib2 "prove") {{ \(x:[8]) (y:[8]) -> x == y ==> x+y == x+x }};
+
+// `write_smtlib2` takes a formula to prove existentially
+write_smtlib2 "sat.smt2" {{ \(x:[8]) -> x != 0 /\ x+x == x }};

--- a/intTests/test_smtlib/test.sh
+++ b/intTests/test_smtlib/test.sh
@@ -1,0 +1,5 @@
+set -e
+
+$SAW test.saw
+z3 prove.prove0.smt2
+z3 sat.smt2


### PR DESCRIPTION
This clarifies, and fixes, the polarity of `write_smtlib2`.

Closes #489, #491.