### PR TITLE
Add strictness to fix a space leak in crucible_llvm_unsafe_assume_spec.

### DIFF
--- a/src/SAWScript/Crucible/Common/MethodSpec.hs
+++ b/src/SAWScript/Crucible/Common/MethodSpec.hs
@@ -335,7 +335,7 @@ data StateSpec ext = StateSpec
     -- ^ equality, propositions, and ghost-variable conditions
   , _csFreshVars     :: [TypedExtCns]
     -- ^ fresh variables created in this state
-  , _csVarTypeNames  :: Map AllocIndex (TypeName ext)
+  , _csVarTypeNames  :: !(Map AllocIndex (TypeName ext))
     -- ^ names for types of variables, for diagnostics
   }
 

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -1755,7 +1755,7 @@ crucible_alloc_with_mutability_and_size mut sz alignment lty =
                 , "Specified alignment: " ++ show (Crucible.fromAlignment a) ++ "-byte"
                 ]
               pure a
-         Nothing -> pure memTyAlign
+         Nothing -> pure $! memTyAlign
 
      crucible_alloc_internal lty $
        LLVMAllocSpec


### PR DESCRIPTION
Due to laziness, some thunks inside the MethodSpec datatype had been
holding references to the `LLVMCrucibleContext`, whose `ccLLVMGlobals`
field contains the crucible-llvm MemImpl data structure, which in turn
contains copies of all const globals. A separate copy of this data
structure was retained for every override value.

Profiling showed that unevaluated thunks resided in the `allocSpecAlign`
field of `LLVMAllocSpec`, and also in the `csVarTypeNames` field of
`StateSpec`, so these areas have been made more strict.

This patch is somewhat related to #850, although this just fixes the space
leak, and doesn't remove any of the unnecessary or duplicated computation.