### PR TITLE
Init CI build/test workflow for heapster

### DIFF
--- a/.github/ci-heapster.sh
+++ b/.github/ci-heapster.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -Eeuxo pipefail
+
+[[ "$RUNNER_OS" == 'Windows' ]] && IS_WIN=true || IS_WIN=false
+BIN=bin
+EXT=""
+$IS_WIN && EXT=".exe"
+mkdir -p "$BIN"
+
+is_exe() { [[ -x "$1/$2$EXT" ]] || command -v "$2" > /dev/null 2>&1; }
+
+extract_exe() {
+  exe="$(cabal v2-exec which "$1$EXT")"
+  name="$(basename "$exe")"
+  echo "Copying $name to $2"
+  mkdir -p "$2"
+  cp -f "$exe" "$2/$name"
+  $IS_WIN || chmod +x "$2/$name"
+}
+
+retry() {
+  echo "Attempting with retry:" "$@"
+  local n=1
+  while true; do
+    if "$@"; then
+      break
+    else
+      if [[ $n -lt 3 ]]; then
+        sleep $n # don't retry immediately
+        ((n++))
+        echo "Command failed. Attempt $n/3:"
+      else
+        echo "The command has failed after $n attempts."
+        return 1
+      fi
+    fi
+  done
+}
+
+setup_dist_bins() {
+  is_exe "dist/bin" "saw" && is_exe "dist/bin" "jss" && return
+  extract_exe "saw" "dist/bin"
+  extract_exe "jss" "dist/bin"
+  export PATH=$PWD/dist/bin:$PATH
+  echo "$PWD/dist/bin" >> $GITHUB_PATH
+  strip dist/bin/saw* || echo "Strip failed: Ignoring harmless error"
+  strip dist/bin/jss* || echo "Strip failed: Ignoring harmless error"
+}
+
+install_z3() {
+  is_exe "$BIN" "z3" && return
+
+  case "$RUNNER_OS" in
+    Linux) file="ubuntu-16.04.zip" ;;
+    macOS) file="osx-10.14.6.zip" ;;
+    Windows) file="win.zip" ;;
+  esac
+  curl -o z3.zip -sL "https://github.com/Z3Prover/z3/releases/download/z3-$Z3_VERSION/z3-$Z3_VERSION-x64-$file"
+
+  if $IS_WIN; then 7z x -bd z3.zip; else unzip z3.zip; fi
+  cp z3-*/bin/z3$EXT $BIN/z3$EXT
+  $IS_WIN || chmod +x $BIN/z3
+  rm z3.zip
+}
+
+install_cvc4() {
+  is_exe "$BIN" "cvc4" && return
+  version="${CVC4_VERSION#4.}" # 4.y.z -> y.z
+
+  case "$RUNNER_OS" in
+    Linux) file="x86_64-linux-opt" ;;
+    Windows) file="win64-opt.exe" ;;
+    macOS) file="macos-opt" ;;
+  esac
+  # Temporary workaround
+  if [[ "$RUNNER_OS" == "Linux" ]]; then
+    curl -o cvc4$EXT -sL "https://cvc4.cs.stanford.edu/downloads/builds/x86_64-linux-opt/unstable/cvc4-2020-08-18-x86_64-linux-opt"
+  else
+    curl -o cvc4$EXT -sL "https://github.com/CVC4/CVC4/releases/download/$version/cvc4-$version-$file"
+  fi
+  $IS_WIN || chmod +x cvc4$EXT
+  mv cvc4$EXT "$BIN/cvc4$EXT"
+}
+
+install_yices() {
+  is_exe "$BIN" "yices" && return
+  ext=".tar.gz"
+  case "$RUNNER_OS" in
+    Linux) file="pc-linux-gnu-static-gmp.tar.gz" ;;
+    macOS) file="apple-darwin18.7.0-static-gmp.tar.gz" ;;
+    Windows) file="pc-mingw32-static-gmp.zip" && ext=".zip" ;;
+  esac
+  curl -o "yices$ext" -sL "https://yices.csl.sri.com/releases/$YICES_VERSION/yices-$YICES_VERSION-x86_64-$file"
+
+  if $IS_WIN; then
+    7z x -bd "yices$ext"
+    mv "yices-$YICES_VERSION"/bin/*.exe "$BIN"
+  else
+    tar -xzf "yices$ext"
+    pushd "yices-$YICES_VERSION" || exit
+    sudo ./install-yices
+    popd || exit
+  fi
+  rm -rf "yices$ext" "yices-$YICES_VERSION"
+}
+
+install_yasm() {
+  is_exe "$BIN" "yasm" && return
+  if [[ "$RUNNER_OS" = "Linux" ]]; then
+    sudo apt-get update -q && sudo apt-get install -y yasm
+  else
+    brew install yasm
+  fi
+}
+
+build() {
+  cabal v2-update
+  cabal v2-configure -j2 --minimize-conflict-set
+  if ! retry cabal v2-build "$@" saw jss && [[ "$RUNNER_OS" == "macOS" ]]; then
+    echo "Working around a dylib issue on macos by removing the cache and trying again"
+    cabal v2-clean
+    retry cabal v2-build "$@" saw jss
+  fi
+}
+
+build_abc() {
+  arch=X86_64
+  case "$RUNNER_OS" in
+    Linux) os="Linux" ;;
+    macOS) os="OSX" ;;
+    Windows) return ;;
+  esac
+  pushd deps/abcBridge
+  $IS_WIN || scripts/build-abc.sh $arch $os
+  popd
+}
+
+install_system_deps() {
+  install_z3 &
+  install_cvc4 &
+  install_yices &
+  install_yasm &
+  wait
+  export PATH=$PWD/$BIN:$PATH
+  echo "$PWD/$BIN" >> $GITHUB_PATH
+  is_exe "$BIN" z3 && is_exe "$BIN" cvc4 && is_exe "$BIN" yices && is_exe "$BIN" yasm
+}
+
+COMMAND="$1"
+shift
+
+"$COMMAND" "$@"

--- a/.github/workflows/heapster.yml
+++ b/.github/workflows/heapster.yml
@@ -1,0 +1,96 @@
+name: SAWScript Heapster
+on:
+  push:
+    branches: [wip-heapster]
+  pull_request:
+    branches: [wip-heapster]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ghc: ["8.6.5"]
+        continue-on-error: [false]
+        include:
+          - os: macos-latest
+            ghc: "8.6.5"
+            continue-on-error: true
+    runs-on: ${{ matrix.os }}
+    name: SAWScript - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
+    continue-on-error: ${{ matrix.continue-on-error }}
+    env:
+      OCAML_VERSION: 4.09.1
+      # also change in setup-ocaml step based on value of opamVersion:
+      # https://github.com/avsm/setup-ocaml/blob/v1.1.2/src/installer.ts#L56
+      SETUP_OCAML_ACTION_VERSION: 1.1.2
+      COQBITS_VERSION: 1.0.0
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          git config --global url.https://github.com/.insteadOf git@github.com:
+          git submodule update --init
+          git -C deps/abcBridge submodule update --init
+
+      - name: Cache ~/.opam
+        uses: actions/cache@v2
+        with:
+          path: ~/.opam
+          key: ocaml-coqbits-${{ runner.os }}-${{ env.OCAML_VERSION }}-${{ env.SETUP_OCAML_ACTION_VERSION }}-${{ env.COQBITS_VERSION }}
+      - name: Set up ocaml and opam
+        uses: avsm/setup-ocaml@v1.1.2
+        with:
+          ocaml-version: ${{ env.OCAML_VERSION }}
+      - name: Install coq-bits
+        shell: bash
+        run: |
+          opam repo add coq-released https://coq.inria.fr/opam/released
+          opam install --unlock-base -y "coq-bits=$COQBITS_VERSION"
+
+      - uses: actions/setup-haskell@v1
+        id: setup-haskell
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          enable-stack: true
+
+      - uses: actions/cache@v2
+        name: Cache cabal store
+        with:
+          path: |
+            ${{ steps.setup-haskell.outputs.cabal-store }}
+            dist-newstyle
+          key: cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}
+          restore-keys: |
+            cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+
+      - shell: bash
+        run: .github/ci-heapster.sh build_abc
+
+      - shell: bash
+        run: .github/ci-heapster.sh build
+
+      - shell: bash
+        run: .github/ci-heapster.sh setup_dist_bins
+
+      - run: git submodule update --init deps/saw-core-coq
+      - name: Build deps/saw-core-coq/coq
+        shell: bash
+        working-directory: deps/saw-core-coq/coq
+        run: |
+          eval $(opam env)
+          make -j2
+
+      - shell: bash
+        run: .github/ci-heapster.sh install_system_deps
+        env:
+          Z3_VERSION: "4.8.8"
+          CVC4_VERSION: "4.1.8"
+          YICES_VERSION: "2.6.2"
+
+      - name: Build deps/heapster-saw/examples
+        shell: bash
+        working-directory: deps/heapster-saw/examples
+        run: |
+          eval $(opam env)
+          make -j2


### PR DESCRIPTION
Basic CI workflow for heapster on Mac + Linux which builds saw-script and then executes the examples in `deps/heapster-saw/examples`. ci-heapster.sh derived from ci.sh in master branch so future integration will be easy.

Example of what a test failure looks like: https://github.com/GaloisInc/saw-script/runs/1244155649