### PR TITLE
Support mutable globals during x86 verification

### DIFF
--- a/intTests/test_llvm_x86_04/test.S
+++ b/intTests/test_llvm_x86_04/test.S
@@ -1,0 +1,15 @@
+section .bss
+global var
+var:    resq 1
+section .text
+global addvar
+addvar:
+        mov rax, [rdi]
+        mov rbx, var
+        add rax, 1
+        mov [rdi], rax
+        ret
+global _start
+_start:
+        mov rax, 60
+        syscall

--- a/intTests/test_llvm_x86_04/test.c
+++ b/intTests/test_llvm_x86_04/test.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+#include <stdio.h>
+
+extern uint64_t var;
+
+extern void addvar(uint64_t *i);
+
+void test() {
+	(void) var;
+	uint64_t i = 42;
+	addvar(&i);
+};

--- a/intTests/test_llvm_x86_04/test.saw
+++ b/intTests/test_llvm_x86_04/test.saw
@@ -1,0 +1,19 @@
+enable_experimental;
+
+m <- llvm_load_module "test.bc";
+
+let addvar_setup = do {
+  crucible_alloc_global "var";
+  var <- crucible_fresh_var "var" (llvm_int 64);
+  crucible_points_to (crucible_global "var") (crucible_term {{ 2 : [64] }});
+
+  ptr <- crucible_alloc (llvm_int 64);
+  val <- crucible_fresh_var "val" (llvm_int 64);
+  crucible_points_to ptr (crucible_term val);
+
+  crucible_execute_func [ptr];
+
+  valprime <- crucible_fresh_var "_val" (llvm_int 64);
+  crucible_points_to ptr (crucible_term valprime);
+};
+crucible_llvm_verify_x86 m "./test" "addvar" [] false addvar_setup;

--- a/intTests/test_llvm_x86_04/test.sh
+++ b/intTests/test_llvm_x86_04/test.sh
@@ -1,0 +1,6 @@
+set -e
+
+yasm -felf64 test.S
+ld test.o -o test
+clang -c -emit-llvm test.c
+$SAW test.saw

--- a/src/SAWScript/Crucible/LLVM/X86.hs
+++ b/src/SAWScript/Crucible/LLVM/X86.hs
@@ -395,7 +395,7 @@ initialState sym opts sc cc elf relf ms globs maxAddr = do
       . fmap Elf.elfSymbolTableEntries
       $ Elf.elfSymtab elf
   sz <- W4.bvLit sym knownNat . maximum $ mconcat
-    [ [maxAddr]
+    [ [maxAddr, globalEnd "_end"]
     , globalEnd . fst <$> globs
     , allocGlobalEnd <$> ms ^. MS.csGlobalAllocs
     ]

--- a/src/SAWScript/Crucible/LLVM/X86.hs
+++ b/src/SAWScript/Crucible/LLVM/X86.hs
@@ -19,17 +19,21 @@ Stability   : provisional
 {-# Language GADTs #-}
 {-# Language DataKinds #-}
 {-# Language ConstraintKinds #-}
+{-# Language GeneralizedNewtypeDeriving #-}
+{-# Language TemplateHaskell #-}
 
 module SAWScript.Crucible.LLVM.X86
   ( crucible_llvm_verify_x86
   ) where
 
-import System.IO (stdout)
+import Control.Lens.TH (makeLenses)
 
-import Control.Exception (catch)
-import Control.Lens (view, (&), (^.), (.~))
+import System.IO (stdout)
+import Control.Exception (catch, throw)
+import Control.Lens (view, use, (&), (^.), (.~), (.=))
 import Control.Monad.ST (stToIO)
 import Control.Monad.State
+import Control.Monad.Catch (MonadThrow)
 
 import Data.Foldable (foldlM)
 import Data.IORef
@@ -103,6 +107,63 @@ import qualified Data.Macaw.X86.Symbolic as Macaw
 import qualified Data.Macaw.X86 as Macaw
 import qualified Data.Macaw.X86.X86Reg as Macaw
 
+import qualified Data.ElfEdit as Elf
+
+-------------------------------------------------------------------------------
+-- ** Utility type synonyms and functions
+
+type LLVMArch = C.LLVM.X86 64
+type LLVM = C.LLVM.LLVM LLVMArch
+type Regs = Assignment (C.RegValue' Sym) (Macaw.MacawCrucibleRegTypes Macaw.X86_64)
+type Register = Macaw.X86Reg (Macaw.BVType 64)
+type Mem = C.LLVM.MemImpl Sym
+type Ptr = C.LLVM.LLVMPtr Sym 64
+type X86Constraints = (C.LLVM.HasPtrWidth (C.LLVM.ArchWidth LLVMArch), C.LLVM.HasLLVMAnn Sym)
+
+newtype X86Sim a = X86Sim { unX86Sim :: StateT X86State IO a }
+  deriving (Functor, Applicative, Monad, MonadIO, MonadState X86State, MonadThrow)
+
+data X86State = X86State
+  { _x86Sym :: Sym
+  , _x86Options :: Options
+  , _x86SharedContext :: SharedContext
+  , _x86CrucibleContext :: LLVMCrucibleContext LLVMArch
+  , _x86RelevantElf :: RelevantElf
+  , _x86MethodSpec :: MS.CrucibleMethodSpecIR LLVM
+  , _x86Mem :: Mem
+  , _x86Regs :: Regs
+  , _x86GlobalBase :: Ptr
+  }
+makeLenses ''X86State
+
+runX86Sim :: X86State -> X86Sim a -> IO (a, X86State)
+runX86Sim st m = runStateT (unX86Sim m) st
+
+throwX86 :: MonadThrow m => String -> m a
+throwX86 = throw . X86Error
+
+setReg ::
+  (MonadIO m, MonadThrow m) =>
+  Register ->
+  C.RegValue Sym (C.LLVM.LLVMPointerType 64) ->
+  Regs ->
+  m Regs
+setReg reg val regs
+  | Just regs' <- Macaw.updateX86Reg reg (C.RV . const val) regs = pure regs'
+  | otherwise = throwX86 $ mconcat ["Invalid register: ", show reg]
+
+getReg ::
+  (MonadIO m, MonadThrow m) =>
+  Register ->
+  Regs ->
+  m (C.RegValue Sym (C.LLVM.LLVMPointerType 64))
+getReg reg regs = case Macaw.lookupX86Reg reg regs of
+  Just (C.RV val) -> pure val
+  Nothing -> throwX86 $ mconcat ["Invalid register: ", show reg]
+
+-------------------------------------------------------------------------------
+-- ** Entrypoint
+
 -- | Verify that an x86_64 function (following the System V AMD64 ABI) conforms
 -- to an LLVM specification. This allows for compositional verification of LLVM
 -- functions that call x86_64 functions (but not the other way around).
@@ -128,7 +189,7 @@ crucible_llvm_verify_x86 bic opts (Some (llvmModule :: LLVMModule x)) path nm gl
       mvar <- liftIO $ C.LLVM.mkMemVar halloc
       sfs <- liftIO $ Macaw.newSymFuns sym
 
-      (C.SomeCFG cfg, elf, addr) <- liftIO $ buildCFG opts halloc path nm
+      (C.SomeCFG cfg, elf, relf, addr) <- liftIO $ buildCFG opts halloc path nm
       addrInt <- if Macaw.segmentBase (Macaw.segoffSegment addr) == 0
         then pure . toInteger $ Macaw.segmentOffset (Macaw.segoffSegment addr) + Macaw.segoffOffset addr
         else fail $ mconcat ["Address of \"", nm, "\" is not an absolute address"]
@@ -156,8 +217,9 @@ crucible_llvm_verify_x86 bic opts (Some (llvmModule :: LLVMModule x)) path nm gl
 
       liftIO $ printOutLn opts Info "Examining specification to determine preconditions"
       methodSpec <- buildMethodSpec bic opts llvmModule nm (show addr) setup
-      (globs :: Macaw.GlobalMap Sym C.LLVM.Mem 64, mem, regs, env) <-
-        liftIO $ initialMemory sym elf cc maxAddr globsyms methodSpec
+
+      emptyState <- liftIO $ initialState sym opts sc cc elf relf methodSpec globsyms maxAddr
+      (env, preState) <- liftIO . runX86Sim emptyState $ setupMemory globsyms
 
       let
         funcLookup = Macaw.LookupFunctionHandle $ \_ _ _ ->
@@ -171,23 +233,28 @@ crucible_llvm_verify_x86 bic opts (Some (llvmModule :: LLVMModule x)) path nm gl
               , C.simHandleAllocator = halloc
               , C.printHandle = stdout
               , C.extensionImpl =
-                Macaw.macawExtensions (Macaw.x86_64MacawEvalFn sfs) mvar globs funcLookup noExtraValidityPred
-              , C._functionBindings =
-                C.insertHandleMap (C.cfgHandle cfg) (C.UseCFG cfg $ C.postdomInfo cfg) C.emptyHandleMap
+                Macaw.macawExtensions (Macaw.x86_64MacawEvalFn sfs) mvar
+                (mkGlobalMap . Map.singleton 0 $ preState ^. x86GlobalBase)
+                funcLookup noExtraValidityPred
+              , C._functionBindings = C.insertHandleMap (C.cfgHandle cfg) (C.UseCFG cfg $ C.postdomInfo cfg) C.emptyHandleMap
               , C._cruciblePersonality = Macaw.MacawSimulatorState
               , C._profilingMetrics = Map.empty
               }
-        globals = C.insertGlobal mvar mem C.emptyGlobals
+        globals = C.insertGlobal mvar (preState ^. x86Mem) C.emptyGlobals
         macawStructRepr = C.StructRepr $ Macaw.crucArchRegTypes Macaw.x86_64MacawSymbolicFns
         initial = C.InitialState ctx globals C.defaultAbortHandler macawStructRepr
                   $ C.runOverrideSim macawStructRepr
                   $ Macaw.crucGenArchConstraints Macaw.x86_64MacawSymbolicFns
                   $ do
-          r <- C.callCFG cfg $ C.RegMap $ singleton $ C.RegEntry macawStructRepr regs
+          r <- C.callCFG cfg . C.RegMap . singleton . C.RegEntry macawStructRepr $ preState ^. x86Regs
           mem' <- C.readGlobal mvar
+          let finalState = preState
+                { _x86Mem = mem'
+                , _x86Regs = C.regValue r
+                }
           liftIO $ printOutLn opts Info
             "Examining specification to determine postconditions"
-          liftIO $ assertPost sym opts cc env methodSpec (mem, mem') (regs, C.regValue r)
+          liftIO . void . runX86Sim finalState $ assertPost env (preState ^. x86Mem) (preState ^. x86Regs)
           pure $ C.regValue r
 
       liftIO $ printOutLn opts Info "Simulating function"
@@ -196,7 +263,7 @@ crucible_llvm_verify_x86 bic opts (Some (llvmModule :: LLVMModule x)) path nm gl
         C.AbortedResult{} -> printOutLn opts Warn "Warning: function never returns"
         C.TimeoutResult{} -> fail "Execution timed out"
 
-      liftIO $ checkGoals sym opts sc
+      liftIO . void $ runX86Sim preState checkGoals
  
       pure $ SomeLLVM methodSpec
   | otherwise = fail "LLVM module must be 64-bit"
@@ -214,27 +281,28 @@ buildCFG ::
        (Macaw.MacawExt Macaw.X86_64)
        (EmptyCtx ::> Macaw.ArchRegStruct Macaw.X86_64)
        (Macaw.ArchRegStruct Macaw.X86_64)
+     , Elf.Elf 64
      , RelevantElf
      , Macaw.MemSegmentOff 64
      )
 buildCFG opts halloc path nm = do
   printOutLn opts Info $ mconcat ["Finding symbol for \"", nm, "\""]
-  elf <- getElf path >>= getRelevant
+  elf <- getElf path
+  relf <- getRelevant elf
   (addr :: Macaw.MemSegmentOff 64) <-
-    case findSymbols (symMap elf) . encodeUtf8 $ Text.pack nm of
+    case findSymbols (symMap relf) . encodeUtf8 $ Text.pack nm of
       (addr:_) -> pure addr
       _ -> fail $ mconcat ["Could not find symbol \"", nm, "\""]
   printOutLn opts Info $ mconcat ["Found symbol at address ", show addr, ", building CFG"]
   let
     initialDiscoveryState =
-      Macaw.emptyDiscoveryState (memory elf) (funSymMap elf) Macaw.x86_64_linux_info
+      Macaw.emptyDiscoveryState (memory relf) (funSymMap relf) Macaw.x86_64_linux_info
       & Macaw.trustedFunctionEntryPoints .~ Set.empty
   (_fstate, Some finfo) <-
     stToIO $ Macaw.analyzeFunction (const $ pure ()) addr Macaw.UserRequest initialDiscoveryState
   scfg <- Macaw.mkFunCFG Macaw.x86_64MacawSymbolicFns halloc
     (W4.functionNameFromText $ Text.pack nm) posFn finfo
-  pure (scfg, elf, addr)
-
+  pure (scfg, elf, relf, addr)
 
 --------------------------------------------------------------------------------
 -- ** Computing the specification
@@ -297,174 +365,218 @@ llvmSignature opts llvmModule nm =
       )
 
 --------------------------------------------------------------------------------
+-- ** Building the initial state
+
+initialState ::
+  X86Constraints =>
+  Sym ->
+  Options ->
+  SharedContext ->
+  LLVMCrucibleContext LLVMArch ->
+  Elf.Elf 64 ->
+  RelevantElf ->
+  MS.CrucibleMethodSpecIR LLVM ->
+  [(String, Integer)] ->
+  Integer ->
+  IO X86State
+initialState sym opts sc cc elf relf ms globs maxAddr = do
+  emptyMem <- C.LLVM.emptyMem C.LLVM.LittleEndian
+  emptyRegs <- traverseWithIndex (freshRegister sym) C.knownRepr
+  let
+    align = C.LLVM.exponentToAlignment 4
+    globalEnd :: String -> Integer
+    globalEnd nm = case
+      Vector.headM
+      . Vector.filter (\e -> Elf.steName e == encodeUtf8 (Text.pack nm))
+      . mconcat
+      . fmap Elf.elfSymbolTableEntries
+      $ Elf.elfSymtab elf of
+        Just entry -> fromIntegral $ Elf.steValue entry + Elf.steSize entry
+        Nothing -> 0
+  sz <- W4.bvLit sym knownNat . maximum $ mconcat
+    [ [maxAddr]
+    , globalEnd . fst <$> globs
+    ]
+  (base, mem) <- C.LLVM.doMalloc sym C.LLVM.GlobalAlloc C.LLVM.Immutable
+    "globals" emptyMem sz align
+  pure $ X86State
+    { _x86Sym = sym
+    , _x86Options = opts
+    , _x86SharedContext = sc
+    , _x86CrucibleContext = cc
+    , _x86RelevantElf = relf
+    , _x86MethodSpec = ms
+    , _x86Mem = mem
+    , _x86Regs = emptyRegs
+    , _x86GlobalBase = base
+    }
+
+--------------------------------------------------------------------------------
 -- ** Precondition
 
 -- | Given the method spec, build the initial memory, register map, and global map.
-initialMemory ::
+setupMemory ::
   X86Constraints =>
-  Sym ->
-  RelevantElf ->
-  LLVMCrucibleContext LLVMArch ->
-  Integer {- ^ Minimum size of the global allocation (here, the end of the .text segment -} ->
   [(String, Integer)] {- ^ Global variable symbol names and sizes (in bytes) -} ->
-  MS.CrucibleMethodSpecIR LLVM ->
-  IO (Macaw.GlobalMap Sym C.LLVM.Mem 64, Mem, Regs, Map MS.AllocIndex Ptr)
-initialMemory sym elf cc endText globsyms ms = do
-  emptyMem <- C.LLVM.emptyMem C.LLVM.LittleEndian
-  emptyRegs <- traverseWithIndex (freshRegister sym) C.knownRepr
+  X86Sim (Map MS.AllocIndex Ptr)
+setupMemory globsyms = do
+  -- emptyMem <- C.LLVM.emptyMem C.LLVM.LittleEndian
+  -- emptyRegs <- traverseWithIndex (freshRegister sym) C.knownRepr
 
-  (globs, initialMem ) <- setupGlobals sym elf emptyMem endText globsyms
+  setupGlobals globsyms
 
   -- Allocate a reasonable amount of stack (4 KiB + 1 qword for IP)
-  (rsp, memWithStack) <- allocateStack sym initialMem 4096
-  regsWithStack <- setReg Macaw.RSP rsp emptyRegs
+  allocateStack 4096
 
-  let tyenv = ms ^. MS.csPreState . MS.csAllocs
-      nameEnv = MS.csTypeNames ms
+  ms <- use x86MethodSpec
 
-  (env, memWithAllocs) <- foldlM (executeAllocation sym) (Map.empty, memWithStack) . Map.assocs
-    $ tyenv
+  let
+    tyenv = ms ^. MS.csPreState . MS.csAllocs
+    nameEnv = MS.csTypeNames ms
 
-  mem <- foldlM (executePointsTo sym cc env tyenv nameEnv) memWithAllocs
-    $ ms ^. MS.csPreState . MS.csPointsTos
+  env <- foldlM executeAllocation Map.empty . Map.assocs $ tyenv
 
-  regs <- setArgs sym cc env tyenv nameEnv mem regsWithStack . fmap snd . Map.elems
-    $ ms ^. MS.csArgBindings
+  mapM_ (executePointsTo env tyenv nameEnv) $ ms ^. MS.csPreState . MS.csPointsTos
 
-  pure (globs, mem, regs, env)
+  setArgs env tyenv nameEnv . fmap snd . Map.elems $ ms ^. MS.csArgBindings
+
+  pure env
 
 -- | Given an alist of symbol names and sizes (in bytes), allocate space and copy
 -- the corresponding globals from the Macaw memory to the Crucible LLVM memory model.
 setupGlobals ::
   X86Constraints =>
-  Sym ->
-  RelevantElf ->
-  Mem ->
-  Integer {- ^ Minimum size of the global allocation -} ->
   [(String, Integer)] {- ^ Global variable symbol names and sizes (in bytes) -} ->
-  IO (Macaw.GlobalMap Sym C.LLVM.Mem 64, Mem)
-setupGlobals sym elf mem endText globsyms = do
-  let align = C.LLVM.exponentToAlignment 4
-  globs <- mconcat <$> mapM readInitialGlobal globsyms
-  sz <- W4.bvLit sym knownNat . maximum $ endText:(globalEnd <$> globs)
-  (base, mem') <- C.LLVM.doMalloc sym C.LLVM.GlobalAlloc C.LLVM.Immutable
-    "globals" mem sz align
-  mem'' <- foldlM (writeGlobal base) mem' globs
-  pure (mkGlobalMap $ Map.singleton 0 base, mem'')
-  where
+  X86Sim ()
+setupGlobals globsyms = do
+  sym <- use x86Sym
+  mem <- use x86Mem
+  relf <- use x86RelevantElf
+  base <- use x86GlobalBase
+  let
     readInitialGlobal :: (String, Integer) -> IO [(String, Integer, [Integer])]
     readInitialGlobal (nm, sz) = do
-      res <- loadGlobal elf (encodeUtf8 $ Text.pack nm, sz, Bytes)
+      res <- loadGlobal relf (encodeUtf8 $ Text.pack nm, sz, Bytes)
       pure $ (\(name, addr, _unit, bytes) -> (name, addr, bytes)) <$> res
-    globalEnd :: (String, Integer, [Integer]) -> Integer
-    globalEnd (_nm, addr, bytes) = addr + toInteger (length bytes)
     convertByte :: Integer -> IO (C.LLVM.LLVMVal Sym)
     convertByte byte =
       C.LLVM.LLVMValInt <$> W4.natLit sym 0 <*> W4.bvLit sym (knownNat @8) byte
-    writeGlobal :: Ptr -> Mem -> (String, Integer, [Integer]) -> IO Mem
-    writeGlobal base m (_nm, addr, bytes) = do
+    writeGlobal :: Mem -> (String, Integer, [Integer]) -> IO Mem
+    writeGlobal m (_nm, addr, bytes) = do
       ptr <- C.LLVM.doPtrAddOffset sym m base =<< W4.bvLit sym knownNat addr
       v <- Vector.fromList <$> mapM convertByte bytes
       let st = C.LLVM.arrayType (fromIntegral $ length bytes) $ C.LLVM.bitvectorType 1
       C.LLVM.storeConstRaw sym m ptr st C.LLVM.noAlignment
         $ C.LLVM.LLVMValArray (C.LLVM.bitvectorType 1) v
+  globs <- liftIO $ mconcat <$> mapM readInitialGlobal globsyms
+  mem' <- liftIO $ foldlM writeGlobal mem globs
+  x86Mem .= mem'
 
 -- | Allocate memory for the stack, and pushes a fresh pointer as the return
--- address. Note that this function only returns a pointer to the top-of-stack,
--- and does not set RSP.
+-- address.
 allocateStack ::
   X86Constraints =>
-  Sym ->
-  Mem ->
   Integer {- ^ Stack size in bytes -} ->
-  IO (Ptr, Mem)
-allocateStack sym mem szInt = do
+  X86Sim ()
+allocateStack szInt = do
+  sym <- use x86Sym
+  mem <- use x86Mem
+  regs <- use x86Regs
   let align = C.LLVM.exponentToAlignment 4
-  sz <- W4.bvLit sym knownNat $ szInt + 8
-  (base, mem') <- C.LLVM.doMalloc sym C.LLVM.HeapAlloc C.LLVM.Mutable
+  sz <- liftIO $ W4.bvLit sym knownNat $ szInt + 8
+  (base, mem') <- liftIO $ C.LLVM.doMalloc sym C.LLVM.HeapAlloc C.LLVM.Mutable
     "stack_alloc" mem sz align
   sn <- case W4.userSymbol "stack" of
-    Left err -> fail $ "Invalid symbol for stack: " <> show err
+    Left err -> throwX86 $ "Invalid symbol for stack: " <> show err
     Right sn -> pure sn
-  fresh <- C.LLVM.LLVMPointer
+  fresh <- liftIO $ C.LLVM.LLVMPointer
     <$> W4.natLit sym 0
     <*> W4.freshConstant sym sn (W4.BaseBVRepr $ knownNat @64)
-  ptr <- C.LLVM.doPtrAddOffset sym mem' base =<< W4.bvLit sym knownNat szInt
-  (ptr,) <$> C.LLVM.doStore sym mem' ptr (C.LLVM.LLVMPointerRepr $ knownNat @64)
+  ptr <- liftIO $ C.LLVM.doPtrAddOffset sym mem' base =<< W4.bvLit sym knownNat szInt
+  finalMem <- liftIO $ C.LLVM.doStore sym mem' ptr
+    (C.LLVM.LLVMPointerRepr $ knownNat @64)
     (C.LLVM.bitvectorType 8) align fresh
+  x86Mem .= finalMem
+  finalRegs <- setReg Macaw.RSP ptr regs
+  x86Regs .= finalRegs
 
 -- | Process a crucible_alloc statement, allocating the requested memory and
 -- associating a pointer to that memory with the appropriate index.
 executeAllocation ::
   X86Constraints =>
-  Sym ->
-  (Map MS.AllocIndex Ptr, Mem) ->
+  Map MS.AllocIndex Ptr ->
   (MS.AllocIndex, LLVMAllocSpec) {- ^ crucible_alloc statement -} ->
-  IO (Map MS.AllocIndex Ptr, Mem)
-executeAllocation sym (env, mem) (i, LLVMAllocSpec mut _memTy align sz loc) = do
+  X86Sim (Map MS.AllocIndex Ptr)
+executeAllocation env (i, LLVMAllocSpec mut _memTy align sz loc) = do
+  sym <- use x86Sym
+  mem <- use x86Mem
   sz' <- liftIO $ W4.bvLit sym knownNat $ C.LLVM.bytesToInteger sz
-  (ptr, mem') <- C.LLVM.doMalloc sym C.LLVM.HeapAlloc mut
+  (ptr, mem') <- liftIO $ C.LLVM.doMalloc sym C.LLVM.HeapAlloc mut
     (show $ W4.plSourceLoc loc) mem sz' align
-  pure (Map.insert i ptr env, mem')
+  x86Mem .= mem'
+  pure $ Map.insert i ptr env
 
 -- | Process a crucible_points_to statement, writing some SetupValue to a pointer.
 executePointsTo ::
   X86Constraints =>
-  Sym ->
-  LLVMCrucibleContext LLVMArch ->
   Map MS.AllocIndex Ptr {- ^ Associates each AllocIndex with the corresponding allocation -} ->
   Map MS.AllocIndex LLVMAllocSpec {- ^ Associates each AllocIndex with its specification -} ->
   Map MS.AllocIndex C.LLVM.Ident {- ^ Associates each AllocIndex with its name -} ->
-  Mem ->
   LLVMPointsTo LLVMArch {- ^ crucible_points_to statement from the precondition -} ->
-  IO Mem
-executePointsTo sym cc env tyenv nameEnv mem (LLVMPointsTo _ cond tptr tval) = do
-  when (isJust cond) $ fail "unsupported x86_64 command: crucible_conditional_points_to"
-  ptr <- C.LLVM.unpackMemValue sym (C.LLVM.LLVMPointerRepr $ knownNat @64)
-    =<< resolveSetupVal cc mem env tyenv Map.empty tptr
-  val <- resolveSetupVal cc mem env tyenv Map.empty tval
-  storTy <- C.LLVM.toStorableType =<< typeOfSetupValue cc tyenv nameEnv tval
-  C.LLVM.storeConstRaw sym mem ptr storTy C.LLVM.noAlignment val
+  X86Sim ()
+executePointsTo env tyenv nameEnv (LLVMPointsTo _ cond tptr tval)
+  | isJust cond = throwX86 "unsupported x86_64 command: crucible_conditional_points_to"
+  | otherwise = do
+      sym <- use x86Sym
+      cc <- use x86CrucibleContext
+      mem <- use x86Mem
+      ptr <- liftIO $ C.LLVM.unpackMemValue sym (C.LLVM.LLVMPointerRepr $ knownNat @64)
+        =<< resolveSetupVal cc mem env tyenv Map.empty tptr
+      val <- liftIO $ resolveSetupVal cc mem env tyenv Map.empty tval
+      storTy <- liftIO $ C.LLVM.toStorableType =<< typeOfSetupValue cc tyenv nameEnv tval
+      mem' <- liftIO $ C.LLVM.storeConstRaw sym mem ptr storTy C.LLVM.noAlignment val
+      x86Mem .= mem'
 
 -- | Write each SetupValue passed to crucible_execute_func to the appropriate
 -- x86_64 register from the calling convention.
 setArgs ::
   X86Constraints =>
-  Sym ->
-  LLVMCrucibleContext LLVMArch ->
   Map MS.AllocIndex Ptr {- ^ Associates each AllocIndex with the corresponding allocation -} ->
   Map MS.AllocIndex LLVMAllocSpec {- ^ Associates each AllocIndex with its specification -} ->
   Map MS.AllocIndex C.LLVM.Ident {- ^ Associates each AllocIndex with its name -} ->
-  Mem ->
-  Regs ->
   [MS.SetupValue LLVM] {- ^ Arguments passed to crucible_execute_func -} ->
-  IO Regs
-setArgs sym cc env tyenv nameEnv mem regs args
-  | length args > length argRegs = fail "More arguments than would fit into general-purpose registers"
-  | otherwise = foldlM setRegSetupValue regs $ zip argRegs args
-  where
-    argRegs :: [Register]
-    argRegs = [Macaw.RDI, Macaw.RSI, Macaw.RDX, Macaw.RCX, Macaw.R8, Macaw.R9]
-    setRegSetupValue rs (reg, sval) = typeOfSetupValue cc tyenv nameEnv sval >>= \ty ->
-      case ty of
-        C.LLVM.PtrType _ -> do
-          val <- C.LLVM.unpackMemValue sym (C.LLVM.LLVMPointerRepr $ knownNat @64)
-            =<< resolveSetupVal cc mem env tyenv nameEnv sval
-          setReg reg val rs
-        C.LLVM.IntType 64 -> do
-          val <- C.LLVM.unpackMemValue sym (C.LLVM.LLVMPointerRepr $ knownNat @64)
-            =<< resolveSetupVal cc mem env tyenv nameEnv sval
-          setReg reg val rs
-        C.LLVM.IntType _ -> do
-          C.LLVM.LLVMValInt base off <- resolveSetupVal cc mem env tyenv nameEnv sval
-          case testLeq (incNat $ W4.bvWidth off) (knownNat @64) of
-            Nothing -> fail "Argument bitvector does not fit in a single general-purpose register"
-            Just LeqProof -> do
-              off' <- W4.bvZext sym (knownNat @64) off
+  X86Sim ()
+setArgs env tyenv nameEnv args
+  | length args > length argRegs = throwX86 "More arguments than would fit into general-purpose registers"
+  | otherwise = do
+      sym <- use x86Sym
+      cc <- use x86CrucibleContext
+      mem <- use x86Mem
+      let
+        setRegSetupValue rs (reg, sval) = typeOfSetupValue cc tyenv nameEnv sval >>= \ty ->
+          case ty of
+            C.LLVM.PtrType _ -> do
               val <- C.LLVM.unpackMemValue sym (C.LLVM.LLVMPointerRepr $ knownNat @64)
-                $ C.LLVM.LLVMValInt base off'
+                =<< resolveSetupVal cc mem env tyenv nameEnv sval
               setReg reg val rs
-        _ -> fail "Argument does not fit into a single general-purpose register"
+            C.LLVM.IntType 64 -> do
+              val <- C.LLVM.unpackMemValue sym (C.LLVM.LLVMPointerRepr $ knownNat @64)
+                =<< resolveSetupVal cc mem env tyenv nameEnv sval
+              setReg reg val rs
+            C.LLVM.IntType _ -> do
+              C.LLVM.LLVMValInt base off <- resolveSetupVal cc mem env tyenv nameEnv sval
+              case testLeq (incNat $ W4.bvWidth off) (knownNat @64) of
+                Nothing -> fail "Argument bitvector does not fit in a single general-purpose register"
+                Just LeqProof -> do
+                  off' <- W4.bvZext sym (knownNat @64) off
+                  val <- C.LLVM.unpackMemValue sym (C.LLVM.LLVMPointerRepr $ knownNat @64)
+                    $ C.LLVM.LLVMValInt base off'
+                  setReg reg val rs
+            _ -> fail "Argument does not fit into a single general-purpose register"
+      regs <- use x86Regs
+      newRegs <- liftIO . foldlM setRegSetupValue regs $ zip argRegs args
+      x86Regs .= newRegs
+  where argRegs = [Macaw.RDI, Macaw.RSI, Macaw.RDX, Macaw.RCX, Macaw.R8, Macaw.R9]
 
 --------------------------------------------------------------------------------
 -- ** Postcondition
@@ -472,32 +584,31 @@ setArgs sym cc env tyenv nameEnv mem regs args
 -- | Assert the postcondition for the spec, given the final memory and register map.
 assertPost ::
   X86Constraints =>
-  Sym ->
-  Options ->
-  LLVMCrucibleContext LLVMArch ->
   Map MS.AllocIndex Ptr ->
-  MS.CrucibleMethodSpecIR LLVM ->
-  (Mem, Mem) {- ^ The state of memory before and after simulation -} ->
-  (Regs, Regs) {- ^ The state of the registers before and after simulation -} ->
-  IO ()
-assertPost sym opts cc env ms (premem, postmem) (preregs, postregs) = do
+  Mem {- ^ The state of memory before simulation -} ->
+  Regs {- ^ The state of the registers before simulation -} ->
+  X86Sim ()
+assertPost env premem preregs = do
+  sym <- use x86Sym
+  ms <- use x86MethodSpec
+  postregs <- use x86Regs
   let tyenv = ms ^. MS.csPreState . MS.csAllocs
       nameEnv = MS.csTypeNames ms
   forM_ (ms ^. MS.csPostState . MS.csPointsTos)
-    $ assertPointsTo sym opts cc env tyenv nameEnv postmem
+    $ assertPointsTo env tyenv nameEnv
 
   prersp <- getReg Macaw.RSP preregs
-  expectedIP <- C.LLVM.doLoad sym premem prersp (C.LLVM.bitvectorType 8)
+  expectedIP <- liftIO $ C.LLVM.doLoad sym premem prersp (C.LLVM.bitvectorType 8)
     (C.LLVM.LLVMPointerRepr $ knownNat @64) C.LLVM.noAlignment
   actualIP <- getReg Macaw.X86_IP postregs
-  correctRetAddr <- C.LLVM.ptrEq sym C.LLVM.PtrWidth actualIP expectedIP
-  C.addAssertion sym . C.LabeledPred correctRetAddr . C.SimError W4.initializationLoc
+  correctRetAddr <- liftIO $ C.LLVM.ptrEq sym C.LLVM.PtrWidth actualIP expectedIP
+  liftIO . C.addAssertion sym . C.LabeledPred correctRetAddr . C.SimError W4.initializationLoc
     $ C.AssertFailureSimError "Instruction pointer not set to return address" ""
 
-  stack <- C.LLVM.doPtrAddOffset sym premem prersp =<< W4.bvLit sym knownNat 8
+  stack <- liftIO $ C.LLVM.doPtrAddOffset sym premem prersp =<< W4.bvLit sym knownNat 8
   postrsp <- getReg Macaw.RSP postregs
-  correctStack <- C.LLVM.ptrEq sym C.LLVM.PtrWidth stack postrsp
-  C.addAssertion sym . C.LabeledPred correctStack . C.SimError W4.initializationLoc
+  correctStack <- liftIO $ C.LLVM.ptrEq sym C.LLVM.PtrWidth stack postrsp
+  liftIO $ C.addAssertion sym . C.LabeledPred correctStack . C.SimError W4.initializationLoc
     $ C.AssertFailureSimError "Stack not preserved" ""
 
   -- TODO: Match return value in RAX
@@ -505,28 +616,28 @@ assertPost sym opts cc env ms (premem, postmem) (preregs, postregs) = do
 -- | Assert that a points-to postcondition holds.
 assertPointsTo ::
   X86Constraints =>
-  Sym ->
-  Options ->
-  LLVMCrucibleContext LLVMArch ->
   Map MS.AllocIndex Ptr {- ^ Associates each AllocIndex with the corresponding allocation -} ->
   Map MS.AllocIndex LLVMAllocSpec {- ^ Associates each AllocIndex with its specification -} ->
   Map MS.AllocIndex C.LLVM.Ident {- ^ Associates each AllocIndex with its name -} ->
-  Mem ->
   LLVMPointsTo LLVMArch {- ^ crucible_points_to statement from the precondition -} ->
-  IO ()
-assertPointsTo sym opts cc env tyenv nameEnv mem (LLVMPointsTo _ cond tptr texpected) = do
-  when (isJust cond) $ fail "unsupported x86_64 command: crucible_conditional_points_to"
-  ptr <- C.LLVM.unpackMemValue sym (C.LLVM.LLVMPointerRepr $ knownNat @64)
+  X86Sim ()
+assertPointsTo env tyenv nameEnv (LLVMPointsTo _ cond tptr texpected) = do
+  when (isJust cond) $ throwX86 "unsupported x86_64 command: crucible_conditional_points_to"
+  sym <- use x86Sym
+  opts <- use x86Options
+  cc <- use x86CrucibleContext
+  mem <- use x86Mem
+  ptr <- liftIO $ C.LLVM.unpackMemValue sym (C.LLVM.LLVMPointerRepr $ knownNat @64)
     =<< resolveSetupVal cc mem env tyenv Map.empty tptr
-  storTy <- C.LLVM.toStorableType =<< typeOfSetupValue cc tyenv nameEnv texpected
-  _actual <- C.LLVM.assertSafe sym =<< C.LLVM.loadRaw sym mem ptr storTy C.LLVM.noAlignment
+  storTy <- liftIO $ C.LLVM.toStorableType =<< typeOfSetupValue cc tyenv nameEnv texpected
+  _actual <- liftIO $ C.LLVM.assertSafe sym =<< C.LLVM.loadRaw sym mem ptr storTy C.LLVM.noAlignment
   -- TODO: actually do matching between actual and expected
   -- For now, we only make sure we can load the memory
   if | MS.SetupTerm expected <- texpected
      , FTermF (ExtCns ec) <- unwrapTermF $ ttTerm expected
      , ('_':_) <- ecName ec
      -> pure ()
-     | otherwise -> printOutLn opts Warn $ mconcat
+     | otherwise -> liftIO . printOutLn opts Warn $ mconcat
        [ "During x86 verification, attempted to match against a term that is not "
        , "a fresh variable with an underscore-prefixed name. "
        , "Note that crucible_points_to only asserts that memory is readable. "
@@ -537,14 +648,17 @@ assertPointsTo sym opts cc env tyenv nameEnv mem (LLVMPointsTo _ cond tptr texpe
 
 -- | Gather and run the solver on goals from the simulator.
 checkGoals ::
-  Sym ->
-  Options ->
-  SharedContext ->
-  IO ()
-checkGoals sym opts sc = do
-  liftIO $ printOutLn opts Info "Simulation finished, running solver on goals"
+  X86Sim ()
+checkGoals = do
+  sym <- use x86Sym
+  opts <- use x86Options
+  sc <- use x86SharedContext
   gs <- liftIO $ getGoals sym
-  liftIO $ print gs
+  liftIO . printOutLn opts Info $ mconcat
+    [ "Simulation finished, running solver on "
+    , show $ length gs
+    , " goals"
+    ]
   liftIO . forM_ gs $ \g ->
     do
       term <- gGoal sc g
@@ -552,34 +666,12 @@ checkGoals sym opts sc = do
       printOutLn opts Info $ ppStats stats
       case mb of
         Nothing -> printOutLn opts Info "Goal succeeded"
-        Just ex -> fail $ "Failure, counterexample: " <> show ex
+        Just ex -> do
+          print g
+          fail $ mconcat
+            ["Failure (", show $ gLoc g
+            , "): ", show $ gMessage g
+            , "\nCounterexample: " <> show ex
+            ]
     `catch` \(X86Error e) -> fail $ "Failure, error: " <> e
   liftIO $ printOutLn opts Info "All goals succeeded"
-
--------------------------------------------------------------------------------
--- ** Utility type synonyms and functions
-
-type LLVMArch = C.LLVM.X86 64
-type LLVM = C.LLVM.LLVM LLVMArch
-type Regs = Assignment (C.RegValue' Sym) (Macaw.MacawCrucibleRegTypes Macaw.X86_64)
-type Register = Macaw.X86Reg (Macaw.BVType 64)
-type Mem = C.LLVM.MemImpl Sym
-type Ptr = C.LLVM.LLVMPtr Sym 64
-type X86Constraints = (C.LLVM.HasPtrWidth (C.LLVM.ArchWidth LLVMArch), C.LLVM.HasLLVMAnn Sym)
-
-setReg ::
-  Register ->
-  C.RegValue Sym (C.LLVM.LLVMPointerType 64) ->
-  Regs ->
-  IO Regs
-setReg reg val regs
-  | Just regs' <- Macaw.updateX86Reg reg (C.RV . const val) regs = pure regs'
-  | otherwise = fail $ mconcat ["Invalid register: ", show reg]
-
-getReg ::
-  Register ->
-  Regs ->
-  IO (C.RegValue Sym (C.LLVM.LLVMPointerType 64))
-getReg reg regs = case Macaw.lookupX86Reg reg regs of
-  Just (C.RV val) -> pure val
-  Nothing -> fail $ mconcat ["Invalid register: ", show reg]


### PR DESCRIPTION
To facilitate this, I've refactored a bunch of functions to use a `MonadState` rather than passing many arguments / returning large tuples. This makes the diff unpleasantly large, but the only "real" changes are in `initialState`, `setupGlobals`, and `executePointsTo`.