### PR TITLE
Add module `SAWScript.Panic` with bindings to `panic` library.

### DIFF
--- a/saw-script.cabal
+++ b/saw-script.cabal
@@ -62,6 +62,7 @@ library
     , mtl >= 2.1
     , old-locale
     , old-time
+    , panic
     , parameterized-utils
     , parsec
     , pretty
@@ -124,6 +125,7 @@ library
     SAWScript.Lexer
     SAWScript.LLVMBuiltins
     SAWScript.Options
+    SAWScript.Panic
     SAWScript.Parser
     SAWScript.PathVC
     SAWScript.Proof

--- a/src/SAWScript/Panic.hs
+++ b/src/SAWScript/Panic.hs
@@ -7,14 +7,12 @@ Stability   : provisional
 
 {-# LANGUAGE Trustworthy, TemplateHaskell #-}
 module SAWScript.Panic
-  (HasCallStack, SawPanic, Saw, Panic, panic) where
+  (HasCallStack, panic) where
 
 import Panic hiding (panic)
 import qualified Panic as Panic
 
 data Saw = Saw
-
-type SawPanic = Panic Saw
 
 panic :: HasCallStack => String -> [String] -> a
 panic = Panic.panic Saw

--- a/src/SAWScript/Panic.hs
+++ b/src/SAWScript/Panic.hs
@@ -1,0 +1,27 @@
+{- |
+Module      : SAWScript.Panic
+License     : BSD3
+Maintainer  : huffman
+Stability   : provisional
+-}
+
+{-# LANGUAGE Trustworthy, TemplateHaskell #-}
+module SAWScript.Panic
+  (HasCallStack, SawPanic, Saw, Panic, panic) where
+
+import Panic hiding (panic)
+import qualified Panic as Panic
+
+data Saw = Saw
+
+type SawPanic = Panic Saw
+
+panic :: HasCallStack => String -> [String] -> a
+panic = Panic.panic Saw
+
+instance PanicComponent Saw where
+  panicComponentName _ = "Saw"
+  panicComponentIssues _ = "https://github.com/GaloisInc/saw-script/issues"
+
+  {-# Noinline panicComponentRevision #-}
+  panicComponentRevision = $useGitRevision

--- a/src/SAWScript/Panic.hs
+++ b/src/SAWScript/Panic.hs
@@ -12,7 +12,7 @@ module SAWScript.Panic
 import Panic hiding (panic)
 import qualified Panic as Panic
 
-data Saw = Saw
+data SAW = SAW
 
 -- | Raise a fatal error. The purpose of 'panic' is to indicate
 -- conditions caused by programmer errors (e.g. violation of datatype
@@ -24,10 +24,10 @@ panic ::
   -- | Problem description (lines)
   [String] ->
   a
-panic = Panic.panic Saw
+panic = Panic.panic SAW
 
-instance PanicComponent Saw where
-  panicComponentName _ = "Saw"
+instance PanicComponent SAW where
+  panicComponentName _ = "SAW"
   panicComponentIssues _ = "https://github.com/GaloisInc/saw-script/issues"
 
   {-# Noinline panicComponentRevision #-}

--- a/src/SAWScript/Panic.hs
+++ b/src/SAWScript/Panic.hs
@@ -14,7 +14,16 @@ import qualified Panic as Panic
 
 data Saw = Saw
 
-panic :: HasCallStack => String -> [String] -> a
+-- | Raise a fatal error. The purpose of 'panic' is to indicate
+-- conditions caused by programmer errors (e.g. violation of datatype
+-- invariants), not problems caused by bad user input.
+panic ::
+  HasCallStack =>
+  -- | Location of problem
+  String ->
+  -- | Problem description (lines)
+  [String] ->
+  a
 panic = Panic.panic Saw
 
 instance PanicComponent Saw where


### PR DESCRIPTION
The new module is based on `Cryptol.Utils.Panic` from cryptol; it provides a function `panic :: String -> [String] -> a` that produces error messages like this:
```
You have encountered a bug in Saw's implementation.
*** Please create an issue at https://github.com/GaloisInc/saw-script/issues

%< ---------------------------------------------------
  Revision:  f7e4738b0648af6fe788bfa937fcd8610dd3940f
  Branch:    panic (uncommited files present)
  Location:  <user-provided string>
  Message:   <user-provided string>
CallStack (from HasCallStack):
  panic, called at src/SAWScript/Panic.hs:20:9 in saw-script-0.6.0.99-1VGCoxQ2nNV4ntdMbYXftm:SAWScript.Panic
  panic, called at src/SAWScript/Crucible/JVM/Builtins.hs:897:22 in saw-script-0.6.0.99-1VGCoxQ2nNV4ntdMbYXftm:SAWScript.Crucible.JVM.Builtins
%< ---------------------------------------------------
```