### PR TITLE
Fix flycheck-saw-script.el

### DIFF
--- a/flycheck-saw-script.el
+++ b/flycheck-saw-script.el
@@ -39,7 +39,7 @@
 
 (defconst flycheck-saw-script--info-start-regexp
   (rx-to-string
-   `(or (regexp ,saw-script--output-regexp)
+   `(or (regexp ,flycheck-saw-script--output-regexp)
         (seq line-start "[error] at "
              (group-n 1 (1+ (not (any ?\:))))
              ":" (group-n 2 (1+ digit)) ":" (group-n 3 (1+ digit))
@@ -79,7 +79,7 @@ See URL `http://saw.galois.com' for more information."
         (with-temp-buffer
           (insert output)
           (goto-char (point-min))
-          (while (re-search-forward saw-script--info-start-regexp nil t)
+          (while (re-search-forward flycheck-saw-script--info-start-regexp nil t)
             (let ((line (string-to-number (match-string 2)))
                   (column (string-to-number (match-string 3)))
                   (end-line (and (match-string 5)

--- a/flycheck-saw-script.el
+++ b/flycheck-saw-script.el
@@ -31,29 +31,41 @@
 (require 'saw-script)
 
 (defconst flycheck-saw-script--output-regexp
-  (rx (seq line-start "[output] at "
+  (rx (seq "] [output] at "
            (group-n 1 (1+ (not (any ?\:))))
            ":" (group-n 2 (1+ digit)) ":" (group-n 3 (1+ digit))
-           "-" (group-n 5 (1+ digit)) ":" (group-n 6 (1+ digit)) ":" (0+ space)))
+           "-" (group-n 5 (1+ digit)) ":" (group-n 6 (1+ digit))
+           ":" (0+ space) "\n" (0+ space) (group-n 4 (1+ (not (any ?\n))))))
   "Output from SAWScript matches this regexp.")
 
 (defconst flycheck-saw-script--info-start-regexp
   (rx-to-string
    `(or (regexp ,flycheck-saw-script--output-regexp)
-        (seq line-start "[error] at "
+        (seq "] [error] at "
              (group-n 1 (1+ (not (any ?\:))))
              ":" (group-n 2 (1+ digit)) ":" (group-n 3 (1+ digit))
-             "--" (group-n 5 (1+ digit)) ":" (group-n 6 (1+ digit)) ":"
-             (group-n 4 (1+ (seq "\n " (1+ (not (any ?\n)))))))
-        (seq line-start "[warning] at "
+             "--" (group-n 5 (1+ digit)) ":" (group-n 6 (1+ digit))
+             ":" (group-n 4 (1+ (seq "\n " (1+ (not (any ?\n)))))))
+        (seq "] [warning] at "
              (group-n 1 (1+ (not (any ?\:))))
              ":" (group-n 2 (1+ digit)) ":" (group-n 3 (1+ digit))
-             "--" (group-n 5 (1+ digit)) ":" (group-n 6 (1+ digit)) ":"
-             (group-n 4 (1+ (seq "\n " (1+ (not (any ?\n)))))))
-        (seq line-start "Parse error at " (group-n 1 (1+ (not (any ?\:))))
+             "--" (group-n 5 (1+ digit)) ":" (group-n 6 (1+ digit))
+             ":" (group-n 4 (1+ (seq "\n " (1+ (not (any ?\n)))))))
+        (seq "] Parse error at " (group-n 1 (1+ (not (any ?\:))))
              ":" (group-n 2 (1+ digit)) ":" (group-n 3 (1+ digit))
-             "-" (group-n 5 (1+ digit)) ":" (group-n 6 (1+ digit)) ":"
-             (group-n 4 (1+ (not (any ?\n))))))))
+             "-" (group-n 5 (1+ digit)) ":" (group-n 6 (1+ digit))
+             ":" (group-n 4 (1+ (not (any ?\n)))))
+        (seq "] " (group-n 1 (1+ (not (any ?\:))))
+             ":" (group-n 2 (1+ digit)) ":" (group-n 3 (1+ digit))
+             "-" (group-n 5 (1+ digit)) ":" (group-n 6 (1+ digit))
+             ": " (group-n 4 (1+ (not (any ?\n)))))
+        (seq "] Stack trace:\n"
+             line-start "\"" (1+ (not (any ?\:)))
+             "\" (" (group-n 1 (1+ (not (any ?\:))))
+             ":" (group-n 2 (1+ digit)) ":" (group-n 3 (1+ digit))
+             "-" (group-n 5 (1+ digit)) ":" (group-n 6 (1+ digit)) "):\n"
+             (0+ line-start "\"" (1+ (not (any ?\n))) "\n")
+             line-start (group-n 4 (1+ (not (any ?\[))))))))
 
 (defun flycheck-saw-script--abbreviate-string (str)
   "Cut off STR if it's too long."


### PR DESCRIPTION
Closes #538.

I've also updated the regular expressions within to work on some common errors from current SAW. I'm almost certain there are still cases where it'll break, however, just due to the myriad of error message formats we've accumulated.

If we want to support this sort of tooling without incurring a large maintenance burden, it might be nice to have an option instructing SAW to output a more structured format than plain text.