### PR TITLE
Error checking for JVMSetup commands

### DIFF
--- a/intTests/test_jvm_setup_errors/test.saw
+++ b/intTests/test_jvm_setup_errors/test.saw
@@ -366,7 +366,7 @@ crucible_jvm_verify test "set" [] false
   } z3;
 
 print "jvm_execute_func with non-monomorphic types";
-KNOWN_FALSE_POSITIVE test "set"
+check_fails test "set"
   do {
     this <- jvm_alloc_object "Test";
     x <- jvm_fresh_var "x" java_long;
@@ -375,7 +375,7 @@ KNOWN_FALSE_POSITIVE test "set"
   };
 
 print "jvm_execute_func with non-jvm types";
-KNOWN_FALSE_POSITIVE test "set"
+check_fails test "set"
   do {
     this <- jvm_alloc_object "Test";
     x <- jvm_fresh_var "x" java_long;
@@ -384,7 +384,7 @@ KNOWN_FALSE_POSITIVE test "set"
   };
 
 print "jvm_execute_func with wrong types";
-KNOWN_FALSE_POSITIVE test "set"
+check_fails test "set"
   do {
     this <- jvm_alloc_object "Test";
     x <- jvm_fresh_var "x" java_long;
@@ -393,7 +393,7 @@ KNOWN_FALSE_POSITIVE test "set"
   };
 
 print "jvm_execute_func with reference type when base type was expected";
-KNOWN_FALSE_POSITIVE test "set"
+check_fails test "set"
   do {
     this <- jvm_alloc_object "Test";
     x <- jvm_fresh_var "x" java_long;
@@ -402,7 +402,7 @@ KNOWN_FALSE_POSITIVE test "set"
   };
 
 print "jvm_execute_func with base type when reference type was expected";
-KNOWN_FALSE_POSITIVE test "set"
+check_fails test "set"
   do {
     this <- jvm_alloc_object "Test";
     x <- jvm_fresh_var "x" java_long;
@@ -411,7 +411,7 @@ KNOWN_FALSE_POSITIVE test "set"
   };
 
 print "jvm_execute_func with too few arguments";
-KNOWN_FALSE_POSITIVE test "set"
+check_fails test "set"
   do {
     this <- jvm_alloc_object "Test";
     x <- jvm_fresh_var "x" java_long;
@@ -420,7 +420,7 @@ KNOWN_FALSE_POSITIVE test "set"
   };
 
 print "jvm_execute_func with too many arguments";
-KNOWN_FALSE_POSITIVE test "set"
+check_fails test "set"
   do {
     this <- jvm_alloc_object "Test";
     x <- jvm_fresh_var "x" java_long;

--- a/intTests/test_jvm_setup_errors/test.saw
+++ b/intTests/test_jvm_setup_errors/test.saw
@@ -429,7 +429,7 @@ check_fails test "set"
   };
 
 print "jvm_return with non-monomorphic type";
-KNOWN_FALSE_POSITIVE test "get"
+check_fails test "get"
   do {
     this <- jvm_alloc_object "Test";
     val <- jvm_fresh_var "val" java_long;
@@ -439,7 +439,7 @@ KNOWN_FALSE_POSITIVE test "get"
   };
 
 print "jvm_return with non-jvm type";
-KNOWN_FALSE_POSITIVE test "get"
+check_fails test "get"
   do {
     this <- jvm_alloc_object "Test";
     val <- jvm_fresh_var "val" java_long;
@@ -449,7 +449,7 @@ KNOWN_FALSE_POSITIVE test "get"
   };
 
 print "jvm_return with wrong base type";
-KNOWN_FALSE_POSITIVE test "get"
+check_fails test "get"
   do {
     this <- jvm_alloc_object "Test";
     val <- jvm_fresh_var "val" java_long;
@@ -459,7 +459,7 @@ KNOWN_FALSE_POSITIVE test "get"
   };
 
 print "jvm_return with reference type when base type was expected";
-KNOWN_FALSE_POSITIVE test "get"
+check_fails test "get"
   do {
     this <- jvm_alloc_object "Test";
     val <- jvm_fresh_var "val" java_long;
@@ -478,7 +478,7 @@ KNOWN_FALSE_POSITIVE test "get"
   };
 
 print "jvm_return when none was expected";
-KNOWN_FALSE_POSITIVE test "set"
+check_fails test "set"
   do {
     this <- jvm_alloc_object "Test";
     x <- jvm_fresh_var "x" java_long;

--- a/intTests/test_jvm_setup_errors/test.saw
+++ b/intTests/test_jvm_setup_errors/test.saw
@@ -198,7 +198,7 @@ check_fails test "lookup"
   };
 
 print "jvm_elem_is with index out of bounds";
-KNOWN_FALSE_POSITIVE test "lookup"
+check_fails test "lookup"
   do {
     arr <- jvm_alloc_array 8 java_long;
     let idx = {{ 12 : [32] }};

--- a/intTests/test_jvm_setup_errors/test.saw
+++ b/intTests/test_jvm_setup_errors/test.saw
@@ -311,7 +311,7 @@ KNOWN_FALSE_POSITIVE test "lookup"
   };
 
 print "jvm_array_is with null reference";
-KNOWN_FALSE_POSITIVE test "lookup"
+check_fails test "lookup"
   do {
     let arr = jvm_null;
     xs <- jvm_fresh_var "xs" (java_array 8 java_long);
@@ -322,7 +322,7 @@ KNOWN_FALSE_POSITIVE test "lookup"
   };
 
 print "jvm_array_is with non-reference";
-KNOWN_FALSE_POSITIVE test "lookup"
+check_fails test "lookup"
   do {
     let arr = jvm_term {{ True }};
     xs <- jvm_fresh_var "xs" (java_array 8 java_long);

--- a/intTests/test_jvm_setup_errors/test.saw
+++ b/intTests/test_jvm_setup_errors/test.saw
@@ -110,7 +110,7 @@ check_fails test "get"
   };
 
 print "jvm_field_is with previous jvm_field_is on same field";
-KNOWN_FALSE_POSITIVE test "get"
+check_fails test "get"
   do {
     this <- jvm_alloc_object "Test";
     val <- jvm_fresh_var "val" java_long;

--- a/intTests/test_jvm_setup_errors/test.saw
+++ b/intTests/test_jvm_setup_errors/test.saw
@@ -245,7 +245,7 @@ crucible_jvm_verify test "lookup" [] false
   } z3;
 
 print "jvm_array_is with non-monomorphic type";
-KNOWN_FALSE_POSITIVE test "lookup"
+check_fails test "lookup"
   do {
     arr <- jvm_alloc_array 8 java_long;
     let xs = {{ zero }};
@@ -256,7 +256,7 @@ KNOWN_FALSE_POSITIVE test "lookup"
   };
 
 print "jvm_array_is with non-array type";
-KNOWN_FALSE_POSITIVE test "lookup"
+check_fails test "lookup"
   do {
     arr <- jvm_alloc_array 8 java_long;
     let xs = {{ (True, False) }};
@@ -267,7 +267,7 @@ KNOWN_FALSE_POSITIVE test "lookup"
   };
 
 print "jvm_array_is with wrong array length";
-KNOWN_FALSE_POSITIVE test "lookup"
+check_fails test "lookup"
   do {
     arr <- jvm_alloc_array 8 java_long;
     xs <- jvm_fresh_var "xs" (java_array 4 java_long);
@@ -278,7 +278,7 @@ KNOWN_FALSE_POSITIVE test "lookup"
   };
 
 print "jvm_array_is with non-jvm element type";
-KNOWN_FALSE_POSITIVE test "lookup"
+check_fails test "lookup"
   do {
     arr <- jvm_alloc_array 8 java_long;
     let xs = {{ zero : [8]Integer }};
@@ -289,7 +289,7 @@ KNOWN_FALSE_POSITIVE test "lookup"
   };
 
 print "jvm_array_is with wrong array element type";
-KNOWN_FALSE_POSITIVE test "lookup"
+check_fails test "lookup"
   do {
     arr <- jvm_alloc_array 8 java_long;
     xs <- jvm_fresh_var "xs" (java_array 8 java_int);
@@ -300,7 +300,7 @@ KNOWN_FALSE_POSITIVE test "lookup"
   };
 
 print "jvm_array_is with object reference";
-KNOWN_FALSE_POSITIVE test "lookup"
+check_fails test "lookup"
   do {
     arr <- jvm_alloc_object "Test";
     xs <- jvm_fresh_var "xs" (java_array 8 java_long);
@@ -486,3 +486,5 @@ KNOWN_FALSE_POSITIVE test "set"
     jvm_field_is this "val" (jvm_term x);
     jvm_return (jvm_term x);
   };
+
+print "DONE!";

--- a/src/SAWScript/Crucible/Common/MethodSpec.hs
+++ b/src/SAWScript/Crucible/Common/MethodSpec.hs
@@ -126,7 +126,7 @@ deriving instance (SetupValueHas Show ext) => Show (SetupValue ext)
 ppSetupValue :: SetupValue ext -> PP.Doc ann
 ppSetupValue setupval = case setupval of
   SetupTerm tm   -> ppTypedTerm tm
-  SetupVar i     -> PP.pretty ("@" ++ show i)
+  SetupVar i     -> ppAllocIndex i
   SetupNull _    -> PP.pretty "NULL"
   SetupStruct _ packed vs
     | packed     -> PP.angles (PP.braces (commaList (map ppSetupValue vs)))
@@ -140,6 +140,9 @@ ppSetupValue setupval = case setupval of
     commaList :: [PP.Doc ann] -> PP.Doc ann
     commaList []     = PP.emptyDoc
     commaList (x:xs) = x PP.<> PP.hcat (map (\y -> PP.comma PP.<+> y) xs)
+
+ppAllocIndex :: AllocIndex -> PP.Doc ann
+ppAllocIndex i = PP.pretty '@' <> PP.viaShow i
 
 ppTypedTerm :: TypedTerm -> PP.Doc ann
 ppTypedTerm (TypedTerm tp tm) =

--- a/src/SAWScript/Crucible/JVM/Builtins.hs
+++ b/src/SAWScript/Crucible/JVM/Builtins.hs
@@ -920,7 +920,7 @@ jvm_field_is ptr fname val =
      let cc = st ^. Setup.csCrucibleContext
      let cb = cc ^. jccCodebase
      let path = Left fname
-     if st ^. Setup.csPrePost == PreState && MS.testResolved ptr [] rs
+     if st ^. Setup.csPrePost == PreState && MS.testResolved ptr [path] rs
        then X.throwM $ JVMFieldMultiple ptr fname
        else Setup.csResolvedState %= MS.markResolved ptr [path]
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)

--- a/src/SAWScript/Crucible/JVM/MethodSpecIR.hs
+++ b/src/SAWScript/Crucible/JVM/MethodSpecIR.hs
@@ -56,7 +56,7 @@ import qualified SAWScript.Crucible.Common.Setup.Type as Setup
 -- ** Language features
 
 type instance MS.HasSetupNull CJ.JVM = 'True
-type instance MS.HasSetupGlobal CJ.JVM = 'True
+type instance MS.HasSetupGlobal CJ.JVM = 'False
 type instance MS.HasSetupStruct CJ.JVM = 'False
 type instance MS.HasSetupArray CJ.JVM = 'False
 type instance MS.HasSetupElem CJ.JVM = 'False

--- a/src/SAWScript/Crucible/JVM/MethodSpecIR.hs
+++ b/src/SAWScript/Crucible/JVM/MethodSpecIR.hs
@@ -127,23 +127,23 @@ type instance MS.AllocSpec CJ.JVM = (ProgramLoc, Allocation)
 type instance MS.PointsTo CJ.JVM = JVMPointsTo
 
 data JVMPointsTo
-  = JVMPointsToField ProgramLoc (MS.SetupValue CJ.JVM) J.FieldId (MS.SetupValue CJ.JVM)
-  | JVMPointsToElem ProgramLoc (MS.SetupValue CJ.JVM) Int (MS.SetupValue CJ.JVM)
-  | JVMPointsToArray ProgramLoc (MS.SetupValue CJ.JVM) TypedTerm
+  = JVMPointsToField ProgramLoc MS.AllocIndex J.FieldId (MS.SetupValue CJ.JVM)
+  | JVMPointsToElem ProgramLoc MS.AllocIndex Int (MS.SetupValue CJ.JVM)
+  | JVMPointsToArray ProgramLoc MS.AllocIndex TypedTerm
 
 ppPointsTo :: JVMPointsTo -> PPL.Doc ann
 ppPointsTo =
   \case
     JVMPointsToField _loc ptr fid val ->
-      MS.ppSetupValue ptr <> PPL.pretty "." <> PPL.pretty (J.fieldIdName fid)
+      MS.ppAllocIndex ptr <> PPL.pretty "." <> PPL.pretty (J.fieldIdName fid)
       PPL.<+> PPL.pretty "points to"
       PPL.<+> MS.ppSetupValue val
     JVMPointsToElem _loc ptr idx val ->
-      MS.ppSetupValue ptr <> PPL.pretty "[" <> PPL.pretty idx <> PPL.pretty "]"
+      MS.ppAllocIndex ptr <> PPL.pretty "[" <> PPL.pretty idx <> PPL.pretty "]"
       PPL.<+> PPL.pretty "points to"
       PPL.<+> MS.ppSetupValue val
     JVMPointsToArray _loc ptr val ->
-      MS.ppSetupValue ptr
+      MS.ppAllocIndex ptr
       PPL.<+> PPL.pretty "points to"
       PPL.<+> MS.ppTypedTerm val
 

--- a/src/SAWScript/Crucible/JVM/ResolveSetupValue.hs
+++ b/src/SAWScript/Crucible/JVM/ResolveSetupValue.hs
@@ -117,8 +117,7 @@ typeOfSetupValue _cc env _nameEnv val =
       -- can be used at, and b) it prevents us from doing any
       -- type-safe field accesses.
       return (J.ClassType (J.mkClassName "java/lang/Object"))
-    MS.SetupGlobal () name ->
-      fail ("typeOfSetupValue: unimplemented jvm_global: " ++ name)
+    MS.SetupGlobal empty _            -> absurd empty
     MS.SetupStruct empty _ _          -> absurd empty
     MS.SetupArray empty _             -> absurd empty
     MS.SetupElem empty _ _            -> absurd empty
@@ -142,8 +141,7 @@ resolveSetupVal cc env _tyenv _nameEnv val =
     MS.SetupTerm tm -> resolveTypedTerm cc tm
     MS.SetupNull () ->
       return (RVal (W4.maybePartExpr sym Nothing))
-    MS.SetupGlobal () name ->
-      fail $ "resolveSetupVal: unimplemented jvm_global: " ++ name
+    MS.SetupGlobal empty _            -> absurd empty
     MS.SetupStruct empty _ _          -> absurd empty
     MS.SetupArray empty _             -> absurd empty
     MS.SetupElem empty _ _            -> absurd empty

--- a/src/SAWScript/Crucible/JVM/ResolveSetupValue.hs
+++ b/src/SAWScript/Crucible/JVM/ResolveSetupValue.hs
@@ -17,6 +17,7 @@ module SAWScript.Crucible.JVM.ResolveSetupValue
   , resolveSetupVal
   -- , typeOfJVMVal
   , typeOfSetupValue
+  , lookupAllocIndex
   , toJVMType
   , resolveTypedTerm
   , resolveBoolTerm
@@ -141,6 +142,12 @@ typeOfSetupValue _cc env _nameEnv val =
     MS.SetupElem empty _ _            -> absurd empty
     MS.SetupField empty _ _           -> absurd empty
     MS.SetupGlobalInitializer empty _ -> absurd empty
+
+lookupAllocIndex :: Map AllocIndex a -> AllocIndex -> a
+lookupAllocIndex env i =
+  case Map.lookup i env of
+    Nothing -> panic "JVMSetup" ["Unresolved prestate variable:" ++ show i]
+    Just x -> x
 
 -- | Translate a SetupValue into a Crucible JVM value, resolving
 -- references

--- a/src/SAWScript/Crucible/JVM/ResolveSetupValue.hs
+++ b/src/SAWScript/Crucible/JVM/ResolveSetupValue.hs
@@ -24,6 +24,7 @@ module SAWScript.Crucible.JVM.ResolveSetupValue
   , resolveSAWPred
   -- , resolveSetupFieldIndex
   , equalValsPred
+  , JVMTypeOfError(..)
   ) where
 
 import           Control.Lens
@@ -90,24 +91,24 @@ type JVMRefVal = Crucible.RegValue Sym CJ.JVMRefType
 
 type SetupValue = MS.SetupValue CJ.JVM
 
-data JvmTypeOfError
-  = JvmPolymorphicType Cryptol.Schema
-  | JvmNonRepresentableType Cryptol.Type
+data JVMTypeOfError
+  = JVMPolymorphicType Cryptol.Schema
+  | JVMNonRepresentableType Cryptol.Type
 
-instance Show JvmTypeOfError where
-  show (JvmPolymorphicType s) =
+instance Show JVMTypeOfError where
+  show (JVMPolymorphicType s) =
     unlines
     [ "Expected monomorphic term"
     , "instead got:"
     , show (Cryptol.pp s)
     ]
-  show (JvmNonRepresentableType ty) =
+  show (JVMNonRepresentableType ty) =
     unlines
     [ "Type not representable in JVM:"
     , show (Cryptol.pp ty)
     ]
 
-instance X.Exception JvmTypeOfError
+instance X.Exception JVMTypeOfError
 
 typeOfSetupValue ::
   X.MonadThrow m =>
@@ -126,9 +127,9 @@ typeOfSetupValue _cc env _nameEnv val =
       case ttSchema tt of
         Cryptol.Forall [] [] ty ->
           case toJVMType (Cryptol.evalValType mempty ty) of
-            Nothing -> X.throwM (JvmNonRepresentableType ty)
+            Nothing -> X.throwM (JVMNonRepresentableType ty)
             Just jty -> return jty
-        s -> X.throwM (JvmPolymorphicType s)
+        s -> X.throwM (JVMPolymorphicType s)
 
     MS.SetupNull () ->
       -- We arbitrarily set the type of NULL to java.lang.Object,

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -2528,13 +2528,6 @@ primitives = Map.fromList
     Experimental
     [ "A JVMValue representing a null pointer value." ]
 
-  , prim "jvm_global"
-    "String -> JVMValue"
-    (pureVal (CMS.SetupGlobal () :: String -> CMS.SetupValue CJ.JVM))
-    Experimental
-    [ "Return a JVMValue representing a pointer to the named global."
-    , "The String may be either the name of a global value or a function name." ]
-
   , prim "jvm_term"
     "Term -> JVMValue"
     (pureVal (CMS.SetupTerm :: TypedTerm -> CMS.SetupValue CJ.JVM))


### PR DESCRIPTION
This PR includes a few things related to error checking for `JVMSetup` blocks:
- Add custom exception datatype for JVMSetup errors
- Use `throwM` from `exceptions` package instead of `fail` to report errors
- Add more well-formedness checks to various `JVMSetup` commands
- Refactor some method-spec datatypes to enforce invariants
- Update regression tests to eliminate known false positives