### PR TITLE
Issue698

### DIFF
--- a/src/SAWScript/MGU.hs
+++ b/src/SAWScript/MGU.hs
@@ -625,7 +625,7 @@ inferRecDecls ds =
                  $ sequence [ withExprPos pos $ inferE (patternLName p, e)
                             | Decl pos p _ e <- ds
                             ]
-     sequence_ $ zipWith (constrainTypeWithPattern (error "FIXME")) ts pats'
+     sequence_ $ zipWith (constrainTypeWithPattern (patternLName (head pats))) ts pats'
      ess <- generalize es ts
      return [ Decl pos p (Just s) e1
             | (pos, p, (e1, s)) <- zip3 (map getPos ds) pats ess

--- a/stack.ghc-8.4.yaml
+++ b/stack.ghc-8.4.yaml
@@ -57,5 +57,7 @@ extra-deps:
   - yaml-0.11.2.0
   - libyaml-0.1.2
   - aeson-1.4.3.0
+  - QuickCheck-2.14
+  - splitmix-0.0.4
 resolver: lts-12.26
 allow-newer: false

--- a/stack.ghc-8.6.yaml
+++ b/stack.ghc-8.6.yaml
@@ -53,5 +53,7 @@ extra-deps:
   - config-value-0.6.3.1
   - simple-get-opt-0.3
   - base-orphans-0.8.2
+  - QuickCheck-2.14
+  - splitmix-0.0.4
 resolver: lts-14.3
 allow-newer: false

--- a/stack.ghc-8.8.yaml
+++ b/stack.ghc-8.8.yaml
@@ -46,5 +46,7 @@ extra-deps:
   - base-orphans-0.8.2
   - base-compat-0.10.5
   - json-0.10
+  - QuickCheck-2.14
+  - splitmix-0.0.4
 resolver: lts-15.1
 allow-newer: false


### PR DESCRIPTION
Remove call to `error` in saw-script type checker.

Fixes #698.