### PR TITLE
Saw core prettyprinter

### DIFF
--- a/saw-script.cabal
+++ b/saw-script.cabal
@@ -66,6 +66,7 @@ library
     , parameterized-utils
     , parsec
     , pretty
+    , prettyprinter
     , pretty-show
     , process
     , rme

--- a/src/SAWScript/Crucible/JVM/Override.hs
+++ b/src/SAWScript/Crucible/JVM/Override.hs
@@ -62,7 +62,7 @@ import qualified Data.Map as Map
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Void (absurd)
-import qualified Text.PrettyPrint.ANSI.Leijen as PPL
+import qualified Prettyprinter as PP
 
 -- cryptol
 import qualified Cryptol.TypeCheck.AST as Cryptol
@@ -123,10 +123,10 @@ type SetupCondition = MS.SetupCondition CJ.JVM
 type instance Pointer CJ.JVM = JVMRefVal
 
 -- TODO: Improve?
-ppJVMVal :: JVMVal -> PPL.Doc
-ppJVMVal = PPL.text . show
+ppJVMVal :: JVMVal -> PP.Doc ann
+ppJVMVal = PP.viaShow
 
-instance PPL.Pretty JVMVal where
+instance PP.Pretty JVMVal where
   pretty = ppJVMVal
 
 
@@ -206,8 +206,10 @@ methodSpecHandler opts sc cc top_loc css h = do
   branches <- case partitionEithers prestates of
                 (e, []) ->
                   fail $ show $
-                    PPL.text "All overrides failed during structural matching:" PPL.<$$>
-                    PPL.vcat (map (\x -> PPL.text "*" PPL.<> PPL.indent 2 (ppOverrideFailure x)) e)
+                  PP.vcat
+                  [ "All overrides failed during structural matching:"
+                  , PP.vcat (map (\x -> "*" <> PP.indent 2 (ppOverrideFailure x)) e)
+                  ]
                 (_, ss) -> liftIO $
                   forM ss $ \(cs,st) ->
                     do precond <- W4.andAllOf sym (folded.labeledPred) (st^.osAsserts)

--- a/src/SAWScript/ImportAIG.hs
+++ b/src/SAWScript/ImportAIG.hs
@@ -26,7 +26,7 @@ import Control.Monad
 import Control.Monad.State.Strict
 import Control.Monad.Trans.Except
 import qualified Data.Vector as V
-import Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
+import Prettyprinter
 
 import qualified Data.AIG as AIG
 
@@ -59,8 +59,10 @@ bitblastSharedTerm sc v (asBitvectorType -> Just w) = do
       scApplyPrelude_at sc wt boolType v =<< scNat sc (fromIntegral i)
   modify (V.++ inputs)
 bitblastSharedTerm _ _ tp = throwTP $ show $
-  text "Could not parse AIG input type:" <$$>
-  indent 2 (ppTerm defaultPPOpts tp)
+  vcat
+  [ pretty "Could not parse AIG input type:"
+  , indent 2 (ppTerm defaultPPOpts tp)
+  ]
 
 parseAIGResultType :: SharedContext
                    -> Term -- ^ Term for type

--- a/src/SAWScript/JavaBuiltins.hs
+++ b/src/SAWScript/JavaBuiltins.hs
@@ -27,7 +27,7 @@ import Data.IORef
 import qualified Data.Map as Map
 import Data.Time.Clock
 import qualified Data.Text as Text
-import Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
+import Prettyprinter
 
 import Language.JVM.Common
 
@@ -397,9 +397,10 @@ getJavaExpr ctx name = do
   case Map.lookup e (bsActualTypeMap (specBehaviors ms)) of
     Just ty -> return (e, ty)
     Nothing -> throwJava $ renderDoc $
-      hsep [ "Unknown expression", ftext name, "in",  ftext ctx ] <> "."
-      <$$>
-      ftext "Maybe you're missing a `java_var` or `java_class_var`?"
+      vcat
+      [ hsep [ "Unknown expression", ftext name, "in",  ftext ctx ] <> "."
+      , ftext "Maybe you're missing a `java_var` or `java_class_var`?"
+      ]
 
 typeJavaExpr :: BuiltinContext -> String -> JavaType
              -> JavaSetup (JavaExpr, JavaActualType)
@@ -415,12 +416,12 @@ typeJavaExpr bic name ty = do
 checkEqualTypes :: Type -> Type -> String -> JavaSetup ()
 checkEqualTypes declared actual name =
   when (declared /= actual) $ throwJava $ show $
-    hsep [ text "WARNING: Declared type"
-         , text (show (ppType declared)) -- TODO: change pretty-printer
-         , text "doesn't match actual type"
-         , text (show (ppType actual)) -- TODO: change pretty-printer
-         , text "for variable"
-         , text name
+    hsep [ "WARNING: Declared type"
+         , viaShow (ppType declared) -- TODO: change pretty-printer
+         , "doesn't match actual type"
+         , viaShow (ppType actual) -- TODO: change pretty-printer
+         , "for variable"
+         , pretty name
          ]
 
 modifySpec :: (JavaMethodSpecIR -> JavaMethodSpecIR) -> JavaSetup ()

--- a/src/SAWScript/JavaMethodSpec.hs
+++ b/src/SAWScript/JavaMethodSpec.hs
@@ -53,7 +53,7 @@ import Data.List (intercalate, sortBy)
 import qualified Data.Map.Strict as Map
 import Data.Maybe
 import qualified Data.Set as Set
-import Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
+import Prettyprinter
 import qualified Text.PrettyPrint.HughesPJ as PP
 
 import Language.JVM.Common (ppFldId)
@@ -78,6 +78,7 @@ import Verifier.Java.SAWBackend hiding (basic_ss)
 import Verifier.SAW.Prelude
 import Verifier.SAW.Recognizer
 import Verifier.SAW.SharedTerm
+import Verifier.SAW.Term.Pretty (SawDoc)
 import Verifier.SAW.TypedTerm
 
 -- JSS Utilities {{{1
@@ -484,7 +485,7 @@ data VerifyState = VState {
          -- verification.
        -- , vsEvalContext :: EvalContext
        , vsCounterexampleFn :: CounterexampleFn
-       , vsStaticErrors :: [Doc]
+       , vsStaticErrors :: [SawDoc]
        }
 
 {- Alternative implementation of JavaMethodSpec -}
@@ -745,7 +746,7 @@ checkFinalState sc ms bs cl initPS = do
       let newClasses = Map.keys ((finalMem ^. memInitialization) `Map.difference`
                                  (initMem ^. memInitialization)) in
       unless (specAllowAlloc ms) $
-        pvcgFail (text ("Initializes extra classes " ++ show newClasses))
+        pvcgFail (pretty ("Initializes extra classes " ++ show newClasses))
     when (initMem ^. memClassObjects /= finalMem ^. memClassObjects) $
       pvcgFail "Allocates a class object."
     when (Map.keys initRefArrays /= Map.keys finalRefArrays) $
@@ -800,9 +801,9 @@ checkFinalState sc ms bs cl initPS = do
               pvcgAssertEq aname ival fval -- TODO: name
           | otherwise -> pvcgFail $ hsep
             [ "Array changed size from"
-            , int (fromIntegral ilen)
+            , pretty ilen
             , "to"
-            , int (fromIntegral flen)
+            , pretty flen
             ]
     -- TODO: check that return value has been specified if method returns a value
     pvcgAssert "final assertions" (finalPS ^. pathAssertions)

--- a/src/SAWScript/PathVC.hs
+++ b/src/SAWScript/PathVC.hs
@@ -8,8 +8,10 @@ Stability   : provisional
 module SAWScript.PathVC where
 
 import Control.Monad.State
-import Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
+import Prettyprinter
+
 import Verifier.SAW.SharedTerm
+import Verifier.SAW.Term.Pretty (SawDoc)
 
 import SAWScript.VerificationCheck
 
@@ -20,24 +22,24 @@ data PathVC l = PathVC {
           -- | Assumptions on inputs.
         , pvcAssumptions :: Term
           -- | Static errors found in path.
-        , pvcStaticErrors :: [Doc]
+        , pvcStaticErrors :: [SawDoc]
           -- | What to verify for this result.
         , pvcChecks :: [VerificationCheck]
         }
 
-ppPathVC :: PathVC l -> Doc
+ppPathVC :: PathVC l -> SawDoc
 ppPathVC pvc =
   nest 2 $
-  vcat [ text "Path VC:"
+  vcat [ pretty "Path VC:"
        , nest 2 $
-         vcat [ text "Assumptions:"
+         vcat [ pretty "Assumptions:"
               , ppTerm defaultPPOpts (pvcAssumptions pvc)
               ]
        , nest 2 $ vcat $
-         text "Static errors:" :
+         pretty "Static errors:" :
          pvcStaticErrors pvc
        , nest 2 $ vcat $
-         text "Checks:" :
+         pretty "Checks:" :
          map ppCheck (pvcChecks pvc)
        ]
 
@@ -56,7 +58,7 @@ pvcgAssert nm v =
   modify $ \pvc -> pvc { pvcChecks = AssertionCheck nm v : pvcChecks pvc }
 
 pvcgFail :: Monad m =>
-            Doc -> PathVCGenerator l m ()
+            SawDoc -> PathVCGenerator l m ()
 pvcgFail msg =
   modify $ \pvc -> pvc { pvcStaticErrors = msg : pvcStaticErrors pvc }
 

--- a/src/SAWScript/Position.hs
+++ b/src/SAWScript/Position.hs
@@ -22,7 +22,8 @@ import GHC.Generics (Generic)
 import System.Directory (makeRelativeToCurrentDirectory)
 import System.FilePath (makeRelative, isAbsolute, (</>), takeDirectory)
 import qualified Data.Text as Text
-import qualified Text.PrettyPrint.ANSI.Leijen as PP hiding ((</>), (<$>))
+import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.String as PP
 
 import qualified What4.ProgramLoc as W4
 import qualified What4.FunctionName as W4
@@ -37,8 +38,9 @@ data Pos = Range !FilePath -- file
          | PosREPL
   deriving (Data, Generic, Eq)
 
-renderDoc :: PP.Doc -> String
-renderDoc doc = PP.displayS (PP.renderPretty 0.8 80 doc) ""
+renderDoc :: PP.Doc ann -> String
+renderDoc doc = PP.renderString (PP.layoutPretty opts doc)
+  where opts = PP.LayoutOptions (PP.AvailablePerLine 80 0.8)
 
 endPos :: FilePath -> Pos
 endPos f = Range f 0 0 0 0

--- a/src/SAWScript/Prover/Exporter.hs
+++ b/src/SAWScript/Prover/Exporter.hs
@@ -37,7 +37,7 @@ import qualified Data.ByteString as BS
 import Data.Parameterized.Nonce (globalNonceGenerator)
 import Data.Set (Set)
 import qualified Data.SBV.Dynamic as SBV
-import Text.PrettyPrint.ANSI.Leijen (vcat)
+import Prettyprinter (vcat)
 
 import Cryptol.Utils.PP(pretty)
 

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -52,10 +52,10 @@ import Data.Map ( Map )
 import Data.Set ( Set )
 import Data.Text (Text, pack, unpack)
 import qualified Data.Vector as Vector
-import qualified Text.PrettyPrint.ANSI.Leijen as PPL
 import Data.Parameterized.Some
 import Data.Typeable
 import GHC.Generics (Generic, Generic1)
+import qualified Prettyprinter as PP
 
 import qualified Data.AIG as AIG
 
@@ -255,11 +255,10 @@ showSimpset opts ss =
   unlines ("Rewrite Rules" : "=============" : map (show . ppRule) (listRules ss))
   where
     ppRule r =
-      PPL.char '*' PPL.<+>
-      (PPL.nest 2 $
-       SAWCorePP.ppTerm opts' (lhsRewriteRule r)
-       PPL.</> PPL.char '=' PPL.<+>
-       ppTerm (rhsRewriteRule r))
+      PP.pretty '*' PP.<+>
+      (PP.nest 2 $ PP.fillSep
+       [ ppTerm (lhsRewriteRule r)
+       , PP.pretty '=' PP.<+> ppTerm (rhsRewriteRule r) ])
     ppTerm t = SAWCorePP.ppTerm opts' t
     opts' = sawPPOpts opts
 

--- a/src/SAWScript/VerificationSummary.hs
+++ b/src/SAWScript/VerificationSummary.hs
@@ -14,7 +14,7 @@ module SAWScript.VerificationSummary
 import Control.Lens
 import qualified Data.Set as Set
 import Data.String
-import Text.PrettyPrint.ANSI.Leijen
+import Prettyprinter
 
 import qualified Lang.Crucible.JVM as CJ
 import SAWScript.Crucible.Common.MethodSpec

--- a/stack.ghc-8.6.yaml
+++ b/stack.ghc-8.6.yaml
@@ -56,5 +56,8 @@ extra-deps:
   - lens-4.19.2
   - network-3.1.1.1
   - scotty-0.12
+  - modern-uri-0.3.3.0
+  - prettyprinter-1.7.0
+  - prettyprinter-ansi-terminal-1.1.2
 resolver: lts-14.27
 allow-newer: false

--- a/stack.ghc-8.8.yaml
+++ b/stack.ghc-8.8.yaml
@@ -53,5 +53,7 @@ extra-deps:
   - bitwise-1.0.0.1
   - libBF-0.5.1
   - scotty-0.12
+  - prettyprinter-1.7.0
+  - prettyprinter-ansi-terminal-1.1.2
 resolver: lts-16.2
 allow-newer: false


### PR DESCRIPTION
Update `saw-core` and `saw-core-coq` to use `prettyprinter` package.

This includes the following two submodule PRs, which have each already been merged to their respective `master` branches:
- GaloisInc/saw-core#106
- GaloisInc/saw-core-coq#28
