### PR TITLE
Add an extended example to the end of the manual

### DIFF
--- a/doc/manual/manual.md
+++ b/doc/manual/manual.md
@@ -2543,7 +2543,7 @@ We now define
 `ptr_to_fresh n ty` returns a pair `(x, p)` consisting of a fresh symbolic
 variable `x` of type `ty` and a pointer `p` to it. `n` specifies the
 name that SAW should use when printing `x`. `ptr_to_fresh_readonly` does the
-same, the variable cannot be written to.
+same, but returns a pointer to space that cannot be written to.
 
 ~~~~
 let ptr_to_fresh n ty = do {
@@ -2583,7 +2583,7 @@ The C function we wish to verify has type
 
 The function's specification generates four symbolic variables and pointers to
 them in the precondition/setup stage. The pointers are passed to the function
-during symbolic execution via `crucible_execute_fun`. Finally, in the
+during symbolic execution via `crucible_execute_func`. Finally, in the
 postcondition/return stage, the expected values are computed using the trusted
 Cryptol implementation and it is asserted that the pointers do in fact point to
 these expected values.
@@ -2627,7 +2627,8 @@ let salsa20_setup =
 
 #### 32-Bit Key Expansion
 
-The next function of substantial behavior that we wish to verify has type
+The next function of substantial behavior that we wish to verify has the
+following prototype:
 
 ~~~~c
 void s20_expand32( uint8_t *k
@@ -2642,7 +2643,7 @@ function does not write to the memory pointed to by `k` or `n` using the
 utility `ptr_to_fresh_readonly`, as this function should only modify
 `keystream`. Besides this, we see the call to the trusted Cryptol
 implementation specialized to `a=2`, which does 32-bit key expansion (since the
-Cryptol implementation can also specialize to `a=1` for 16-bit keys.) This
+Cryptol implementation can also specialize to `a=1` for 16-bit keys). This
 specification can easily be changed to work with 16-bit keys.
 
 ~~~~
@@ -2702,7 +2703,10 @@ let s20_encrypt32 n = do {
 
 Finally, we can verify all of the functions. Notice the use of compositional
 verification and that path satisfiability checking is enabled for those
-functions with loops not bounded by explicit constants.
+functions with loops not bounded by explicit constants. Notice that we prove
+the top-level function for several sizes; this is due to the limitation that
+SAW can only operate on finite programs (while Salsa20 can operate on any input
+size.)
 
 ~~~~
 let main : TopLevel () = do {

--- a/doc/manual/manual.md
+++ b/doc/manual/manual.md
@@ -2479,7 +2479,7 @@ either before or after the execution of the function, respectively.
 
 ## An Extended Example
 
-In order to tie together many of the concepts in this manual, we now present a
+To tie together many of the concepts in this manual, we now present a
 non-trivial verification task in its entirety. All of the code for this example
 can be found in the `examples/salsa20` directory of
 [the SAWScript repository](https://github.com/GaloisInc/saw-script).
@@ -2488,19 +2488,20 @@ can be found in the `examples/salsa20` directory of
 
 Salsa20 is a stream cipher developed in 2005 by Daniel J. Bernstein, built on a
 pseudorandom function utilizing add-rotate-XOR (ARX) operations on 32-bit
-words[^4]. Bernstein himself has provided a number of public domain
+words[^4]. Bernstein himself has provided several public domain
 implementations of the cipher, optimized for common machine architectures.
 For the mathematically inclined, his specification for the cipher can be
 found [here](http://cr.yp.to/snuffle/spec.pdf).
 
 The repository referenced above contains three implementations of the Salsa20
 cipher: A reference Cryptol implementation (which we take as correct in this
-example), and two C implmentations, one of which is from Bernstein himself. For
-the purposes of this example, we focus on the second of these C implementations,
-which more closely matches the Cryptol implementation. A full verification of
-Bernstein's implementation is available in `examples/salsa20/djb`, for the
-interested. The code for this verification task can be found in the files named
-according to the pattern `examples/salsa20/(s|S)alsa20.*`.
+example), and two C implementations, one of which is from Bernstein himself.
+For this example, we focus on the second of these C
+implementations, which more closely matches the Cryptol implementation. Full
+verification of Bernstein's implementation is available in
+`examples/salsa20/djb`, for the interested. The code for this verification task
+can be found in the files named according to the pattern
+`examples/salsa20/(s|S)alsa20.*`.
 
 ### Verifications
 
@@ -2562,7 +2563,7 @@ Finally, we define
 `oneptr_update_func : String -> LLVMType -> Term -> CrucibleSetup ()`.
 
 `oneptr_update_func n ty f` specifies the behavior of a function that takes
-a single pointer (with printable name given by `n`) to memory containing a
+a single pointer (with a printable name given by `n`) to memory containing a
 value of type `ty` and mutates the contents of that memory. The specification
 asserts that the contents of this memory after execution are equal to the value
 given by the application of `f` to the value in that memory before execution.
@@ -2581,9 +2582,9 @@ The C function we wish to verify has type
 `void s20_quarterround(uint32_t *y0, uint32_t *y1, uint32_t *y2, uint32_t *y3)`.
 
 The function's specification generates four symbolic variables and pointers to
-them in the precondition / setup stage. The pointers are passed to the function
+them in the precondition/setup stage. The pointers are passed to the function
 during symbolic execution via `crucible_execute_fun`. Finally, in the
-postcondition / return stage, the expected values are computed using the trusted
+postcondition/return stage, the expected values are computed using the trusted
 Cryptol implementation and it is asserted that the pointers do in fact point to
 these expected values.
 
@@ -2700,7 +2701,7 @@ let s20_encrypt32 n = do {
 #### Verifying
 
 Finally, we can verify all of the functions. Notice the use of compositional
-verification, and that path satisfiability checking is enabled for those
+verification and that path satisfiability checking is enabled for those
 functions with loops not bounded by explicit constants.
 
 ~~~~

--- a/doc/manual/manual.md
+++ b/doc/manual/manual.md
@@ -2503,7 +2503,7 @@ verification of Bernstein's implementation is available in
 can be found in the files named according to the pattern
 `examples/salsa20/(s|S)alsa20.*`.
 
-### Verifications
+### Specifications
 
 We now take on the actual verification task. This will be done in two stages:
 We first define some useful utility functions for constructing common patterns
@@ -2698,7 +2698,7 @@ let s20_encrypt32 n = do {
 };
 ~~~~
 
-#### Verifying
+### Verifying Everything
 
 Finally, we can verify all of the functions. Notice the use of compositional
 verification and that path satisfiability checking is enabled for those

--- a/doc/manual/manual.md
+++ b/doc/manual/manual.md
@@ -2477,14 +2477,14 @@ that will likely be generalized in the future. It can be used in either
 the pre state or the post state, to specify the value of ghost state
 either before or after the execution of the function, respectively.
 
-# An Extended Example
+## An Extended Example
 
 In order to tie together many of the concepts in this manual, we now present a
 non-trivial verification task in its entirety. All of the code for this example
 can be found in the `examples/salsa20` directory of
 [the SAWScript repository](https://github.com/GaloisInc/saw-script).
 
-## Salsa20 Overview
+### Salsa20 Overview
 
 Salsa20 is a stream cipher developed in 2005 by Daniel J. Bernstein, built on a
 pseudorandom function utilizing add-rotate-XOR (ARX) operations on 32-bit
@@ -2502,7 +2502,7 @@ Bernstein's implementation is available in `examples/salsa20/djb`, for the
 interested. The code for this verification task can be found in the files named
 according to the pattern `examples/salsa20/(s|S)alsa20.*`.
 
-## Verifications
+### Verifications
 
 We now take on the actual verification task. This will be done in two stages:
 We first define some useful utility functions for constructing common patterns
@@ -2511,7 +2511,7 @@ functions are modified in-place.) We then demonstrate how one might construct a
 specification for each of the functions in the Salsa20 implementation described
 above.
 
-### Utility Functions
+#### Utility Functions
 
 We first define the function
 `alloc_init : LLVMType -> Term -> CrucibleSetup SetupValue`.
@@ -2575,7 +2575,7 @@ let oneptr_update_func n ty f = do {
 };
 ~~~~
 
-### The `quarterround` operation
+#### The `quarterround` operation
 
 The C function we wish to verify has type
 `void s20_quarterround(uint32_t *y0, uint32_t *y1, uint32_t *y2, uint32_t *y3)`.
@@ -2604,7 +2604,7 @@ let quarterround_setup : CrucibleSetup () = do {
 };
 ~~~~
 
-### Simple Updating Functions
+#### Simple Updating Functions
 
 The following functions can all have their specifications given by the utility
 function `oneptr_update_func` implemented above, so there isn't much to say
@@ -2624,7 +2624,7 @@ let salsa20_setup =
     oneptr_update_func "seq" (llvm_array 64 (llvm_int 8)) {{ Salsa20 }};
 ~~~~
 
-### 32-Bit Key Expansion
+#### 32-Bit Key Expansion
 
 The next function of substantial behavior that we wish to verify has type
 
@@ -2658,7 +2658,7 @@ let salsa20_expansion_32 = do {
 };
 ~~~~
 
-### 32-bit Key Encryption
+#### 32-bit Key Encryption
 
 Finally, we write a specification for the encryption function itself, which has
 type
@@ -2697,7 +2697,7 @@ let s20_encrypt32 n = do {
 };
 ~~~~
 
-### Verifying
+#### Verifying
 
 Finally, we can verify all of the functions. Notice the use of compositional
 verification, and that path satisfiability checking is enabled for those

--- a/doc/manual/manual.md
+++ b/doc/manual/manual.md
@@ -2476,3 +2476,43 @@ Currently, this function can only be used for LLVM verification, though
 that will likely be generalized in the future. It can be used in either
 the pre state or the post state, to specify the value of ghost state
 either before or after the execution of the function, respectively.
+
+# An Extended Example
+
+In order to tie together many of the concepts in this manual, we now present a
+non-trivial verification task in its entirety. All of the code for this example
+can be found in the `examples/salsa20` directory of
+[the SAWScript repository](https://github.com/GaloisInc/saw-script).
+
+## Salsa20 Overview
+
+Salsa20 is a stream cipher developed in 2005 by Daniel J. Bernstein, built on a
+pseudorandom function utilizing add-rotate-XOR (ARX) operations on 32-bit
+words[^4]. Bernstein himself has provided a number of public domain
+implementations of the cipher, optimized for common machine architectures.
+
+The full example code referenced above contains three implementations of
+Salsa20: A reference Cryptol implementation (which we take as correct), and two
+C implmentations, one of which is from Bernstein himself. For the purposes of
+this example, we focus on the second of these implementations, which more
+closely matches the Cryptol implementation. A full verification of Bernstein's
+implementation is available in `examples/salsa20/djb`.
+
+We now give a brief description of each function to verify, presented using
+both the Cryptol and C names.
+
+### `quarterround` / `s20_quarterround`
+
+### `rowround` / `s20_rowround`
+
+### `columnround` / `s20_columnround`
+
+### `doubleround` / `s20_doubleround`
+
+### `Salsa20` / `s20_hash`
+
+### `Salsa20_expansion` / `s20_expand32`
+
+### `Salsa20_encrypt` / `s20_crypt32`
+
+[^4]: https://en.wikipedia.org/wiki/Salsa20


### PR DESCRIPTION
This resolves #195 by implementing (with commentary) most of the Salsa20 example from the `examples` directory.