### PR TITLE
Add command-line option to write verification summary to a file

### DIFF
--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -353,10 +353,10 @@ writeVerificationSummary = do
      let jspecs  = [ s | VJVMMethodSpec s <- values ]
          lspecs  = [ s | VLLVMCrucibleMethodSpec s <- values ]
          thms    = [ t | VTheorem t <- values ]
-         summary = computeVerificationSummary jspecs lspecs thms -- TODO: this is duplicated in Builtins.hs
+         summary = computeVerificationSummary jspecs lspecs thms
      opts <- roOptions <$> getTopLevelRO
      dir <- roInitWorkDir <$> getTopLevelRO
-     case (summaryFile opts) of
+     case summaryFile opts of
        Nothing -> return ()
        Just f ->
          let f' = if hasDrive f then f else dir </> f

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -41,7 +41,7 @@ import Data.Map ( Map )
 import qualified Data.Set as Set
 import Data.Set ( Set )
 import System.Directory (getCurrentDirectory, setCurrentDirectory, canonicalizePath)
-import System.FilePath (takeDirectory, hasDrive, replaceDirectory)
+import System.FilePath (takeDirectory, hasDrive, (</>))
 import System.Process (readProcess)
 
 import qualified SAWScript.AST as SS
@@ -359,7 +359,7 @@ writeVerificationSummary = do
      case (summaryFile opts) of
        Nothing -> return ()
        Just f ->
-         let f' = if hasDrive f then f else replaceDirectory f dir
+         let f' = if hasDrive f then f else dir </> f
           in io $ writeFile f' $ prettyVerificationSummary summary
 
 

--- a/src/SAWScript/Options.hs
+++ b/src/SAWScript/Options.hs
@@ -31,7 +31,7 @@ data Options = Options
   , printShowPos     :: Bool
   , useColor         :: Bool
   , printOutFn       :: Verbosity -> String -> IO ()
-  , summaryFile        :: Maybe FilePath
+  , summaryFile      :: Maybe FilePath
   } deriving (Show)
 
 -- | Verbosity is currently a linear setting (vs a mask or tree).  Any given

--- a/src/SAWScript/Options.hs
+++ b/src/SAWScript/Options.hs
@@ -31,6 +31,7 @@ data Options = Options
   , printShowPos     :: Bool
   , useColor         :: Bool
   , printOutFn       :: Verbosity -> String -> IO ()
+  , summaryFile        :: Maybe FilePath
   } deriving (Show)
 
 -- | Verbosity is currently a linear setting (vs a mask or tree).  Any given
@@ -60,6 +61,7 @@ defaultOptions
     , showHelp = False
     , showVersion = False
     , useColor = True
+    , summaryFile = Nothing
     }
 
 printOutWith :: Verbosity -> Verbosity -> String -> IO ()
@@ -127,6 +129,11 @@ options =
   , Option [] ["no-color"]
     (NoArg (\opts -> opts { useColor = False }))
     "Disable ANSI color and Unicode output"
+  , Option "s" ["summary"]
+    (ReqArg
+     (\file opts -> opts { summaryFile = Just file })
+     "filename")
+    "Write a verification summary to the provided filename"
   ]
 
 -- Try to read verbosity as either a string or number and default to 'Debug'.

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -389,6 +389,7 @@ data TopLevelRO =
   , roHandleAlloc   :: Crucible.HandleAllocator
   , roPosition      :: SS.Pos
   , roProxy         :: AIGProxy
+  , roInitWorkDir   :: FilePath
   }
 
 data TopLevelRW =


### PR DESCRIPTION
This adds a command-line option `-s filename` which causes SAW to write the verification summary to the given file. Btw, I'm a Haskell novice and I would welcome constructive criticism.