### PR TITLE
Fix s2n tests to use our saw and link the right libtinfo library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,8 @@ jobs:
       - run: |
           git submodule update --init
           git -C deps/abcBridge submodule update --init
+      - uses: satackey/action-docker-layer-caching@v0.0.8
+        continue-on-error: true
       - name: Publish to Registry
         uses: docker/build-push-action@v1
         with:
@@ -164,6 +166,13 @@ jobs:
         with:
           name: "saw-Linux-${{ matrix.ghc }}"
           path: ./s2nTests/bin
+
+      - shell: bash
+        working-directory: s2nTests
+        run: docker-compose pull
+
+      - uses: satackey/action-docker-layer-caching@v0.0.8
+        continue-on-error: true
 
       - shell: bash
         name: "s2n tests: ${{ matrix.s2n-target }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,7 @@ jobs:
 
   s2n-tests:
     name: "Test s2n proofs"
+    timeout-minutes: 20
     needs: build
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,8 @@ jobs:
           git -C deps/abcBridge submodule update --init
       - run: .github/ci.sh set_version
         id: outputs
+      - uses: satackey/action-docker-layer-caching@v0.0.8
+        continue-on-error: true
       - name: Publish to Registry
         uses: docker/build-push-action@v1
         with:

--- a/s2nTests/docker-compose.yml
+++ b/s2nTests/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '3'
 services:
   saw-script:
-    build: ..
+    build:
+      context: ..
+      dockerfile: docker/saw.dockerfile
     entrypoint: ["cp", "/usr/local/bin/saw", "/saw-bin"]
     volumes:
       - ./bin:/saw-bin:rw

--- a/s2nTests/docker-compose.yml
+++ b/s2nTests/docker-compose.yml
@@ -3,15 +3,16 @@ services:
   saw-script:
     build:
       context: ..
-      dockerfile: docker/saw.dockerfile
+      dockerfile: ${PWD:-.}/docker/saw.dockerfile
     entrypoint: ["cp", "/usr/local/bin/saw", "/saw-bin"]
+    user: root
     volumes:
-      - ./bin:/saw-bin:rw
+      - ${PWD:-}/bin:/saw-bin:rw
 
   s2n:
     build:
       context: .
-      dockerfile: docker/s2n.dockerfile
+      dockerfile: ${PWD:-.}/docker/s2n.dockerfile
     image: s2n
     volumes:
-      - ./bin:/saw-bin:rw
+      - ${PWD:-.}/bin:/saw-bin:rw

--- a/s2nTests/docker/saw.dockerfile
+++ b/s2nTests/docker/saw.dockerfile
@@ -1,0 +1,70 @@
+FROM debian:stretch AS solvers
+
+# Install needed packages for building
+RUN apt-get update \
+    && apt-get install -y curl cmake gcc g++ git libreadline-dev unzip
+RUN useradd -m user
+RUN install -d -o user -g user /solvers
+USER user
+WORKDIR /solvers
+RUN mkdir -p rootfs/usr/local/bin
+
+# Get Z3 4.8.8 from GitHub
+RUN curl -L https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-ubuntu-16.04.zip --output z3.zip
+RUN unzip z3.zip
+RUN mv z3-*/bin/z3 rootfs/usr/local/bin
+
+# Build abc from GitHub. (Latest version.)
+RUN git clone https://github.com/berkeley-abc/abc.git
+RUN cd abc && make -j$(nproc)
+RUN cp abc/abc rootfs/usr/local/bin
+
+# Build Boolector release 3.2.1 from source
+RUN curl -L https://github.com/Boolector/boolector/archive/3.2.1.tar.gz | tar xz
+RUN cd boolector* && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./configure.sh && cd build && make -j$(nproc)
+RUN cp boolector*/build/bin/boolector rootfs/usr/local/bin
+
+# Install Yices 2.6.2
+RUN curl -L https://yices.csl.sri.com/releases/2.6.2/yices-2.6.2-x86_64-pc-linux-gnu-static-gmp.tar.gz | tar xz
+RUN cp yices*/bin/yices-smt2 rootfs/usr/local/bin \
+    && cp yices*/bin/yices rootfs/usr/local/bin
+
+# Install CVC4 1.8
+RUN curl -L https://github.com/CVC4/CVC4/releases/download/1.8/cvc4-1.8-x86_64-linux-opt --output rootfs/usr/local/bin/cvc4
+
+# Install MathSAT 5.6.3 - Uncomment if you are in compliance with MathSAT's license.
+# RUN curl -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.3-linux-x86_64.tar.gz | tar xz
+# RUN cp mathsat-5.6.3-linux-x86_64/bin/mathsat rootfs/usr/local/bin
+
+# Set executable and run tests
+RUN chmod +x rootfs/usr/local/bin/*
+
+FROM haskell:8.8.4-stretch AS build
+USER root
+RUN apt-get update && apt-get install -y wget libncurses-dev unzip
+COPY --from=solvers /solvers/rootfs /
+RUN useradd -m saw
+COPY --chown=saw:saw . /home/saw
+USER saw
+WORKDIR /home/saw
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+COPY cabal.GHC-8.8.4.config cabal.project.freeze
+RUN cabal v2-update
+RUN cabal v2-build
+RUN mkdir -p /home/saw/rootfs/usr/local/bin
+RUN cp $(cabal v2-exec which saw) /home/saw/rootfs/usr/local/bin/saw
+WORKDIR /home/saw
+USER root
+RUN chown -R root:root /home/saw/rootfs
+
+FROM debian:buster-slim
+RUN apt-get update \
+    && apt-get install -y libgmp10 libgomp1 libffi6 wget libncurses5 unzip
+COPY --from=build /home/saw/rootfs /
+COPY --from=solvers /solvers/rootfs /
+RUN useradd -m saw && chown -R saw:saw /home/saw
+USER saw
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+ENTRYPOINT ["/usr/local/bin/saw"]

--- a/s2nTests/docker/saw.dockerfile
+++ b/s2nTests/docker/saw.dockerfile
@@ -58,7 +58,7 @@ WORKDIR /home/saw
 USER root
 RUN chown -R root:root /home/saw/rootfs
 
-FROM debian:buster-slim
+FROM debian:stretch-slim
 RUN apt-get update \
     && apt-get install -y libgmp10 libgomp1 libffi6 wget libncurses5 unzip
 COPY --from=build /home/saw/rootfs /

--- a/s2nTests/scripts/s2n-entrypoint.sh
+++ b/s2nTests/scripts/s2n-entrypoint.sh
@@ -10,7 +10,6 @@ cd /saw-script/s2n
 echo 'JOBS=1' >> codebuild/bin/jobs.sh
 source codebuild/bin/s2n_setup_env.sh
 SAW=true SAW_INSTALL_DIR=tmp-saw codebuild/bin/s2n_install_test_dependencies.sh
-export PATH=/saw-bin:$PATH
 cp /saw-bin/saw "$SAW_INSTALL_DIR"/bin/saw
 "$SAW_INSTALL_DIR"/bin/saw --version
 exec codebuild/bin/s2n_codebuild.sh

--- a/s2nTests/scripts/s2n-entrypoint.sh
+++ b/s2nTests/scripts/s2n-entrypoint.sh
@@ -12,4 +12,5 @@ source codebuild/bin/s2n_setup_env.sh
 SAW=true SAW_INSTALL_DIR=tmp-saw codebuild/bin/s2n_install_test_dependencies.sh
 export PATH=/saw-bin:$PATH
 cp /saw-bin/saw "$SAW_INSTALL_DIR"/bin/saw
+"$SAW_INSTALL_DIR"/bin/saw --version
 exec codebuild/bin/s2n_codebuild.sh

--- a/s2nTests/scripts/s2n-entrypoint.sh
+++ b/s2nTests/scripts/s2n-entrypoint.sh
@@ -11,4 +11,5 @@ echo 'JOBS=1' >> codebuild/bin/jobs.sh
 source codebuild/bin/s2n_setup_env.sh
 SAW=true SAW_INSTALL_DIR=tmp-saw codebuild/bin/s2n_install_test_dependencies.sh
 export PATH=/saw-bin:$PATH
+cp /saw-bin/saw "$SAW_INSTALL_DIR"/bin/saw
 exec codebuild/bin/s2n_codebuild.sh


### PR DESCRIPTION
Let's try this out. Fixes a spot where I didn't copy the logic in the existing travis file correctly, and fixes (hopefully) a linking error when copying the binary out of a debian container into an ubuntu container.

Some thoughts: @atomb it might be time to start thinking about fully statically building release binaries for our more 'product-like' programs (eg saw-script, cryptol, ...)?