### PR TITLE
Fix method resolution

### DIFF
--- a/src/SAWScript/Crucible/JVM/MethodSpecIR.hs
+++ b/src/SAWScript/Crucible/JVM/MethodSpecIR.hs
@@ -172,14 +172,14 @@ initialDefCrucibleMethodSpecIR cb cname method loc =
 
 initialCrucibleSetupState ::
   JVMCrucibleContext ->
-  J.Method ->
+  (J.Class, J.Method) ->
   ProgramLoc ->
   Setup.CrucibleSetupState CJ.JVM
-initialCrucibleSetupState cc method loc =
+initialCrucibleSetupState cc (cls, method) loc =
   Setup.makeCrucibleSetupState cc $
     initialDefCrucibleMethodSpecIR
       (cc ^. jccCodebase)
-      (J.className $ cc ^. jccJVMClass)
+      (J.className cls)
       method
       loc
 

--- a/src/SAWScript/Utils.hs
+++ b/src/SAWScript/Utils.hs
@@ -121,9 +121,7 @@ lookupClass cb site nm = do
 -- | Returns method with given name in this class or one of its subclasses.
 -- Throws an ExecException if method could not be found or is ambiguous.
 findMethod :: JSS.Codebase -> Pos -> String -> JSS.Class -> IO (JSS.Class, JSS.Method)
-findMethod cb site nm initClass =
-  do putStrLn $ "findMethod " ++ show nm
-     impl initClass
+findMethod cb site nm initClass = impl initClass
   where javaClassName = JSS.slashesToDots (JSS.unClassName (JSS.className initClass))
         methodType m = (JSS.methodParameterTypes m, JSS.methodReturnType m)
         baseName m = JSS.methodName m


### PR DESCRIPTION
Avoid mixing up original jvm class and class for resolved method.

#884 redid jvm method verification so that it would only perform method resolution (where it searches superclasses to find the given method name) a single time. However, subsequent method lookups were using the original class name instead of the name of the superclass where the method was found. This caused method handle lookups to fail in examples (like ecdsa) where methods were defined in superclasses. This PR fixes that bug.