### PR TITLE
Build docker on tags with vX.X.X or X.X.X

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: Docker
 on:
   push:
-    tags: ["[0-9]+.[0-9]+.[0-9]+"]
+    tags: ["v?[0-9]+.[0-9]+.[0-9]+"]
 
 jobs:
   docker:


### PR DESCRIPTION
This'll fix building docker on semver style tags that start with v in addition to "true" semver tags.