### PR TITLE
What4 eval3

### DIFF
--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -1298,12 +1298,15 @@ setupLLVMCrucibleContext bic opts pathSat lm action =
                        return (gp^.Crucible.gpGlobals, st)
                      _ -> fail "simulator initialization failed!"
 
+               cacheRef <- newIORef mempty
+
                return
                   LLVMCrucibleContext{ _ccLLVMModule = lm
                                      , _ccBackend = sym
                                      , _ccLLVMSimContext = lsimctx
                                      , _ccLLVMGlobals = lglobals
                                      , _ccBasicSS = biBasicSS bic
+                                     , _ccUninterpCache = cacheRef
                                      }
           action cc
 

--- a/src/SAWScript/Crucible/LLVM/MethodSpecIR.hs
+++ b/src/SAWScript/Crucible/LLVM/MethodSpecIR.hs
@@ -64,6 +64,7 @@ module SAWScript.Crucible.LLVM.MethodSpecIR
   , ccLLVMModuleTrans
   , ccLLVMContext
   , ccTypeCtx
+  , ccUninterpCache
     -- * PointsTo
   , LLVMPointsTo(..)
   , LLVMPointsToValue(..)
@@ -141,6 +142,7 @@ import           Verifier.SAW.Rewriter (Simpset)
 import           Verifier.SAW.SharedTerm
 import           Verifier.SAW.TypedTerm
 
+import qualified Verifier.SAW.Simulator.What4 as W4SC
 
 --------------------------------------------------------------------------------
 -- ** Language features
@@ -321,6 +323,7 @@ data LLVMCrucibleContext arch =
   , _ccLLVMSimContext  :: Crucible.SimContext (Crucible.SAWCruciblePersonality Sym) Sym (CL.LLVM arch)
   , _ccLLVMGlobals     :: Crucible.SymGlobalState Sym
   , _ccBasicSS         :: Simpset
+  , _ccUninterpCache   :: IORef (W4SC.SymFnCache Sym)
   }
 
 makeLenses ''LLVMCrucibleContext

--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -99,7 +99,6 @@ import qualified What4.Expr.Builder as W4
 import qualified What4.Interface as W4
 import qualified What4.LabeledPred as W4
 import qualified What4.ProgramLoc as W4
-import qualified What4.Symbol as W4
 
 import qualified SAWScript.Crucible.LLVM.CrucibleLLVM as Crucible
 import           SAWScript.Crucible.LLVM.CrucibleLLVM (LLVM)
@@ -1766,7 +1765,7 @@ executeFreshPointer ::
   AllocIndex      {- ^ SetupVar allocation ID -} ->
   IO (LLVMPtr (Crucible.ArchWidth arch)) {- ^ Symbolic pointer value -}
 executeFreshPointer cc (AllocIndex i) =
-  do let mkName base = W4.systemSymbol (base ++ show i ++ "!")
+  do let mkName base = W4.safeSymbol (base ++ show i)
          sym         = cc^.ccBackend
      blk <- W4.freshConstant sym (mkName "blk") W4.BaseNatRepr
      off <- W4.freshConstant sym (mkName "off") (W4.BaseBVRepr Crucible.PtrWidth)

--- a/src/SAWScript/Crucible/LLVM/X86.hs
+++ b/src/SAWScript/Crucible/LLVM/X86.hs
@@ -36,6 +36,7 @@ import Control.Monad.Catch (MonadThrow)
 
 import qualified Data.BitVector.Sized as BV
 import Data.Foldable (foldlM)
+import Data.IORef
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Vector as Vector
 import qualified Data.Text as Text
@@ -257,12 +258,15 @@ crucible_llvm_verify_x86 bic opts (Some (llvmModule :: LLVMModule x)) path nm gl
         else fail $ mconcat ["Address of \"", nm, "\" is not an absolute address"]
       let maxAddr = addrInt + toInteger (Macaw.segmentSize $ Macaw.segoffSegment addr)
 
+      ref <- liftIO $ newIORef mempty
+
       let
         cc :: LLVMCrucibleContext x
         cc = LLVMCrucibleContext
           { _ccLLVMModule = llvmModule
           , _ccBackend = sym
           , _ccBasicSS = biBasicSS bic
+          , _ccUninterpCache = ref
 
           -- It's unpleasant that we need to do this to use resolveSetupVal.
           , _ccLLVMSimContext = error "Attempted to access ccLLVMSimContext"


### PR DESCRIPTION
Another attempt at improving the situation WRT evaluating terms more fully before passing them down to the Crucible symbolic simulator.

These patches cause the `ResolveSetupValue` phase to evaluate terms using the What4 SAWCore backend, but limits the definitions it will unfold to those from the prelude, or those defined locally with "let", relying on the new structured name infrastructure in SAWCore to reliably make this determination.