### PR TITLE
Modify JVM class loader to avoid redundant map union operations.

### DIFF
--- a/src/SAWScript/Crucible/JVM/BuiltinsJVM.hs
+++ b/src/SAWScript/Crucible/JVM/BuiltinsJVM.hs
@@ -124,7 +124,7 @@ prepareClassTopLevel bic str = do
      ctx <- io $ execStateT (CJ.extendJVMContext halloc c) ctx0
 
      -- update ctx
-     addJVMTrans ctx
+     putJVMTrans ctx
 
 
 -----------------------------------------------------------------------

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -486,6 +486,12 @@ returnProof v = do
 getJVMTrans :: TopLevel  CJ.JVMContext
 getJVMTrans = TopLevel (gets rwJVMTrans)
 
+-- | Access the current state of Java Class translation
+putJVMTrans :: CJ.JVMContext -> TopLevel ()
+putJVMTrans jc =
+  do rw <- getTopLevelRW
+     putTopLevelRW rw { rwJVMTrans = jc }
+
 -- | Add a newly translated class to the translation
 addJVMTrans :: CJ.JVMContext -> TopLevel ()
 addJVMTrans trans = do


### PR DESCRIPTION
The monoid append operation on JVMContext is rather inefficient,
because it involves unions on maps with keys that are expensive
to compare. In this case the append operation was completely
redundant, because the old context was being combined with a new
one that was the same as the old one extended with some new entries.