### PR TITLE
Use TypedExtCns operations from cryptol-saw-core package

### DIFF
--- a/src/SAWScript/Crucible/Common/MethodSpec.hs
+++ b/src/SAWScript/Crucible/Common/MethodSpec.hs
@@ -147,6 +147,12 @@ ppTypedTerm (TypedTerm tp tm) =
   PP.<+> PP.text ":" PP.<+>
   PP.text (show (Cryptol.ppPrec 0 tp))
 
+ppTypedExtCns :: TypedExtCns -> PP.Doc
+ppTypedExtCns (TypedExtCns tp ec) =
+  PP.text (ecName ec)
+  PP.<+> PP.text ":" PP.<+>
+  PP.text (show (Cryptol.ppPrec 0 tp))
+
 setupToTypedTerm ::
   Options {-^ Printing options -} ->
   SharedContext ->
@@ -326,7 +332,7 @@ data StateSpec ext = StateSpec
     -- ^ points-to statements
   , _csConditions    :: [SetupCondition ext]
     -- ^ equality, propositions, and ghost-variable conditions
-  , _csFreshVars     :: [TypedTerm]
+  , _csFreshVars     :: [TypedExtCns]
     -- ^ fresh variables created in this state
   , _csVarTypeNames  :: Map AllocIndex (TypeName ext)
     -- ^ names for types of variables, for diagnostics

--- a/src/SAWScript/Crucible/Common/Override.hs
+++ b/src/SAWScript/Crucible/Common/Override.hs
@@ -148,7 +148,7 @@ initialState sym globals allocs terms free loc = OverrideState
 
 data OverrideFailureReason ext
   = AmbiguousPointsTos [MS.PointsTo ext]
-  | AmbiguousVars [TypedTerm]
+  | AmbiguousVars [TypedExtCns]
   | BadTermMatch Term Term -- ^ simulated and specified terms did not match
   | BadPointerCast -- ^ Pointer required to process points-to
   | BadReturnSpecification (Some Crucible.TypeRepr)
@@ -184,7 +184,7 @@ ppOverrideFailureReason rsn = case rsn of
     (PP.indent 2 $ PP.vcat (map PP.pretty pts))
   AmbiguousVars vs ->
     PP.text "Fresh variable(s) not reachable via points-tos from function inputs/outputs:" PP.<$$>
-    (PP.indent 2 $ PP.vcat (map MS.ppTypedTerm vs))
+    (PP.indent 2 $ PP.vcat (map MS.ppTypedExtCns vs))
   BadTermMatch x y ->
     PP.text "terms do not match" PP.<$$>
     (PP.indent 2 (ppTerm defaultPPOpts x)) PP.<$$>

--- a/src/SAWScript/Crucible/Common/Setup/Type.hs
+++ b/src/SAWScript/Crucible/Common/Setup/Type.hs
@@ -35,10 +35,10 @@ import           Control.Lens
 import           Control.Monad.State (StateT)
 import           Control.Monad.IO.Class (MonadIO(liftIO))
 
-import qualified Cryptol.TypeCheck.Type as Cryptol (Type, tMono)
+import qualified Cryptol.TypeCheck.Type as Cryptol (Type)
 import qualified Verifier.SAW.Cryptol as Cryptol (importType, emptyEnv)
-import           Verifier.SAW.TypedTerm (TypedTerm(..))
-import           Verifier.SAW.SharedTerm (SharedContext, scFreshGlobal)
+import           Verifier.SAW.TypedTerm (TypedExtCns(..))
+import           Verifier.SAW.SharedTerm (SharedContext, scFreshGlobalVar, ExtCns(..))
 
 import qualified SAWScript.Crucible.Common.MethodSpec as MS
 
@@ -102,10 +102,10 @@ freshVariable ::
   SharedContext {- ^ shared context -} ->
   String        {- ^ variable name  -} ->
   Cryptol.Type  {- ^ variable type  -} ->
-  CrucibleSetupT arch m TypedTerm
+  CrucibleSetupT arch m TypedExtCns
 freshVariable sc name cty =
   do ty <- liftIO $ Cryptol.importType sc Cryptol.emptyEnv cty
-     trm <- liftIO $ scFreshGlobal sc name ty
-     let tt = TypedTerm (Cryptol.tMono cty) trm
+     i <- liftIO $ scFreshGlobalVar sc
+     let tt = TypedExtCns cty (EC i name ty)
      currentState . MS.csFreshVars %= cons tt
      return tt

--- a/src/SAWScript/Crucible/JVM/Builtins.hs
+++ b/src/SAWScript/Crucible/JVM/Builtins.hs
@@ -65,9 +65,6 @@ import qualified Verifier.Java.Codebase as CB
 -- cryptol
 import qualified Cryptol.TypeCheck.Type as Cryptol
 
--- cryptol-saw-core
-import Verifier.SAW.Cryptol (importType, emptyEnv)
-
 -- what4
 import qualified What4.Partial as W4
 import qualified What4.ProgramLoc as W4
@@ -662,12 +659,13 @@ verifyPoststate opts sc cc mspec env0 globals ret =
   do poststateLoc <- SS.toW4Loc "_SAW_verify_poststate" <$> getPosition
      io $ W4.setCurrentProgramLoc sym poststateLoc
 
-     let terms0 = Map.fromList
-           [ (ecVarIndex ec, ttTerm tt)
+     let ecs0 = Map.fromList
+           [ (ecVarIndex ec, ec)
            | tt <- mspec ^. MS.csPreState . MS.csFreshVars
-           , let Just ec = asExtCns (ttTerm tt) ]
+           , let ec = tecExt tt ]
+     terms0 <- io $ traverse (scExtCns sc) ecs0
 
-     let initialFree = Set.fromList (map (termId . ttTerm)
+     let initialFree = Set.fromList (map (ecVarIndex . tecExt)
                                     (view (MS.csPostState . MS.csFreshVars) mspec))
      matchPost <- io $
           runOverrideMatcher sym globals env0 terms0 initialFree poststateLoc $
@@ -823,23 +821,9 @@ jvm_fresh_var bic _opts name jty =
   do let sc = biSharedContext bic
      case cryptolTypeOfActual jty of
        Nothing -> fail $ "Unsupported type in jvm_fresh_var: " ++ show jty
-       Just ty -> freshVariable sc name ty
-
--- | Allocate a fresh variable and record this allocation in the
--- setup state.
-freshVariable ::
-  SharedContext {- ^ shared context -} ->
-  String        {- ^ variable name  -} ->
-  Cryptol.Type  {- ^ variable type  -} ->
-  JVMSetup TypedTerm
-freshVariable sc name cty =
-  do let schema = Cryptol.Forall [] [] cty
-     ty <- liftIO $ importType sc emptyEnv cty
-     var <- liftIO $ scFreshGlobal sc name ty
-     let tt = TypedTerm schema var
-     Setup.currentState . MS.csFreshVars %= cons tt
-     return tt
-
+       Just cty ->
+         do tec <- Setup.freshVariable sc name cty
+            liftIO $ typedTermOfExtCns sc tec
 
 jvm_alloc_object ::
   BuiltinContext ->

--- a/src/SAWScript/Crucible/JVM/Builtins.hs
+++ b/src/SAWScript/Crucible/JVM/Builtins.hs
@@ -821,9 +821,7 @@ jvm_fresh_var bic _opts name jty =
   do let sc = biSharedContext bic
      case cryptolTypeOfActual jty of
        Nothing -> fail $ "Unsupported type in jvm_fresh_var: " ++ show jty
-       Just cty ->
-         do tec <- Setup.freshVariable sc name cty
-            liftIO $ typedTermOfExtCns sc tec
+       Just cty -> Setup.freshVariable sc name cty
 
 jvm_alloc_object ::
   BuiltinContext ->

--- a/src/SAWScript/Crucible/JVM/BuiltinsJVM.hs
+++ b/src/SAWScript/Crucible/JVM/BuiltinsJVM.hs
@@ -64,10 +64,10 @@ import qualified What4.Interface as W4
 import qualified What4.Solver.Yices as Yices
 
 -- saw-core
-import Verifier.SAW.SharedTerm(Term, SharedContext, mkSharedContext, scImplies, scAbstractExts)
+import Verifier.SAW.SharedTerm(Term, SharedContext, mkSharedContext, scImplies)
 
 -- cryptol-saw-core
-import Verifier.SAW.TypedTerm(TypedTerm(..))
+import Verifier.SAW.TypedTerm (TypedTerm(..), abstractTypedExts)
 
 -- saw-script
 import SAWScript.Builtins(fixPos)
@@ -180,9 +180,8 @@ crucible_java_extract bic opts c mname = do
                     case baseCryptolType bt of
                       Nothing -> failure
                       Just cty -> return cty
-              t' <- scAbstractExts sc (map snd (toList ecs)) t
-              let cty' = foldr Cryptol.tFun cty (map fst (toList ecs))
-              return $ TypedTerm (Cryptol.tMono cty') t'
+              let tt = TypedTerm (Cryptol.tMono cty) t
+              abstractTypedExts sc (toList ecs) tt
             Crucible.AbortedResult _ _ar -> do
               fail $ unlines [ "Symbolic execution failed." ]
             Crucible.TimeoutResult _cxt -> do

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -1561,9 +1561,7 @@ crucible_fresh_var bic _opts name lty =
      let dl = Crucible.llvmDataLayout (ccTypeCtx cctx)
      case cryptolTypeOfActual dl lty' of
        Nothing -> throwCrucibleSetup loc $ "Unsupported type in crucible_fresh_var: " ++ show (L.ppType lty)
-       Just cty ->
-         do tec <- Setup.freshVariable sc name cty
-            liftIO $ typedTermOfExtCns sc tec
+       Just cty -> Setup.freshVariable sc name cty
 
 crucible_fresh_cryptol_var ::
   BuiltinContext ->
@@ -1577,8 +1575,7 @@ crucible_fresh_cryptol_var bic _opts name s =
      case s of
        Cryptol.Forall [] [] ty ->
          do let sc = biSharedContext bic
-            tec <- Setup.freshVariable sc name ty
-            liftIO $ typedTermOfExtCns sc tec
+            Setup.freshVariable sc name ty
        _ ->
          throwCrucibleSetup loc $ "Unsupported polymorphic Cryptol type schema: " ++ show s
 
@@ -1616,8 +1613,7 @@ constructExpandedSetupValue cc sc loc t =
   case t of
     Crucible.IntType w ->
       do let cty = Cryptol.tWord (Cryptol.tNum w)
-         tec <- Setup.freshVariable sc "" cty
-         fv <- liftIO $ typedTermOfExtCns sc tec
+         fv <- Setup.freshVariable sc "" cty
          pure $ mkAllLLVM (SetupTerm fv)
 
     Crucible.StructType si -> do

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -1281,10 +1281,7 @@ baseCryptolType bt =
     Crucible.BaseBVRepr w -> pure $ Cryptol.tWord (Cryptol.tNum (natValue w))
     Crucible.BaseNatRepr  -> Nothing
     Crucible.BaseIntegerRepr -> pure $ Cryptol.tInteger
-    Crucible.BaseArrayRepr indexTypes range ->
-      do ts <- baseCryptolTypes indexTypes
-         t <- baseCryptolType range
-         pure $ foldr Cryptol.tFun t ts
+    Crucible.BaseArrayRepr {} -> Nothing
     Crucible.BaseFloatRepr _ -> Nothing
     Crucible.BaseStringRepr _ -> Nothing
     Crucible.BaseComplexRepr  -> Nothing


### PR DESCRIPTION
Reimplement some saw-script commands using new `TypedExtCns` and `TypedTerm` operations from the cryptol-saw-core package, which were added in GaloisInc/saw-core#69.