### PR TITLE
Add offline versions of what4 tactics

### DIFF
--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -798,22 +798,6 @@ w4_unint_cvc4 = wrapW4Prover . Prover.proveWhat4_cvc4
 w4_unint_yices :: [String] -> ProofScript SV.SatResult
 w4_unint_yices = wrapW4Prover . Prover.proveWhat4_yices
 
-offline_w4_boolector :: String -> ProofScript SV.SatResult
-offline_w4_boolector = offline_w4_unint_boolector []
-
-offline_w4_z3 :: String -> ProofScript SV.SatResult
-offline_w4_z3 = offline_w4_unint_z3 []
-
-offline_w4_cvc4 :: String -> ProofScript SV.SatResult
-offline_w4_cvc4 = offline_w4_unint_cvc4 []
-
-offline_w4_yices :: String -> ProofScript SV.SatResult
-offline_w4_yices = offline_w4_unint_yices []
-
-offline_w4_unint_boolector :: [String] -> String -> ProofScript SV.SatResult
-offline_w4_unint_boolector unints path =
-  wrapW4ProveExporter (Prover.proveExportWhat4_boolector unints) path ".smt2"
-
 offline_w4_unint_z3 :: [String] -> String -> ProofScript SV.SatResult
 offline_w4_unint_z3 unints path =
   wrapW4ProveExporter (Prover.proveExportWhat4_z3 unints) path ".smt2"

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -694,16 +694,12 @@ proveUnintSBV conf unints =
   do timeout <- psTimeout <$> get
      wrapProver (Prover.proveUnintSBV conf unints timeout)
 
-
-
-wrapProver ::
-  ( SharedContext ->
-    Prop -> IO (Maybe [(String, FirstOrderValue)], SolverStats)) ->
-  ProofScript SV.SatResult
-wrapProver f = do
-  sc <- lift $ SV.getSharedContext
-  withFirstGoal $ \g -> do
-
+applyProverToGoal :: (SharedContext
+                      -> Prop -> IO (Maybe [(String, FirstOrderValue)], SolverStats))
+                     -> SharedContext
+                     -> ProofGoal
+                     -> TopLevel (SV.SatResult, SolverStats, Maybe ProofGoal)
+applyProverToGoal f sc g = do
   (mb, stats) <- io $ f sc (goalProp g)
 
   let nope r = do ft <- io $ scEqTrue sc =<< scApplyPrelude_False sc
@@ -713,6 +709,17 @@ wrapProver f = do
     Nothing -> return (SV.Unsat stats, stats, Nothing)
     Just a  -> nope (SV.SatMulti stats a)
 
+
+
+wrapProver ::
+  ( SharedContext ->
+    Prop -> IO (Maybe [(String, FirstOrderValue)], SolverStats)) ->
+  ProofScript SV.SatResult
+wrapProver f = do
+  sc <- lift $ SV.getSharedContext
+  withFirstGoal (applyProverToGoal f sc)
+
+
 wrapW4Prover ::
   ( SharedContext -> Bool ->
     Prop -> IO (Maybe [(String, FirstOrderValue)], SolverStats)) ->
@@ -720,6 +727,19 @@ wrapW4Prover ::
 wrapW4Prover f = do
   hashConsing <- lift $ gets SV.rwWhat4HashConsing
   wrapProver $ \sc -> f sc hashConsing
+
+wrapW4ProveExporter ::
+  ( SharedContext -> Bool -> FilePath ->
+    Prop -> IO (Maybe [(String, FirstOrderValue)], SolverStats)) ->
+  String ->
+  String ->
+  ProofScript SV.SatResult
+wrapW4ProveExporter f path ext = do
+  hashConsing <- lift $ gets SV.rwWhat4HashConsing
+  sc <- lift $ SV.getSharedContext
+  withFirstGoal $ \g -> do
+    let file = path ++ "." ++ goalType g ++ show (goalNum g) ++ ext
+    applyProverToGoal (\s -> f s hashConsing file) sc g
 
 --------------------------------------------------
 proveBoolector :: ProofScript SV.SatResult
@@ -777,6 +797,34 @@ w4_unint_cvc4 = wrapW4Prover . Prover.proveWhat4_cvc4
 
 w4_unint_yices :: [String] -> ProofScript SV.SatResult
 w4_unint_yices = wrapW4Prover . Prover.proveWhat4_yices
+
+offline_w4_boolector :: String -> ProofScript SV.SatResult
+offline_w4_boolector = offline_w4_unint_boolector []
+
+offline_w4_z3 :: String -> ProofScript SV.SatResult
+offline_w4_z3 = offline_w4_unint_z3 []
+
+offline_w4_cvc4 :: String -> ProofScript SV.SatResult
+offline_w4_cvc4 = offline_w4_unint_cvc4 []
+
+offline_w4_yices :: String -> ProofScript SV.SatResult
+offline_w4_yices = offline_w4_unint_yices []
+
+offline_w4_unint_boolector :: [String] -> String -> ProofScript SV.SatResult
+offline_w4_unint_boolector unints path =
+  wrapW4ProveExporter (Prover.proveExportWhat4_boolector unints) path ".smt2"
+
+offline_w4_unint_z3 :: [String] -> String -> ProofScript SV.SatResult
+offline_w4_unint_z3 unints path =
+  wrapW4ProveExporter (Prover.proveExportWhat4_z3 unints) path ".smt2"
+
+offline_w4_unint_cvc4 :: [String] -> String -> ProofScript SV.SatResult
+offline_w4_unint_cvc4 unints path =
+  wrapW4ProveExporter (Prover.proveExportWhat4_cvc4 unints) path ".smt2"
+
+offline_w4_unint_yices :: [String] -> String -> ProofScript SV.SatResult
+offline_w4_unint_yices unints path =
+  wrapW4ProveExporter (Prover.proveExportWhat4_yices unints) path ".smt2"
 
 proveWithExporter ::
   (SharedContext -> FilePath -> Prop -> IO ()) ->

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1324,6 +1324,36 @@ primitives = Map.fromList
     , "given list of names, as defined with 'define', as uninterpreted."
     ]
 
+  , prim "offline_w4"             "String -> ProofScript SatResult"
+    (pureVal offline_w4_z3)
+    Current
+    [ "Write the current goal to the given file using What4 (Z3 backend) in"
+    , "SMT-Lib2 format."]
+
+  , prim "offline_w4_unint_z3"    "[String] -> String -> ProofScript SatResult"
+    (pureVal offline_w4_unint_z3)
+    Current
+    [ "Write the current goal to the given file using What4 (Z3 backend) in"
+    ," SMT-Lib2 format. Leave the given list of names, as defined with"
+    , "'define', as uninterpreted."
+    ]
+
+  , prim "offline_w4_unint_yices" "[String] -> String -> ProofScript SatResult"
+    (pureVal offline_w4_unint_yices)
+    Current
+    [ "Write the current goal to the given file using What4 (Yices backend) in"
+    ," SMT-Lib2 format. Leave the given list of names, as defined with"
+    , "'define', as uninterpreted."
+    ]
+
+  , prim "offline_w4_unint_cvc4"  "[String] -> String -> ProofScript SatResult"
+    (pureVal offline_w4_unint_cvc4)
+    Current
+    [ "Write the current goal to the given file using What4 (CVC4 backend) in"
+    ," SMT-Lib2 format. Leave the given list of names, as defined with"
+    , "'define', as uninterpreted."
+    ]
+
   , prim "split_goal"          "ProofScript ()"
     (pureVal split_goal)
     Experimental

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1324,12 +1324,6 @@ primitives = Map.fromList
     , "given list of names, as defined with 'define', as uninterpreted."
     ]
 
-  , prim "offline_w4"             "String -> ProofScript SatResult"
-    (pureVal offline_w4_z3)
-    Current
-    [ "Write the current goal to the given file using What4 (Z3 backend) in"
-    , "SMT-Lib2 format."]
-
   , prim "offline_w4_unint_z3"    "[String] -> String -> ProofScript SatResult"
     (pureVal offline_w4_unint_z3)
     Current

--- a/src/SAWScript/Prover/What4.hs
+++ b/src/SAWScript/Prover/What4.hs
@@ -148,7 +148,6 @@ proveWhat4_solver :: forall st t ff.
   IO (Maybe [(String, FirstOrderValue)], SolverStats)
   -- ^ (example/counter-example, solver statistics)
 proveWhat4_solver solver sym unints sc goal =
-
   do
      (argNames, bvs, lit, stats) <- setupWhat4_solver solver sym unints sc goal
 

--- a/src/SAWScript/Prover/What4.hs
+++ b/src/SAWScript/Prover/What4.hs
@@ -73,7 +73,7 @@ proveExportWhat4_sym solver un sc hashConsing outFilePath t =
 
      -- Write smt out
      (_, _, lit, stats) <- setupWhat4_solver solver sym un sc t
-     withFile outFilePath AppendMode $ \handle ->
+     withFile outFilePath WriteMode $ \handle ->
        solver_adapter_write_smt2 solver sym handle [lit]
 
      -- Assume unsat

--- a/src/SAWScript/Prover/What4.hs
+++ b/src/SAWScript/Prover/What4.hs
@@ -6,6 +6,8 @@
 
 module SAWScript.Prover.What4 where
 
+import System.IO
+
 import qualified Data.Vector as V
 import           Control.Monad(filterM)
 import           Data.Maybe (catMaybes)
@@ -36,6 +38,17 @@ import qualified What4.Expr.Builder as B
 -- trivial state
 data St t = St
 
+setupWhat4_sym :: Bool -> IO (B.ExprBuilder
+                              GlobalNonceGenerator
+                              St
+                              (B.Flags B.FloatReal))
+setupWhat4_sym hashConsing =
+  do -- TODO: get rid of GlobalNonceGenerator ???
+     sym <- B.newExprBuilder B.FloatRealRepr St globalNonceGenerator
+     cacheTermsSetting <- getOptionSetting B.cacheTerms $ getConfiguration sym
+     _ <- setOpt cacheTermsSetting hashConsing
+     return sym
+
 proveWhat4_sym ::
   SolverAdapter St ->
   [String] ->
@@ -44,12 +57,27 @@ proveWhat4_sym ::
   Prop ->
   IO (Maybe [(String, FirstOrderValue)], SolverStats)
 proveWhat4_sym solver un sc hashConsing t =
-  do -- TODO: get rid of GlobalNonceGenerator ???
-     sym <- B.newExprBuilder B.FloatRealRepr St globalNonceGenerator
-     cacheTermsSetting <- getOptionSetting B.cacheTerms $ getConfiguration sym
-     _ <- setOpt cacheTermsSetting hashConsing
+  do sym <- setupWhat4_sym hashConsing
      proveWhat4_solver solver sym un sc t
 
+proveExportWhat4_sym ::
+  SolverAdapter St ->
+  [String] ->
+  SharedContext ->
+  Bool ->
+  FilePath ->
+  Prop ->
+  IO (Maybe [(String, FirstOrderValue)], SolverStats)
+proveExportWhat4_sym solver un sc hashConsing outFilePath t =
+  do sym <- setupWhat4_sym hashConsing
+
+     -- Write smt out
+     (_, _, lit, stats) <- setupWhat4_solver solver sym un sc t
+     withFile outFilePath AppendMode $ \handle ->
+       solver_adapter_write_smt2 solver sym handle [lit]
+
+     -- Assume unsat
+     return (Nothing, stats)
 
 proveWhat4_z3, proveWhat4_boolector, proveWhat4_cvc4,
   proveWhat4_dreal, proveWhat4_stp, proveWhat4_yices ::
@@ -66,20 +94,34 @@ proveWhat4_dreal     = proveWhat4_sym drealAdapter
 proveWhat4_stp       = proveWhat4_sym stpAdapter
 proveWhat4_yices     = proveWhat4_sym yicesAdapter
 
+proveExportWhat4_z3, proveExportWhat4_boolector, proveExportWhat4_cvc4,
+  proveExportWhat4_dreal, proveExportWhat4_stp, proveExportWhat4_yices ::
+  [String]      {- ^ Uninterpreted functions -} ->
+  SharedContext {- ^ Context for working with terms -} ->
+  Bool          {- ^ Hash-consing of ExportWhat4 terms -}->
+  FilePath      {- ^ Path of file to write SMT to -}->
+  Prop          {- ^ A proposition to be proved -} ->
+  IO (Maybe [(String, FirstOrderValue)], SolverStats)
+
+proveExportWhat4_z3        = proveExportWhat4_sym z3Adapter
+proveExportWhat4_boolector = proveExportWhat4_sym boolectorAdapter
+proveExportWhat4_cvc4      = proveExportWhat4_sym cvc4Adapter
+proveExportWhat4_dreal     = proveExportWhat4_sym drealAdapter
+proveExportWhat4_stp       = proveExportWhat4_sym stpAdapter
+proveExportWhat4_yices     = proveExportWhat4_sym yicesAdapter
 
 
-
--- | Check the validity of a proposition using What4.
-proveWhat4_solver :: forall st t ff.
+setupWhat4_solver :: forall st t ff.
   SolverAdapter st   {- ^ Which solver to use -} ->
   B.ExprBuilder t st ff {- ^ The glorious sym -}  ->
   [String]           {- ^ Uninterpreted functions -} ->
   SharedContext      {- ^ Context for working with terms -} ->
   Prop               {- ^ A proposition to be proved/checked. -} ->
-  IO (Maybe [(String, FirstOrderValue)], SolverStats)
-  -- ^ (example/counter-example, solver statistics)
-proveWhat4_solver solver sym unints sc goal =
-
+  IO ( [String]
+     , [Maybe (W.Labeler (B.ExprBuilder t st ff))]
+     , Pred (B.ExprBuilder t st ff)
+     , SolverStats)
+setupWhat4_solver solver sym unints sc goal =
   do
      -- convert goal to lambda term
      term <- propToPredicate sc goal
@@ -93,6 +135,22 @@ proveWhat4_solver solver sym unints sc goal =
 
      let stats = solverStats ("W4 ->" ++ solver_adapter_name solver)
                              (scSharedSize t')
+
+     return (argNames, bvs, lit, stats)
+
+-- | Check the validity of a proposition using What4.
+proveWhat4_solver :: forall st t ff.
+  SolverAdapter st   {- ^ Which solver to use -} ->
+  B.ExprBuilder t st ff {- ^ The glorious sym -}  ->
+  [String]           {- ^ Uninterpreted functions -} ->
+  SharedContext      {- ^ Context for working with terms -} ->
+  Prop               {- ^ A proposition to be proved/checked. -} ->
+  IO (Maybe [(String, FirstOrderValue)], SolverStats)
+  -- ^ (example/counter-example, solver statistics)
+proveWhat4_solver solver sym unints sc goal =
+
+  do
+     (argNames, bvs, lit, stats) <- setupWhat4_solver solver sym unints sc goal
 
      -- log to stdout
      let logger _ str = putStrLn str


### PR DESCRIPTION
This pull request adds offline versions of the existing What4 tactics.  These new tactics write the SMT normally sent to the various solvers to an `.smt2` file instead and return unsat.