### PR TITLE
Disable `get_color true` when `--no-color` command-line option is present

### DIFF
--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -562,7 +562,10 @@ set_base b = do
 set_color :: Bool -> TopLevel ()
 set_color b = do
   rw <- getTopLevelRW
-  putTopLevelRW rw { rwPPOpts = (rwPPOpts rw) { ppOptsColor = b } }
+  opts <- getOptions
+  -- Keep color disabled if `--no-color` command-line option is present
+  let b' = b && useColor opts
+  putTopLevelRW rw { rwPPOpts = (rwPPOpts rw) { ppOptsColor = b' } }
 
 print_value :: Value -> TopLevel ()
 print_value (VString s) = printOutLnTop Info s


### PR DESCRIPTION
Also update saw-core to GaloisInc/saw-core#113 to prevent output of
ANSI escape sequences when `get_color` is disabled.

Fixes #957.