### PR TITLE
Avoid arithmetic underflow on type Natural.

### DIFF
--- a/intTests/test0058/test.saw
+++ b/intTests/test0058/test.saw
@@ -21,10 +21,9 @@ print (eval_int neg_x); // [..] 15 (which has the same base-2 representation as
 
 // Sequences more generally
 
-// Note: Commented out due to bug #783, which crashes SAW
 // empty sequence
-// let l0 = {{ [] : [0]Bit }};
-// print (eval_list l0);
+let l0 = {{ [] : [0]Bit }};
+print (eval_list l0);
 
 // nonempty sequences
 let l1   = {{ [0x01, 0x02, 0x03 ]}};

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -1164,7 +1164,7 @@ eval_list t = do
       _ -> fail "eval_list: not a monomorphic array type"
   n' <- io $ scNat sc (fromInteger n)
   a' <- io $ Cryptol.importType sc Cryptol.emptyEnv a
-  idxs <- io $ traverse (scNat sc) [0 .. fromInteger n - 1]
+  idxs <- io $ traverse (scNat sc) $ map fromInteger [0 .. n - 1]
   ts <- io $ traverse (scAt sc n' a' (ttTerm t)) idxs
   return (map (TypedTerm (C.tMono a)) ts)
 


### PR DESCRIPTION
Fixes #783.