### PR TITLE
Evaluate saw-core terms into What4 more thoughougly when setting up

### DIFF
--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -1274,12 +1274,15 @@ setupLLVMCrucibleContext bic opts lm action =
                        return (gp^.Crucible.gpGlobals, st)
                      _ -> fail "simulator initialization failed!"
 
+               cacheRef <- newIORef mempty
+
                return
                   LLVMCrucibleContext{ _ccLLVMModule = lm
                                      , _ccBackend = sym
                                      , _ccLLVMSimContext = lsimctx
                                      , _ccLLVMGlobals = lglobals
                                      , _ccBasicSS = biBasicSS bic
+                                     , _ccUninterpCache = cacheRef
                                      }
           action cc
 

--- a/src/SAWScript/Crucible/LLVM/MethodSpecIR.hs
+++ b/src/SAWScript/Crucible/LLVM/MethodSpecIR.hs
@@ -64,6 +64,7 @@ module SAWScript.Crucible.LLVM.MethodSpecIR
   , ccLLVMModuleTrans
   , ccLLVMContext
   , ccTypeCtx
+  , ccUninterpCache
     -- * PointsTo
   , LLVMPointsTo(..)
   , LLVMPointsToValue(..)
@@ -139,6 +140,8 @@ import qualified SAWScript.Crucible.LLVM.CrucibleLLVM as CL
 import           Verifier.SAW.Rewriter (Simpset)
 import           Verifier.SAW.SharedTerm
 import           Verifier.SAW.TypedTerm
+
+import qualified Verifier.SAW.Simulator.What4 as W4SC
 
 --------------------------------------------------------------------------------
 -- ** Language features
@@ -318,6 +321,7 @@ data LLVMCrucibleContext arch =
   , _ccLLVMSimContext  :: Crucible.SimContext (Crucible.SAWCruciblePersonality Sym) Sym (CL.LLVM arch)
   , _ccLLVMGlobals     :: Crucible.SymGlobalState Sym
   , _ccBasicSS         :: Simpset
+  , _ccUninterpCache   :: IORef (W4SC.SymFnCache Sym)
   }
 
 makeLenses ''LLVMCrucibleContext


### PR DESCRIPTION
the symbolic simulator.  This currently breaks some tests, as there
are some constructs that cannot be handled by this new code path.