### PR TITLE
No crucible prefix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,19 @@ The new `cryptol_add_path` command adds a directory to the search path
 used when loading Cryptol modules (and following imports within
 explicitly-loaded modules).
 
+New, shorter names are available for all LLVM commands starting with
+the `crucible_` prefix. The new names use the `llvm_` prefix instead.
+The top-level function `crucible_llvm_verify` is now `llvm_verify`,
+and `crucible_llvm_unsafe_assume_spec` is `llvm_unsafe_assume_spec`.
+The old names are still supported for now. The in-REPL documentation
+(`:? <command>`) gives the new name for each command.
+
+Shorter names are available for some saw-script types: `CrucibleSetup`
+is now `LLVMSetup`, `CrucibleMethodSpec` is now simply `LLVMSpec`, and
+`JVMMethodSpec` is `JVMSpec`. The old type names are still supported
+for backward compatibility.
+
+
 ## Bug Fixes
 
 * Catch more exceptions at the REPL (issues #138, #560, #745, and #814).

--- a/doc/manual/manual.md
+++ b/doc/manual/manual.md
@@ -1655,7 +1655,7 @@ such simple code. The first, for LLVM is the more stable of the two:
 
 A similar function exists for Java, but is more experimental.
 
-* `java_extract : JavaClass -> String -> TopLevel Term`
+* `jvm_extract : JavaClass -> String -> TopLevel Term`
 
 Because of its lack of maturity, it (and later Java-related commands)
 must be enabled by running the `enable_experimental` command beforehand.

--- a/doc/manual/manual.md
+++ b/doc/manual/manual.md
@@ -1245,7 +1245,7 @@ techniques that do not require significant computation.
 
 * `assume_unsat : ProofScript SatResult` indicates that the current goal
 should be assumed to be unsatisfiable. At the moment,
-`jvm_verify` and `crucible_llvm_verify` (described below) run
+`jvm_verify` and `llvm_verify` (described below) run
 their proofs in a satisfiability-checking (negated) context, so
 `assume_unsat` indicates that the property being checked should be
 assumed to be true. This is likely to change in the future.
@@ -1612,7 +1612,7 @@ can[^3] be useful for this.
 
 The C++ standard library includes a number of key global variables, and
 any code that touches them will require that they be initialized using
-`crucible_alloc_global`.
+`llvm_alloc_global`.
 
 Many C++ names are slightly awkward to deal with in SAW. They may be
 mangled relative to the text that appears in the C++ source code. SAW
@@ -1635,7 +1635,7 @@ llvm_type "%\"class.quux::Foo\""
 
 Finally, there is no support for calling constructors in specifications,
 so you will need to construct objects piece-by-piece using, *e.g.*,
-`crucible_alloc` and `crucible_points_to`.
+`llvm_alloc` and `llvm_points_to`.
 
 [^2]: https://libcxx.llvm.org/docs/BuildingLibcxx.html
 [^3]: https://github.com/travitch/whole-program-llvm
@@ -1651,11 +1651,11 @@ In cases like this, a direct translation is possible, given only an
 identification of which code to execute. Two functions exist to handle
 such simple code. The first, for LLVM is the more stable of the two:
 
-* `crucible_llvm_extract : LLVMModule -> String -> TopLevel Term`
+* `llvm_extract : LLVMModule -> String -> TopLevel Term`
 
 A similar function exists for Java, but is more experimental.
 
-* `crucible_java_extract : JavaClass -> String -> TopLevel Term`
+* `java_extract : JavaClass -> String -> TopLevel Term`
 
 Because of its lack of maturity, it (and later Java-related commands)
 must be enabled by running the `enable_experimental` command beforehand.
@@ -1817,11 +1817,10 @@ verifications, allowing the proof process to be decomposed.
 
 ## Running a Verification
 
-Verification of LLVM is controlled by the `crucible_llvm_verify`
-command.
+Verification of LLVM is controlled by the `llvm_verify` command.
 
 ~~~~
-crucible_llvm_verify :
+llvm_verify :
   LLVMModule ->
   String ->
   [CrucibleMethodSpec] ->
@@ -1870,11 +1869,11 @@ A specifications for Crucible consists of three logical components:
 
 These three portions of the specification are written in sequence within
 a `do` block of `CrucibleSetup` (or `JVMSetup`) type. The command
-`crucible_execute_func` (or `jvm_execute_func`) separates the
+`llvm_execute_func` (or `jvm_execute_func`) separates the
 specification of the initial state from the specification of the final
 state, and specifies the arguments to the function in terms of the
 initial state. Most of the commands available for state description will
-work either before or after `crucible_execute_func`, though with
+work either before or after `llvm_execute_func`, though with
 slightly different meaning, as described below.
 
 ## Creating Fresh Variables
@@ -1883,10 +1882,10 @@ In any case where you want to prove a property of a function for an
 entire class of inputs (perhaps all inputs) rather than concrete values,
 the initial values of at least some elements of the program state must
 contain fresh variables. These are created in a specification with the
-`crucible_fresh_var` and `jvm_fresh_var` commands rather than
+`llvm_fresh_var` and `jvm_fresh_var` commands rather than
 `fresh_symbolic`.
 
-* `crucible_fresh_var : String -> LLVMType -> CrucibleSetup Term`
+* `llvm_fresh_var : String -> LLVMType -> CrucibleSetup Term`
 
 * `jvm_fresh_var : String -> JavaType -> JVMSetup Term`
 
@@ -1937,8 +1936,8 @@ particular function should have the specified behaviour for arbitrary
 initial values of the variables in question. Sometimes, however, it can
 be useful to specify that a function returns (or stores, more about this
 later) an arbitrary value, without specifying what that value should be.
-To express such a pattern, you can also run `crucible_fresh_var` from
-the post state (i.e., after `crucible_execute_func`).
+To express such a pattern, you can also run `llvm_fresh_var` from
+the post state (i.e., after `llvm_execute_func`).
 
 ## The SetupValue and JVMValue Types
 
@@ -1948,26 +1947,26 @@ values that can occur during symbolic execution, which includes both
 `Term` values, pointers, and composite types consisting of either of
 these (both structures and arrays).
 
-The `crucible_term` and `jvm_term` functions create a `SetupValue` or
+The `llvm_term` and `jvm_term` functions create a `SetupValue` or
 `JVMValue` from a `Term`:
 
-* `crucible_term : Term -> SetupValue`
+* `llvm_term : Term -> SetupValue`
 * `jvm_term : Term -> JVMValue`
 
 ## Executing
 
-Once the initial state has been configured, the `crucible_execute_func`
+Once the initial state has been configured, the `llvm_execute_func`
 command specifies the parameters of the function being analyzed in terms
 of the state elements already configured.
 
-* `crucible_execute_func : [SetupValue] -> CrucibleSetup ()`
+* `llvm_execute_func : [SetupValue] -> CrucibleSetup ()`
 
 ## Return Values
 
 To specify the value that should be returned by the function being
-verified use the `crucible_return` or `jvm_return` command.
+verified use the `llvm_return` or `jvm_return` command.
 
-* `crucible_return : SetupValue -> CrucibleSetup ()`
+* `llvm_return : SetupValue -> CrucibleSetup ()`
 * `jvm_return : JVMValue -> JVMSetup ()`
 
 ## A First Simple Example
@@ -1987,10 +1986,10 @@ We can specify this function's expected behavior as follows:
 
 ~~~~
 let add_setup = do {
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    y <- crucible_fresh_var "y" (llvm_int 32);
-    crucible_execute_func [crucible_term x, crucible_term y];
-    crucible_return (crucible_term {{ x + y : [32] }});
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    y <- llvm_fresh_var "y" (llvm_int 32);
+    llvm_execute_func [llvm_term x, llvm_term y];
+    llvm_return (llvm_term {{ x + y : [32] }});
 };
 ~~~~
 
@@ -1999,7 +1998,7 @@ and verify it with ABC:
 
 ~~~~
 m <- llvm_load_module "add.bc";
-add_ms <- crucible_llvm_verify m "add" [] false add_setup abc;
+add_ms <- llvm_verify m "add" [] false add_setup abc;
 ~~~~
 
 ## Compositional Verification
@@ -2011,7 +2010,7 @@ of properties we have already proved about its callees rather than
 analyzing them anew. This enables us to reason about much larger
 and more complex systems than otherwise possible.
 
-The `crucible_llvm_verify` and `jvm_verify` functions return values of
+The `llvm_verify` and `jvm_verify` functions return values of
 type `CrucibleMethodSpec` and `JVMMethodSpec`, respectively. These
 values are opaque objects that internally contain both the information
 provided in the associated `JVMSetup` or `CrucibleSetup` blocks and
@@ -2023,7 +2022,7 @@ specified by one of these parameters, the simulator will not follow
 calls to the associated target. Instead, it will perform the following
 steps:
 
-* Check that all `crucible_points_to` and `crucible_precond` statements
+* Check that all `llvm_points_to` and `llvm_precond` statements
   (or the corresponding JVM statements) in the specification are
   satisfied.
 
@@ -2043,16 +2042,16 @@ It has a similar specification to `add`:
 
 ~~~~
 let dbl_setup = do {
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    crucible_execute_func [crucible_term x];
-    crucible_return (crucible_term {{ x + x : [32] }});
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    llvm_execute_func [llvm_term x];
+    llvm_return (llvm_term {{ x + x : [32] }});
 };
 ~~~~
 
 And we can verify it using what we've already proved about `add`:
 
 ~~~~
-crucible_llvm_verify m "dbl" [add_ms] false dbl_setup abc;
+llvm_verify m "dbl" [add_ms] false dbl_setup abc;
 ~~~~
 
 In this case, doing the verification compositionally doesn't save
@@ -2062,17 +2061,17 @@ illustrates the approach.
 ## Specifying Heap Layout
 
 Most functions that operate on pointers expect that certain pointers
-point to allocated memory before they are called. The `crucible_alloc`
+point to allocated memory before they are called. The `llvm_alloc`
 command allows you to specify that a function expects a particular
 pointer to refer to an allocated region appropriate for a specific type.
 
-* `crucible_alloc : LLVMType -> CrucibleSetup SetupValue`
+* `llvm_alloc : LLVMType -> CrucibleSetup SetupValue`
 
 This command returns a `SetupValue` consisting of a pointer to the
 allocated space, which can be used wherever a pointer-valued
 `SetupValue` can be used.
 
-In the initial state, `crucible_alloc` specifies that the function
+In the initial state, `llvm_alloc` specifies that the function
 expects a pointer to allocated space to exist. In the final state, it
 specifies that the function itself performs an allocation.
 
@@ -2089,27 +2088,27 @@ In LLVM, it's also possible to construct fresh pointers that do not
 point to allocated memory (which can be useful for functions that
 manipulate pointers but not the values they point to):
 
-* `crucible_fresh_pointer : LLVMType -> CrucibleSetup SetupValue`
+* `llvm_fresh_pointer : LLVMType -> CrucibleSetup SetupValue`
 
-The NULL pointer is called `crucible_null` in LLVM and `jvm_null` in
+The NULL pointer is called `llvm_null` in LLVM and `jvm_null` in
 JVM:
 
-* `crucible_null : SetupValue`
+* `llvm_null : SetupValue`
 * `jvm_null : JVMValue`
 
 One final, slightly more obscure command is the following:
 
-* `crucible_alloc_readonly : LLVMType -> CrucibleSetup SetupValue`
+* `llvm_alloc_readonly : LLVMType -> CrucibleSetup SetupValue`
 
-This works like `crucible_alloc` except that writes to the space
+This works like `llvm_alloc` except that writes to the space
 allocated are forbidden. This can be useful for specifying that a
 function should take as an argument a pointer to allocated space that it
-will not modify. Unlike `crucible_alloc`, regions allocated with
-`crucible_alloc_readonly` are allowed to alias other read-only regions.
+will not modify. Unlike `llvm_alloc`, regions allocated with
+`llvm_alloc_readonly` are allowed to alias other read-only regions.
 
 ## Specifying Heap Values
 
-Pointers returned by `crucible_alloc` don't, initially, point to
+Pointers returned by `llvm_alloc` don't, initially, point to
 anything. So if you pass such a pointer directly into a function that
 tried to dereference it, symbolic execution will fail with a message
 about an invalid load. For some functions, such as those that are
@@ -2117,15 +2116,15 @@ intended to initialize data structures (writing to the memory pointed
 to, but never reading from it), this sort of uninitialized memory is
 appropriate. In most cases, however, it's more useful to state that a
 pointer points to some specific (usually symbolic) value, which you can
-do with the `crucible_points_to` command.
+do with the `llvm_points_to` command.
 
-* `crucible_points_to : SetupValue -> SetupValue -> CrucibleSetup ()`
+* `llvm_points_to : SetupValue -> SetupValue -> CrucibleSetup ()`
 takes two `SetupValue` arguments, the first of which must be a pointer,
 and states that the memory specified by that pointer should contain the
 value given in the second argument (which may be any type of
 `SetupValue`).
 
-When used in the final state, `crucible_points_to` specifies that the
+When used in the final state, `llvm_points_to` specifies that the
 given pointer *should* point to the given value when the function
 finishes.
 
@@ -2133,8 +2132,8 @@ Occasionally, because C programs frequently reinterpret memory of one
 type as another through casts, it can be useful to specify that a
 pointer points to a value that does not agree with its static type.
 
-* `crucible_points_to_untyped : SetupValue -> SetupValue ->
-CrucibleSetup ()` works like `crucible_points_to` but omits type
+* `llvm_points_to_untyped : SetupValue -> SetupValue ->
+CrucibleSetup ()` works like `llvm_points_to` but omits type
 checking. Rather than omitting type checking across the board, we
 introduced this additional function to make it clear when a type
 reinterpretation is intentional.
@@ -2145,42 +2144,42 @@ The commands mentioned so far give us no way to specify the values of
 compound types (arrays or `struct`s). Compound values can be dealt with
 either piecewise or in their entirety.
 
-* `crucible_elem : SetupValue -> Int -> SetupValue` yields a pointer to
+* `llvm_elem : SetupValue -> Int -> SetupValue` yields a pointer to
 an internal element of a compound value. For arrays, the `Int` parameter
 is the array index. For `struct` values, it is the field index.
 
-* `crucible_field : SetupValue -> String -> SetupValue` yields a pointer
+* `llvm_field : SetupValue -> String -> SetupValue` yields a pointer
 to a particular named `struct` field, if debugging information is
 available in the bitcode
 
-Either of these functions can be used with `crucible_points_to` to
+Either of these functions can be used with `llvm_points_to` to
 specify the value of a particular array element or `struct` field.
 Sometimes, however, it is more convenient to specify all array elements
-or field values at once. The `crucible_array` and `crucible_struct`
+or field values at once. The `llvm_array_value` and `llvm_struct_value`
 functions construct compound values from lists of element values.
 
-* `crucible_array : [SetupValue] -> SetupValue`
-* `crucible_struct : [SetupValue] -> SetupValue`
+* `llvm_array_value : [SetupValue] -> SetupValue`
+* `llvm_struct_value : [SetupValue] -> SetupValue`
 
 To specify an array or struct in which each element or field is
 symbolic, it would be possible, but tedious, to use a large combination
-of `crucible_fresh_var` and `crucible_elem` or `crucible_field`
-commands. However, the following function can simplify the common case
+of `llvm_fresh_var` and `llvm_elem` or `llvm_field` commands.
+However, the following function can simplify the common case
 where you want every element or field to have a fresh value.
 
-* `crucible_fresh_expanded_val : LLVMType -> CrucibleSetup SetupValue`
+* `llvm_fresh_expanded_val : LLVMType -> CrucibleSetup SetupValue`
 
-The `crucible_struct` function normally creates a `struct` whose layout
+The `llvm_struct_value` function normally creates a `struct` whose layout
 obeys the alignment rules of the platform specified in the LLVM file
 being analyzed. Structs in LLVM can explicitly be "packed", however, so
 that every field immediately follows the previous in memory. The
 following command will create values of such types:
 
-* `crucible_packed_struct : [SetupValue] -> SetupValue`
+* `llvm_packed_struct_value : [SetupValue] -> SetupValue`
 
 In the experimental Java verification implementation, the following
 functions can be used to state the equivalent of a combination of
-`crucible_points_to` and either `crucible_elem` or `crucible_field`.
+`llvm_points_to` and either `llvm_elem` or `llvm_field`.
 
 * `jvm_elem_is : JVMValue -> Int -> JVMValue -> JVMSetup ()` specifies
 the value of an array element.
@@ -2191,26 +2190,26 @@ specifies the name of an object field.
 ## Global variables
 
 Mutable global variables that are accessed in a function must first be allocated
-by calling `crucible_alloc_global` on the name of the global.
+by calling `llvm_alloc_global` on the name of the global.
 
-* `crucible_alloc_global : String -> CrucibleSetup ()`
+* `llvm_alloc_global : String -> CrucibleSetup ()`
 
 This ensures that all global variables that might influence the function are
-accounted for explicitly in the specification: if `crucible_alloc_global` is
-used in the precondition, there must be a corresponding `crucible_points_to`
+accounted for explicitly in the specification: if `llvm_alloc_global` is
+used in the precondition, there must be a corresponding `llvm_points_to`
 in the postcondition describing the new state of that global. Otherwise, a
 specification might not fully capture the behavior of the function, potentially
 leading to unsoundness in the presence of compositional verification.
 
 Immutable (i.e. `const`) global variables are allocated implicitly, and do not
-require a call to `crucible_alloc_global`.
+require a call to `llvm_alloc_global`.
 
 Pointers to global variables or functions can be accessed with
-`crucible_global`:
+`llvm_global`:
 
-* `crucible_global : String -> SetupValue`
+* `llvm_global : String -> SetupValue`
 
-Like the pointers returned by `crucible_alloc`, however, these aren't
+Like the pointers returned by `llvm_alloc`, however, these aren't
 initialized at the beginning of symbolic -- setting global variables may
 be unsound in the presence of [compositional
 verification](#compositional-verification).
@@ -2239,16 +2238,16 @@ One might initially write the following specifications for `f` and `g`:
 ~~~
 m <- llvm_load_module "./test.bc";
 
-f_spec <- crucible_llvm_verify m "f" [] true (do {
-    y <- crucible_fresh_var "y" (llvm_int 32);
-    crucible_execute_func [crucible_term y];
-    crucible_return (crucible_term {{ 1 + y : [32] }});
+f_spec <- llvm_verify m "f" [] true (do {
+    y <- llvm_fresh_var "y" (llvm_int 32);
+    llvm_execute_func [llvm_term y];
+    llvm_return (llvm_term {{ 1 + y : [32] }});
 }) abc;
 
-g_spec <- crucible_llvm_verify m "g" [] true (do {
-    z <- crucible_fresh_var "z" (llvm_int 32);
-    crucible_execute_func [crucible_term z];
-    crucible_return (crucible_term {{ 2 + z : [32] }});
+g_spec <- llvm_llvm_verify m "g" [] true (do {
+    z <- llvm_fresh_var "z" (llvm_int 32);
+    llvm_execute_func [llvm_term z];
+    llvm_return (llvm_term {{ 2 + z : [32] }});
 }) abc;
 ~~~
 
@@ -2260,7 +2259,7 @@ z + 3` for all `z`, because both `f` and `g` modify the global variable
 
 To deal with this, we can use the following function:
 
-* `crucible_global_initializer : String -> SetupValue` returns the value
+* `llvm_global_initializer : String -> SetupValue` returns the value
   of the constant global initializer for the named global variable.
 
 Given this function, the specifications for `f` and `g` can make this
@@ -2272,15 +2271,15 @@ m <- llvm_load_module "./test.bc";
 
 
 let init_global name = do {
-  crucible_points_to (crucible_global name)
-                     (crucible_global_initializer name);
+  llvm_points_to (llvm_global name)
+                 (llvm_global_initializer name);
 };
 
-f_spec <- crucible_llvm_verify m "f" [] true (do {
-    y <- crucible_fresh_var "y" (llvm_int 32);
+f_spec <- llvm_verify m "f" [] true (do {
+    y <- llvm_fresh_var "y" (llvm_int 32);
     init_global "x";
-    crucible_execute_func [crucible_term y];
-    crucible_return (crucible_term {{ 1 + y : [32] }});
+    llvm_execute_func [llvm_term y];
+    llvm_return (llvm_term {{ 1 + y : [32] }});
 }) abc;
 ~~~
 
@@ -2298,19 +2297,19 @@ rise to specific final conditions. For these cases, you can specify an
 arbitrary predicate as a precondition or post-condition, using any
 values in scope at the time.
 
-* `crucible_precond : Term -> CrucibleSetup ()`
-* `crucible_postcond : Term -> CrucibleSetup ()`
+* `llvm_precond : Term -> CrucibleSetup ()`
+* `llvm_postcond : Term -> CrucibleSetup ()`
 * `jvm_precond : Term -> JVMSetup ()`
 * `jvm_postcond : Term -> JVMSetup ()`
 
 These two commands take `Term` arguments, and therefore cannot describe
-the values of pointers. The `crucible_equal` command states that two
+the values of pointers. The `llvm_equal` command states that two
 `SetupValue`s should be equal, and can be used in either the initial or
 the final state.
 
-* `crucible_equal : SetupValue -> SetupValue -> CrucibleSetup ()`
+* `llvm_equal : SetupValue -> SetupValue -> CrucibleSetup ()`
 
-The use of `crucible_equal` can also sometimes lead to more efficient
+The use of `llvm_equal` can also sometimes lead to more efficient
 symbolic execution when the predicate of interest is an equality.
 
 ## Assuming specifications
@@ -2323,7 +2322,7 @@ tactic](#miscellaneous-tactics) omits proof but does not prevent
 simulation of the function. To skip simulation altogether, one can use:
 
 ~~~
-crucible_llvm_unsafe_assume_spec :
+llvm_unsafe_assume_spec :
   LLVMModule -> String -> CrucibleSetup () -> TopLevel CrucibleMethodSpec
 ~~~
 
@@ -2385,8 +2384,8 @@ initialization to a specific value can make many scripts more concise:
 
 ~~~~
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 ~~~~
@@ -2400,8 +2399,8 @@ initial value should be entirely symbolic.
 
 ~~~~
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 ~~~~
@@ -2414,15 +2413,15 @@ specified as follows:
 
 ~~~~
 let dotprod_spec n = do {
-    let nt = crucible_term {{ `n : [32] }};
+    let nt = llvm_term {{ `n : [32] }};
     (xs, xsp) <- ptr_to_fresh "xs" (llvm_array n (llvm_int 32));
     (ys, ysp) <- ptr_to_fresh "ys" (llvm_array n (llvm_int 32));
-    let xval = crucible_struct [ xsp, nt ];
-    let yval = crucible_struct [ ysp, nt ];
+    let xval = llvm_struct [ xsp, nt ];
+    let yval = llvm_struct [ ysp, nt ];
     xp <- alloc_init (llvm_struct "struct.vec_t") xval;
     yp <- alloc_init (llvm_struct "struct.vec_t") yval;
-    crucible_execute_func [xp, yp];
-    crucible_return (crucible_term {{ dotprod xs ys }});
+    llvm_execute_func [xp, yp];
+    llvm_return (llvm_term {{ dotprod xs ys }});
 };
 ~~~~
 
@@ -2465,13 +2464,13 @@ thought of as additional global state that is visible only to the
 verifier. Ghost state with a given name can be declared at the top level
 with the following function:
 
-* `crucible_declare_ghost_state : String -> TopLevel Ghost`
+* `llvm_declare_ghost_state : String -> TopLevel Ghost`
 
 Ghost state variables do not initially have any particluar type, and can
 store data of any type. Given an existing ghost variable the following
 function can be used to specify its value:
 
-* `crucible_ghost_value : Ghost -> Term -> CrucibleSetup ()`
+* `llvm_ghost_value : Ghost -> Term -> CrucibleSetup ()`
 
 Currently, this function can only be used for LLVM verification, though
 that will likely be generalized in the future. It can be used in either
@@ -2526,14 +2525,14 @@ does the same, except the memory allocated cannot be written to.
 import "Salsa20.cry";
 
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p (crucible_term v);
+    p <- llvm_alloc ty;
+    llvm_points_to p (llvm_term v);
     return p;
 };
 
 let alloc_init_readonly ty v = do {
-    p <- crucible_alloc_readonly ty;
-    crucible_points_to p (crucible_term v);
+    p <- llvm_alloc_readonly ty;
+    llvm_points_to p (llvm_term v);
     return p;
 };
 ~~~~
@@ -2548,13 +2547,13 @@ same, but returns a pointer to space that cannot be written to.
 
 ~~~~
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
+    x <- llvm_fresh_var n ty;
     p <- alloc_init ty x;
     return (x, p);
 };
 
 let ptr_to_fresh_readonly n ty = do {
-    x <- crucible_fresh_var n ty;
+    x <- llvm_fresh_var n ty;
     p <- alloc_init_readonly ty x;
     return (x, p);
 };
@@ -2572,8 +2571,8 @@ given by the application of `f` to the value in that memory before execution.
 ~~~~
 let oneptr_update_func n ty f = do {
     (x, p) <- ptr_to_fresh n ty;
-    crucible_execute_func [p];
-    crucible_points_to p (crucible_term {{ f x }});
+    llvm_execute_func [p];
+    llvm_points_to p (llvm_term {{ f x }});
 };
 ~~~~
 
@@ -2584,7 +2583,7 @@ The C function we wish to verify has type
 
 The function's specification generates four symbolic variables and pointers to
 them in the precondition/setup stage. The pointers are passed to the function
-during symbolic execution via `crucible_execute_func`. Finally, in the
+during symbolic execution via `llvm_execute_func`. Finally, in the
 postcondition/return stage, the expected values are computed using the trusted
 Cryptol implementation and it is asserted that the pointers do in fact point to
 these expected values.
@@ -2596,13 +2595,13 @@ let quarterround_setup : CrucibleSetup () = do {
     (y2, p2) <- ptr_to_fresh "y2" (llvm_int 32);
     (y3, p3) <- ptr_to_fresh "y3" (llvm_int 32);
 
-    crucible_execute_func [p0, p1, p2, p3];
+    llvm_execute_func [p0, p1, p2, p3];
 
     let zs = {{ quarterround [y0,y1,y2,y3] }}; // from Salsa20.cry
-    crucible_points_to p0 (crucible_term {{ zs@0 }});
-    crucible_points_to p1 (crucible_term {{ zs@1 }});
-    crucible_points_to p2 (crucible_term {{ zs@2 }});
-    crucible_points_to p3 (crucible_term {{ zs@3 }});
+    llvm_points_to p0 (llvm_term {{ zs@0 }});
+    llvm_points_to p1 (llvm_term {{ zs@1 }});
+    llvm_points_to p2 (llvm_term {{ zs@2 }});
+    llvm_points_to p3 (llvm_term {{ zs@3 }});
 };
 ~~~~
 
@@ -2652,12 +2651,12 @@ let salsa20_expansion_32 = do {
     (k, pk) <- ptr_to_fresh_readonly "k" (llvm_array 32 (llvm_int 8));
     (n, pn) <- ptr_to_fresh_readonly "n" (llvm_array 16 (llvm_int 8));
 
-    pks <- crucible_alloc (llvm_array 64 (llvm_int 8));
+    pks <- llvm_alloc (llvm_array 64 (llvm_int 8));
 
-    crucible_execute_fun [pk, pn, pks];
+    llvm_execute_func [pk, pn, pks];
 
     let rks = {{ Salsa20_expansion`{a=2}(k, n) }};
-    crucible_points_to pks (crucible_term rks);
+    llvm_points_to pks (llvm_term rks);
 };
 ~~~~
 
@@ -2688,15 +2687,15 @@ let s20_encrypt32 n = do {
     (v, pv) <- ptr_to_fresh_readonly "nonce" (llvm_array 8 (llvm_int 8));
     (m, pm) <- ptr_to_fresh "buf" (llvm_array n (llvm_int 8));
 
-    crucible_execute_func [ pkey
-                          , pv
-                          , crucible_term {{ 0 : [32] }}
-                          , pm
-                          , crucible_term {{ `n : [32] }}
-                          ];
+    llvm_execute_func [ pkey
+                      , pv
+                      , llvm_term {{ 0 : [32] }}
+                      , pm
+                      , llvm_term {{ `n : [32] }}
+                      ];
 
-    crucible_points_to pm (crucible_term {{ Salsa20_encrypt (key, v, m) }});
-    crucible_return (crucible_term {{ 0 : [32] }});
+    llvm_points_to pm (llvm_term {{ Salsa20_encrypt (key, v, m) }});
+    llvm_return (llvm_term {{ 0 : [32] }});
 };
 ~~~~
 
@@ -2712,15 +2711,15 @@ size.)
 ~~~~
 let main : TopLevel () = do {
     m      <- llvm_load_module "salsa20.bc";
-    qr     <- crucible_llvm_verify m "s20_quarterround" []      false quarterround_setup   abc;
-    rr     <- crucible_llvm_verify m "s20_rowround"     [qr]    false rowround_setup       abc;
-    cr     <- crucible_llvm_verify m "s20_columnround"  [qr]    false columnround_setup    abc;
-    dr     <- crucible_llvm_verify m "s20_doubleround"  [cr,rr] false doubleround_setup    abc;
-    s20    <- crucible_llvm_verify m "s20_hash"         [dr]    false salsa20_setup        abc;
-    s20e32 <- crucible_llvm_verify m "s20_expand32"     [s20]   true  salsa20_expansion_32 abc;
-    s20encrypt_63 <- crucible_llvm_verify m "s20_crypt32" [s20e32] true (s20_encrypt32 63) abc;
-    s20encrypt_64 <- crucible_llvm_verify m "s20_crypt32" [s20e32] true (s20_encrypt32 64) abc;
-    s20encrypt_65 <- crucible_llvm_verify m "s20_crypt32" [s20e32] true (s20_encrypt32 65) abc;
+    qr     <- llvm_verify m "s20_quarterround" []      false quarterround_setup   abc;
+    rr     <- llvm_verify m "s20_rowround"     [qr]    false rowround_setup       abc;
+    cr     <- llvm_verify m "s20_columnround"  [qr]    false columnround_setup    abc;
+    dr     <- llvm_verify m "s20_doubleround"  [cr,rr] false doubleround_setup    abc;
+    s20    <- llvm_verify m "s20_hash"         [dr]    false salsa20_setup        abc;
+    s20e32 <- llvm_verify m "s20_expand32"     [s20]   true  salsa20_expansion_32 abc;
+    s20encrypt_63 <- llvm_verify m "s20_crypt32" [s20e32] true (s20_encrypt32 63) abc;
+    s20encrypt_64 <- llvm_verify m "s20_crypt32" [s20e32] true (s20_encrypt32 64) abc;
+    s20encrypt_65 <- llvm_verify m "s20_crypt32" [s20e32] true (s20_encrypt32 65) abc;
 
     print "Done!";
 };

--- a/doc/tutorial/code/dotprod.saw
+++ b/doc/tutorial/code/dotprod.saw
@@ -1,25 +1,25 @@
 import "dotprod.cry";
 
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
 let dotprod_spec n = do {
-    let nt = crucible_term {{ `n : [32] }};
+    let nt = llvm_term {{ `n : [32] }};
     (xs, xsp) <- ptr_to_fresh "xs" (llvm_array n (llvm_int 32));
     (ys, ysp) <- ptr_to_fresh "ys" (llvm_array n (llvm_int 32));
-    crucible_execute_func [xsp, ysp, nt];
-    crucible_return (crucible_term {{ dotprod xs ys }});
+    llvm_execute_func [xsp, ysp, nt];
+    llvm_return (llvm_term {{ dotprod xs ys }});
 };
 
 m <- llvm_load_module "dotprod.bc";
 
-dotprod_ov <- crucible_llvm_verify m "dotprod" [] true (dotprod_spec 10) z3;
+dotprod_ov <- llvm_verify m "dotprod" [] true (dotprod_spec 10) z3;

--- a/doc/tutorial/code/double.saw
+++ b/doc/tutorial/code/double.saw
@@ -1,6 +1,6 @@
 l <- llvm_load_module "double.bc";
-double_imp <- crucible_llvm_extract l "double_imp";
-double_ref <- crucible_llvm_extract l "double_ref";
+double_imp <- llvm_extract l "double_imp";
+double_ref <- llvm_extract l "double_ref";
 let thm = {{ \x -> double_ref x == double_imp x }};
 
 r <- prove abc thm;

--- a/doc/tutorial/code/ffs_compare.saw
+++ b/doc/tutorial/code/ffs_compare.saw
@@ -1,7 +1,7 @@
 import "ffs.cry";
 j <- java_load_class "FFS";
-java_ffs_ref <- java_extract j "ffs_ref";
-java_ffs_imp <- java_extract j "ffs_imp";
+java_ffs_ref <- jvm_extract j "ffs_ref";
+java_ffs_imp <- jvm_extract j "ffs_imp";
 
 l <- llvm_load_module "ffs.bc";
 c_ffs_ref <- llvm_extract l "ffs_ref";

--- a/doc/tutorial/code/ffs_compare.saw
+++ b/doc/tutorial/code/ffs_compare.saw
@@ -1,11 +1,11 @@
 import "ffs.cry";
 j <- java_load_class "FFS";
-java_ffs_ref <- crucible_java_extract j "ffs_ref";
-java_ffs_imp <- crucible_java_extract j "ffs_imp";
+java_ffs_ref <- java_extract j "ffs_ref";
+java_ffs_imp <- java_extract j "ffs_imp";
 
 l <- llvm_load_module "ffs.bc";
-c_ffs_ref <- crucible_llvm_extract l "ffs_ref";
-c_ffs_imp <- crucible_llvm_extract l "ffs_imp";
+c_ffs_ref <- llvm_extract l "ffs_ref";
+c_ffs_imp <- llvm_extract l "ffs_imp";
 
 print "java ref <-> java imp";
 let thm1 = {{ \x -> java_ffs_ref x == java_ffs_imp x }};

--- a/doc/tutorial/code/ffs_gen_aig.saw
+++ b/doc/tutorial/code/ffs_gen_aig.saw
@@ -1,9 +1,9 @@
 cls <- java_load_class "FFS";
 bc <- llvm_load_module "ffs.bc";
-java_ffs_ref <- crucible_java_extract cls "ffs_ref";
-java_ffs_imp <- crucible_java_extract cls "ffs_imp";
-c_ffs_ref <- crucible_llvm_extract bc "ffs_ref";
-c_ffs_imp <- crucible_llvm_extract bc "ffs_imp";
+java_ffs_ref <- java_extract cls "ffs_ref";
+java_ffs_imp <- java_extract cls "ffs_imp";
+c_ffs_ref <- llvm_extract bc "ffs_ref";
+c_ffs_imp <- llvm_extract bc "ffs_imp";
 write_aig "java_ffs_ref.aig" java_ffs_ref;
 write_aig "java_ffs_imp.aig" java_ffs_imp;
 write_aig "c_ffs_ref.aig" c_ffs_ref;

--- a/doc/tutorial/code/ffs_gen_aig.saw
+++ b/doc/tutorial/code/ffs_gen_aig.saw
@@ -1,7 +1,7 @@
 cls <- java_load_class "FFS";
 bc <- llvm_load_module "ffs.bc";
-java_ffs_ref <- java_extract cls "ffs_ref";
-java_ffs_imp <- java_extract cls "ffs_imp";
+java_ffs_ref <- jvm_extract cls "ffs_ref";
+java_ffs_imp <- jvm_extract cls "ffs_imp";
 c_ffs_ref <- llvm_extract bc "ffs_ref";
 c_ffs_imp <- llvm_extract bc "ffs_imp";
 write_aig "java_ffs_ref.aig" java_ffs_ref;

--- a/doc/tutorial/code/ffs_java.saw
+++ b/doc/tutorial/code/ffs_java.saw
@@ -1,9 +1,9 @@
 print "Extracting reference term";
 j <- java_load_class "FFS";
-ffs_ref <- java_extract j "ffs_ref";
+ffs_ref <- jvm_extract j "ffs_ref";
 
 print "Extracting implementation term";
-ffs_imp <- java_extract j "ffs_imp";
+ffs_imp <- jvm_extract j "ffs_imp";
 
 print "Proving equivalence";
 let thm1 = {{ \x -> ffs_ref x == ffs_imp x }};

--- a/doc/tutorial/code/ffs_java.saw
+++ b/doc/tutorial/code/ffs_java.saw
@@ -1,9 +1,9 @@
 print "Extracting reference term";
 j <- java_load_class "FFS";
-ffs_ref <- crucible_java_extract j "ffs_ref";
+ffs_ref <- java_extract j "ffs_ref";
 
 print "Extracting implementation term";
-ffs_imp <- crucible_java_extract j "ffs_imp";
+ffs_imp <- java_extract j "ffs_imp";
 
 print "Proving equivalence";
 let thm1 = {{ \x -> ffs_ref x == ffs_imp x }};

--- a/doc/tutorial/code/ffs_java_crucible.saw
+++ b/doc/tutorial/code/ffs_java_crucible.saw
@@ -1,9 +1,9 @@
 print "Extracting reference term";
 j <- java_load_class "FFS";
-ffs_ref <- java_extract j "ffs_ref";
+ffs_ref <- jvm_extract j "ffs_ref";
 
 print "Extracting implementation term";
-ffs_imp <- java_extract j "ffs_imp";
+ffs_imp <- jvm_extract j "ffs_imp";
 
 print "Proving equivalence";
 let thm1 = {{ \x -> ffs_ref x == ffs_imp x }};

--- a/doc/tutorial/code/ffs_java_crucible.saw
+++ b/doc/tutorial/code/ffs_java_crucible.saw
@@ -1,9 +1,9 @@
 print "Extracting reference term";
 j <- java_load_class "FFS";
-ffs_ref <- crucible_java_extract j "ffs_ref";
+ffs_ref <- java_extract j "ffs_ref";
 
 print "Extracting implementation term";
-ffs_imp <- crucible_java_extract j "ffs_imp";
+ffs_imp <- java_extract j "ffs_imp";
 
 print "Proving equivalence";
 let thm1 = {{ \x -> ffs_ref x == ffs_imp x }};

--- a/doc/tutorial/code/ffs_llvm.saw
+++ b/doc/tutorial/code/ffs_llvm.saw
@@ -2,16 +2,16 @@ set_base 16;
 
 print "Extracting reference term: ffs_ref";
 l <- llvm_load_module "ffs.bc";
-ffs_ref <- crucible_llvm_extract l "ffs_ref";
+ffs_ref <- llvm_extract l "ffs_ref";
 
 print "Extracting implementation term: ffs_imp";
-ffs_imp <- crucible_llvm_extract l "ffs_imp";
+ffs_imp <- llvm_extract l "ffs_imp";
 
 print "Extracting implementation term: ffs_musl";
-ffs_musl <- crucible_llvm_extract l "ffs_musl";
+ffs_musl <- llvm_extract l "ffs_musl";
 
 print "Extracting buggy term: ffs_bug";
-ffs_bug <- crucible_llvm_extract l "ffs_bug";
+ffs_bug <- llvm_extract l "ffs_bug";
 
 print "Proving equivalence: ffs_ref == ffs_imp";
 let thm1 = {{ \x -> ffs_ref x == ffs_imp x }};

--- a/doc/tutorial/code/picosat.saw
+++ b/doc/tutorial/code/picosat.saw
@@ -1,6 +1,6 @@
 l <- llvm_load_module "double.bc";
-double_imp <- crucible_llvm_extract l "double_imp";
-double_ref <- crucible_llvm_extract l "double_ref";
+double_imp <- llvm_extract l "double_imp";
+double_ref <- llvm_extract l "double_ref";
 let thm = {{ \x -> double_ref x == double_imp x }};
 
 let picosat = external_cnf_solver "picosat" ["%f"];

--- a/doc/tutorial/tutorial.md
+++ b/doc/tutorial/tutorial.md
@@ -139,7 +139,7 @@ $include all code/ffs_llvm.saw
 ```
 
 In this script, the `print` commands simply display text for the user.
-The `crucible_llvm_extract` command instructs the SAWScript interpreter
+The `llvm_extract` command instructs the SAWScript interpreter
 to perform symbolic simulation of the given C function (e.g., `ffs_ref`)
 from a given bitcode file (e.g., `ffs.bc`), and return a term
 representing the semantics of the function.
@@ -254,10 +254,10 @@ Now we can do the proof both within and across languages (from
 $include all code/ffs_compare.saw
 ```
 
-Here, the `crucible_java_extract` function works like
-`crucible_llvm_extract`, but on a Java class and method name. The
-`prove_print` command works similarly to the `prove` followed by `print`
-combination used for the LLVM example above.
+Here, the `java_extract` function works like `llvm_extract`, but on a
+Java class and method name. The `prove_print` command works similarly
+to the `prove` followed by `print` combination used for the LLVM
+example above.
 
 Using SMT-Lib Solvers
 =====================
@@ -378,7 +378,7 @@ In this example, the definitions of `add_spec` and `dbl_spec` provide
 extra information about how to configure the symbolic simulator when
 analyzing Java code. In this case, the setup blocks provide explicit
 descriptions of the implicit configuration used by
-`crucible_java_extract` (used in the earlier Java FFS example and in the
+`java_extract` (used in the earlier Java FFS example and in the
 next section). The `jvm_fresh_var` commands instruct the simulator to
 create fresh symbolic inputs to correspond to the Java variables `x` and
 `y`. Then, the `jvm_return` commands indicate the expected return value

--- a/doc/tutorial/tutorial.md
+++ b/doc/tutorial/tutorial.md
@@ -254,7 +254,7 @@ Now we can do the proof both within and across languages (from
 $include all code/ffs_compare.saw
 ```
 
-Here, the `java_extract` function works like `llvm_extract`, but on a
+Here, the `jvm_extract` function works like `llvm_extract`, but on a
 Java class and method name. The `prove_print` command works similarly
 to the `prove` followed by `print` combination used for the LLVM
 example above.
@@ -378,7 +378,7 @@ In this example, the definitions of `add_spec` and `dbl_spec` provide
 extra information about how to configure the symbolic simulator when
 analyzing Java code. In this case, the setup blocks provide explicit
 descriptions of the implicit configuration used by
-`java_extract` (used in the earlier Java FFS example and in the
+`jvm_extract` (used in the earlier Java FFS example and in the
 next section). The `jvm_fresh_var` commands instruct the simulator to
 create fresh symbolic inputs to correspond to the Java variables `x` and
 `y`. Then, the `jvm_return` commands indicate the expected return value

--- a/examples/chacha20/chacha20-crucible.saw
+++ b/examples/chacha20/chacha20-crucible.saw
@@ -4,16 +4,16 @@ import "../../deps/cryptol-specs/Primitive/Symmetric/Cipher/Stream/chacha20.cry"
 
 // Allocate a pointer of type 'ty', referring to the value 'v'
 let alloc_init ty v = do {
-  p <- crucible_alloc ty;
-  crucible_points_to p v;
+  p <- llvm_alloc ty;
+  llvm_points_to p v;
   return p;
 };
 
 // Allocate a pointer to a fresh symbolic value
 // Returns a pair of the symbolic variable and the pointer
 let ptr_to_fresh n ty = do {
-  x <- crucible_fresh_var n ty;
-  p <- alloc_init ty (crucible_term x);
+  x <- llvm_fresh_var n ty;
+  p <- alloc_init ty (llvm_term x);
   return (x, p);
 };
 
@@ -33,16 +33,16 @@ crypto_stream_chacha20(unsigned char* out,
 
   (_, out_p)       <- ptr_to_fresh       "out"     (llvm_array 256 (llvm_int 8));
   let olen         =                                            {{ 256 : [64] }};
-  counter          <- crucible_fresh_var "counter"                 (llvm_int 32);
+  counter          <- llvm_fresh_var     "counter"                 (llvm_int 32);
   (nonce, nonce_p) <- ptr_to_fresh       "nonce"   (llvm_array 12  (llvm_int 8));
   (key, key_p)     <- ptr_to_fresh       "key"     (llvm_array 32  (llvm_int 8));
 
   // symbolically executing the function
 
-  crucible_execute_func
+  llvm_execute_func
     [ out_p
-    , crucible_term olen
-    , crucible_term counter
+    , llvm_term olen
+    , llvm_term counter
     , nonce_p
     , key_p
     ];
@@ -50,9 +50,9 @@ crypto_stream_chacha20(unsigned char* out,
   // assert the specification
 
   let spec_result =
-    crucible_term {{ chacha20::stream key counter nonce : [256][8] }};
+    llvm_term {{ chacha20::stream key counter nonce : [256][8] }};
 
-  crucible_points_to out_p spec_result;
+  llvm_points_to out_p spec_result;
 
 };
 
@@ -62,4 +62,4 @@ mod <- llvm_load_module "chacha20.bc";
 let solver = abc;
 
 print "Testing equality...";
-time (crucible_llvm_verify mod "crypto_stream_chacha20" [] false chacha20_setup solver);
+time (llvm_verify mod "crypto_stream_chacha20" [] false chacha20_setup solver);

--- a/examples/chacha20/chacha20.saw
+++ b/examples/chacha20/chacha20.saw
@@ -8,14 +8,14 @@ print "loading LLVM bitcode...";
 mod <- llvm_load_module "chacha20.bc";
 
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
@@ -23,20 +23,20 @@ let i8 = llvm_int 8;
 let i32 = llvm_int 32;
 
 let stream_spec len = do {
-  outp <- crucible_alloc (llvm_array len i8);
+  outp <- llvm_alloc (llvm_array len i8);
   (key, keyp) <- ptr_to_fresh "key" (llvm_array 32 i8);
   (nonce, noncep) <- ptr_to_fresh "nonce" (llvm_array 12 i8);
-  counter <- crucible_fresh_var "counter" i32;
+  counter <- llvm_fresh_var "counter" i32;
 
-  crucible_execute_func [ outp
-                        , crucible_term {{ `len : [64] }}
-                        , crucible_term counter
-                        , noncep
-                        , keyp
-                        ];
+  llvm_execute_func [ outp
+                    , llvm_term {{ `len : [64] }}
+                    , llvm_term counter
+                    , noncep
+                    , keyp
+                    ];
 
-  crucible_points_to outp (crucible_term {{ chacha20::stream key counter nonce : [len][8] }});
+  llvm_points_to outp (llvm_term {{ chacha20::stream key counter nonce : [len][8] }});
 };
 
 print "running verification...";
-time (crucible_llvm_verify mod "crypto_stream_chacha20" [] true (stream_spec 256) abc);
+time (llvm_llvm_verify mod "crypto_stream_chacha20" [] true (stream_spec 256) abc);

--- a/examples/fresh-post/fresh-post-bad.saw
+++ b/examples/fresh-post/fresh-post-bad.saw
@@ -1,15 +1,15 @@
 let whoknows_spec : CrucibleSetup () = do {
-  crucible_execute_func [];
-  y <- crucible_fresh_var "y" (llvm_int 32);
-  crucible_postcond {{ y < 0x0000FFFF }};
-  crucible_return (crucible_term y);
+  llvm_execute_func [];
+  y <- llvm_fresh_var "y" (llvm_int 32);
+  llvm_postcond {{ y < 0x0000FFFF }};
+  llvm_return (llvm_term y);
 };
 
 let bad_spec : CrucibleSetup () = do {
-  crucible_execute_func [];
-  crucible_return (crucible_term {{0:[32]}});
+  llvm_execute_func [];
+  llvm_return (llvm_term {{0:[32]}});
 };
 
 m <- llvm_load_module "source.bc";
-whoknows <- crucible_llvm_unsafe_assume_spec m "whoknows" whoknows_spec;
-fails (crucible_llvm_verify m "bad" [whoknows] false bad_spec abc);
+whoknows <- llvm_unsafe_assume_spec m "whoknows" whoknows_spec;
+fails (llvm_verify m "bad" [whoknows] false bad_spec abc);

--- a/examples/fresh-post/fresh-post-good.saw
+++ b/examples/fresh-post/fresh-post-good.saw
@@ -1,25 +1,25 @@
 let whoknows_spec : CrucibleSetup () = do {
-  crucible_execute_func [];
-  y <- crucible_fresh_var "y" (llvm_int 32);
-  crucible_return (crucible_term y);
+  llvm_execute_func [];
+  y <- llvm_fresh_var "y" (llvm_int 32);
+  llvm_return (llvm_term y);
 };
 
 let example_spec : CrucibleSetup () = do {
-  crucible_execute_func [];
-  crucible_return (crucible_term {{0:[32]}});
+  llvm_execute_func [];
+  llvm_return (llvm_term {{0:[32]}});
 };
 
 let one_spec : CrucibleSetup () = do {
-  crucible_execute_func [];
-  x <- crucible_fresh_var "x" (llvm_int 32);
-  crucible_return (crucible_term x);
+  llvm_execute_func [];
+  x <- llvm_fresh_var "x" (llvm_int 32);
+  llvm_return (llvm_term x);
 };
 
 let main : TopLevel () = do {
 
     m <- llvm_load_module "source.bc";
-    whoknows <- crucible_llvm_unsafe_assume_spec m "whoknows" whoknows_spec;
-    crucible_llvm_verify m "example" [whoknows] false example_spec abc;
-    crucible_llvm_verify m "one" [] false one_spec ( do { print_goal; abc; } );
+    whoknows <- llvm_unsafe_assume_spec m "whoknows" whoknows_spec;
+    llvm_verify m "example" [whoknows] false example_spec abc;
+    llvm_verify m "one" [] false one_spec ( do { print_goal; abc; } );
     print "done";
 };

--- a/examples/ghost/ghost.saw
+++ b/examples/ghost/ghost.saw
@@ -1,26 +1,26 @@
 let next_spec counter : CrucibleSetup () = do {
-  n <- crucible_fresh_var "n" (llvm_int 32);
-  crucible_ghost_value counter n;
-  crucible_execute_func [];
-  crucible_ghost_value counter {{n+1}};
-  crucible_return (crucible_term {{n}});
+  n <- llvm_fresh_var "n" (llvm_int 32);
+  llvm_ghost_value counter n;
+  llvm_execute_func [];
+  llvm_ghost_value counter {{n+1}};
+  llvm_return (llvm_term {{n}});
 };
 
 let example_spec counter : CrucibleSetup () = do {
-  n <- crucible_fresh_var "nm" (llvm_int 32);
-  crucible_precond {{n < 2}};
-  crucible_ghost_value counter n;
-  crucible_execute_func [];
-  crucible_ghost_value counter {{n+3}};
-  crucible_return (crucible_term {{n+2}});
+  n <- llvm_fresh_var "nm" (llvm_int 32);
+  llvm_precond {{n < 2}};
+  llvm_ghost_value counter n;
+  llvm_execute_func [];
+  llvm_ghost_value counter {{n+3}};
+  llvm_return (llvm_term {{n+2}});
 };
 
 let main : TopLevel () = do {
-    counter <- crucible_declare_ghost_state "ctr";
+    counter <- llvm_declare_ghost_state "ctr";
 
     m <- llvm_load_module "simple.bc";
-    next <- crucible_llvm_unsafe_assume_spec m "next" (next_spec counter);
-    crucible_llvm_verify m "example" [next] false (example_spec counter)
+    next <- llvm_unsafe_assume_spec m "next" (next_spec counter);
+    llvm_verify m "example" [next] false (example_spec counter)
                 (do { print_goal; z3;} );
     print "done";
 };

--- a/examples/java/arrays.saw
+++ b/examples/java/arrays.saw
@@ -45,8 +45,8 @@ let main : TopLevel () = do {
     sum_ms <- java_verify c "sum" [] sum_setup;
     comp_ms <- java_verify c "comp" [unit_ms] comp_setup;
     print "Extracting model of sum, which has type:";
-    sum_tm <- java_extract c "sum" sum_setup';
-    id_tm <- java_extract c "arr_id" id_setup;
+    sum_tm <- jvm_extract c "sum" sum_setup';
+    id_tm <- jvm_extract c "arr_id" id_setup;
     check_term sum_tm;
     print "Running sum on ten 1 inputs:";
     print {{ sum_tm [1, 1, 1, 1, 1, 1, 1, 1, 1, 1] }};

--- a/examples/java/javatoaig.saw
+++ b/examples/java/javatoaig.saw
@@ -1,5 +1,5 @@
 enable_deprecated;
 c <- java_load_class "Double";
-t <- crucible_java_extract c "f";
+t <- java_extract c "f";
 print_term t;
 write_aig "java_f.aig" t;

--- a/examples/java/javatoaig.saw
+++ b/examples/java/javatoaig.saw
@@ -1,5 +1,5 @@
 enable_deprecated;
 c <- java_load_class "Double";
-t <- java_extract c "f";
+t <- jvm_extract c "f";
 print_term t;
 write_aig "java_f.aig" t;

--- a/examples/llvm/assert-null.saw
+++ b/examples/llvm/assert-null.saw
@@ -1,14 +1,14 @@
 let f_spec1 = do {
-    p <- crucible_alloc (llvm_int 32);
-    crucible_execute_func [p];
-    crucible_return (crucible_term {{ 0 : [32] }});
+    p <- llvm_alloc (llvm_int 32);
+    llvm_execute_func [p];
+    llvm_return (llvm_term {{ 0 : [32] }});
 };
 
 let f_spec2 = do {
-    crucible_execute_func [crucible_null];
-    crucible_return (crucible_term {{ 1 : [32] }});
+    llvm_execute_func [llvm_null];
+    llvm_return (llvm_term {{ 1 : [32] }});
 };
 
 m <- llvm_load_module "assert-null.bc";
-crucible_llvm_verify m "f" [] false f_spec1 abc;
-crucible_llvm_verify m "f" [] false f_spec2 abc;
+llvm_verify m "f" [] false f_spec1 abc;
+llvm_verify m "f" [] false f_spec2 abc;

--- a/examples/llvm/assert.saw
+++ b/examples/llvm/assert.saw
@@ -1,8 +1,8 @@
 let f_spec = do {
-  x <- crucible_fresh_var "x" (llvm_int 32);
-  crucible_precond {{ x > 0 }};
-  crucible_execute_func [crucible_term x];
+  x <- llvm_fresh_var "x" (llvm_int 32);
+  llvm_precond {{ x > 0 }};
+  llvm_execute_func [llvm_term x];
 };
 
 m <- llvm_load_module "assert.bc";
-crucible_llvm_verify m "f" [] true f_spec abc;
+llvm_verify m "f" [] true f_spec abc;

--- a/examples/llvm/basic.saw
+++ b/examples/llvm/basic.saw
@@ -1,17 +1,17 @@
 let add_setup = do {
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    y <- crucible_fresh_var "y" (llvm_int 32);
-    crucible_execute_func [crucible_term x, crucible_term y];
-    crucible_return (crucible_term {{ x + y : [32] }});
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    y <- llvm_fresh_var "y" (llvm_int 32);
+    llvm_execute_func [llvm_term x, llvm_term y];
+    llvm_return (llvm_term {{ x + y : [32] }});
 };
 
 let dbl_setup = do {
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    crucible_execute_func [crucible_term x];
-    crucible_return (crucible_term {{ x + x : [32] }});
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    llvm_execute_func [llvm_term x];
+    llvm_return (llvm_term {{ x + x : [32] }});
 };
 
 m <- llvm_load_module "basic.bc";
-add_ms <- crucible_llvm_verify m "add" [] false add_setup abc;
-crucible_llvm_verify m "dbl" [add_ms] false dbl_setup abc;
+add_ms <- llvm_verify m "add" [] false add_setup abc;
+llvm_verify m "dbl" [add_ms] false dbl_setup abc;
 print "Done.";

--- a/examples/llvm/dotprod_struct.saw
+++ b/examples/llvm/dotprod_struct.saw
@@ -1,30 +1,30 @@
 import "dotprod.cry";
 
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
 let dotprod_spec n = do {
-    let nt = crucible_term {{ `n : [32] }};
+    let nt = llvm_term {{ `n : [32] }};
     (xs, xsp) <- ptr_to_fresh "xs" (llvm_array n (llvm_int 32));
     (ys, ysp) <- ptr_to_fresh "ys" (llvm_array n (llvm_int 32));
-    let xval = crucible_struct [ xsp, nt ];
-    let yval = crucible_struct [ ysp, nt ];
+    let xval = llvm_struct_value [ xsp, nt ];
+    let yval = llvm_struct_value [ ysp, nt ];
     xp <- alloc_init (llvm_struct "struct.vec_t") xval;
     yp <- alloc_init (llvm_struct "struct.vec_t") yval;
-    crucible_execute_func [xp, yp];
-    crucible_return (crucible_term {{ dotprod xs ys }});
+    llvm_execute_func [xp, yp];
+    llvm_return (llvm_term {{ dotprod xs ys }});
 };
 
 m <- llvm_load_module "dotprod_struct.bc";
 
-dotprod_ov <- crucible_llvm_verify m "dotprod_struct" [] true (dotprod_spec 2) z3;
-crucible_llvm_verify m "dotprod_wrap" [dotprod_ov] true (dotprod_spec 2) z3;
+dotprod_ov <- llvm_verify m "dotprod_struct" [] true (dotprod_spec 2) z3;
+llvm_verify m "dotprod_wrap" [dotprod_ov] true (dotprod_spec 2) z3;

--- a/examples/llvm/global.saw
+++ b/examples/llvm/global.saw
@@ -1,31 +1,31 @@
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
 let clear_setup = do {
-    crucible_alloc_global "g";
-    crucible_execute_func [];
-    crucible_points_to (crucible_global "g") (crucible_term {{ 0 : [32] }});
+    llvm_alloc_global "g";
+    llvm_execute_func [];
+    llvm_points_to (llvm_global "g") (llvm_term {{ 0 : [32] }});
 };
 
 let set_setup = do {
-    crucible_alloc_global "g";
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    crucible_execute_func [crucible_term x];
-    crucible_points_to (crucible_global "g") (crucible_term x);
+    llvm_alloc_global "g";
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    llvm_execute_func [llvm_term x];
+    llvm_points_to (llvm_global "g") (llvm_term x);
 };
 
 let main : TopLevel () = do {
     m <- llvm_load_module "global.bc";
-    crucible_llvm_verify m "clear" [] false clear_setup abc;
-    crucible_llvm_verify m "set" [] false set_setup abc;
+    llvm_verify m "clear" [] false clear_setup abc;
+    llvm_verify m "set" [] false set_setup abc;
     print "Done.";
 };

--- a/examples/llvm/iterative_average/test.saw
+++ b/examples/llvm/iterative_average/test.saw
@@ -2,14 +2,14 @@ import "test.cry";
 m <- llvm_load_module "tmp/test.bc";
 
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
@@ -18,15 +18,15 @@ let ptr_to_fresh n ty = do {
 let init_spec = do {
   (s, sp) <- ptr_to_fresh "st" (llvm_struct "struct.state");
 
-  crucible_execute_func [sp];
+  llvm_execute_func [sp];
 
-  let res = crucible_struct [ crucible_term {{ init.sum }}
-                            , crucible_term {{ init.len }}
-                            ];
-  crucible_points_to sp res;
+  let res = llvm_struct_value [ llvm_term {{ init.sum }}
+                              , llvm_term {{ init.len }}
+                              ];
+  llvm_points_to sp res;
 };
-print "Verifying 'init' using 'crucible_llvm_verify':";
-init_ov <- crucible_llvm_verify m "init" [] true init_spec abc;
+print "Verifying 'init' using 'llvm_verify':";
+init_ov <- llvm_verify m "init" [] true init_spec abc;
 print "";
 
 // Verify 'update'.
@@ -35,40 +35,40 @@ let update_spec xs_len = do {
   (st0, stp) <- ptr_to_fresh "st" (llvm_struct "struct.state");
   (xs0, xsp) <- ptr_to_fresh "xs" (llvm_array xs_len (llvm_int 32));
 
-  crucible_execute_func [stp, xsp, crucible_term {{ `xs_len : [32] }}];
+  llvm_execute_func [stp, xsp, llvm_term {{ `xs_len : [32] }}];
 
   let st1 = {{ updatef {sum = st0.0, len = st0.1} xs0 }};
 
-  
-  let res = crucible_struct [ crucible_term {{ st1.sum }}
-                            , crucible_term {{ st1.len }}
-                            ];
-  crucible_points_to stp res;
+
+  let res = llvm_struct_value [ llvm_term {{ st1.sum }}
+                              , llvm_term {{ st1.len }}
+                              ];
+  llvm_points_to stp res;
   // Also prove that the content of xs is unchanged.
-  crucible_points_to xsp (crucible_term xs0);
+  llvm_points_to xsp (llvm_term xs0);
 };
-print "Verifying 'update' using 'crucible_llvm_verify':";
-update_ov <- crucible_llvm_verify m "update" [] true (update_spec 3) abc;
+print "Verifying 'update' using 'llvm_verify':";
+update_ov <- llvm_verify m "update" [] true (update_spec 3) abc;
 print "";
 
 // Verify 'digest'.
 
 let digest_spec = do {
   (st0, stp) <- ptr_to_fresh "st" (llvm_struct "struct.state");
-  avgp <- crucible_alloc (llvm_int 32);
+  avgp <- llvm_alloc (llvm_int 32);
 
   // Avoid division by zero
-  crucible_precond {{ st0.1 != 0 }};
+  llvm_precond {{ st0.1 != 0 }};
 
-  crucible_execute_func [stp, avgp];
+  llvm_execute_func [stp, avgp];
 
-  crucible_points_to avgp (crucible_term {{ digest {sum = st0.0, len = st0.1} }});
+  llvm_points_to avgp (llvm_term {{ digest {sum = st0.0, len = st0.1} }});
   // Also prove that the content of 'st' is unchanged.
-  crucible_points_to stp (crucible_term st0);
+  llvm_points_to stp (llvm_term st0);
 
 };
-print "Verifying 'digest' using 'crucible_llvm_verify':";
-digest_ov <- crucible_llvm_verify m "digest" [] true digest_spec abc;
+print "Verifying 'digest' using 'llvm_verify':";
+digest_ov <- llvm_verify m "digest" [] true digest_spec abc;
 print "";
 
 // Verify imperative spec against pure spec.

--- a/examples/llvm/llvmtoaig.saw
+++ b/examples/llvm/llvmtoaig.saw
@@ -1,5 +1,5 @@
 m <- llvm_load_module "double.bc";
-t <- crucible_llvm_extract m "f";
+t <- llvm_extract m "f";
 print "Type:";
 print_type t;
 print "Writing llvm_f.aig";

--- a/examples/llvm/nested-full.saw
+++ b/examples/llvm/nested-full.saw
@@ -1,19 +1,19 @@
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let f_spec = do {
-    a <- crucible_fresh_var "a" (llvm_int 32);
-    b <- crucible_fresh_var "b" (llvm_int 32);
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    z <- crucible_fresh_var "z" (llvm_int 32);
-    let s = (crucible_term {{ (x, (a, b), z) }});
+    a <- llvm_fresh_var "a" (llvm_int 32);
+    b <- llvm_fresh_var "b" (llvm_int 32);
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    z <- llvm_fresh_var "z" (llvm_int 32);
+    let s = (llvm_term {{ (x, (a, b), z) }});
     p <- alloc_init (llvm_struct "struct.t") s;
-    crucible_execute_func [p];
-    crucible_return (crucible_term {{ b }});
+    llvm_execute_func [p];
+    llvm_return (llvm_term {{ b }});
 };
 
 m <- llvm_load_module "nested.bc";
-crucible_llvm_verify m "f" [] false f_spec abc;
+llvm_verify m "f" [] false f_spec abc;

--- a/examples/llvm/nested.saw
+++ b/examples/llvm/nested.saw
@@ -1,18 +1,18 @@
 let f_spec = do {
-    tp <- crucible_alloc (llvm_struct "struct.t");
-    b <- crucible_fresh_var "b" (llvm_int 32);
+    tp <- llvm_alloc (llvm_struct "struct.t");
+    b <- llvm_fresh_var "b" (llvm_int 32);
 
     // The following will work if nested.bc is compiled with debug info
     // with Clang 3.7 or greater
-    crucible_points_to (crucible_field (crucible_field tp "n") "b") (crucible_term b);
+    llvm_points_to (llvm_field (llvm_field tp "n") "b") (llvm_term b);
 
     // The following can be a workaround if debug info is not available
-    //crucible_points_to (crucible_elem (crucible_elem tp 1) 1) (crucible_term b);
+    //llvm_points_to (llvm_elem (llvm_elem tp 1) 1) (llvm_term b);
 
-    crucible_execute_func [tp];
-    crucible_return (crucible_term b);
+    llvm_execute_func [tp];
+    llvm_return (llvm_term b);
 };
 
 m <- llvm_load_module "nested.bc";
 
-crucible_llvm_verify m "f" [] false f_spec abc;
+llvm_verify m "f" [] false f_spec abc;

--- a/examples/llvm/ptr.saw
+++ b/examples/llvm/ptr.saw
@@ -1,39 +1,39 @@
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
 let add_setup = do {
     (x, xp) <- ptr_to_fresh "x" (llvm_int 32);
     (y, yp) <- ptr_to_fresh "y" (llvm_int 32);
-    crucible_execute_func [xp, yp];
-    crucible_return (crucible_term {{ x + y : [32] }});
+    llvm_execute_func [xp, yp];
+    llvm_return (llvm_term {{ x + y : [32] }});
 };
 
 let clear_setup = do {
     (a, ap) <- ptr_to_fresh "a" (llvm_array 10 (llvm_int 32));
-    crucible_execute_func [ap];
-    crucible_points_to ap (crucible_term {{ zero : [10][32] }}); 
+    llvm_execute_func [ap];
+    llvm_points_to ap (llvm_term {{ zero : [10][32] }});
 };
 
 let copy_setup = do {
     (a, ap) <- ptr_to_fresh "a" (llvm_array 10 (llvm_int 32));
     (b, bp) <- ptr_to_fresh "b" (llvm_array 10 (llvm_int 32));
-    crucible_execute_func [ap, bp];
-    crucible_points_to ap (crucible_term b);
+    llvm_execute_func [ap, bp];
+    llvm_points_to ap (llvm_term b);
 };
 
 let main : TopLevel () = do {
     m <- llvm_load_module "ptr.bc";
-    add_ms <- crucible_llvm_verify m "add" [] false add_setup abc;
-    clear_ms <- crucible_llvm_verify m "clear" [] false clear_setup abc;
-    copy_ms <- crucible_llvm_verify m "copy" [] false copy_setup abc;
+    add_ms <- llvm_verify m "add" [] false add_setup abc;
+    clear_ms <- llvm_verify m "clear" [] false clear_setup abc;
+    copy_ms <- llvm_verify m "copy" [] false copy_setup abc;
     print "Done.";
 };

--- a/examples/llvm/ptrcheck.saw
+++ b/examples/llvm/ptrcheck.saw
@@ -1,19 +1,19 @@
 m <- llvm_load_module "ptrcheck.bc";
 
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
-crucible_llvm_verify m "f" [] false do {
+llvm_verify m "f" [] false do {
     (s, sp) <- ptr_to_fresh "s" (llvm_struct "struct.s");
-    crucible_execute_func [sp];
-    crucible_return (crucible_term {{ 0 : [32] }});
+    llvm_execute_func [sp];
+    llvm_return (llvm_term {{ 0 : [32] }});
 } abc;

--- a/examples/llvm/safety/set.saw
+++ b/examples/llvm/safety/set.saw
@@ -1,38 +1,38 @@
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
 let set_bad_spec n = do {
     (a, ap) <- ptr_to_fresh "a" (llvm_array n (llvm_int 32));
-    i <- crucible_fresh_var "i" (llvm_int 32);
-    v <- crucible_fresh_var "v" (llvm_int 32);
-    crucible_execute_func [ap, crucible_term i, crucible_term v];
-    crucible_points_to ap (crucible_term {{ update a i v }});
+    i <- llvm_fresh_var "i" (llvm_int 32);
+    v <- llvm_fresh_var "v" (llvm_int 32);
+    llvm_execute_func [ap, llvm_term i, llvm_term v];
+    llvm_points_to ap (llvm_term {{ update a i v }});
 };
 
 let set_good_spec n = do {
     (a, ap) <- ptr_to_fresh "a" (llvm_array n (llvm_int 32));
-    i <- crucible_fresh_var "i" (llvm_int 32);
-    v <- crucible_fresh_var "v" (llvm_int 32);
+    i <- llvm_fresh_var "i" (llvm_int 32);
+    v <- llvm_fresh_var "v" (llvm_int 32);
 
     // The ` in the following is to convert an unbounded integer into a
     // fixed-size bit vector.
-    crucible_precond {{ i < (`n : [32]) }};
-    
-    crucible_execute_func [ap, crucible_term i, crucible_term v];
+    llvm_precond {{ i < (`n : [32]) }};
 
-    crucible_points_to ap (crucible_term {{ update a i v }});
+    llvm_execute_func [ap, llvm_term i, llvm_term v];
+
+    llvm_points_to ap (llvm_term {{ update a i v }});
 };
 
 m <- llvm_load_module "set.bc";
 
-crucible_llvm_verify m "set" [] false (set_good_spec 10) abc;
-fails (crucible_llvm_verify m "set" [] false (set_bad_spec 10) abc);
+llvm_verify m "set" [] false (set_good_spec 10) abc;
+fails (llvm_verify m "set" [] false (set_bad_spec 10) abc);

--- a/examples/llvm/struct.saw
+++ b/examples/llvm/struct.saw
@@ -1,38 +1,38 @@
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
 let set_spec = do {
     (x, px) <- ptr_to_fresh "x" (llvm_array 2 (llvm_int 32));
-    po <- alloc_init (llvm_struct "struct.s") (crucible_struct [px]);
-    crucible_execute_func [po];
-    crucible_points_to po (crucible_struct [px]);
-    crucible_points_to px (crucible_term {{ [0, 0] : [2][32] }});
+    po <- alloc_init (llvm_struct "struct.s") (llvm_struct [px]);
+    llvm_execute_func [po];
+    llvm_points_to po (llvm_struct [px]);
+    llvm_points_to px (llvm_term {{ [0, 0] : [2][32] }});
 };
 
 let add_spec = do {
     (x, px) <- ptr_to_fresh "x" (llvm_array 2 (llvm_int 32));
-    po <- alloc_init (llvm_struct "struct.s") (crucible_struct [px]);
-    crucible_execute_func [po];
-    crucible_return (crucible_term {{ x@0 + x@1 }});
+    po <- alloc_init (llvm_struct "struct.s") (llvm_struct [px]);
+    llvm_execute_func [po];
+    llvm_return (llvm_term {{ x@0 + x@1 }});
 };
 
 let id_spec = do {
     (x, px) <- ptr_to_fresh "x" (llvm_array 2 (llvm_int 32));
-    po <- alloc_init (llvm_struct "struct.s") (crucible_struct [px]);
-    crucible_execute_func [po];
-    crucible_return po;
+    po <- alloc_init (llvm_struct "struct.s") (llvm_struct [px]);
+    llvm_execute_func [po];
+    llvm_return po;
 };
 
 m <- llvm_load_module "struct.bc";
-crucible_llvm_verify m "set_indirect" [] false set_spec abc;
-crucible_llvm_verify m "add_indirect" [] false add_spec abc;
-crucible_llvm_verify m "s_id" [] false id_spec abc;
+llvm_verify m "set_indirect" [] false set_spec abc;
+llvm_verify m "add_indirect" [] false add_spec abc;
+llvm_verify m "s_id" [] false id_spec abc;

--- a/examples/llvm/union/test.saw
+++ b/examples/llvm/union/test.saw
@@ -2,34 +2,34 @@ import "test.cry";
 m <- llvm_load_module "tmp/test.bc";
 
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
-// Verify using 'crucible_llvm_verify'.
+// Verify using 'llvm_verify'.
 
 // The argument 'INC' specifies which 'alg' enum to test.
 let inc_spec INC = do {
 
-  stp <- crucible_alloc (llvm_struct "struct.st");
+  stp <- llvm_alloc (llvm_struct "struct.st");
 
   // The union is represented by the largest element type,
   // i.e. 'inc_2_st'. The inner '.0' dereferences the union itself.
-  x0 <- crucible_fresh_var "((st->1).0).0" (llvm_int 32);
-  y0 <- crucible_fresh_var "((st->1).0).1" (llvm_int 32);
+  x0 <- llvm_fresh_var "((st->1).0).0" (llvm_int 32);
+  y0 <- llvm_fresh_var "((st->1).0).1" (llvm_int 32);
 
-  crucible_points_to (crucible_elem stp 0) (crucible_term {{ INC }});
-  crucible_points_to (crucible_elem (crucible_elem (crucible_elem stp 1) 0) 0) (crucible_term x0);
-  crucible_points_to (crucible_elem (crucible_elem (crucible_elem stp 1) 0) 1) (crucible_term y0);
+  llvm_points_to (llvm_elem stp 0) (llvm_term {{ INC }});
+  llvm_points_to (llvm_elem (llvm_elem (llvm_elem stp 1) 0) 0) (llvm_term x0);
+  llvm_points_to (llvm_elem (llvm_elem (llvm_elem stp 1) 0) 1) (llvm_term y0);
 
-  crucible_execute_func [stp];
+  llvm_execute_func [stp];
 
   // We construct an 'inc_2_st' here independent of 'INC', since we
   // need to account for all of the bits in the union field 'inc_st',
@@ -43,17 +43,17 @@ let inc_spec INC = do {
   let st1 = {{ inc st0 }};
   let inc_2_st1 = {{ bits_to_inc_2_st st1.bits }};
 
-  crucible_points_to (crucible_elem stp 0) (crucible_term {{ st1.alg }});
-  crucible_points_to (crucible_elem (crucible_elem (crucible_elem stp 1) 0) 0) (crucible_term {{ inc_2_st1.x }});
-  crucible_points_to (crucible_elem (crucible_elem (crucible_elem stp 1) 0) 1) (crucible_term {{ inc_2_st1.y }});
+  llvm_points_to (llvm_elem stp 0) (llvm_term {{ st1.alg }});
+  llvm_points_to (llvm_elem (llvm_elem (llvm_elem stp 1) 0) 0) (llvm_term {{ inc_2_st1.x }});
+  llvm_points_to (llvm_elem (llvm_elem (llvm_elem stp 1) 0) 1) (llvm_term {{ inc_2_st1.y }});
 
-  crucible_return (crucible_term {{ 0 : [32] }});
+  llvm_return (llvm_term {{ 0 : [32] }});
 };
 
-print "Verifying 'inc_1' using 'crucible_llvm_verify':";
-crucible_llvm_verify m "inc" [] true (inc_spec {{ INC_1 }}) abc;
+print "Verifying 'inc_1' using 'llvm_verify':";
+llvm_verify m "inc" [] true (inc_spec {{ INC_1 }}) abc;
 print "";
 
-print "Verifying 'inc_2' using 'crucible_llvm_verify':";
-crucible_llvm_verify m "inc" [] true (inc_spec {{ INC_2 }}) abc;
+print "Verifying 'inc_2' using 'llvm_verify':";
+llvm_verify m "inc" [] true (inc_spec {{ INC_2 }}) abc;
 print "";

--- a/examples/multi-override/multi-override.saw
+++ b/examples/multi-override/multi-override.saw
@@ -1,77 +1,77 @@
 import "imports.cry";
 
 let identity_spec n : CrucibleSetup () = do {
-  crucible_execute_func [crucible_term n];
-  crucible_return (crucible_term n);
+  llvm_execute_func [llvm_term n];
+  llvm_return (llvm_term n);
 };
 
 let example_spec : CrucibleSetup () = do {
-  crucible_execute_func [];
-  crucible_return (crucible_term {{3:[32]}});
+  llvm_execute_func [];
+  llvm_return (llvm_term {{3:[32]}});
 };
 
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
 let sum_spec n : CrucibleSetup() = do {
   (arr,arrp) <- ptr_to_fresh "arr" (llvm_array n (llvm_int 32));
 
-  crucible_execute_func[arrp, crucible_term {{ `n:[32]}}];
-  crucible_return (crucible_term {{ mysum arr }});
-  crucible_points_to arrp (crucible_term arr);
+  llvm_execute_func[arrp, llvm_term {{ `n:[32]}}];
+  llvm_return (llvm_term {{ mysum arr }});
+  llvm_points_to arrp (llvm_term arr);
 };
 
 let example_sums : CrucibleSetup() = do {
-  crucible_execute_func[];
-  crucible_return (crucible_term {{ 70:[32] }});
+  llvm_execute_func[];
+  llvm_return (llvm_term {{ 70:[32] }});
 };
 
 let set_myglobal n : CrucibleSetup() = do {
-  crucible_alloc_global "myglobal";
-  old <- crucible_fresh_var "old" (llvm_int 32);
-  crucible_precond {{ old < 1000 }};
-  crucible_points_to (crucible_global "myglobal") (crucible_term old);
-  crucible_execute_func[crucible_term {{ `n : [32] }}];
-  crucible_points_to (crucible_global "myglobal")
-                     (crucible_term {{ `n + old*old : [32] }});
+  llvm_alloc_global "myglobal";
+  old <- llvm_fresh_var "old" (llvm_int 32);
+  llvm_precond {{ old < 1000 }};
+  llvm_points_to (llvm_global "myglobal") (llvm_term old);
+  llvm_execute_func[llvm_term {{ `n : [32] }}];
+  llvm_points_to (llvm_global "myglobal")
+                     (llvm_term {{ `n + old*old : [32] }});
 };
 
 let myglobal_example : CrucibleSetup() = do {
-  crucible_alloc_global "myglobal";
-  crucible_execute_func[];
-  crucible_return (crucible_term {{ 120 : [32] }});
-  crucible_points_to (crucible_global "myglobal")
-                     (crucible_term {{ 120 : [32] }});
+  llvm_alloc_global "myglobal";
+  llvm_execute_func[];
+  llvm_return (llvm_term {{ 120 : [32] }});
+  llvm_points_to (llvm_global "myglobal")
+                 (llvm_term {{ 120 : [32] }});
 };
 
 let main : TopLevel () = do {
 
     m <- llvm_load_module "source.bc";
-    id1 <- crucible_llvm_verify m "identity" [] false (identity_spec {{1:[32]}}) abc;
-    id2 <- crucible_llvm_verify m "identity" [] false (identity_spec {{2:[32]}}) abc;
-    crucible_llvm_verify m "example"     [id1,id2] false example_spec z3;
-    //crucible_llvm_verify "bad_example" [id1,id2] false example_spec (do { print_goal; assume_unsat; });
+    id1 <- llvm_verify m "identity" [] false (identity_spec {{1:[32]}}) abc;
+    id2 <- llvm_verify m "identity" [] false (identity_spec {{2:[32]}}) abc;
+    llvm_verify m "example"     [id1,id2] false example_spec z3;
+    //llvm_verify "bad_example" [id1,id2] false example_spec (do { print_goal; assume_unsat; });
 
-    sum3  <- crucible_llvm_verify m "sum" [] false (sum_spec  3) z3;
-    sum6  <- crucible_llvm_verify m "sum" [] false (sum_spec  6) z3;
-    sum10 <- crucible_llvm_verify m "sum" [] false (sum_spec 10) z3;
-    sum12 <- crucible_llvm_verify m "sum" [] false (sum_spec 12) z3;
-    crucible_llvm_verify m "example_sums" [sum3,sum12, sum6,sum10] false example_sums z3;
+    sum3  <- llvm_verify m "sum" [] false (sum_spec  3) z3;
+    sum6  <- llvm_verify m "sum" [] false (sum_spec  6) z3;
+    sum10 <- llvm_verify m "sum" [] false (sum_spec 10) z3;
+    sum12 <- llvm_verify m "sum" [] false (sum_spec 12) z3;
+    llvm_verify m "example_sums" [sum3,sum12, sum6,sum10] false example_sums z3;
 
-    set10 <- crucible_llvm_verify m "add_myglobal" [] false (set_myglobal 10) z3;
-    set20 <- crucible_llvm_verify m "add_myglobal" [] false (set_myglobal 20) z3;
-    set30 <- crucible_llvm_verify m "add_myglobal" [] false (set_myglobal 30) z3;
-    crucible_llvm_verify m "myglobal_example" [set10,set20,set30] false myglobal_example z3;
-    crucible_llvm_verify m "myglobal_example" [set20,set30,set10] false myglobal_example z3;
-    crucible_llvm_verify m "myglobal_example" [set30,set10,set20] false myglobal_example z3;
+    set10 <- llvm_verify m "add_myglobal" [] false (set_myglobal 10) z3;
+    set20 <- llvm_verify m "add_myglobal" [] false (set_myglobal 20) z3;
+    set30 <- llvm_verify m "add_myglobal" [] false (set_myglobal 30) z3;
+    llvm_verify m "myglobal_example" [set10,set20,set30] false myglobal_example z3;
+    llvm_verify m "myglobal_example" [set20,set30,set10] false myglobal_example z3;
+    llvm_verify m "myglobal_example" [set30,set10,set20] false myglobal_example z3;
     print "done";
 };

--- a/examples/openssl_aes/aes.saw
+++ b/examples/openssl_aes/aes.saw
@@ -4,30 +4,30 @@ import "AES128TBox.cry";
 let i8 = llvm_int 8;
 
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
 let aes_spec = do {
   (msg, msgp) <- ptr_to_fresh "in" (llvm_array 16 i8);
   (key, keyp) <- ptr_to_fresh "key" (llvm_array 16 i8);
-  outp <- crucible_alloc (llvm_array 16 i8);
-  crucible_execute_func [msgp, outp, keyp];
+  outp <- llvm_alloc (llvm_array 16 i8);
+  llvm_execute_func [msgp, outp, keyp];
   let {{
     key' = split (join key) : [4][32]
     msg' = split (join msg) : [4][32]
     res  = split (join (aesEncrypt msg' key')) : [16][8]
   }};
-  crucible_points_to outp (crucible_term {{ res }});
-  crucible_return (crucible_term {{ 0 : [32] }});
+  llvm_points_to outp (llvm_term {{ res }});
+  llvm_return (llvm_term {{ 0 : [32] }});
 };
 
 m <- llvm_load_module "aes_all.bc";
-crucible_llvm_verify m "aes_encrypt" [] false aes_spec abc;
+llvm_verify m "aes_encrypt" [] false aes_spec abc;

--- a/examples/partial-spec/partial-spec.saw
+++ b/examples/partial-spec/partial-spec.saw
@@ -1,19 +1,19 @@
 let inc_spec : CrucibleSetup () = do {
-  m <- crucible_alloc (llvm_struct "struct.my_struct");
-  counter <- crucible_fresh_var "counter" (llvm_int 32);
-  crucible_points_to (crucible_field m "counter") (crucible_term counter);
-  crucible_execute_func [m];
-  crucible_points_to (crucible_field m "counter") (crucible_term {{counter+1}});
+  m <- llvm_alloc (llvm_struct "struct.my_struct");
+  counter <- llvm_fresh_var "counter" (llvm_int 32);
+  llvm_points_to (llvm_field m "counter") (llvm_term counter);
+  llvm_execute_func [m];
+  llvm_points_to (llvm_field m "counter") (llvm_term {{counter+1}});
 };
 
 let use_inc_spec : CrucibleSetup () = do {
-  crucible_execute_func [];
-  crucible_return (crucible_term {{1:[32]}});
+  llvm_execute_func [];
+  llvm_return (llvm_term {{1:[32]}});
 };
 
 let main : TopLevel () = do {
     m <- llvm_load_module "source.bc";
-    inc <- crucible_llvm_verify m "inc" [] false inc_spec abc;
-    crucible_llvm_verify m "use_inc" [inc] false use_inc_spec abc;
+    inc <- llvm_verify m "inc" [] false inc_spec abc;
+    llvm_verify m "use_inc" [inc] false use_inc_spec abc;
     print "done";
 };

--- a/examples/salsa20/djb/salsa20.saw
+++ b/examples/salsa20/djb/salsa20.saw
@@ -86,9 +86,9 @@ let u32 = (llvm_int 32);
 let salsa20_doubleround_setup : CrucibleSetup () = do {
     (x, p_x) <- ptr_to_fresh "output" (llvm_array 16 u32);
 
-    crucible_execute_func [p_x];
+    llvm_execute_func [p_x];
 
-    crucible_points_to p_x (crucible_term {{ Salsa20::doubleround x }});
+    llvm_points_to p_x (llvm_term {{ Salsa20::doubleround x }});
 };
 
 /*
@@ -112,13 +112,13 @@ let salsa20_doubleround_setup : CrucibleSetup () = do {
  * static void salsa20_wordtobyte(u8 output[64], const u32 input[16])
  */
 let salsa20_wordtobyte_setup : CrucibleSetup () = do {
-    p_output <- crucible_alloc (llvm_array 64 u8);
+    p_output <- llvm_alloc (llvm_array 64 u8);
     (input, p_input) <- ptr_to_fresh "input" (llvm_array 16 u32);
 
-    crucible_execute_func [p_output, p_input];
+    llvm_execute_func [p_output, p_input];
 
-    crucible_points_to p_output (crucible_term {{ Salsa20::Salsa20 (U32TO8_LITTLE input) }});
-    crucible_points_to p_input (crucible_term {{ input }});
+    llvm_points_to p_output (llvm_term {{ Salsa20::Salsa20 (U32TO8_LITTLE input) }});
+    llvm_points_to p_input (llvm_term {{ input }});
 };
 
 /*
@@ -178,21 +178,21 @@ let {{
  * ECRYPT validation framework
  */
 let ECRYPT_keysetup_setup (kBytes: Int) : CrucibleSetup () = do {
-    x_input <- crucible_fresh_var "x->input" (llvm_array 16 u32); let x = {{ {input = x_input} }};
-    p_x <- alloc_init (llvm_struct "struct.ECRYPT_ctx") (crucible_struct [ crucible_term x_input ]);
+    x_input <- llvm_fresh_var "x->input" (llvm_array 16 u32); let x = {{ {input = x_input} }};
+    p_x <- alloc_init (llvm_struct "struct.ECRYPT_ctx") (llvm_struct_value [ llvm_term x_input ]);
     (k, p_k) <- ptr_to_fresh "k" (llvm_array kBytes u8);
-    let kbits = {{ (`kBytes * 8):u32 }}; let ct_kbits = crucible_term kbits;
-    let ivbits = {{ 0:u32 }}; let ct_ivbits = crucible_term ivbits; // ignored (ECRYPT test suite compatibility)
+    let kbits = {{ (`kBytes * 8):u32 }}; let ct_kbits = llvm_term kbits;
+    let ivbits = {{ 0:u32 }}; let ct_ivbits = llvm_term ivbits; // ignored (ECRYPT test suite compatibility)
 
-    crucible_precond {{ ks_guard (x, k, kbits, ivbits) }};
+    llvm_precond {{ ks_guard (x, k, kbits, ivbits) }};
 
-    crucible_execute_func [p_x, p_k, ct_kbits, ct_ivbits];
+    llvm_execute_func [p_x, p_k, ct_kbits, ct_ivbits];
 
     let {{ (_, (x', k', _, _)) = ECRYPT_keysetup (x, k, kbits, undefined) }};
     let x_input' = {{ x'.input }};
 
-    crucible_points_to p_x (crucible_struct [ crucible_term x_input' ]);
-    crucible_points_to p_k (crucible_term {{ k' }});
+    llvm_points_to p_x (llvm_struct_value [ llvm_term x_input' ]);
+    llvm_points_to p_k (llvm_term {{ k' }});
 };
 
 // void ECRYPT_ivsetup(ECRYPT_ctx *x,const u8 *iv)
@@ -212,17 +212,17 @@ let {{
 
 /** method specification for ECRYPT_ivsetup, which initializes the IV and counter component of a "context" for encryption in a manner compatible with the ECRYPT validation framework */
 let ECRYPT_ivsetup_setup : CrucibleSetup () = do {
-    x_input <- crucible_fresh_var "x->input" (llvm_array 16 u32); let x = {{ {input = x_input} }};
-    p_x <- alloc_init (llvm_struct "struct.ECRYPT_ctx") (crucible_struct [ crucible_term x_input ]);
+    x_input <- llvm_fresh_var "x->input" (llvm_array 16 u32); let x = {{ {input = x_input} }};
+    p_x <- alloc_init (llvm_struct "struct.ECRYPT_ctx") (llvm_struct [ llvm_term x_input ]);
     (iv, p_iv) <- ptr_to_fresh "iv" (llvm_array 8 u8);
 
-    crucible_execute_func [p_x, p_iv];
+    llvm_execute_func [p_x, p_iv];
 
     let {{ (_, (x', iv')) = ECRYPT_ivsetup (x, iv) }};
-    let ct_x_input' = crucible_term {{ x'.input }};
+    let ct_x_input' = llvm_term {{ x'.input }};
 
-    crucible_points_to p_x (crucible_struct [ ct_x_input' ]);
-    crucible_points_to p_iv (crucible_term {{ iv' }});
+    llvm_points_to p_x (llvm_struct_value [ ct_x_input' ]);
+    llvm_points_to p_iv (llvm_term {{ iv' }});
 };
 
 // void ECRYPT_encrypt_bytes(ECRYPT_ctx *x, const u8 *m, u8 *c, u32 bytes)
@@ -253,21 +253,21 @@ let {{
 
 /** method specification of ECRYPT_encrypt_bytes */
 let ECRYPT_encrypt_bytes_setup (bytes: Int) : CrucibleSetup () = do {
-    x_input <- crucible_fresh_var "x->input" (llvm_array 16 u32); let x = {{ {input = x_input} }};
-    p_x <- alloc_init (llvm_struct "struct.ECRYPT_ctx") (crucible_struct [ crucible_term x_input ]);
+    x_input <- llvm_fresh_var "x->input" (llvm_array 16 u32); let x = {{ {input = x_input} }};
+    p_x <- alloc_init (llvm_struct "struct.ECRYPT_ctx") (llvm_struct_value [ llvm_term x_input ]);
     (m, p_m) <- ptr_to_fresh "m" (llvm_array bytes u8);
-    p_c <- crucible_alloc (llvm_array bytes u8);
+    p_c <- llvm_alloc (llvm_array bytes u8);
     let {{ bytes = `bytes:u32 }};
-    let ct_bytes = crucible_term {{ bytes }};
+    let ct_bytes = llvm_term {{ bytes }};
 
-    crucible_execute_func [p_x, p_m, p_c, ct_bytes];
+    llvm_execute_func [p_x, p_m, p_c, ct_bytes];
 
     let {{ (_, (x', m', c', _)) = ECRYPT_encrypt_bytes (x, m, undefined, bytes) }};
     let x_input' = {{ x'.input }};
 
-    crucible_points_to p_x (crucible_struct [ crucible_term x_input' ]);
-    crucible_points_to p_m (crucible_term {{ m' }});
-    crucible_points_to p_c (crucible_term {{ c' }});
+    llvm_points_to p_x (llvm_struct_value [ llvm_term x_input' ]);
+    llvm_points_to p_m (llvm_term {{ m' }});
+    llvm_points_to p_c (llvm_term {{ c' }});
 };
 
 /*
@@ -313,8 +313,8 @@ let {{
  */
 // void ECRYPT_encrypt_bytes(ECRYPT_ctx *x, const u8 *m, u8 *c, u32 bytes)
 let ECRYPT_encrypt_bytes_setup' (bytes: Int) (a: Int) : CrucibleSetup () = do {
-    k <- crucible_fresh_var "k" (llvm_array (eval_int {{ `(a * 16):[6] }}) u8);
-    v <- crucible_fresh_var "v" (llvm_array 8 u8);
+    k <- llvm_fresh_var "k" (llvm_array (eval_int {{ `(a * 16):[6] }}) u8);
+    v <- llvm_fresh_var "v" (llvm_array 8 u8);
 
     let x_input = {{ (if (`a == (2:[2])) then [s0] # k0 # [s1] # n # [s2] # k1 # [s3]
                                          else [t0] # k0 # [t1] # n # [t2] # k0 # [t3])
@@ -323,16 +323,16 @@ let ECRYPT_encrypt_bytes_setup' (bytes: Int) (a: Int) : CrucibleSetup () = do {
                 [t0, t1, t2, t3] = U8TO32_LITTLE "expand 16-byte k"
                 n = (U8TO32_LITTLE v) # (zero:[2][32])
                 [k0, k1] = (split ((U8TO32_LITTLE k) # zero)):[2][4][32] }};
-    // x_input <- crucible_fresh_var "x->input" (llvm_array 16 u32);
-    p_x <- alloc_init (llvm_struct "struct.ECRYPT_ctx") (crucible_struct [ crucible_term x_input ]);
+    // x_input <- llvm_fresh_var "x->input" (llvm_array 16 u32);
+    p_x <- alloc_init (llvm_struct "struct.ECRYPT_ctx") (llvm_struct_value [ llvm_term x_input ]);
 
     (m, p_m) <- ptr_to_fresh "m" (llvm_array bytes u8);
-    p_c <- crucible_alloc (llvm_array bytes u8);
+    p_c <- llvm_alloc (llvm_array bytes u8);
 
     let {{ bytes = `bytes:u32 }};
-    let ct_bytes = crucible_term {{ bytes }};
+    let ct_bytes = llvm_term {{ bytes }};
 
-    crucible_execute_func [p_x, p_m, p_c, ct_bytes];
+    llvm_execute_func [p_x, p_m, p_c, ct_bytes];
 
     let x_input' = {{
       updates x_input indices ((reverse (split chunks)):[2][32])
@@ -341,9 +341,9 @@ let ECRYPT_encrypt_bytes_setup' (bytes: Int) (a: Int) : CrucibleSetup () = do {
           indices = [8..9]:[2]size_t
     }};
 
-    crucible_points_to p_x (crucible_struct [ crucible_term x_input' ]);
-    crucible_points_to p_m (crucible_term {{ m }});
-    crucible_points_to p_c (crucible_term {{ Salsa20::Salsa20_encrypt (k, v, m) }});
+    llvm_points_to p_x (llvm_struct_value [ llvm_term x_input' ]);
+    llvm_points_to p_m (llvm_term {{ m }});
+    llvm_points_to p_c (llvm_term {{ Salsa20::Salsa20_encrypt (k, v, m) }});
 };
 
 let main : TopLevel() = do {
@@ -352,49 +352,49 @@ let main : TopLevel() = do {
     print m;
 
     // print "Verifying salsa20_doubleround...";
-    // salsa20_doubleround_result <- time (crucible_llvm_verify m "salsa20_doubleround" [] false salsa20_doubleround_setup abc);
+    // salsa20_doubleround_result <- time (llvm_verify m "salsa20_doubleround" [] false salsa20_doubleround_setup abc);
 
     print "Verifying salsa20_wordtobyte...";
-    salsa20_wordtobyte_result <- time (crucible_llvm_verify m "salsa20_wordtobyte" [/*salsa20_doubleround_result*/] false salsa20_wordtobyte_setup abc);
+    salsa20_wordtobyte_result <- time (llvm_verify m "salsa20_wordtobyte" [/*salsa20_doubleround_result*/] false salsa20_wordtobyte_setup abc);
 
     print "Verifying ECRYPT_keysetup (kbits=128)...";
-    ECRYPT_keysetup_16_result <- time (crucible_llvm_verify m "ECRYPT_keysetup" [] false (ECRYPT_keysetup_setup 16) abc);
+    ECRYPT_keysetup_16_result <- time (llvm_verify m "ECRYPT_keysetup" [] false (ECRYPT_keysetup_setup 16) abc);
 
     print "Verifying ECRYPT_keysetup (kbits=256)...";
-    ECRYPT_keysetup_32_result <- time (crucible_llvm_verify m "ECRYPT_keysetup" [] false (ECRYPT_keysetup_setup 32) abc);
+    ECRYPT_keysetup_32_result <- time (llvm_verify m "ECRYPT_keysetup" [] false (ECRYPT_keysetup_setup 32) abc);
 
     print "Verifying ECRYPT_ivsetup...";
-    ECRYPT_ivsetup_result <- time (crucible_llvm_verify m "ECRYPT_ivsetup" [] false ECRYPT_ivsetup_setup abc);
+    ECRYPT_ivsetup_result <- time (llvm_verify m "ECRYPT_ivsetup" [] false ECRYPT_ivsetup_setup abc);
 
     print "Verifying ECRYPT_encrypt_bytes based on context (1 byte message)...";
-    ECRYPT_encrypt_bytes_1_result <- time (crucible_llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 1) abc);
+    ECRYPT_encrypt_bytes_1_result <- time (llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 1) abc);
 
     print "Verifying ECRYPT_encrypt_bytes based on context (2 byte message)...";
-    ECRYPT_encrypt_bytes_2_result <- time (crucible_llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 2) abc);
+    ECRYPT_encrypt_bytes_2_result <- time (llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 2) abc);
 
     print "Verifying ECRYPT_encrypt_bytes based on context (4 byte message)...";
-    ECRYPT_encrypt_bytes_4_result <- time (crucible_llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 4) abc);
+    ECRYPT_encrypt_bytes_4_result <- time (llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 4) abc);
 
     print "Verifying ECRYPT_encrypt_bytes based on context (8 byte message)...";
-    ECRYPT_encrypt_bytes_8_result <- time (crucible_llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 8) abc);
+    ECRYPT_encrypt_bytes_8_result <- time (llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 8) abc);
 
     print "Verifying ECRYPT_encrypt_bytes based on context (16 byte message)...";
-    ECRYPT_encrypt_bytes_16_result <- time (crucible_llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 16) abc);
+    ECRYPT_encrypt_bytes_16_result <- time (llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 16) abc);
 
     print "Verifying ECRYPT_encrypt_bytes based on context (32 byte message)...";
-    ECRYPT_encrypt_bytes_32_result <- time (crucible_llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 32) abc);
+    ECRYPT_encrypt_bytes_32_result <- time (llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 32) abc);
 
     print "Verifying ECRYPT_encrypt_bytes based on context (64 byte message)...";
-    ECRYPT_encrypt_bytes_64_result <- time (crucible_llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 64) abc);
+    ECRYPT_encrypt_bytes_64_result <- time (llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 64) abc);
 
     print "Verifying ECRYPT_encrypt_bytes based on context (65 byte message)...";
-    ECRYPT_encrypt_bytes_65_result <- time (crucible_llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 65) abc);
+    ECRYPT_encrypt_bytes_65_result <- time (llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 65) abc);
 
     print "Verifying ECRYPT_encrypt_bytes based on context (96 byte message)...";
-    ECRYPT_encrypt_bytes_96_result <- time (crucible_llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 96) abc);
+    ECRYPT_encrypt_bytes_96_result <- time (llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 96) abc);
 
     print "Verifying ECRYPT_encrypt_bytes based on context (128 byte message)...";
-    ECRYPT_encrypt_bytes_128_result <- time (crucible_llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 128) abc);
+    ECRYPT_encrypt_bytes_128_result <- time (llvm_verify m "ECRYPT_encrypt_bytes" [salsa20_wordtobyte_result] false (ECRYPT_encrypt_bytes_setup 128) abc);
 
     print "Verifying that the implementation is actually related to the spec for various key/message sizes...";
 

--- a/examples/salsa20/djb/util.saw
+++ b/examples/salsa20/djb/util.saw
@@ -1,12 +1,12 @@
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 

--- a/examples/salsa20/salsa.saw
+++ b/examples/salsa20/salsa.saw
@@ -1,41 +1,41 @@
 import "Salsa20.cry";
 
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p (crucible_term v);
+    p <- llvm_alloc ty;
+    llvm_points_to p (llvm_term v);
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
+    x <- llvm_fresh_var n ty;
     p <- alloc_init ty x;
     return (x, p);
 };
 
 let oneptr_update_func n ty f = do {
     (x, p) <- ptr_to_fresh n ty;
-    crucible_execute_func [p];
-    crucible_points_to p (crucible_term {{ f x }});
+    llvm_execute_func [p];
+    llvm_points_to p (llvm_term {{ f x }});
 };
 
 let quarterround_setup : CrucibleSetup () = do {
-    //ys <- crucible_fresh_var "ys" (llvm_array 4 (llvm_int 32));
-    y0 <- crucible_fresh_var "y0" (llvm_int 32);
-    y1 <- crucible_fresh_var "y1" (llvm_int 32);
-    y2 <- crucible_fresh_var "y2" (llvm_int 32);
-    y3 <- crucible_fresh_var "y3" (llvm_int 32);
+    //ys <- llvm_fresh_var "ys" (llvm_array 4 (llvm_int 32));
+    y0 <- llvm_fresh_var "y0" (llvm_int 32);
+    y1 <- llvm_fresh_var "y1" (llvm_int 32);
+    y2 <- llvm_fresh_var "y2" (llvm_int 32);
+    y3 <- llvm_fresh_var "y3" (llvm_int 32);
     p0 <- alloc_init (llvm_int 32) {{ y0 }};
     p1 <- alloc_init (llvm_int 32) {{ y1 }};
     p2 <- alloc_init (llvm_int 32) {{ y2 }};
     p3 <- alloc_init (llvm_int 32) {{ y3 }};
 
-    crucible_execute_func [p0, p1, p2, p3];
+    llvm_execute_func [p0, p1, p2, p3];
 
     let zs = {{ quarterround [y0,y1,y2,y3] }};
-    crucible_points_to p0 (crucible_term {{ zs@0 }});
-    crucible_points_to p1 (crucible_term {{ zs@1 }});
-    crucible_points_to p2 (crucible_term {{ zs@2 }});
-    crucible_points_to p3 (crucible_term {{ zs@3 }});
+    llvm_points_to p0 (llvm_term {{ zs@0 }});
+    llvm_points_to p1 (llvm_term {{ zs@1 }});
+    llvm_points_to p2 (llvm_term {{ zs@2 }});
+    llvm_points_to p3 (llvm_term {{ zs@3 }});
 };
 
 let rowround_setup =
@@ -53,8 +53,8 @@ let salsa20_setup =
 let salsa20_djb_setup = do {
     (input, ip) <- ptr_to_fresh "input" (llvm_array 16 (llvm_int 32));
     (_, op) <- ptr_to_fresh "output" (llvm_array 64 (llvm_int 8));
-    crucible_execute_func [op, ip];
-    crucible_points_to op (crucible_term {{
+    llvm_execute_func [op, ip];
+    llvm_points_to op (llvm_term {{
         Salsa20 (join [ littleendian_inverse x | x <- input ])
     }});
 };
@@ -62,45 +62,45 @@ let salsa20_djb_setup = do {
 let salsa20_expansion_32 = do {
     // (k, pk) <- ptr_to_fresh "k" (llvm_array 32 (llvm_int 8));
     // (n, pn) <- ptr_to_fresh "n" (llvm_array 16 (llvm_int 8));
-    k <- crucible_fresh_var "k" (llvm_array 32 (llvm_int 8));
-    pk <- crucible_alloc_readonly (llvm_array 32 (llvm_int 8));
-    crucible_points_to pk (crucible_term k);
-    n <- crucible_fresh_var "n" (llvm_array 16 (llvm_int 8));
-    pn <- crucible_alloc_readonly (llvm_array 16 (llvm_int 8));
-    crucible_points_to pn (crucible_term n);
-    pks <- crucible_alloc (llvm_array 64 (llvm_int 8));
-    crucible_execute_func [pk, pn, pks];
+    k <- llvm_fresh_var "k" (llvm_array 32 (llvm_int 8));
+    pk <- llvm_alloc_readonly (llvm_array 32 (llvm_int 8));
+    llvm_points_to pk (llvm_term k);
+    n <- llvm_fresh_var "n" (llvm_array 16 (llvm_int 8));
+    pn <- llvm_alloc_readonly (llvm_array 16 (llvm_int 8));
+    llvm_points_to pn (llvm_term n);
+    pks <- llvm_alloc (llvm_array 64 (llvm_int 8));
+    llvm_execute_func [pk, pn, pks];
     let rks = {{ Salsa20_expansion`{a=2}(k, n)}};
-    crucible_points_to pks (crucible_term rks);
+    llvm_points_to pks (llvm_term rks);
 };
 
 let s20_encrypt32 n = do {
     (key, pkey) <- ptr_to_fresh "key" (llvm_array 32 (llvm_int 8));
     (v, pv) <- ptr_to_fresh "nonce" (llvm_array 8 (llvm_int 8));
     (m, pm) <- ptr_to_fresh "buf" (llvm_array n (llvm_int 8));
-    crucible_execute_func [ pkey
-                          , pv
-                          , crucible_term {{ 0 : [32] }}
-                          , pm
-                          , crucible_term {{ `n : [32] }}
-                          ];
-    crucible_points_to pm (crucible_term {{ Salsa20_encrypt (key, v, m) }});
-    crucible_return (crucible_term {{ 0 : [32] }});
+    llvm_execute_func [ pkey
+                      , pv
+                      , llvm_term {{ 0 : [32] }}
+                      , pm
+                      , llvm_term {{ `n : [32] }}
+                      ];
+    llvm_points_to pm (llvm_term {{ Salsa20_encrypt (key, v, m) }});
+    llvm_return (llvm_term {{ 0 : [32] }});
 };
 
 let main : TopLevel () = do {
-    m      <- llvm_load_module "salsa20.bc";
-    qr     <- crucible_llvm_verify m "s20_quarterround" []      false quarterround_setup   abc;
-    rr     <- crucible_llvm_verify m "s20_rowround"     [qr]    false rowround_setup       abc;
-    cr     <- crucible_llvm_verify m "s20_columnround"  [qr]    false columnround_setup    abc;
-    dr     <- crucible_llvm_verify m "s20_doubleround"  [cr,rr] false doubleround_setup    abc;
-    s20    <- crucible_llvm_verify m "s20_hash"         [dr]    false salsa20_setup        abc;
-    s20e32 <- crucible_llvm_verify m "s20_expand32"     [s20]   true  salsa20_expansion_32 abc;
-    s20encrypt_63 <- crucible_llvm_verify m "s20_crypt32" [s20e32] true (s20_encrypt32 63) abc;
-    s20encrypt_64 <- crucible_llvm_verify m "s20_crypt32" [s20e32] true (s20_encrypt32 64) abc;
-    s20encrypt_65 <- crucible_llvm_verify m "s20_crypt32" [s20e32] true (s20_encrypt32 65) abc;
+    m      <- load_module "salsa20.bc";
+    qr     <- llvm_verify m "s20_quarterround" []      false quarterround_setup   abc;
+    rr     <- llvm_verify m "s20_rowround"     [qr]    false rowround_setup       abc;
+    cr     <- llvm_verify m "s20_columnround"  [qr]    false columnround_setup    abc;
+    dr     <- llvm_verify m "s20_doubleround"  [cr,rr] false doubleround_setup    abc;
+    s20    <- llvm_verify m "s20_hash"         [dr]    false salsa20_setup        abc;
+    s20e32 <- llvm_verify m "s20_expand32"     [s20]   true  salsa20_expansion_32 abc;
+    s20encrypt_63 <- llvm_verify m "s20_crypt32" [s20e32] true (s20_encrypt32 63) abc;
+    s20encrypt_64 <- llvm_verify m "s20_crypt32" [s20e32] true (s20_encrypt32 64) abc;
+    s20encrypt_65 <- llvm_verify m "s20_crypt32" [s20e32] true (s20_encrypt32 65) abc;
 
     djb    <- llvm_load_module "djb/salsa20.bc";
-    s20djb <- crucible_llvm_verify djb "salsa20_wordtobyte" [] false salsa20_djb_setup     abc;
+    s20djb <- llvm_verify djb "salsa20_wordtobyte" [] false salsa20_djb_setup     abc;
     print "Done!";
 };

--- a/examples/simon-speck/simon.saw
+++ b/examples/simon-speck/simon.saw
@@ -10,14 +10,14 @@ l_64_128 <- llvm_load_module "simon-64-128.bc";
 l_128_128 <- llvm_load_module "simon-128-128.bc";
 
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
@@ -25,11 +25,11 @@ let block_spec keyt wsz tn fn = do {
   let msgt = llvm_array 2 (llvm_int wsz);
   (key, keyp) <- ptr_to_fresh "key" keyt;
   (msg, msgp) <- ptr_to_fresh "msg" msgt;
-  cryptp <- crucible_alloc msgt;
-  crucible_points_to (crucible_global "z") (crucible_global_initializer "z");
-  crucible_execute_func [msgp, cryptp, keyp];
+  cryptp <- llvm_alloc msgt;
+  llvm_points_to (llvm_global "z") (llvm_global_initializer "z");
+  llvm_execute_func [msgp, cryptp, keyp];
   let res = {{ fn (reverse (take `{tn} key)) (msg@0, msg@1) }};
-  crucible_points_to cryptp (crucible_term {{ split (res.0 # res.1) : [2][wsz] }});
+  llvm_points_to cryptp (llvm_term {{ split (res.0 # res.1) : [2][wsz] }});
 };
 
 let i32 = llvm_int 32;
@@ -40,9 +40,9 @@ let enc_128_128_spec = block_spec (llvm_array 68 i64) 64 2 {{ Simon128_128 }};
 let dec_128_128_spec = block_spec (llvm_array 68 i64) 64 2 {{ Simon128_128' }};
 
 print "Proving Simon 64/128 C encrypt & decrypt";
-crucible_llvm_verify l_64_128 "Encrypt" [] true enc_64_128_spec abc;
-crucible_llvm_verify l_64_128 "Decrypt" [] true dec_64_128_spec abc;
+llvm_verify l_64_128 "Encrypt" [] true enc_64_128_spec abc;
+llvm_verify l_64_128 "Decrypt" [] true dec_64_128_spec abc;
 
 print "Proving Simon 128/128 C encrypt & decrypt";
-crucible_llvm_verify l_128_128 "Encrypt" [] true enc_128_128_spec abc;
-crucible_llvm_verify l_128_128 "Decrypt" [] true dec_128_128_spec abc;
+llvm_verify l_128_128 "Encrypt" [] true enc_128_128_spec abc;
+llvm_verify l_128_128 "Decrypt" [] true dec_128_128_spec abc;

--- a/examples/simon-speck/speck.saw
+++ b/examples/simon-speck/speck.saw
@@ -10,14 +10,14 @@ l_64_128 <- llvm_load_module "speck-64-128.bc";
 l_128_128 <- llvm_load_module "speck-128-128.bc";
 
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
@@ -25,9 +25,9 @@ let block_spec keyt wsz tn fn = do {
   let msgt = llvm_array 2 (llvm_int wsz);
   (key, keyp) <- ptr_to_fresh "key" keyt;
   (msg, msgp) <- ptr_to_fresh "msg" msgt;
-  crucible_execute_func [msgp, keyp];
+  llvm_execute_func [msgp, keyp];
   let res = {{ fn (reverse (take `{tn} key)) (msg@1, msg@0) }};
-  crucible_points_to msgp (crucible_term {{ split (res.1 # res.0) : [2][wsz] }});
+  llvm_points_to msgp (llvm_term {{ split (res.1 # res.0) : [2][wsz] }});
 };
 
 let i32 = llvm_int 32;
@@ -38,9 +38,9 @@ let enc_128_128_spec = block_spec (llvm_array 68 i64) 64 2 {{ Speck128_128 }};
 let dec_128_128_spec = block_spec (llvm_array 68 i64) 64 2 {{ Speck128_128' }};
 
 print "Proving Speck 64/128 C encrypt & decrypt";
-crucible_llvm_verify l_64_128 "speck_encrypt" [] false enc_64_128_spec yices;
-crucible_llvm_verify l_64_128 "speck_decrypt" [] false dec_64_128_spec yices;
+llvm_verify l_64_128 "speck_encrypt" [] false enc_64_128_spec yices;
+llvm_verify l_64_128 "speck_decrypt" [] false dec_64_128_spec yices;
 
 print "Proving Speck 128/128 C encrypt & decrypt";
-crucible_llvm_verify l_128_128 "speck_encrypt" [] false enc_128_128_spec yices;
-crucible_llvm_verify l_128_128 "speck_decrypt" [] false dec_128_128_spec yices;
+llvm_verify l_128_128 "speck_encrypt" [] false enc_128_128_spec yices;
+llvm_verify l_128_128 "speck_decrypt" [] false dec_128_128_spec yices;

--- a/examples/sv-comp/byte_add.saw
+++ b/examples/sv-comp/byte_add.saw
@@ -1,8 +1,8 @@
 include "sv-comp.saw";
 
 m <- llvm_load_module "byte_add.bc";
-let assume = crucible_llvm_unsafe_assume_spec m;
+let assume = llvm_unsafe_assume_spec m;
 error_ov <- assume "__VERIFIER_error" error_spec;
 nondet_int_ov <- assume "__VERIFIER_nondet_uint" nondet_int_spec;
 let ovs = [error_ov, nondet_int_ov];
-crucible_llvm_verify m "main" ovs true main_spec yices;
+llvm_verify m "main" ovs true main_spec yices;

--- a/examples/sv-comp/modulus.saw
+++ b/examples/sv-comp/modulus.saw
@@ -1,9 +1,9 @@
 include "sv-comp.saw";
 
 m <- llvm_load_module "modulus.bc";
-let assume = crucible_llvm_unsafe_assume_spec m;
+let assume = llvm_unsafe_assume_spec m;
 error_ov <- assume "__VERIFIER_error" error_spec;
 assume_ov <- assume "__VERIFIER_assume" assume_spec;
 nondet_int_ov <- assume "__VERIFIER_nondet_uint" nondet_int_spec;
 let ovs = [error_ov, assume_ov, nondet_int_ov];
-crucible_llvm_verify m "main" ovs true main_spec yices;
+llvm_verify m "main" ovs true main_spec yices;

--- a/examples/sv-comp/parity.saw
+++ b/examples/sv-comp/parity.saw
@@ -1,8 +1,8 @@
 include "sv-comp.saw";
 
 m <- llvm_load_module "parity.bc";
-let assume = crucible_llvm_unsafe_assume_spec m;
+let assume = llvm_unsafe_assume_spec m;
 error_ov <- assume "__VERIFIER_error" error_spec;
 nondet_int_ov <- assume "__VERIFIER_nondet_uint" nondet_int_spec;
 let ovs = [error_ov, nondet_int_ov];
-crucible_llvm_verify m "main" ovs true main_spec yices;
+llvm_verify m "main" ovs true main_spec yices;

--- a/examples/sv-comp/sv-comp.saw
+++ b/examples/sv-comp/sv-comp.saw
@@ -4,22 +4,22 @@
  */
 
 let error_spec = do {
-    crucible_precond {{ False }};
-    crucible_execute_func [];
+    llvm_precond {{ False }};
+    llvm_execute_func [];
 };
 
 let assume_spec = do {
-    p <- crucible_fresh_var "p" (llvm_int 32);
-    crucible_execute_func [crucible_term p];
-    crucible_postcond {{ p != 0 }};
+    p <- llvm_fresh_var "p" (llvm_int 32);
+    llvm_execute_func [llvm_term p];
+    llvm_postcond {{ p != 0 }};
 };
 
 let nondet_int_spec = do {
-    crucible_execute_func [];
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    crucible_return (crucible_term x);
+    llvm_execute_func [];
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    llvm_return (llvm_term x);
 };
 
 let main_spec = do {
-    crucible_execute_func [];
+    llvm_execute_func [];
 };

--- a/examples/zuc/zuc.saw
+++ b/examples/zuc/zuc.saw
@@ -1,14 +1,14 @@
 let {{ t (x : [32]) = drop`{1} x : [31] }};
 
 let fresh_global n t = do {
-    x <- crucible_fresh_var n t;
-    let p = crucible_global n;
-    crucible_points_to p (crucible_term x);
+    x <- llvm_fresh_var n t;
+    let p = llvm_global n;
+    llvm_points_to p (llvm_term x);
     return x;
 };
 
 let ensure_global n v = do {
-    crucible_points_to (crucible_global n) (crucible_term v);
+    llvm_points_to (llvm_global n) (llvm_term v);
 };
 
 // Common declarations of all the globals used by the various proofs
@@ -30,22 +30,22 @@ let use_LFSR = do {
     S13 <- fresh_global "LFSR_S13" (llvm_int 32);
     S14 <- fresh_global "LFSR_S14" (llvm_int 32);
     S15 <- fresh_global "LFSR_S15" (llvm_int 32);
-    crucible_precond {{ S0 == (S0 && 0x7FFFFFFF) }};
-    crucible_precond {{ S1 == (S1 && 0x7FFFFFFF) }};
-    crucible_precond {{ S2 == (S2 && 0x7FFFFFFF) }};
-    crucible_precond {{ S3 == (S3 && 0x7FFFFFFF) }};
-    crucible_precond {{ S4 == (S4 && 0x7FFFFFFF) }};
-    crucible_precond {{ S5 == (S5 && 0x7FFFFFFF) }};
-    crucible_precond {{ S6 == (S6 && 0x7FFFFFFF) }};
-    crucible_precond {{ S7 == (S7 && 0x7FFFFFFF) }};
-    crucible_precond {{ S8 == (S8 && 0x7FFFFFFF) }};
-    crucible_precond {{ S9 == (S9 && 0x7FFFFFFF) }};
-    crucible_precond {{ S10 == (S10 && 0x7FFFFFFF) }};
-    crucible_precond {{ S11 == (S11 && 0x7FFFFFFF) }};
-    crucible_precond {{ S12 == (S12 && 0x7FFFFFFF) }};
-    crucible_precond {{ S13 == (S13 && 0x7FFFFFFF) }};
-    crucible_precond {{ S14 == (S14 && 0x7FFFFFFF) }};
-    crucible_precond {{ S15 == (S15 && 0x7FFFFFFF) }};
+    llvm_precond {{ S0 == (S0 && 0x7FFFFFFF) }};
+    llvm_precond {{ S1 == (S1 && 0x7FFFFFFF) }};
+    llvm_precond {{ S2 == (S2 && 0x7FFFFFFF) }};
+    llvm_precond {{ S3 == (S3 && 0x7FFFFFFF) }};
+    llvm_precond {{ S4 == (S4 && 0x7FFFFFFF) }};
+    llvm_precond {{ S5 == (S5 && 0x7FFFFFFF) }};
+    llvm_precond {{ S6 == (S6 && 0x7FFFFFFF) }};
+    llvm_precond {{ S7 == (S7 && 0x7FFFFFFF) }};
+    llvm_precond {{ S8 == (S8 && 0x7FFFFFFF) }};
+    llvm_precond {{ S9 == (S9 && 0x7FFFFFFF) }};
+    llvm_precond {{ S10 == (S10 && 0x7FFFFFFF) }};
+    llvm_precond {{ S11 == (S11 && 0x7FFFFFFF) }};
+    llvm_precond {{ S12 == (S12 && 0x7FFFFFFF) }};
+    llvm_precond {{ S13 == (S13 && 0x7FFFFFFF) }};
+    llvm_precond {{ S14 == (S14 && 0x7FFFFFFF) }};
+    llvm_precond {{ S15 == (S15 && 0x7FFFFFFF) }};
     return {{ [t S0, t S1, t S2, t S3, t S4, t S5, t S6, t S7,
                t S8, t S9, t S10, t S11, t S12, t S13, t S14, t S15] }};
 };
@@ -71,30 +71,30 @@ let assign_LFSR s' = do {
 
 let AddM_spec cry_plus = do {
     /*
-    a <- crucible_fresh_var "a" (llvm_int 31);
-    b <- crucible_fresh_var "b" (llvm_int 31);
+    a <- llvm_fresh_var "a" (llvm_int 31);
+    b <- llvm_fresh_var "b" (llvm_int 31);
 
-    crucible_execute_func [ (crucible_term {{ [False] # a }})
-                          , (crucible_term {{ [False] # b }})
-                          ];
-    crucible_return (crucible_term {{ (0 # (cry_add [a, b])) : [32] }});
+    llvm_execute_func [ (llvm_term {{ [False] # a }})
+                      , (llvm_term {{ [False] # b }})
+                      ];
+    llvm_return (llvm_term {{ (0 # (cry_add [a, b])) : [32] }});
     */
-    a <- crucible_fresh_var "a" (llvm_int 32);
-    b <- crucible_fresh_var "b" (llvm_int 32);
-    crucible_precond {{ a == (a && 0x7FFFFFFF) }};
-    crucible_precond {{ b == (b && 0x7FFFFFFF) }};
-    crucible_execute_func [crucible_term a, crucible_term b];
-    crucible_return (crucible_term {{ 0 # cry_plus (drop`{1} a, drop`{1} b) : [32] }});
+    a <- llvm_fresh_var "a" (llvm_int 32);
+    b <- llvm_fresh_var "b" (llvm_int 32);
+    llvm_precond {{ a == (a && 0x7FFFFFFF) }};
+    llvm_precond {{ b == (b && 0x7FFFFFFF) }};
+    llvm_execute_func [llvm_term a, llvm_term b];
+    llvm_return (llvm_term {{ 0 # cry_plus (drop`{1} a, drop`{1} b) : [32] }});
 };
 
 let MulPow_spec cry_mulpow = do {
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    k <- crucible_fresh_var "k" (llvm_int 32);
-    crucible_precond {{ x == (x && 0x7FFFFFFF) }};
-    crucible_precond {{ k == (k && 0x7FFFFFFF) }};
-    crucible_precond {{ (k >= 8) /\ (k <= 21) }};
-    crucible_execute_func [crucible_term x, crucible_term k];
-    crucible_return (crucible_term {{ (0 # (cry_mulpow (t x, t k))) : [32] }});
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    k <- llvm_fresh_var "k" (llvm_int 32);
+    llvm_precond {{ x == (x && 0x7FFFFFFF) }};
+    llvm_precond {{ k == (k && 0x7FFFFFFF) }};
+    llvm_precond {{ (k >= 8) /\ (k <= 21) }};
+    llvm_execute_func [llvm_term x, llvm_term k];
+    llvm_return (llvm_term {{ (0 # (cry_mulpow (t x, t k))) : [32] }});
 };
 
 let BR_spec (zuc : CryptolModule) = do {
@@ -103,7 +103,7 @@ let BR_spec (zuc : CryptolModule) = do {
     X1 <- fresh_global "BRC_X1" (llvm_int 32);
     X2 <- fresh_global "BRC_X2" (llvm_int 32);
     X3 <- fresh_global "BRC_X3" (llvm_int 32);
-    crucible_execute_func [];
+    llvm_execute_func [];
     let res = {{ zuc::BitReorganization s }};
     ensure_global "BRC_X0" {{ res @ 0 }};
     ensure_global "BRC_X1" {{ res @ 1 }};
@@ -119,26 +119,26 @@ let F_spec (zuc : CryptolModule) = do {
     R2 <- fresh_global "F_R2" (llvm_int 32);
     S0a <- fresh_global "S0" (llvm_array 256 (llvm_int 8));
     S1a <- fresh_global "S1" (llvm_array 256 (llvm_int 8));
-    crucible_precond {{ S0a == zuc::S0Table }};
-    crucible_precond {{ S1a == zuc::S1Table }};
+    llvm_precond {{ S0a == zuc::S0Table }};
+    llvm_precond {{ S1a == zuc::S1Table }};
     let res = {{ zuc::F ([X0, X1, X2], [R1, R2]) }};
-    crucible_execute_func [];
-    crucible_return (crucible_term {{ res.0 }});
+    llvm_execute_func [];
+    llvm_return (llvm_term {{ res.0 }});
     ensure_global "F_R1" {{ res.1 @ 0 }};
     ensure_global "F_R2" {{ res.1 @ 1 }};
 };
 
 let L12_spec cry_L12 = do {
-    X <- crucible_fresh_var "X" (llvm_int 32);
-    crucible_execute_func [crucible_term X];
-    crucible_return (crucible_term {{ cry_L12 X }});
+    X <- llvm_fresh_var "X" (llvm_int 32);
+    llvm_execute_func [llvm_term X];
+    llvm_return (llvm_term {{ cry_L12 X }});
 };
 
 let LFSRWithInitializationMode_spec cry_LIM = do {
-    u <- crucible_fresh_var "u" (llvm_int 32);
-    crucible_precond {{ u == (u && 0x7FFFFFFF) }};
+    u <- llvm_fresh_var "u" (llvm_int 32);
+    llvm_precond {{ u == (u && 0x7FFFFFFF) }};
     s <- use_LFSR;
-    crucible_execute_func [crucible_term u];
+    llvm_execute_func [llvm_term u];
     assign_LFSR {{ cry_LIM (t u, s) }};
 };
 
@@ -146,11 +146,11 @@ m <- llvm_load_module "zuc.bc";
 zuccry <- cryptol_load "zuc.cry";
 
 print "Proving equivalence with Cryptol spec.";
-AddM_ov <- crucible_llvm_verify m "AddM" [] false (AddM_spec {{ zuccry::plus }}) abc;
-mulpow_ov <- crucible_llvm_verify m "MulByPow2" [] false (MulPow_spec {{ zuccry::mulpow }}) abc;
-BR_ov <- crucible_llvm_verify m "BitReorganization" [] false (BR_spec zuccry) abc;
-L1_ov <- crucible_llvm_verify m "L1" [] false (L12_spec {{ zuccry::L1 }}) abc;
-L2_ov <- crucible_llvm_verify m "L2" [] false (L12_spec {{ zuccry::L2 }}) abc;
-LIM_ov <- crucible_llvm_verify m "LFSRWithInitialisationMode" [AddM_ov, mulpow_ov] false
+AddM_ov <- llvm_verify m "AddM" [] false (AddM_spec {{ zuccry::plus }}) abc;
+mulpow_ov <- llvm_verify m "MulByPow2" [] false (MulPow_spec {{ zuccry::mulpow }}) abc;
+BR_ov <- llvm_verify m "BitReorganization" [] false (BR_spec zuccry) abc;
+L1_ov <- llvm_verify m "L1" [] false (L12_spec {{ zuccry::L1 }}) abc;
+L2_ov <- llvm_verify m "L2" [] false (L12_spec {{ zuccry::L2 }}) abc;
+LIM_ov <- llvm_verify m "LFSRWithInitialisationMode" [AddM_ov, mulpow_ov] false
   (LFSRWithInitializationMode_spec {{zuccry::LFSRWithInitializationModeC}}) abc;
-F_ov <- crucible_llvm_verify m "F" [L1_ov, L2_ov] false (F_spec zuccry) abc;
+F_ov <- llvm_verify m "F" [L1_ov, L2_ov] false (F_spec zuccry) abc;

--- a/intTests/test0019_jss_switch_statement/test.saw
+++ b/intTests/test0019_jss_switch_statement/test.saw
@@ -1,8 +1,8 @@
 import "../../doc/tutorial/code/ffs.cry";
 FFS <- java_load_class "FFS";
-java_ffs_imp <- java_extract FFS "ffs_imp";
+java_ffs_imp <- jvm_extract FFS "ffs_imp";
 prove_print abc {{ \x -> java_ffs_imp x == ffs_ref x }};
 
 Id <- java_load_class "Id";
-java_id_imp <- java_extract Id "id_imp";
+java_id_imp <- jvm_extract Id "id_imp";
 prove_print abc {{ \x -> java_id_imp x == x }};

--- a/intTests/test0019_jss_switch_statement/test.saw
+++ b/intTests/test0019_jss_switch_statement/test.saw
@@ -1,8 +1,8 @@
 import "../../doc/tutorial/code/ffs.cry";
 FFS <- java_load_class "FFS";
-java_ffs_imp <- crucible_java_extract FFS "ffs_imp";
+java_ffs_imp <- java_extract FFS "ffs_imp";
 prove_print abc {{ \x -> java_ffs_imp x == ffs_ref x }};
 
 Id <- java_load_class "Id";
-java_id_imp <- crucible_java_extract Id "id_imp";
+java_id_imp <- java_extract Id "id_imp";
 prove_print abc {{ \x -> java_id_imp x == x }};

--- a/intTests/test0020_lss_switch_statement/test.saw
+++ b/intTests/test0020_lss_switch_statement/test.saw
@@ -3,18 +3,18 @@ let {{ f x = if x == (0:[8]) then (1:[8]) else 4
 
 
 m1 <- llvm_load_module "test_switch.bc";
-l1 <- crucible_llvm_extract m1 "test_case";
-l2 <- crucible_llvm_extract m1 "test_case_indirect";
+l1 <- llvm_extract m1 "test_case";
+l2 <- llvm_extract m1 "test_case_indirect";
 
 prove_print abc {{ \x -> f x == l1 x }};
 prove_print abc {{ \x -> f x == l2 x }};
 
 m2 <- llvm_load_module "test_switch2.bc";
-l3 <- crucible_llvm_extract m2 "test_case_wrapper";
+l3 <- llvm_extract m2 "test_case_wrapper";
 
 prove_print abc {{ \x -> f x == l3 x }};
 
 m3 <- llvm_load_module "test_switch3.bc";
-l4 <- crucible_llvm_extract m3 "test_case_wrapper";
+l4 <- llvm_extract m3 "test_case_wrapper";
 
 prove_print abc {{ \x -> f x == l4 x }};

--- a/intTests/test0021_llvm_unsound/side.saw
+++ b/intTests/test0021_llvm_unsound/side.saw
@@ -1,31 +1,31 @@
 c <- llvm_load_module "side.bc";
 
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
 let side_spec = do {
   (a, ap) <- ptr_to_fresh "a" (llvm_int 32);
-  crucible_execute_func [ap];
-  crucible_points_to ap (crucible_term {{ 0:[32] }});
-  crucible_return (crucible_term {{ a }});
+  llvm_execute_func [ap];
+  llvm_points_to ap (llvm_term {{ 0:[32] }});
+  llvm_return (llvm_term {{ a }});
   };
 
-side_proof <- crucible_llvm_verify c "side_effect" [] false side_spec abc;
+side_proof <- llvm_verify c "side_effect" [] false side_spec abc;
 
 let foo_spec = do {
-  x <- crucible_fresh_var "x" (llvm_int 32);
-  crucible_execute_func [crucible_term x];
-  crucible_return (crucible_term {{ x }});
+  x <- llvm_fresh_var "x" (llvm_int 32);
+  llvm_execute_func [llvm_term x];
+  llvm_return (llvm_term {{ x }});
   };
 
-bad <- crucible_llvm_verify c "foo" [side_proof] false foo_spec abc;
+bad <- llvm_verify c "foo" [side_proof] false foo_spec abc;
 print "Done.";

--- a/intTests/test0024_llvm_assert_false/test.saw
+++ b/intTests/test0024_llvm_assert_false/test.saw
@@ -1,7 +1,7 @@
 m <- llvm_load_module "test0024.bc";
-crucible_llvm_verify m "id" [] false do {
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    crucible_precond {{ x > 5 }};
-    crucible_execute_func [crucible_term x];
-    crucible_return {{ 6 : [32] }};
+llvm_verify m "id" [] false do {
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    llvm_precond {{ x > 5 }};
+    llvm_execute_func [llvm_term x];
+    llvm_return {{ 6 : [32] }};
 } abc;

--- a/intTests/test0026_bad_pointers/test.saw
+++ b/intTests/test0026_bad_pointers/test.saw
@@ -4,9 +4,9 @@ let bad_pointer_no_biscuit nm =
   do { print "=======================================";
        print (str_concat "Testing failure case: " nm);
        print "";
-       fails (crucible_llvm_verify m nm [] false
-         do { crucible_execute_func [];
-              crucible_return (crucible_term {{ 1:[32] }});
+       fails (llvm_verify m nm [] false
+         do { llvm_execute_func [];
+              llvm_return (llvm_term {{ 1:[32] }});
             }
          trivial);
   };

--- a/intTests/test0027_crucible_llvm/test.saw
+++ b/intTests/test0027_crucible_llvm/test.saw
@@ -1,18 +1,18 @@
 m <- llvm_load_module "test.bc";
 
-crucible_llvm_verify m "add_nums32" [] false
-  do { x <- crucible_fresh_var "x" (llvm_int 32);
-       y <- crucible_fresh_var "y" (llvm_int 32);
-       crucible_execute_func [ crucible_term x, crucible_term y ];
-       crucible_return (crucible_term {{ x + y }});
+llvm_verify m "add_nums32" [] false
+  do { x <- llvm_fresh_var "x" (llvm_int 32);
+       y <- llvm_fresh_var "y" (llvm_int 32);
+       llvm_execute_func [ llvm_term x, llvm_term y ];
+       llvm_return (llvm_term {{ x + y }});
      }
   z3;
 
 
-crucible_llvm_verify m "add_nums64" [] false
-  do { x <- crucible_fresh_var "x" (llvm_int 64);
-       y <- crucible_fresh_var "y" (llvm_int 64);
-       crucible_execute_func [ crucible_term x, crucible_term y ];
-       crucible_return (crucible_term {{ x + y }});
+llvm_verify m "add_nums64" [] false
+  do { x <- llvm_fresh_var "x" (llvm_int 64);
+       y <- llvm_fresh_var "y" (llvm_int 64);
+       llvm_execute_func [ llvm_term x, llvm_term y ];
+       llvm_return (llvm_term {{ x + y }});
      }
   z3;

--- a/intTests/test0028/test.saw
+++ b/intTests/test0028/test.saw
@@ -1,17 +1,17 @@
 /** f clears the 2x4 array of 32-bit unsigned ints in the referenced struct */
     let f_spec : CrucibleSetup() = do {
-        i <- crucible_fresh_var "w.i" (llvm_array 2 (llvm_array 4 (llvm_int 32)));
-        pw <- crucible_alloc (llvm_struct "struct.BI");
-        crucible_points_to pw (crucible_struct [crucible_term i]);
-        
-        crucible_execute_func [pw];
-        crucible_points_to pw (crucible_struct [crucible_term {{ zero:[2][4][32] }} ]);
+        i <- llvm_fresh_var "w.i" (llvm_array 2 (llvm_array 4 (llvm_int 32)));
+        pw <- llvm_alloc (llvm_struct "struct.BI");
+        llvm_points_to pw (llvm_struct_value [llvm_term i]);
+
+        llvm_execute_func [pw];
+        llvm_points_to pw (llvm_struct_value [llvm_term {{ zero:[2][4][32] }} ]);
     };
-    
+
     let main : TopLevel () = do {
         structTest <- llvm_load_module "test.bc";
-        
-        f_result <- crucible_llvm_verify structTest "f" [] false f_spec z3;
-        
+
+        f_result <- llvm_verify structTest "f" [] false f_spec z3;
+
         print "Done!";
     };

--- a/intTests/test0029/test.saw
+++ b/intTests/test0029/test.saw
@@ -1,56 +1,56 @@
-/** 
- * spec for mockup of subroutine that clears the given number of bytes from the 
- * arbitrary array pointed to by a given void * 
+/**
+ * spec for mockup of subroutine that clears the given number of bytes from the
+ * arbitrary array pointed to by a given void *
  */
 let clear_void_spec : CrucibleSetup() = do {
     let voidArrayType = (llvm_array 12 (llvm_int 8));
-    
-    arr <- (crucible_fresh_var "arr" voidArrayType);
-    p_arr <- (crucible_alloc voidArrayType);
-    let v_arr = (crucible_term arr);
-    
-    //size <- (crucible_fresh_var "size" (llvm_int 32));
-    //let v_size = (crucible_term size); 
-    //crucible_equal v_size (crucible_term {{ 12:[32] }});
 
-    let v_size = crucible_term {{ 12:[32] }};
+    arr <- (llvm_fresh_var "arr" voidArrayType);
+    p_arr <- (llvm_alloc voidArrayType);
+    let v_arr = (llvm_term arr);
 
-    crucible_points_to p_arr v_arr;
-    
-    crucible_execute_func [p_arr, v_size];
-    
-    crucible_points_to p_arr (crucible_term {{ zero:[12][8] }});
+    //size <- (llvm_fresh_var "size" (llvm_int 32));
+    //let v_size = (llvm_term size);
+    //llvm_equal v_size (llvm_term {{ 12:[32] }});
+
+    let v_size = llvm_term {{ 12:[32] }};
+
+    llvm_points_to p_arr v_arr;
+
+    llvm_execute_func [p_arr, v_size];
+
+    llvm_points_to p_arr (llvm_term {{ zero:[12][8] }});
 };
 
-/** 
- * spec for function that calls the subroutine to clear the given number of 
- * unsigned ints from the array pointed to by a specified unsigned int * 
- */ 
+/**
+ * spec for function that calls the subroutine to clear the given number of
+ * unsigned ints from the array pointed to by a specified unsigned int *
+ */
 let clear_uints_spec : CrucibleSetup() = do {
     let uintsType = (llvm_array 3 (llvm_int 32));
-    
-    uints <- (crucible_fresh_var "uints" uintsType);
-    p_uints <- (crucible_alloc uintsType);
-    let v_uints = (crucible_term uints);
-    
-    numUInts <- (crucible_fresh_var "numUInts" (llvm_int 32));
-    let v_numUInts = (crucible_term numUInts); 
-    crucible_equal v_numUInts (crucible_term {{ 3:[32] }});
-    //let v_numUInts = (crucible_term {{ 3:[32] }});
 
-    crucible_points_to p_uints v_uints;
-    
-    crucible_execute_func [p_uints, v_numUInts];
-    
-    crucible_points_to p_uints (crucible_term {{ zero:[3][32] }});
+    uints <- (llvm_fresh_var "uints" uintsType);
+    p_uints <- (llvm_alloc uintsType);
+    let v_uints = (llvm_term uints);
+
+    numUInts <- (llvm_fresh_var "numUInts" (llvm_int 32));
+    let v_numUInts = (llvm_term numUInts);
+    llvm_equal v_numUInts (llvm_term {{ 3:[32] }});
+    //let v_numUInts = (llvm_term {{ 3:[32] }});
+
+    llvm_points_to p_uints v_uints;
+
+    llvm_execute_func [p_uints, v_numUInts];
+
+    llvm_points_to p_uints (llvm_term {{ zero:[3][32] }});
 };
 
 let main : TopLevel () = do {
     voidTest <- llvm_load_module "test.bc";
-    
-    // The actual subroutine result would be "crucible_llvm_unsafe_assume_spec ..."
-    clear_void_12_result <- crucible_llvm_verify voidTest "clear_void" [] false clear_void_spec z3;
-    clear_uints_3_result <- crucible_llvm_verify voidTest "clear_uints" [clear_void_12_result] false clear_uints_spec z3;
-    
+
+    // The actual subroutine result would be "llvm_unsafe_assume_spec ..."
+    clear_void_12_result <- llvm_verify voidTest "clear_void" [] false clear_void_spec z3;
+    clear_uints_3_result <- llvm_verify voidTest "clear_uints" [clear_void_12_result] false clear_uints_spec z3;
+
     print "Done!";
 };

--- a/intTests/test0030_vectors/test.saw
+++ b/intTests/test0030_vectors/test.saw
@@ -2,7 +2,7 @@
 m <- llvm_load_module "vectortest.bc";
 
 let setup = do {
-  crucible_execute_func [ crucible_term {{ zero:[32] }}, crucible_null ];
-  crucible_return (crucible_term {{ zero:[32] }});
+  llvm_execute_func [ llvm_term {{ zero:[32] }}, llvm_null ];
+  llvm_return (llvm_term {{ zero:[32] }});
 };
-crucible_llvm_verify m "main" [] false setup z3;
+llvm_verify m "main" [] false setup z3;

--- a/intTests/test0031_unit_test/test.saw
+++ b/intTests/test0031_unit_test/test.saw
@@ -1,15 +1,15 @@
 
 let setup = do {
-  x <- crucible_fresh_var "x" (llvm_int 32);
+  x <- llvm_fresh_var "x" (llvm_int 32);
 
-  p_a <- crucible_alloc (llvm_struct "struct.a_t");
-  crucible_points_to p_a ( crucible_term {{ x }} );
+  p_a <- llvm_alloc (llvm_struct "struct.a_t");
+  llvm_points_to p_a ( llvm_term {{ x }} );
 
-  crucible_execute_func [ p_a ];
-  crucible_return (crucible_term {{ 3:[32] }});
+  llvm_execute_func [ p_a ];
+  llvm_return (llvm_term {{ 3:[32] }});
 
-  crucible_points_to p_a ( crucible_term {{ 3:[32] }} );
+  llvm_points_to p_a ( llvm_term {{ 3:[32] }} );
 };
 
 m <- llvm_load_module "test.bc";
-crucible_llvm_verify m "foo" [] false setup z3;
+llvm_verify m "foo" [] false setup z3;

--- a/intTests/test0032_clear_void/test.saw
+++ b/intTests/test0032_clear_void/test.saw
@@ -7,19 +7,19 @@
 let clear_void_spec : CrucibleSetup() = do {
     let voidArrayType = (llvm_array 12 (llvm_int 8));
     
-    arr <- (crucible_fresh_var "arr" voidArrayType);
-    p_arr <- (crucible_alloc voidArrayType);
-    let v_arr = (crucible_term arr);
+    arr <- (llvm_fresh_var "arr" voidArrayType);
+    p_arr <- (llvm_alloc voidArrayType);
+    let v_arr = (llvm_term arr);
     
-    size <- (crucible_fresh_var "size" (llvm_int 32));
-    let v_size = (crucible_term size); 
+    size <- (llvm_fresh_var "size" (llvm_int 32));
+    let v_size = (llvm_term size);
     
-    crucible_equal v_size (crucible_term {{ 12:[32] }});
-    crucible_points_to p_arr v_arr;
+    llvm_equal v_size (llvm_term {{ 12:[32] }});
+    llvm_points_to p_arr v_arr;
     
-    crucible_execute_func [p_arr, v_size];
+    llvm_execute_func [p_arr, v_size];
     
-    crucible_points_to p_arr (crucible_term {{ zero:[12][8] }});
+    llvm_points_to p_arr (llvm_term {{ zero:[12][8] }});
 };
 
 /** 
@@ -29,29 +29,29 @@ let clear_void_spec : CrucibleSetup() = do {
 let clear_uints_spec : CrucibleSetup() = do {
     let uintsType = (llvm_array 3 (llvm_int 32));
     
-    uints <- (crucible_fresh_var "uints" uintsType);
-    p_uints <- (crucible_alloc uintsType);
-    let v_uints = (crucible_term uints);
+    uints <- (llvm_fresh_var "uints" uintsType);
+    p_uints <- (llvm_alloc uintsType);
+    let v_uints = (llvm_term uints);
     
-    numUInts <- (crucible_fresh_var "numUInts" (llvm_int 32));
-    let v_numUInts = (crucible_term numUInts); 
+    numUInts <- (llvm_fresh_var "numUInts" (llvm_int 32));
+    let v_numUInts = (llvm_term numUInts);
     
-    crucible_equal v_numUInts (crucible_term {{ 3:[32] }});
-    crucible_points_to p_uints v_uints;
+    llvm_equal v_numUInts (llvm_term {{ 3:[32] }});
+    llvm_points_to p_uints v_uints;
     
-    crucible_execute_func [p_uints, v_numUInts];
+    llvm_execute_func [p_uints, v_numUInts];
     
-    crucible_points_to p_uints (crucible_term {{ zero:[3][32] }});
+    llvm_points_to p_uints (llvm_term {{ zero:[3][32] }});
 };
 
 let main : TopLevel () = do {
     voidTest <- llvm_load_module "voidTest.bc";
     
-    // The actual subroutine result would be "crucible_llvm_unsafe_assume_spec ..."
+    // The actual subroutine result would be "llvm_unsafe_assume_spec ..."
     enable_crucible_assert_then_assume;
-    clear_void_12_result <- crucible_llvm_verify voidTest "clear_void" [] true clear_void_spec z3;
+    clear_void_12_result <- llvm_verify voidTest "clear_void" [] true clear_void_spec z3;
     disable_crucible_assert_then_assume;
-    clear_uints_3_result <- crucible_llvm_verify voidTest "clear_uints" [clear_void_12_result] true clear_uints_spec z3;
+    clear_uints_3_result <- llvm_verify voidTest "clear_uints" [clear_void_12_result] true clear_uints_spec z3;
     
     print "Done!";
 };

--- a/intTests/test0036_global/test-fail.saw
+++ b/intTests/test0036_global/test-fail.saw
@@ -1,15 +1,15 @@
 m <- llvm_load_module "./test.bc";
 
-crucible_llvm_verify m "f" [] true (do {
-    y <- crucible_fresh_var "y" (llvm_int 32);
+llvm_verify m "f" [] true (do {
+    y <- llvm_fresh_var "y" (llvm_int 32);
     // We don't initialize x
-    crucible_execute_func [crucible_term y];
-    crucible_return (crucible_term {{ 1 + y : [32] }});
+    llvm_execute_func [llvm_term y];
+    llvm_return (llvm_term {{ 1 + y : [32] }});
 }) abc;
 
-crucible_llvm_verify m "g" [] true (do {
-    z <- crucible_fresh_var "z" (llvm_int 32);
+llvm_verify m "g" [] true (do {
+    z <- llvm_fresh_var "z" (llvm_int 32);
     // We don't initialize x
-    crucible_execute_func [crucible_term z];
-    crucible_return (crucible_term {{ 2 + z : [32] }});
+    llvm_execute_func [llvm_term z];
+    llvm_return (llvm_term {{ 2 + z : [32] }});
 }) abc;

--- a/intTests/test0036_global/test.saw
+++ b/intTests/test0036_global/test.saw
@@ -1,30 +1,30 @@
 m <- llvm_load_module "./test.bc";
 
 let init_global name = do {
-  crucible_alloc_global name;
-  crucible_points_to (crucible_global name)
-                     (crucible_global_initializer name);
+  llvm_alloc_global name;
+  llvm_points_to (llvm_global name)
+                 (llvm_global_initializer name);
 };
 
-f_spec <- crucible_llvm_verify m "f" [] true (do {
-    y <- crucible_fresh_var "y" (llvm_int 32);
+f_spec <- llvm_verify m "f" [] true (do {
+    y <- llvm_fresh_var "y" (llvm_int 32);
     init_global "x";
-    crucible_execute_func [crucible_term y];
-    crucible_return (crucible_term {{ 1 + y : [32] }});
+    llvm_execute_func [llvm_term y];
+    llvm_return (llvm_term {{ 1 + y : [32] }});
 }) abc;
 
-g_spec <- crucible_llvm_verify m "g" [] true (do {
-    z <- crucible_fresh_var "z" (llvm_int 32);
+g_spec <- llvm_verify m "g" [] true (do {
+    z <- llvm_fresh_var "z" (llvm_int 32);
     init_global "x";
-    crucible_execute_func [crucible_term z];
-    crucible_return (crucible_term {{ 2 + z : [32] }});
+    llvm_execute_func [llvm_term z];
+    llvm_return (llvm_term {{ 2 + z : [32] }});
 }) abc;
 
 // Note that the f and g overrides are not actually used for
 // rewriting, because their preconditions aren't met.
-crucible_llvm_verify m "h" [f_spec, g_spec] true (do {
-    w <- crucible_fresh_var "w" (llvm_int 32);
+llvm_verify m "h" [f_spec, g_spec] true (do {
+    w <- llvm_fresh_var "w" (llvm_int 32);
     init_global "x";
-    crucible_execute_func [crucible_term w];
-    crucible_return (crucible_term {{ 4 + w : [32] }});
+    llvm_execute_func [llvm_term w];
+    llvm_return (llvm_term {{ 4 + w : [32] }});
 }) abc;

--- a/intTests/test0037_popcount/test.saw
+++ b/intTests/test0037_popcount/test.saw
@@ -4,20 +4,20 @@ import "./spec.cry";
 let solver = z3;
 let sz = 32;
 
-crucible_llvm_verify m "popcount" [] true (do {
-  x <- crucible_fresh_var "x" (llvm_int sz);
-  crucible_execute_func [crucible_term {{ (zero # x):[32] }}];
-  crucible_return (crucible_term {{ popcount ((zero # x):[32]) }});
+llvm_verify m "popcount" [] true (do {
+  x <- llvm_fresh_var "x" (llvm_int sz);
+  llvm_execute_func [llvm_term {{ (zero # x):[32] }}];
+  llvm_return (llvm_term {{ popcount ((zero # x):[32]) }});
 }) solver;
 
-crucible_llvm_verify m "clz" [] true (do {
-  x <- crucible_fresh_var "x" (llvm_int sz);
-  crucible_execute_func [crucible_term {{ (zero # x):[32] }}];
-  crucible_return (crucible_term {{ clz ((zero # x):[32]) }});
+llvm_verify m "clz" [] true (do {
+  x <- llvm_fresh_var "x" (llvm_int sz);
+  llvm_execute_func [llvm_term {{ (zero # x):[32] }}];
+  llvm_return (llvm_term {{ clz ((zero # x):[32]) }});
 }) solver;
 
-crucible_llvm_verify m "ctz" [] true (do {
-  x <- crucible_fresh_var "x" (llvm_int sz);
-  crucible_execute_func [crucible_term {{ (zero # x):[32] }}];
-  crucible_return (crucible_term {{ ctz ((zero # x):[32]) }});
+llvm_verify m "ctz" [] true (do {
+  x <- llvm_fresh_var "x" (llvm_int sz);
+  llvm_execute_func [llvm_term {{ (zero # x):[32] }}];
+  llvm_return (llvm_term {{ ctz ((zero # x):[32]) }});
 }) solver;

--- a/intTests/test0038_rust/test.saw
+++ b/intTests/test0038_rust/test.saw
@@ -7,29 +7,29 @@ let f_spec : CrucibleSetup() = do {
     //
     //     %BI = type { [0 x i32], [2 x [4 x i32]], [0 x i32] }
     //
-    i <- crucible_fresh_var "w.i" (llvm_array 2 (llvm_array 4 (llvm_int 32)));
-    pw <- crucible_alloc (llvm_struct "BI");
-    crucible_points_to pw
-      (crucible_struct [ crucible_term {{ zero:[0][32] }}
-                        , crucible_term i
-                        , crucible_term {{ zero:[0][32] }}
-                        ]);
+    i <- llvm_fresh_var "w.i" (llvm_array 2 (llvm_array 4 (llvm_int 32)));
+    pw <- llvm_alloc (llvm_struct "BI");
+    llvm_points_to pw
+      (llvm_struct_value [ llvm_term {{ zero:[0][32] }}
+                         , llvm_term i
+                         , llvm_term {{ zero:[0][32] }}
+                         ]);
 
-    crucible_execute_func [pw];
-    crucible_points_to (crucible_elem pw 1) (crucible_term {{ zero:[2][4][32] }});
+    llvm_execute_func [pw];
+    llvm_points_to (llvm_elem pw 1) (llvm_term {{ zero:[2][4][32] }});
 
     // TODO: The following fails with a "generic memory load error"
-    // crucible_points_to pw
-    //   (crucible_struct [ crucible_term {{ zero:[0][32] }}
-    //                    , crucible_term {{ zero:[2][4][32] }}
-    //                    , crucible_term {{ zero:[0][32] }}
-    //                    ]);
+    // llvm_points_to pw
+    //   (llvm_struct_value [ llvm_term {{ zero:[0][32] }}
+    //                      , llvm_term {{ zero:[2][4][32] }}
+    //                      , llvm_term {{ zero:[0][32] }}
+    //                      ]);
 };
 
 let main : TopLevel () = do {
     structTest <- llvm_load_module "test.bc";
 
-    f_result <- crucible_llvm_verify structTest "f" [] false f_spec z3;
+    f_result <- llvm_verify structTest "f" [] false f_spec z3;
 
     print "Done!";
 };

--- a/intTests/test0039_rust/test.saw
+++ b/intTests/test0039_rust/test.saw
@@ -1,29 +1,29 @@
 m <- llvm_load_module "./test.bc";
 
 let init_global name = do {
-  crucible_points_to (crucible_global name)
-                     (crucible_global_initializer name);
+  llvm_points_to (llvm_global name)
+                 (llvm_global_initializer name);
 };
 
-f_spec <- crucible_llvm_verify m "f" [] true (do {
-    y <- crucible_fresh_var "y" (llvm_int 32);
+f_spec <- llvm_llvm_verify m "f" [] true (do {
+    y <- llvm_fresh_var "y" (llvm_int 32);
     init_global "X";
-    crucible_execute_func [crucible_term y];
-    crucible_return (crucible_term {{ 1 + y : [32] }});
+    llvm_execute_func [llvm_term y];
+    llvm_return (llvm_term {{ 1 + y : [32] }});
 }) abc;
 
-g_spec <- crucible_llvm_verify m "g" [] true (do {
-    z <- crucible_fresh_var "z" (llvm_int 32);
+g_spec <- llvm_verify m "g" [] true (do {
+    z <- llvm_fresh_var "z" (llvm_int 32);
     init_global "X";
-    crucible_execute_func [crucible_term z];
-    crucible_return (crucible_term {{ 2 + z : [32] }});
+    llvm_execute_func [llvm_term z];
+    llvm_return (llvm_term {{ 2 + z : [32] }});
 }) abc;
 
 // Note that the f and g overrides are not actually used for
 // rewriting, because their preconditions aren't met.
-crucible_llvm_verify m "h" [f_spec, g_spec] true (do {
-    w <- crucible_fresh_var "w" (llvm_int 32);
+llvm_verify m "h" [f_spec, g_spec] true (do {
+    w <- llvm_fresh_var "w" (llvm_int 32);
     init_global "X";
-    crucible_execute_func [crucible_term w];
-    crucible_return (crucible_term {{ 4 + w : [32] }});
+    llvm_execute_func [llvm_term w];
+    llvm_return (llvm_term {{ 4 + w : [32] }});
 }) abc;

--- a/intTests/test0040_statics/test.saw
+++ b/intTests/test0040_statics/test.saw
@@ -1,20 +1,20 @@
 m <- llvm_load_module "static.bc";
 
-f_ov <- crucible_llvm_verify m "f" [] false do {
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    let xtm = crucible_term x;
-    crucible_execute_func [xtm];
-    crucible_return xtm;
+f_ov <- llvm_verify m "f" [] false do {
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    let xtm = llvm_term x;
+    llvm_execute_func [xtm];
+    llvm_return xtm;
 } abc;
 
-crucible_llvm_verify m "f1" [f_ov] false do {
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    crucible_execute_func [crucible_term x];
-    crucible_return (crucible_term {{ x + 1}});
+llvm_verify m "f1" [f_ov] false do {
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    llvm_execute_func [llvm_term x];
+    llvm_return (llvm_term {{ x + 1}});
 } abc;
 
-crucible_llvm_verify m "f2" [f_ov] false do {
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    crucible_execute_func [crucible_term x];
-    crucible_return (crucible_term {{ x - 1}});
+llvm_verify m "f2" [f_ov] false do {
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    llvm_execute_func [llvm_term x];
+    llvm_return (llvm_term {{ x - 1}});
 } abc;

--- a/intTests/test0041_invariant_1/test.saw
+++ b/intTests/test0041_invariant_1/test.saw
@@ -1,24 +1,24 @@
 m <- llvm_load_module "test.bc";
 
 let ptr_to_fresh n ty = do {
-  p <- crucible_alloc ty;
-  x <- crucible_fresh_var n ty;
-  crucible_points_to p (crucible_term x);
+  p <- llvm_alloc ty;
+  x <- llvm_fresh_var n ty;
+  llvm_points_to p (llvm_term x);
   return (p, x);
 };
 
 let add2_spec = do {
-  x <- crucible_fresh_var "x" (llvm_int 64);
-  crucible_execute_func [crucible_term x];
-  crucible_return (crucible_term {{ x + 2 }});
+  x <- llvm_fresh_var "x" (llvm_int 64);
+  llvm_execute_func [llvm_term x];
+  llvm_return (llvm_term {{ x + 2 }});
 };
 
 let inv_spec = do {
   (px, x) <- ptr_to_fresh "x" (llvm_int 64);
-  crucible_execute_func [px];
-  crucible_return (crucible_term {{ x + 1 }});
+  llvm_execute_func [px];
+  llvm_return (llvm_term {{ x + 1 }});
 };
 
-inv <- crucible_llvm_verify m "__breakpoint__inv#add2" [] false inv_spec abc;
-crucible_llvm_verify m "add2" [inv] false add2_spec abc;
+inv <- llvm_verify m "__breakpoint__inv#add2" [] false inv_spec abc;
+llvm_verify m "add2" [inv] false add2_spec abc;
 

--- a/intTests/test0042_invariant_2/test.saw
+++ b/intTests/test0042_invariant_2/test.saw
@@ -1,26 +1,26 @@
 m <- llvm_load_module "test.bc";
 
 let ptr_to_fresh n ty = do {
-  p <- crucible_alloc ty;
-  x <- crucible_fresh_var n ty;
-  crucible_points_to p (crucible_term x);
+  p <- llvm_alloc ty;
+  x <- llvm_fresh_var n ty;
+  llvm_points_to p (llvm_term x);
   return (p, x);
 };
 
 let zero_inc_spec = do {
-  x <- crucible_fresh_var "x" (llvm_int 64);
-  crucible_execute_func [crucible_term x];
-  r <- crucible_fresh_var "r" (llvm_int 64);
-  crucible_postcond {{ r > 0 }};
-  crucible_return (crucible_term {{ r }});
+  x <- llvm_fresh_var "x" (llvm_int 64);
+  llvm_execute_func [llvm_term x];
+  r <- llvm_fresh_var "r" (llvm_int 64);
+  llvm_postcond {{ r > 0 }};
+  llvm_return (llvm_term {{ r }});
 };
 
 let inv_spec = do {
   (px, x) <- ptr_to_fresh "x" (llvm_int 64);
-  crucible_execute_func [px];
-  crucible_return (crucible_term {{ x + 1 }});
+  llvm_execute_func [px];
+  llvm_return (llvm_term {{ x + 1 }});
 };
 
-inv <- crucible_llvm_verify m "__breakpoint__inv#zero_inc" [] false inv_spec abc;
-crucible_llvm_verify m "zero_inc" [inv] false zero_inc_spec abc;
+inv <- llvm_verify m "__breakpoint__inv#zero_inc" [] false inv_spec abc;
+llvm_verify m "zero_inc" [inv] false zero_inc_spec abc;
 

--- a/intTests/test0043_invariant_3/test.saw
+++ b/intTests/test0043_invariant_3/test.saw
@@ -1,28 +1,28 @@
 m <- llvm_load_module "test.bc";
 
 let ptr_to_fresh n ty = do {
-  p <- crucible_alloc ty;
-  x <- crucible_fresh_var n ty;
-  crucible_points_to p (crucible_term x);
+  p <- llvm_alloc ty;
+  x <- llvm_fresh_var n ty;
+  llvm_points_to p (llvm_term x);
   return (p, x);
 };
 
 let count_n_spec = do {
-  n <- crucible_fresh_var "n" (llvm_int 64);
-  crucible_execute_func [crucible_term n];
-  crucible_return (crucible_term n);
+  n <- llvm_fresh_var "n" (llvm_int 64);
+  llvm_execute_func [llvm_term n];
+  llvm_return (llvm_term n);
 };
 
 let inv_spec = do {
   (pn, n) <- ptr_to_fresh "n" (llvm_int 64);
   (pc, c) <- ptr_to_fresh "c" (llvm_int 64);
   (pi, i) <- ptr_to_fresh "i" (llvm_int 64);
-  crucible_precond {{ 0 <= i /\ i <= n }};
-  crucible_execute_func [pn, pc, pi];
-  crucible_return (crucible_term {{ c + (n - i) }});
+  llvm_precond {{ 0 <= i /\ i <= n }};
+  llvm_execute_func [pn, pc, pi];
+  llvm_return (llvm_term {{ c + (n - i) }});
 };
 
-inv <- crucible_llvm_unsafe_assume_spec m "__breakpoint__inv#count_n" inv_spec;
-crucible_llvm_verify m "__breakpoint__inv#count_n" [inv] false inv_spec abc;
-crucible_llvm_verify m "count_n" [inv] false count_n_spec abc;
+inv <- llvm_unsafe_assume_spec m "__breakpoint__inv#count_n" inv_spec;
+llvm_verify m "__breakpoint__inv#count_n" [inv] false inv_spec abc;
+llvm_verify m "count_n" [inv] false count_n_spec abc;
 

--- a/intTests/test0044_invariant_4/test.saw
+++ b/intTests/test0044_invariant_4/test.saw
@@ -1,9 +1,9 @@
 m <- llvm_load_module "test.bc";
 
 let ptr_to_fresh n ty = do {
-  p <- crucible_alloc ty;
-  x <- crucible_fresh_var n ty;
-  crucible_points_to p (crucible_term x);
+  p <- llvm_alloc ty;
+  x <- llvm_fresh_var n ty;
+  llvm_points_to p (llvm_term x);
   return (p, x);
 };
 
@@ -11,23 +11,23 @@ let len = 100;
 
 let array_inc_spec = do {
   (pa, a) <- ptr_to_fresh "a" (llvm_array len (llvm_int 8));
-  let n = crucible_term {{ `len : [64] }};
-  crucible_execute_func [pa, n];
+  let n = llvm_term {{ `len : [64] }};
+  llvm_execute_func [pa, n];
 };
 
 let inv_spec = do {
   (pa, a) <- ptr_to_fresh "a" (llvm_array len (llvm_int 8));
-  ppa <- crucible_alloc (llvm_int 64);
-  crucible_points_to ppa pa;
-  let n = crucible_term {{ `len : [64] }};
-  pn <- crucible_alloc (llvm_int 64);
-  crucible_points_to pn n;
+  ppa <- llvm_alloc (llvm_int 64);
+  llvm_points_to ppa pa;
+  let n = llvm_term {{ `len : [64] }};
+  pn <- llvm_alloc (llvm_int 64);
+  llvm_points_to pn n;
   (pi, i) <- ptr_to_fresh "i" (llvm_int 64);
-  crucible_precond {{ 0 <= i /\ i <= `len }};
-  crucible_execute_func [ppa, pn, pi];
+  llvm_precond {{ 0 <= i /\ i <= `len }};
+  llvm_execute_func [ppa, pn, pi];
 };
 
-inv <- crucible_llvm_unsafe_assume_spec m "__breakpoint__inv#array_inc" inv_spec;
-crucible_llvm_verify m "__breakpoint__inv#array_inc" [inv] false inv_spec abc;
-crucible_llvm_verify m "array_inc" [inv] false array_inc_spec abc;
+inv <- llvm_unsafe_assume_spec m "__breakpoint__inv#array_inc" inv_spec;
+llvm_verify m "__breakpoint__inv#array_inc" [inv] false inv_spec abc;
+llvm_verify m "array_inc" [inv] false array_inc_spec abc;
 

--- a/intTests/test0045_invariant_5/test.saw
+++ b/intTests/test0045_invariant_5/test.saw
@@ -1,9 +1,9 @@
 m <- llvm_load_module "test.bc";
 
 let ptr_to_fresh n ty = do {
-  p <- crucible_alloc ty;
-  x <- crucible_fresh_var n ty;
-  crucible_points_to p (crucible_term x);
+  p <- llvm_alloc ty;
+  x <- llvm_fresh_var n ty;
+  llvm_points_to p (llvm_term x);
   return (p, x);
 };
 
@@ -11,47 +11,47 @@ let len = 100;
 
 let multiple_array_inc_spec = do {
   (pa, a) <- ptr_to_fresh "a" (llvm_array len (llvm_int 8));
-  let n = crucible_term {{ `len : [64] }};
-  m <- crucible_fresh_var "m" (llvm_int 64);
-  crucible_execute_func [pa, n, crucible_term m];
+  let n = llvm_term {{ `len : [64] }};
+  m <- llvm_fresh_var "m" (llvm_int 64);
+  llvm_execute_func [pa, n, llvm_term m];
 };
 
 let outer_inv_spec = do {
   (pa, a) <- ptr_to_fresh "a" (llvm_array len (llvm_int 8));
-  ppa <- crucible_alloc (llvm_int 64);
-  crucible_points_to ppa pa;
-  let n = crucible_term {{ `len : [64] }};
-  pn <- crucible_alloc (llvm_int 64);
-  crucible_points_to pn n;
+  ppa <- llvm_alloc (llvm_int 64);
+  llvm_points_to ppa pa;
+  let n = llvm_term {{ `len : [64] }};
+  pn <- llvm_alloc (llvm_int 64);
+  llvm_points_to pn n;
   (pm, m) <- ptr_to_fresh "m" (llvm_int 64);
-  pi <- crucible_alloc (llvm_int 64);
+  pi <- llvm_alloc (llvm_int 64);
   (pj, j) <- ptr_to_fresh "j" (llvm_int 64);
-  crucible_precond {{ 0 <= j /\ j <= m }};
-  crucible_execute_func [ppa, pn, pm, pi, pj];
+  llvm_precond {{ 0 <= j /\ j <= m }};
+  llvm_execute_func [ppa, pn, pm, pi, pj];
 };
 
 let inner_inv_spec = do {
   (pa, a) <- ptr_to_fresh "a" (llvm_array len (llvm_int 8));
-  ppa <- crucible_alloc (llvm_int 64);
-  crucible_points_to ppa pa;
-  let n = crucible_term {{ `len : [64] }};
-  pn <- crucible_alloc (llvm_int 64);
-  crucible_points_to pn n;
+  ppa <- llvm_alloc (llvm_int 64);
+  llvm_points_to ppa pa;
+  let n = llvm_term {{ `len : [64] }};
+  pn <- llvm_alloc (llvm_int 64);
+  llvm_points_to pn n;
   (pm, m) <- ptr_to_fresh "m" (llvm_int 64);
   (pi, i) <- ptr_to_fresh "i" (llvm_int 64);
   (pj, j) <- ptr_to_fresh "j" (llvm_int 64);
-  crucible_precond {{ 0 <= j /\ j < m }};
-  crucible_precond {{ 0 <= i /\ i <= `len }};
-  crucible_execute_func [ppa, pn, pm, pi, pj];
+  llvm_precond {{ 0 <= j /\ j < m }};
+  llvm_precond {{ 0 <= i /\ i <= `len }};
+  llvm_execute_func [ppa, pn, pm, pi, pj];
 };
 
-inner_inv <- crucible_llvm_unsafe_assume_spec m "__breakpoint__inner_inv#multiple_array_inc" inner_inv_spec;
-outer_inv <- crucible_llvm_unsafe_assume_spec m "__breakpoint__outer_inv#multiple_array_inc" outer_inv_spec;
+inner_inv <- llvm_unsafe_assume_spec m "__breakpoint__inner_inv#multiple_array_inc" inner_inv_spec;
+outer_inv <- llvm_unsafe_assume_spec m "__breakpoint__outer_inv#multiple_array_inc" outer_inv_spec;
 
-crucible_llvm_verify m "__breakpoint__inner_inv#multiple_array_inc" [inner_inv, outer_inv] false inner_inv_spec abc;
-crucible_llvm_verify m "__breakpoint__outer_inv#multiple_array_inc" [inner_inv, outer_inv] false outer_inv_spec abc;
-crucible_llvm_verify m "multiple_array_inc" [inner_inv, outer_inv] false multiple_array_inc_spec abc;
+llvm_verify m "__breakpoint__inner_inv#multiple_array_inc" [inner_inv, outer_inv] false inner_inv_spec abc;
+llvm_verify m "__breakpoint__outer_inv#multiple_array_inc" [inner_inv, outer_inv] false outer_inv_spec abc;
+llvm_verify m "multiple_array_inc" [inner_inv, outer_inv] false multiple_array_inc_spec abc;
 
-crucible_llvm_verify m "__breakpoint__inner_inv#multiple_array_inc" [inner_inv] false inner_inv_spec abc;
-crucible_llvm_verify m "multiple_array_inc" [inner_inv] false multiple_array_inc_spec abc;
+llvm_verify m "__breakpoint__inner_inv#multiple_array_inc" [inner_inv] false inner_inv_spec abc;
+llvm_verify m "multiple_array_inc" [inner_inv] false multiple_array_inc_spec abc;
 

--- a/intTests/test0046_memcpy/test.saw
+++ b/intTests/test0046_memcpy/test.saw
@@ -1,21 +1,21 @@
 m <- llvm_load_module "test.bc";
 
 let f_setup = do {
-  xp <- crucible_alloc_readonly (llvm_array 4 (llvm_int 8));
-  crucible_execute_func [xp];
+  xp <- llvm_alloc_readonly (llvm_array 4 (llvm_int 8));
+  llvm_execute_func [xp];
   };
 
 // should fail because destination is not mutable,
 // even though the memcpy is 0 length
-fails (crucible_llvm_verify m "f" [] false f_setup z3);
+fails (llvm_verify m "f" [] false f_setup z3);
 
 let g_setup = do {
-  xp <- crucible_alloc (llvm_array 4 (llvm_int 8));
-  crucible_execute_func [xp];
+  xp <- llvm_alloc (llvm_array 4 (llvm_int 8));
+  llvm_execute_func [xp];
   };
 
 // should succeed because memcpy is allowed to copy uninitilized bytes
-crucible_llvm_verify m "g" [] false g_setup z3;
+llvm_verify m "g" [] false g_setup z3;
 
 // fails because direct reading of uninitialized bytes is not allowed
-fails (crucible_llvm_verify m "h" [] false g_setup z3); // as it should
+fails (llvm_verify m "h" [] false g_setup z3); // as it should

--- a/intTests/test0047_alloc_sized/test.saw
+++ b/intTests/test0047_alloc_sized/test.saw
@@ -1,12 +1,12 @@
 // Ultimately, this spec is unsound when used as an override due to issue #30,
-// but it demonstrates the crucible_alloc_with_size feature.
+// but it demonstrates the llvm_alloc_with_size feature.
 m <- llvm_load_module "test.bc";
 enable_experimental;
 let set_spec = do {
   // sizeof(A_t) + sizeof(B_t) = 8
-  both_ptr <- crucible_alloc_with_size 8 (llvm_type "%struct.A");
-  crucible_points_to (crucible_field both_ptr "x") (crucible_term {{ 0 : [32] }});
-  crucible_execute_func [both_ptr];
-  crucible_points_to (crucible_field both_ptr "x") (crucible_term {{ 10 : [32] }});
+  both_ptr <- llvm_alloc_with_size 8 (llvm_type "%struct.A");
+  llvm_points_to (llvm_field both_ptr "x") (llvm_term {{ 0 : [32] }});
+  llvm_execute_func [both_ptr];
+  llvm_points_to (llvm_field both_ptr "x") (llvm_term {{ 10 : [32] }});
 };
-crucible_llvm_verify m "set" [] false set_spec z3;
+llvm_verify m "set" [] false set_spec z3;

--- a/intTests/test0048_alloc_post/test.saw
+++ b/intTests/test0048_alloc_post/test.saw
@@ -1,9 +1,9 @@
 m <- llvm_load_module "test.bc";
 let make_A_spec = do {
-  b <- crucible_fresh_var "b" (llvm_type "%struct.B");
-  crucible_execute_func [crucible_term b];
-  a_ptr <- crucible_alloc (llvm_type "%struct.A");
-  crucible_points_to (crucible_field a_ptr "b") (crucible_term b);
-  crucible_return a_ptr;
+  b <- llvm_fresh_var "b" (llvm_type "%struct.B");
+  llvm_execute_func [llvm_term b];
+  a_ptr <- llvm_alloc (llvm_type "%struct.A");
+  llvm_points_to (llvm_field a_ptr "b") (llvm_term b);
+  llvm_return a_ptr;
 };
-crucible_llvm_verify m "make_A" [] false make_A_spec z3;
+llvm_verify m "make_A" [] false make_A_spec z3;

--- a/intTests/test0049_conditional_points_to/test.saw
+++ b/intTests/test0049_conditional_points_to/test.saw
@@ -1,67 +1,67 @@
 m <- llvm_load_module "test.bc";
 
 let get_val_impl_spec = do {
-  p <- crucible_alloc (llvm_int 32);
-  x <- crucible_fresh_var "x" (llvm_int 32);
-  crucible_execute_func [p, crucible_term x];
-  crucible_conditional_points_to {{ x >$ 0 }} p (crucible_term x);
-  crucible_return (crucible_term {{ (if x >$ 0 then 0 else 1) : [32] }});
+  p <- llvm_alloc (llvm_int 32);
+  x <- llvm_fresh_var "x" (llvm_int 32);
+  llvm_execute_func [p, llvm_term x];
+  llvm_conditional_points_to {{ x >$ 0 }} p (llvm_term x);
+  llvm_return (llvm_term {{ (if x >$ 0 then 0 else 1) : [32] }});
 };
 
 let get_val_impl_failure_spec = do {
-  p <- crucible_alloc (llvm_int 32);
-  x <- crucible_fresh_var "x" (llvm_int 32);
-  crucible_execute_func [p, crucible_term x];
+  p <- llvm_alloc (llvm_int 32);
+  x <- llvm_fresh_var "x" (llvm_int 32);
+  llvm_execute_func [p, llvm_term x];
   // incorrect spec: {{ x > 0 }} instead of {{ x >$ 0 }}
-  crucible_conditional_points_to {{ x > 0 }} p (crucible_term x);
+  llvm_conditional_points_to {{ x > 0 }} p (llvm_term x);
 };
 
 let get_val_spec = do {
-  p <- crucible_alloc (llvm_int 32);
-  x <- crucible_fresh_var "x" (llvm_int 32);
-  crucible_execute_func [p, crucible_term x];
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  y <- crucible_fresh_var "y" (llvm_int 32);
-  crucible_conditional_points_to {{ ret == 0 }} p (crucible_term y);
-  crucible_postcond {{ ret == 0 ==> y >$ 0 }};
-  crucible_return (crucible_term ret);
+  p <- llvm_alloc (llvm_int 32);
+  x <- llvm_fresh_var "x" (llvm_int 32);
+  llvm_execute_func [p, llvm_term x];
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  y <- llvm_fresh_var "y" (llvm_int 32);
+  llvm_conditional_points_to {{ ret == 0 }} p (llvm_term y);
+  llvm_postcond {{ ret == 0 ==> y >$ 0 }};
+  llvm_return (llvm_term ret);
 };
 
 let get_val_failure0_spec = do {
-  p <- crucible_alloc (llvm_int 32);
-  x <- crucible_fresh_var "x" (llvm_int 32);
-  crucible_execute_func [p, crucible_term x];
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  y <- crucible_fresh_var "y" (llvm_int 32);
-  crucible_conditional_points_to {{ ret == 0 }} p (crucible_term y);
+  p <- llvm_alloc (llvm_int 32);
+  x <- llvm_fresh_var "x" (llvm_int 32);
+  llvm_execute_func [p, llvm_term x];
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  y <- llvm_fresh_var "y" (llvm_int 32);
+  llvm_conditional_points_to {{ ret == 0 }} p (llvm_term y);
   // incorrect spec: {{ y >$ 0 }} instead of {{ ret == 0 ==> y >$ 0 }}
-  crucible_postcond {{ y >$ 0 }};
-  crucible_return (crucible_term ret);
+  llvm_postcond {{ y >$ 0 }};
+  llvm_return (llvm_term ret);
 };
 
 let get_val_failure1_spec = do {
-  p <- crucible_alloc (llvm_int 32);
-  v <- crucible_fresh_var "v" (llvm_int 32);
-  crucible_points_to p (crucible_term v);
-  x <- crucible_fresh_var "x" (llvm_int 32);
-  crucible_execute_func [p, crucible_term x];
-  y <- crucible_fresh_var "y" (llvm_int 32);
+  p <- llvm_alloc (llvm_int 32);
+  v <- llvm_fresh_var "v" (llvm_int 32);
+  llvm_points_to p (llvm_term v);
+  x <- llvm_fresh_var "x" (llvm_int 32);
+  llvm_execute_func [p, llvm_term x];
+  y <- llvm_fresh_var "y" (llvm_int 32);
   // incorrect spec: p is invalidated by get_val_impl_spec
-  crucible_points_to p (crucible_term y);
+  llvm_points_to p (llvm_term y);
 };
 
 let get_val_default_spec = do {
-  x <- crucible_fresh_var "x" (llvm_int 32);
-  crucible_execute_func [crucible_term x];
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  crucible_postcond {{ ret >= 0 }};
-  crucible_return (crucible_term ret);
+  x <- llvm_fresh_var "x" (llvm_int 32);
+  llvm_execute_func [llvm_term x];
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  llvm_postcond {{ ret >= 0 }};
+  llvm_return (llvm_term ret);
 };
 
-get_val_imp_ov <- crucible_llvm_verify m "get_val_impl" [] false get_val_impl_spec (w4_unint_yices []);
-fails (crucible_llvm_verify m "get_val_impl" [] false get_val_impl_failure_spec (w4_unint_yices []));
-get_val_ov <- crucible_llvm_verify m "get_val" [get_val_imp_ov] false get_val_spec (w4_unint_yices []);
-fails (crucible_llvm_verify m "get_val" [get_val_imp_ov] false get_val_failure0_spec (w4_unint_yices []));
-fails (crucible_llvm_verify m "get_val" [get_val_imp_ov] false get_val_failure1_spec (w4_unint_yices []));
-crucible_llvm_verify m "get_val_default" [get_val_ov] false get_val_default_spec (w4_unint_yices []);
+get_val_imp_ov <- llvm_verify m "get_val_impl" [] false get_val_impl_spec (w4_unint_yices []);
+fails (llvm_verify m "get_val_impl" [] false get_val_impl_failure_spec (w4_unint_yices []));
+get_val_ov <- llvm_verify m "get_val" [get_val_imp_ov] false get_val_spec (w4_unint_yices []);
+fails (llvm_verify m "get_val" [get_val_imp_ov] false get_val_failure0_spec (w4_unint_yices []));
+fails (llvm_verify m "get_val" [get_val_imp_ov] false get_val_failure1_spec (w4_unint_yices []));
+llvm_verify m "get_val_default" [get_val_ov] false get_val_default_spec (w4_unint_yices []);
 

--- a/intTests/test0050_compositional_extract_1/test.saw
+++ b/intTests/test0050_compositional_extract_1/test.saw
@@ -3,31 +3,31 @@ enable_experimental;
 m <- llvm_load_module "test.bc";
 
 let ptr_to_fresh nm ty = do {
-    x <- crucible_fresh_var nm ty;
-    p <- crucible_alloc ty;
-    crucible_points_to p (crucible_term x);
+    x <- llvm_fresh_var nm ty;
+    p <- llvm_alloc ty;
+    llvm_points_to p (llvm_term x);
     return (x, p);
 };
 
 let foo_spec = do {
   (_, p_p) <- ptr_to_fresh "p" (llvm_int 32);
-  x <- crucible_fresh_var "x" (llvm_int 32);
-  crucible_execute_func [p_p, crucible_term x];
-  p <- crucible_fresh_var "p" (llvm_int 32);
-  crucible_points_to p_p (crucible_term p);
-  r <- crucible_fresh_var "r" (llvm_int 32);
-  crucible_return (crucible_term r);
+  x <- llvm_fresh_var "x" (llvm_int 32);
+  llvm_execute_func [p_p, llvm_term x];
+  p <- llvm_fresh_var "p" (llvm_int 32);
+  llvm_points_to p_p (llvm_term p);
+  r <- llvm_fresh_var "r" (llvm_int 32);
+  llvm_return (llvm_term r);
 };
 
 let bar_spec = do {
   (_, p_p) <- ptr_to_fresh "p" (llvm_int 32);
-  crucible_execute_func [p_p];
-  p <- crucible_fresh_var "p" (llvm_int 32);
-  crucible_points_to p_p (crucible_term p);
+  llvm_execute_func [p_p];
+  p <- llvm_fresh_var "p" (llvm_int 32);
+  llvm_points_to p_p (llvm_term p);
 };
 
-foo_ov <- crucible_llvm_compositional_extract m "foo" "f" [] false foo_spec abc;
-_ <- crucible_llvm_compositional_extract m "bar" "g" [foo_ov] false bar_spec abc;
+foo_ov <- llvm_compositional_extract m "foo" "f" [] false foo_spec abc;
+_ <- llvm_compositional_extract m "bar" "g" [foo_ov] false bar_spec abc;
 
 f_thm <- prove_print abc {{ \x p -> f x p == (p + x, p + x) }};
 fails (prove_print (do { unfolding ["g"]; w4_unint_yices ["f"]; }) {{ \p -> g p == 2 * (p + 1) }});

--- a/intTests/test0051_compositional_extract_2/test.saw
+++ b/intTests/test0051_compositional_extract_2/test.saw
@@ -3,31 +3,31 @@ enable_experimental;
 m <- llvm_load_module "test.bc";
 
 let ptr_to_fresh nm ty = do {
-    x <- crucible_fresh_var nm ty;
-    p <- crucible_alloc ty;
-    crucible_points_to p (crucible_term x);
+    x <- llvm_fresh_var nm ty;
+    p <- llvm_alloc ty;
+    llvm_points_to p (llvm_term x);
     return (x, p);
 };
 
 let add_spec = do {
-  r_p <- crucible_alloc (llvm_struct "struct.uint128_t");
+  r_p <- llvm_alloc (llvm_struct "struct.uint128_t");
   (_, a_p) <- ptr_to_fresh "a" (llvm_struct "struct.uint128_t");
   (_, b_p) <- ptr_to_fresh "b" (llvm_struct "struct.uint128_t");
-  crucible_execute_func [r_p, a_p, b_p];
-  r <- crucible_fresh_var "r" (llvm_struct "struct.uint128_t");
-  crucible_points_to r_p (crucible_term r);
+  llvm_execute_func [r_p, a_p, b_p];
+  r <- llvm_fresh_var "r" (llvm_struct "struct.uint128_t");
+  llvm_points_to r_p (llvm_term r);
 };
 
 let sum_spec n = do {
-  s_p <- crucible_alloc (llvm_struct "struct.uint128_t");
+  s_p <- llvm_alloc (llvm_struct "struct.uint128_t");
   (_, a_p) <- ptr_to_fresh "a" (llvm_array n (llvm_struct "struct.uint128_t"));
-  crucible_execute_func [s_p, a_p, (crucible_term {{ `n:[64] }})];
-  s <- crucible_fresh_var "s" (llvm_struct "struct.uint128_t");
-  crucible_points_to s_p (crucible_term s);
+  llvm_execute_func [s_p, a_p, (llvm_term {{ `n:[64] }})];
+  s <- llvm_fresh_var "s" (llvm_struct "struct.uint128_t");
+  llvm_points_to s_p (llvm_term s);
 };
 
-add_ov <- crucible_llvm_compositional_extract m "add" "add" [] false add_spec abc;
-_ <- crucible_llvm_compositional_extract m "sum" "sum" [add_ov] false (sum_spec 10) abc;
+add_ov <- llvm_compositional_extract m "add" "add" [] false add_spec abc;
+_ <- llvm_compositional_extract m "sum" "sum" [add_ov] false (sum_spec 10) abc;
 
 add_thm <- prove_print abc
   {{ \a b -> add a b == reverse (split ((join (reverse a)) + (join (reverse b)))) }};

--- a/intTests/test0053_crucible_symbolic_alloc/test.saw
+++ b/intTests/test0053_crucible_symbolic_alloc/test.saw
@@ -3,28 +3,28 @@ enable_experimental;
 m <- llvm_load_module "test.bc";
 
 let foo_spec check = do {
-  n <- crucible_fresh_var "n" (llvm_int 64);
-  x_ptr <- crucible_symbolic_alloc false 4 {{ n * 4 }};
-  i <- crucible_fresh_var "i" (llvm_int 64);
-  crucible_precond {{ n < 2 ^^ 61 }};
+  n <- llvm_fresh_var "n" (llvm_int 64);
+  x_ptr <- llvm_symbolic_alloc false 4 {{ n * 4 }};
+  i <- llvm_fresh_var "i" (llvm_int 64);
+  llvm_precond {{ n < 2 ^^ 61 }};
   if check then do {
-    crucible_precond {{ i < n }};
+    llvm_precond {{ i < n }};
   } else do {
     return ();
   };
-  crucible_execute_func [x_ptr, (crucible_term n), (crucible_term i)];
+  llvm_execute_func [x_ptr, (llvm_term n), (llvm_term i)];
 };
 
 let bar_spec = do {
-  n <- crucible_fresh_var "n" (llvm_int 64);
-  x_ptr <- crucible_symbolic_alloc false 4 n;
-  i <- crucible_fresh_var "i" (llvm_int 64);
-  crucible_precond {{ n < 2 ^^ 63 }};
-  crucible_precond {{ n && 3 == 0 }};
-  crucible_execute_func [x_ptr, (crucible_term n), (crucible_term i)];
+  n <- llvm_fresh_var "n" (llvm_int 64);
+  x_ptr <- llvm_symbolic_alloc false 4 n;
+  i <- llvm_fresh_var "i" (llvm_int 64);
+  llvm_precond {{ n < 2 ^^ 63 }};
+  llvm_precond {{ n && 3 == 0 }};
+  llvm_execute_func [x_ptr, (llvm_term n), (llvm_term i)];
 };
 
-fails (crucible_llvm_verify m "foo" [] false (foo_spec false) abc);
-foo_ov <- crucible_llvm_verify m "foo" [] false (foo_spec true) abc;
-crucible_llvm_verify m "bar" [foo_ov] false bar_spec abc;
+fails (llvm_verify m "foo" [] false (foo_spec false) abc);
+foo_ov <- llvm_verify m "foo" [] false (foo_spec true) abc;
+llvm_verify m "bar" [foo_ov] false bar_spec abc;
 

--- a/intTests/test0056_instantiate_match_term/test.saw
+++ b/intTests/test0056_instantiate_match_term/test.saw
@@ -1,15 +1,15 @@
 m <- llvm_load_module "test.bc";
 
 let foo_spec = do {
-  x <- crucible_fresh_var "x" (llvm_int 32);
-  crucible_execute_func [(crucible_term x), (crucible_term {{ x + 1 }})];
-  crucible_return (crucible_term {{ 0 : [32] }});
+  x <- llvm_fresh_var "x" (llvm_int 32);
+  llvm_execute_func [(llvm_term x), (llvm_term {{ x + 1 }})];
+  llvm_return (llvm_term {{ 0 : [32] }});
 };
 
 let bar_spec = do {
-  crucible_execute_func [];
+  llvm_execute_func [];
 };
 
-foo_ov <- crucible_llvm_verify m "foo" [] false foo_spec abc;
-crucible_llvm_verify m "bar" [foo_ov] false bar_spec abc;
+foo_ov <- llvm_verify m "foo" [] false foo_spec abc;
+llvm_verify m "bar" [foo_ov] false bar_spec abc;
 

--- a/intTests/test0059_smt_array_2/test.saw
+++ b/intTests/test0059_smt_array_2/test.saw
@@ -5,36 +5,36 @@ enable_experimental;
 m <- llvm_load_module "test.bc";
 
 let foo_spec = do {
-  size <- crucible_fresh_var "size" (llvm_int 64);
-  dest_ptr <- crucible_symbolic_alloc false 1 size;
-  src_ptr <- crucible_symbolic_alloc false 1 size;
-  src <- crucible_fresh_cryptol_var "src" {| ByteArray |};
-  crucible_points_to_array_prefix src_ptr src size;
-  crucible_execute_func [dest_ptr, src_ptr, (crucible_term size)];
-  crucible_points_to_array_prefix dest_ptr {{ f size src }} size;
+  size <- llvm_fresh_var "size" (llvm_int 64);
+  dest_ptr <- llvm_symbolic_alloc false 1 size;
+  src_ptr <- llvm_symbolic_alloc false 1 size;
+  src <- llvm_fresh_cryptol_var "src" {| ByteArray |};
+  llvm_points_to_array_prefix src_ptr src size;
+  llvm_execute_func [dest_ptr, src_ptr, (llvm_term size)];
+  llvm_points_to_array_prefix dest_ptr {{ f size src }} size;
 };
 
 let foo_failure_spec = do {
-  size <- crucible_fresh_var "size" (llvm_int 64);
-  dest_ptr <- crucible_symbolic_alloc false 1 size;
-  src_ptr <- crucible_symbolic_alloc false 1 size;
-  src <- crucible_fresh_cryptol_var "src" {| ByteArray |};
-  crucible_points_to_array_prefix src_ptr src {{ drop`{32} size }};
-  crucible_execute_func [dest_ptr, src_ptr, (crucible_term size)];
+  size <- llvm_fresh_var "size" (llvm_int 64);
+  dest_ptr <- llvm_symbolic_alloc false 1 size;
+  src_ptr <- llvm_symbolic_alloc false 1 size;
+  src <- llvm_fresh_cryptol_var "src" {| ByteArray |};
+  llvm_points_to_array_prefix src_ptr src {{ drop`{32} size }};
+  llvm_execute_func [dest_ptr, src_ptr, (llvm_term size)];
 };
 
 let bar_spec = do {
-  len <- crucible_fresh_var "len" (llvm_int 64);
+  len <- llvm_fresh_var "len" (llvm_int 64);
   let byte_len = rewrite (cryptol_ss ()) {{ 8 * len }};
-  a_ptr <- crucible_symbolic_alloc false 8 byte_len;
-  b_ptr <- crucible_symbolic_alloc false 8 byte_len;
-  b <- crucible_fresh_cryptol_var "b" {| ByteArray |};
-  crucible_points_to_array_prefix b_ptr b byte_len;
-  crucible_execute_func [a_ptr, b_ptr, (crucible_term len)];
-  crucible_points_to_array_prefix a_ptr {{ f byte_len b }} byte_len;
+  a_ptr <- llvm_symbolic_alloc false 8 byte_len;
+  b_ptr <- llvm_symbolic_alloc false 8 byte_len;
+  b <- llvm_fresh_cryptol_var "b" {| ByteArray |};
+  llvm_points_to_array_prefix b_ptr b byte_len;
+  llvm_execute_func [a_ptr, b_ptr, (llvm_term len)];
+  llvm_points_to_array_prefix a_ptr {{ f byte_len b }} byte_len;
 };
 
-foo_ov <- crucible_llvm_unsafe_assume_spec m "foo" foo_spec;
-fails (crucible_llvm_unsafe_assume_spec m "foo" foo_failure_spec);
-crucible_llvm_verify m "bar" [foo_ov] false bar_spec (w4_unint_z3 ["f"]);
+foo_ov <- llvm_unsafe_assume_spec m "foo" foo_spec;
+fails (llvm_unsafe_assume_spec m "foo" foo_failure_spec);
+llvm_verify m "bar" [foo_ov] false bar_spec (w4_unint_z3 ["f"]);
 

--- a/intTests/test0060/test.saw
+++ b/intTests/test0060/test.saw
@@ -1,57 +1,57 @@
 m <- llvm_load_module "./test.bc";
 
 let id_spec = do {
-    p <- crucible_fresh_pointer (llvm_int 32);
-    crucible_execute_func [p];
-    crucible_return p;
+    p <- llvm_fresh_pointer (llvm_int 32);
+    llvm_execute_func [p];
+    llvm_return p;
 };
 
-crucible_llvm_verify m "id_p" [] false id_spec z3;
+llvm_verify m "id_p" [] false id_spec z3;
 
 // NOTE: Commented out due to bug #31 in cryptol-verifier
 // let incr_spec = do {
-//     p <- crucible_fresh_pointer (llvm_array 10 (llvm_int 32));
-//     crucible_execute_func [p];
-//     crucible_return (crucible_elem p 1);
+//     p <- llvm_fresh_pointer (llvm_array 10 (llvm_int 32));
+//     llvm_execute_func [p];
+//     llvm_return (llvm_elem p 1);
 // };
-// crucible_llvm_verify m "incr_p" [] false incr_spec z3;
+// llvm_verify m "incr_p" [] false incr_spec z3;
 
 let add_two_spec = do {
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    xp <- crucible_alloc (llvm_int 64);
-    crucible_points_to_untyped xp (crucible_term x);
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    xp <- llvm_alloc (llvm_int 64);
+    llvm_points_to_untyped xp (llvm_term x);
 
-    crucible_execute_func [xp];
+    llvm_execute_func [xp];
 
-    crucible_points_to_untyped xp (crucible_term {{ x + 2 }});
+    llvm_points_to_untyped xp (llvm_term {{ x + 2 }});
 };
 
-crucible_llvm_verify m "add_two" [] false add_two_spec z3;
+llvm_verify m "add_two" [] false add_two_spec z3;
 
 let array_swap_spec = do {
-    a0 <- crucible_fresh_var "a0" (llvm_int 32);
-    a1 <- crucible_fresh_var "a1" (llvm_int 32);
-    a  <- crucible_alloc (llvm_array 2 (llvm_int 32));
-    crucible_points_to a (crucible_array [crucible_term a0, crucible_term a1]);
+    a0 <- llvm_fresh_var "a0" (llvm_int 32);
+    a1 <- llvm_fresh_var "a1" (llvm_int 32);
+    a  <- llvm_alloc (llvm_array 2 (llvm_int 32));
+    llvm_points_to a (llvm_array_value [llvm_term a0, llvm_term a1]);
 
-    crucible_execute_func [a];
+    llvm_execute_func [a];
 
-    crucible_points_to (crucible_elem a 0) (crucible_term a1);
-    crucible_points_to (crucible_elem a 1) (crucible_term a0);
+    llvm_points_to (llvm_elem a 0) (llvm_term a1);
+    llvm_points_to (llvm_elem a 1) (llvm_term a0);
 };
 
-crucible_llvm_verify m "array_swap" [] false array_swap_spec z3;
+llvm_verify m "array_swap" [] false array_swap_spec z3;
 
 let struct_swap_spec = do {
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    y <- crucible_fresh_var "y" (llvm_int 32);
-    s <- crucible_alloc (llvm_struct "struct.foo");
-    crucible_points_to s (crucible_packed_struct [crucible_term x, crucible_term y]);
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    y <- llvm_fresh_var "y" (llvm_int 32);
+    s <- llvm_alloc (llvm_struct "struct.foo");
+    llvm_points_to s (llvm_packed_struct_value [llvm_term x, llvm_term y]);
 
-    crucible_execute_func [s];
+    llvm_execute_func [s];
 
-    crucible_points_to (crucible_field s "x") (crucible_term y);
-    crucible_points_to (crucible_field s "y") (crucible_term x);
+    llvm_points_to (llvm_field s "x") (llvm_term y);
+    llvm_points_to (llvm_field s "y") (llvm_term x);
 };
 
-crucible_llvm_verify m "struct_swap" [] false struct_swap_spec z3;
+llvm_verify m "struct_swap" [] false struct_swap_spec z3;

--- a/intTests/test0061_path_sat/test.saw
+++ b/intTests/test0061_path_sat/test.saw
@@ -1,12 +1,12 @@
 m <- llvm_load_module "termination.bc";
 
 let g_spec = do {
-  x <- crucible_fresh_var "x" (llvm_int 64);
-  crucible_execute_func [crucible_term x];
+  x <- llvm_fresh_var "x" (llvm_int 64);
+  llvm_execute_func [llvm_term x];
   };
 
-crucible_llvm_verify m "g1" [] false g_spec z3;
+llvm_verify m "g1" [] false g_spec z3;
 
 // NB: path sat checking is required for this
 // to terminate in a reasonable time
-crucible_llvm_verify m "g2" [] true g_spec z3;
+llvm_verify m "g2" [] true g_spec z3;

--- a/intTests/test0062_resolve_pred/test.saw
+++ b/intTests/test0062_resolve_pred/test.saw
@@ -3,22 +3,22 @@
 m <- llvm_load_module "test.bc";
 
 let f_spec y = do {
-  x_p <- crucible_alloc (llvm_int 32);
-  crucible_execute_func [x_p, (crucible_term {{ `y : [32] }})];
-  crucible_points_to x_p (crucible_term {{ `y : [32] }});
+  x_p <- llvm_alloc (llvm_int 32);
+  llvm_execute_func [x_p, (llvm_term {{ `y : [32] }})];
+  llvm_points_to x_p (llvm_term {{ `y : [32] }});
 };
 
 let g_spec y = do {
-  x_p <- crucible_alloc (llvm_int 32);
-  crucible_execute_func [x_p, (crucible_term {{ `y : [32] }})];
-  crucible_points_to x_p (crucible_term {{ `y : [32] }});
+  x_p <- llvm_alloc (llvm_int 32);
+  llvm_execute_func [x_p, (llvm_term {{ `y : [32] }})];
+  llvm_points_to x_p (llvm_term {{ `y : [32] }});
 };
 
-f_0_ov <- crucible_llvm_verify m "f" [] false (f_spec 0) (w4_unint_z3 []);
-f_1_ov <- crucible_llvm_verify m "f" [] false (f_spec 1) (w4_unint_z3 []);
+f_0_ov <- llvm_verify m "f" [] false (f_spec 0) (w4_unint_z3 []);
+f_1_ov <- llvm_verify m "f" [] false (f_spec 1) (w4_unint_z3 []);
 let f_ovs =
   [ f_0_ov
   , f_1_ov
   ];
-g_ov <- crucible_llvm_verify m "g" f_ovs false (g_spec 0) trivial;
+g_ov <- llvm_verify m "g" f_ovs false (g_spec 0) trivial;
 

--- a/intTests/test0064_detect_vacuity/test.saw
+++ b/intTests/test0064_detect_vacuity/test.saw
@@ -3,13 +3,13 @@
 // the detected contradiction in its output.
 
 let bad_spec = do {
-    a <- crucible_fresh_var "a" (llvm_int 32);
-    crucible_precond {{ a == 0 }};
-    crucible_precond {{ a == 1 }};
-    crucible_execute_func [crucible_term a];
-    crucible_postcond {{ a == 2 }};
+    a <- llvm_fresh_var "a" (llvm_int 32);
+    llvm_precond {{ a == 0 }};
+    llvm_precond {{ a == 1 }};
+    llvm_execute_func [llvm_term a];
+    llvm_postcond {{ a == 2 }};
 };
 
 m <- llvm_load_module "test.bc";
 
-crucible_llvm_verify m "double_imp" [] true bad_spec z3;
+llvm_verify m "double_imp" [] true bad_spec z3;

--- a/intTests/test_boilerplate/test.saw
+++ b/intTests/test_boilerplate/test.saw
@@ -2,10 +2,10 @@ enable_experimental;
 
 MODULE <- llvm_load_module "test.bc";
 let profile_setup = do {
-  crucible_points_to (crucible_global "GLOBAL") (crucible_global_initializer "GLOBAL");
-  crucible_execute_func [];
+  llvm_points_to (llvm_global "GLOBAL") (llvm_global_initializer "GLOBAL");
+  llvm_execute_func [];
 };
-profiles <- crucible_llvm_array_size_profile MODULE "entrypoint" profile_setup;
+profiles <- llvm_array_size_profile MODULE "entrypoint" profile_setup;
 print profiles;
 llvm_boilerplate_info MODULE profiles;
 llvm_boilerplate "test_boilerplate.saw" MODULE profiles;

--- a/intTests/test_crucible_jvm/arr_crucible.java
+++ b/intTests/test_crucible_jvm/arr_crucible.java
@@ -2,7 +2,7 @@ enable_experimental;
 a <- java_load_class "Arr";
 
 print "**Extracting main";
-main <- java_extract j "main";
+main <- jvm_extract j "main";
 
 
 print "**Evaluating: single array ref";

--- a/intTests/test_crucible_jvm/arr_crucible.java
+++ b/intTests/test_crucible_jvm/arr_crucible.java
@@ -2,7 +2,7 @@ enable_experimental;
 a <- java_load_class "Arr";
 
 print "**Extracting main";
-main <- crucible_java_extract j "main";
+main <- java_extract j "main";
 
 
 print "**Evaluating: single array ref";

--- a/intTests/test_crucible_jvm/arr_crucible.saw
+++ b/intTests/test_crucible_jvm/arr_crucible.saw
@@ -3,16 +3,16 @@ j <- java_load_class "Dyn";
 a <- java_load_class "Arr";
 
 print "**Extracting f_ref";
-f_ref <- crucible_java_extract j "f_ref";
+f_ref <- java_extract j "f_ref";
 
 print "**Extracting single";
-single <- crucible_java_extract a "single";
+single <- java_extract a "single";
 
 print "**Extracting doub";
-doub <- crucible_java_extract a "doub";
+doub <- java_extract a "doub";
 
 print "**Extracting obj";
-h_ref <- crucible_java_extract j "h_ref";
+h_ref <- java_extract j "h_ref";
 
 print "**Evaluating: single array ref";
 sat_print abc {{ \(x:[32]) -> single 0 == x }};

--- a/intTests/test_crucible_jvm/arr_crucible.saw
+++ b/intTests/test_crucible_jvm/arr_crucible.saw
@@ -3,16 +3,16 @@ j <- java_load_class "Dyn";
 a <- java_load_class "Arr";
 
 print "**Extracting f_ref";
-f_ref <- java_extract j "f_ref";
+f_ref <- jvm_extract j "f_ref";
 
 print "**Extracting single";
-single <- java_extract a "single";
+single <- jvm_extract a "single";
 
 print "**Extracting doub";
-doub <- java_extract a "doub";
+doub <- jvm_extract a "doub";
 
 print "**Extracting obj";
-h_ref <- java_extract j "h_ref";
+h_ref <- jvm_extract j "h_ref";
 
 print "**Evaluating: single array ref";
 sat_print abc {{ \(x:[32]) -> single 0 == x }};

--- a/intTests/test_crucible_jvm/dyn_crucible.saw
+++ b/intTests/test_crucible_jvm/dyn_crucible.saw
@@ -5,25 +5,25 @@ iface <- java_load_class "Iface";
 j <- java_load_class "Dyn";
 
 print "**Extracting f_ref";
-f_ref <- crucible_java_extract j "f_ref";
+f_ref <- java_extract j "f_ref";
 
 print "**Extracting f_imp";
-f_imp <- crucible_java_extract j "f_imp";
+f_imp <- java_extract j "f_imp";
 
 print "**Extracting f_virt";
-f_virt <- crucible_java_extract j "f_virt";
+f_virt <- java_extract j "f_virt";
 
 print "**Extracting h_ref";
-h_ref <- crucible_java_extract j "h_ref";
+h_ref <- java_extract j "h_ref";
 
 print "**Extracting h_imp";
-h_imp <- crucible_java_extract j "h_imp";
+h_imp <- java_extract j "h_imp";
 
 print "**Extracting i_imp";
-i_imp <- crucible_java_extract j "i_imp";
+i_imp <- java_extract j "i_imp";
 
 print "**Extracting b";
-b <- crucible_java_extract j "b";
+b <- java_extract j "b";
 
 
 print "**Evaluating: instance variable";

--- a/intTests/test_crucible_jvm/dyn_crucible.saw
+++ b/intTests/test_crucible_jvm/dyn_crucible.saw
@@ -5,25 +5,25 @@ iface <- java_load_class "Iface";
 j <- java_load_class "Dyn";
 
 print "**Extracting f_ref";
-f_ref <- java_extract j "f_ref";
+f_ref <- jvm_extract j "f_ref";
 
 print "**Extracting f_imp";
-f_imp <- java_extract j "f_imp";
+f_imp <- jvm_extract j "f_imp";
 
 print "**Extracting f_virt";
-f_virt <- java_extract j "f_virt";
+f_virt <- jvm_extract j "f_virt";
 
 print "**Extracting h_ref";
-h_ref <- java_extract j "h_ref";
+h_ref <- jvm_extract j "h_ref";
 
 print "**Extracting h_imp";
-h_imp <- java_extract j "h_imp";
+h_imp <- jvm_extract j "h_imp";
 
 print "**Extracting i_imp";
-i_imp <- java_extract j "i_imp";
+i_imp <- jvm_extract j "i_imp";
 
 print "**Extracting b";
-b <- java_extract j "b";
+b <- jvm_extract j "b";
 
 
 print "**Evaluating: instance variable";

--- a/intTests/test_crucible_jvm/ffs_crucible.saw
+++ b/intTests/test_crucible_jvm/ffs_crucible.saw
@@ -1,10 +1,10 @@
 enable_experimental;
 print "Extracting reference term";
 j <- java_load_class "FFS";
-ffs_ref <- java_extract j "ffs_ref";
+ffs_ref <- jvm_extract j "ffs_ref";
 
 print "Extracting implementation term";
-ffs_imp <- java_extract j "ffs_imp";
+ffs_imp <- jvm_extract j "ffs_imp";
 
 print "Proving equivalence";
 let thm1 = {{ \x -> ffs_ref x == ffs_imp x }};

--- a/intTests/test_crucible_jvm/ffs_crucible.saw
+++ b/intTests/test_crucible_jvm/ffs_crucible.saw
@@ -1,10 +1,10 @@
 enable_experimental;
 print "Extracting reference term";
 j <- java_load_class "FFS";
-ffs_ref <- crucible_java_extract j "ffs_ref";
+ffs_ref <- java_extract j "ffs_ref";
 
 print "Extracting implementation term";
-ffs_imp <- crucible_java_extract j "ffs_imp";
+ffs_imp <- java_extract j "ffs_imp";
 
 print "Proving equivalence";
 let thm1 = {{ \x -> ffs_ref x == ffs_imp x }};

--- a/intTests/test_crucible_jvm/obj_crucible.saw
+++ b/intTests/test_crucible_jvm/obj_crucible.saw
@@ -4,7 +4,7 @@ str <- java_load_class "java/lang/String";
 teststr <- java_load_class "TestStr";
 
 print "**Extracting m";
-m <- crucible_java_extract teststr "main";
+m <- java_extract teststr "main";
 
 print "**Evaluating: main, should be 3";
 sat_print abc {{ \(x:[32]) -> (m 3 == x) }};

--- a/intTests/test_crucible_jvm/obj_crucible.saw
+++ b/intTests/test_crucible_jvm/obj_crucible.saw
@@ -4,7 +4,7 @@ str <- java_load_class "java/lang/String";
 teststr <- java_load_class "TestStr";
 
 print "**Extracting m";
-m <- java_extract teststr "main";
+m <- jvm_extract teststr "main";
 
 print "**Evaluating: main, should be 3";
 sat_print abc {{ \(x:[32]) -> (m 3 == x) }};

--- a/intTests/test_crucible_jvm/stat_crucible.saw
+++ b/intTests/test_crucible_jvm/stat_crucible.saw
@@ -1,10 +1,10 @@
 enable_experimental;
 print "**Extracting reference term";
 j <- java_load_class "Stat";
-f_ref <- crucible_java_extract j "f_ref";
+f_ref <- java_extract j "f_ref";
 
 print "**Extracting implementation term";
-f_imp <- crucible_java_extract j "f_imp";
+f_imp <- java_extract j "f_imp";
 
 print "**Proving equivalence";
 let thm1 = {{ \x -> f_ref x == f_imp x }};

--- a/intTests/test_crucible_jvm/stat_crucible.saw
+++ b/intTests/test_crucible_jvm/stat_crucible.saw
@@ -1,10 +1,10 @@
 enable_experimental;
 print "**Extracting reference term";
 j <- java_load_class "Stat";
-f_ref <- java_extract j "f_ref";
+f_ref <- jvm_extract j "f_ref";
 
 print "**Extracting implementation term";
-f_imp <- java_extract j "f_imp";
+f_imp <- jvm_extract j "f_imp";
 
 print "**Proving equivalence";
 let thm1 = {{ \x -> f_ref x == f_imp x }};

--- a/intTests/test_crucible_jvm/statdyn_crucible.saw
+++ b/intTests/test_crucible_jvm/statdyn_crucible.saw
@@ -3,22 +3,22 @@ jdyn <- java_load_class "Dyn";
 jstat <- java_load_class "Stat";
 
 print "**Extracting f_ref";
-f_ref <- crucible_java_extract jdyn "f_ref";
+f_ref <- java_extract jdyn "f_ref";
 
 print "**Extracting f_imp";
-f_imp <- crucible_java_extract jdyn "f_imp";
+f_imp <- java_extract jdyn "f_imp";
 
 print "**Extracting f_virt";
-f_virt <- crucible_java_extract jdyn "f_virt";
+f_virt <- java_extract jdyn "f_virt";
 
 print "**Extracting h_ref";
-h_ref <- crucible_java_extract jdyn "h_ref";
+h_ref <- java_extract jdyn "h_ref";
 
 print "**Extracting h_imp";
-h_imp <- crucible_java_extract jdyn "h_imp";
+h_imp <- java_extract jdyn "h_imp";
 
 print "**Extracting g_imp";
-g_imp <- crucible_java_extract jstat "g_imp";
+g_imp <- java_extract jstat "g_imp";
 
 
 

--- a/intTests/test_crucible_jvm/statdyn_crucible.saw
+++ b/intTests/test_crucible_jvm/statdyn_crucible.saw
@@ -3,22 +3,22 @@ jdyn <- java_load_class "Dyn";
 jstat <- java_load_class "Stat";
 
 print "**Extracting f_ref";
-f_ref <- java_extract jdyn "f_ref";
+f_ref <- jvm_extract jdyn "f_ref";
 
 print "**Extracting f_imp";
-f_imp <- java_extract jdyn "f_imp";
+f_imp <- jvm_extract jdyn "f_imp";
 
 print "**Extracting f_virt";
-f_virt <- java_extract jdyn "f_virt";
+f_virt <- jvm_extract jdyn "f_virt";
 
 print "**Extracting h_ref";
-h_ref <- java_extract jdyn "h_ref";
+h_ref <- jvm_extract jdyn "h_ref";
 
 print "**Extracting h_imp";
-h_imp <- java_extract jdyn "h_imp";
+h_imp <- jvm_extract jdyn "h_imp";
 
 print "**Extracting g_imp";
-g_imp <- java_extract jstat "g_imp";
+g_imp <- jvm_extract jstat "g_imp";
 
 
 

--- a/intTests/test_crucible_jvm/sub_crucible.saw
+++ b/intTests/test_crucible_jvm/sub_crucible.saw
@@ -5,13 +5,13 @@ ifc <- java_load_class "Iface";
 sub <- java_load_class "Sub";
 
 print "**Extracting Dyn.f_virt";
-f_virt <- crucible_java_extract dyn "f_virt";
+f_virt <- java_extract dyn "f_virt";
 print "**Extracting Dyn.i_imp";
-i_imp <- crucible_java_extract dyn "i_imp";
+i_imp <- java_extract dyn "i_imp";
 print "**Extracting Sub.dyn";
-dyn_g <- crucible_java_extract sub "dyn";
+dyn_g <- java_extract sub "dyn";
 print "**Extracting Sub.sub";
-sub_g <- crucible_java_extract sub "sub";
+sub_g <- java_extract sub "sub";
 
 print "**Evaluating: dyn (12) ";
 sat_print abc {{ \(x:[32]) -> dyn_g 12 == x }};

--- a/intTests/test_crucible_jvm/sub_crucible.saw
+++ b/intTests/test_crucible_jvm/sub_crucible.saw
@@ -5,13 +5,13 @@ ifc <- java_load_class "Iface";
 sub <- java_load_class "Sub";
 
 print "**Extracting Dyn.f_virt";
-f_virt <- java_extract dyn "f_virt";
+f_virt <- jvm_extract dyn "f_virt";
 print "**Extracting Dyn.i_imp";
-i_imp <- java_extract dyn "i_imp";
+i_imp <- jvm_extract dyn "i_imp";
 print "**Extracting Sub.dyn";
-dyn_g <- java_extract sub "dyn";
+dyn_g <- jvm_extract sub "dyn";
 print "**Extracting Sub.sub";
-sub_g <- java_extract sub "sub";
+sub_g <- jvm_extract sub "sub";
 
 print "**Evaluating: dyn (12) ";
 sat_print abc {{ \(x:[32]) -> dyn_g 12 == x }};

--- a/intTests/test_crucible_jvm/teststr_crucible.saw
+++ b/intTests/test_crucible_jvm/teststr_crucible.saw
@@ -9,10 +9,10 @@ sob <- java_load_class "java/lang/StringIndexOutOfBoundsException";
 teststr <- java_load_class "TestStr";
 
 print "**Extracting methods";
-m      <- java_extract teststr "main";
-append <- java_extract teststr "append";
-pr     <- java_extract teststr "pr";
-//trim   <- java_extract teststr "trim";
+m      <- jvm_extract teststr "main";
+append <- jvm_extract teststr "append";
+pr     <- jvm_extract teststr "pr";
+//trim   <- jvm_extract teststr "trim";
 
 
 

--- a/intTests/test_crucible_jvm/teststr_crucible.saw
+++ b/intTests/test_crucible_jvm/teststr_crucible.saw
@@ -9,10 +9,10 @@ sob <- java_load_class "java/lang/StringIndexOutOfBoundsException";
 teststr <- java_load_class "TestStr";
 
 print "**Extracting methods";
-m      <- crucible_java_extract teststr "main";
-append <- crucible_java_extract teststr "append";
-pr     <- crucible_java_extract teststr "pr";
-//trim   <- crucible_java_extract teststr "trim";
+m      <- java_extract teststr "main";
+append <- java_extract teststr "append";
+pr     <- java_extract teststr "pr";
+//trim   <- java_extract teststr "trim";
 
 
 

--- a/intTests/test_ghost/test.saw
+++ b/intTests/test_ghost/test.saw
@@ -1,35 +1,35 @@
 let pre_counter (counter : Ghost) = do {
-  n <- crucible_fresh_var "n" (llvm_int 32);
-  crucible_precond {{n < 128}};
-  crucible_ghost_value counter n;
+  n <- llvm_fresh_var "n" (llvm_int 32);
+  llvm_precond {{n < 128}};
+  llvm_ghost_value counter n;
   return n;
 };
 
 let post_counter (counter : Ghost) n = do {
-  crucible_ghost_value counter {{n+1}};
+  llvm_ghost_value counter {{n+1}};
 };
 
 let get_and_increment_spec (counter : Ghost) : CrucibleSetup () = do {
   n <- pre_counter counter;
-  crucible_execute_func [];
+  llvm_execute_func [];
   post_counter counter n;
-  crucible_return (crucible_term {{n}});
+  llvm_return (llvm_term {{n}});
 };
 
 let f_spec (counter : Ghost) : CrucibleSetup () = do {
   n <- pre_counter counter;
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_precond {{i < 512}};
-  crucible_execute_func [crucible_term i];
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_precond {{i < 512}};
+  llvm_execute_func [llvm_term i];
   post_counter counter n;
-  crucible_return (crucible_term {{i*n}});
+  llvm_return (llvm_term {{i*n}});
 };
 
 let main : TopLevel () = do {
-  counter <- crucible_declare_ghost_state "counter";
+  counter <- llvm_declare_ghost_state "counter";
   m <- llvm_load_module "test.bc";
   get_and_increment_ov <-
-    crucible_llvm_unsafe_assume_spec m "get_and_increment" (get_and_increment_spec counter);
-  crucible_llvm_verify m "f" [get_and_increment_ov] false (f_spec counter) z3;
+    llvm_unsafe_assume_spec m "get_and_increment" (get_and_increment_spec counter);
+  llvm_verify m "f" [get_and_increment_ov] false (f_spec counter) z3;
   print "done";
 };

--- a/intTests/test_ghost_branch_00/test.saw
+++ b/intTests/test_ghost_branch_00/test.saw
@@ -1,34 +1,34 @@
 let f_lt_spec (x : Ghost) : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_precond {{ i < 42 }};
-  crucible_execute_func [crucible_term i];
-  crucible_ghost_value x i;
-  crucible_return (crucible_term i);
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_precond {{ i < 42 }};
+  llvm_execute_func [llvm_term i];
+  llvm_ghost_value x i;
+  llvm_return (llvm_term i);
 };
 
 let f_ge_spec (x : Ghost) : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_precond {{ (i >= 42) && (i < 512) }};
-  crucible_execute_func [crucible_term i];
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_precond {{ (i >= 42) && (i < 512) }};
+  llvm_execute_func [llvm_term i];
   let ret = {{ 2 * i }};
-  crucible_ghost_value x ret;
-  crucible_return (crucible_term ret);
+  llvm_ghost_value x ret;
+  llvm_return (llvm_term ret);
 };
 
 let g_spec : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_precond {{i < 512}};
-  crucible_execute_func [crucible_term i];
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  crucible_return (crucible_term ret);
-  crucible_postcond {{ ret >= i }};
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_precond {{i < 512}};
+  llvm_execute_func [llvm_term i];
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  llvm_return (llvm_term ret);
+  llvm_postcond {{ ret >= i }};
 };
 
 let main : TopLevel () = do {
-  x <- crucible_declare_ghost_state "x";
+  x <- llvm_declare_ghost_state "x";
   m <- llvm_load_module "test.bc";
-  f_lt_ov <- crucible_llvm_unsafe_assume_spec m "f" (f_lt_spec x);
-  f_ge_ov <- crucible_llvm_unsafe_assume_spec m "f" (f_ge_spec x);
-  crucible_llvm_verify m "g" [f_lt_ov, f_ge_ov] false g_spec z3;
+  f_lt_ov <- llvm_unsafe_assume_spec m "f" (f_lt_spec x);
+  f_ge_ov <- llvm_unsafe_assume_spec m "f" (f_ge_spec x);
+  llvm_verify m "g" [f_lt_ov, f_ge_ov] false g_spec z3;
   print "done";
 };

--- a/intTests/test_ghost_branch_01/test.saw
+++ b/intTests/test_ghost_branch_01/test.saw
@@ -1,38 +1,38 @@
 let get_spec (x : Ghost) : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_ghost_value x i;
-  crucible_execute_func [];
-  crucible_ghost_value x i;
-  crucible_return (crucible_term i);
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_ghost_value x i;
+  llvm_execute_func [];
+  llvm_ghost_value x i;
+  llvm_return (llvm_term i);
 };
 
 let f_spec (x : Ghost) : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_execute_func [crucible_term i];
-  crucible_ghost_value x i;
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_execute_func [llvm_term i];
+  llvm_ghost_value x i;
 };
 
 let g_spec (x : Ghost) : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_execute_func [crucible_term i];
-  crucible_ghost_value x {{ 2 * i }};
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_execute_func [llvm_term i];
+  llvm_ghost_value x {{ 2 * i }};
 };
 
 let h_spec : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_precond {{i < 512}};
-  crucible_execute_func [crucible_term i];
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  crucible_return (crucible_term ret);
-  crucible_postcond {{ ret >= i }};
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_precond {{i < 512}};
+  llvm_execute_func [llvm_term i];
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  llvm_return (llvm_term ret);
+  llvm_postcond {{ ret >= i }};
 };
 
 let main : TopLevel () = do {
-  x <- crucible_declare_ghost_state "x";
+  x <- llvm_declare_ghost_state "x";
   m <- llvm_load_module "test.bc";
-  get_ov <- crucible_llvm_unsafe_assume_spec m "get" (get_spec x);
-  f_ov <- crucible_llvm_unsafe_assume_spec m "f" (f_spec x);
-  g_ov <- crucible_llvm_unsafe_assume_spec m "g" (g_spec x);
-  crucible_llvm_verify m "h" [get_ov, f_ov, g_ov] false h_spec z3;
+  get_ov <- llvm_unsafe_assume_spec m "get" (get_spec x);
+  f_ov <- llvm_unsafe_assume_spec m "f" (f_spec x);
+  g_ov <- llvm_unsafe_assume_spec m "g" (g_spec x);
+  llvm_verify m "h" [get_ov, f_ov, g_ov] false h_spec z3;
   print "done";
 };

--- a/intTests/test_ghost_branch_02/test.saw
+++ b/intTests/test_ghost_branch_02/test.saw
@@ -1,30 +1,30 @@
 let f_lt_spec (x : Ghost) : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_precond {{ i < 42 }};
-  crucible_execute_func [crucible_term i];
-  crucible_return (crucible_term i);
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_precond {{ i < 42 }};
+  llvm_execute_func [llvm_term i];
+  llvm_return (llvm_term i);
 };
 
 let f_ge_spec (x : Ghost) : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_precond {{ (i >= 42) && (i < 512) }};
-  crucible_execute_func [crucible_term i];
-  crucible_ghost_value x i;
-  crucible_return (crucible_term i);
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_precond {{ (i >= 42) && (i < 512) }};
+  llvm_execute_func [llvm_term i];
+  llvm_ghost_value x i;
+  llvm_return (llvm_term i);
 };
 
 let g_spec : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_precond {{i < 512}};
-  crucible_execute_func [crucible_term i];
-  crucible_return (crucible_term i);
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_precond {{i < 512}};
+  llvm_execute_func [llvm_term i];
+  llvm_return (llvm_term i);
 };
 
 let main : TopLevel () = do {
-  x <- crucible_declare_ghost_state "x";
+  x <- llvm_declare_ghost_state "x";
   m <- llvm_load_module "test.bc";
-  f_lt_ov <- crucible_llvm_unsafe_assume_spec m "f" (f_lt_spec x);
-  f_ge_ov <- crucible_llvm_unsafe_assume_spec m "f" (f_ge_spec x);
-  fails (crucible_llvm_verify m "g" [f_lt_ov, f_ge_ov] false g_spec z3);
+  f_lt_ov <- llvm_unsafe_assume_spec m "f" (f_lt_spec x);
+  f_ge_ov <- llvm_unsafe_assume_spec m "f" (f_ge_spec x);
+  fails (llvm_verify m "g" [f_lt_ov, f_ge_ov] false g_spec z3);
   print "done";
 };

--- a/intTests/test_ghost_branch_03/test.saw
+++ b/intTests/test_ghost_branch_03/test.saw
@@ -1,38 +1,38 @@
 let get_spec (x : Ghost) : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_ghost_value x i;
-  crucible_execute_func [];
-  crucible_ghost_value x i;
-  crucible_return (crucible_term i);
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_ghost_value x i;
+  llvm_execute_func [];
+  llvm_ghost_value x i;
+  llvm_return (llvm_term i);
 };
 
 let f_spec (x : Ghost) : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_execute_func [crucible_term i];
-  crucible_ghost_value x i;
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_execute_func [llvm_term i];
+  llvm_ghost_value x i;
 };
 
 let g_spec (x : Ghost) : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_execute_func [crucible_term i];
-  crucible_ghost_value x {{ True : Bit }}; // should be [32]
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_execute_func [llvm_term i];
+  llvm_ghost_value x {{ True : Bit }}; // should be [32]
 };
 
 let h_spec : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_precond {{i < 512}};
-  crucible_execute_func [crucible_term i];
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  crucible_return (crucible_term ret);
-  crucible_postcond {{ ret == i }};
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_precond {{i < 512}};
+  llvm_execute_func [llvm_term i];
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  llvm_return (llvm_term ret);
+  llvm_postcond {{ ret == i }};
 };
 
 let main : TopLevel () = do {
-  x <- crucible_declare_ghost_state "x";
+  x <- llvm_declare_ghost_state "x";
   m <- llvm_load_module "test.bc";
-  get_ov <- crucible_llvm_unsafe_assume_spec m "get" (get_spec x);
-  f_ov <- crucible_llvm_unsafe_assume_spec m "f" (f_spec x);
-  g_ov <- crucible_llvm_unsafe_assume_spec m "g" (g_spec x);
-  fails (crucible_llvm_verify m "h" [get_ov, f_ov, g_ov] false h_spec z3);
+  get_ov <- llvm_unsafe_assume_spec m "get" (get_spec x);
+  f_ov <- llvm_unsafe_assume_spec m "f" (f_spec x);
+  g_ov <- llvm_unsafe_assume_spec m "g" (g_spec x);
+  fails (llvm_verify m "h" [get_ov, f_ov, g_ov] false h_spec z3);
   print "done";
 };

--- a/intTests/test_ghost_types_00/test.saw
+++ b/intTests/test_ghost_types_00/test.saw
@@ -1,33 +1,33 @@
 let f_spec (x : Ghost) : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_execute_func [crucible_term i];
-  crucible_ghost_value x i;
-  crucible_return (crucible_term i);
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_execute_func [llvm_term i];
+  llvm_ghost_value x i;
+  llvm_return (llvm_term i);
 };
 
 let g_spec (y : Ghost) : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_execute_func [crucible_term i];
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_execute_func [llvm_term i];
   let v = {{ drop (i / 8) : [8] }};
-  crucible_ghost_value y v;
-  crucible_return (crucible_term v);
+  llvm_ghost_value y v;
+  llvm_return (llvm_term v);
 };
 
 let h_spec : CrucibleSetup () = do {
-  i <- crucible_fresh_var "i" (llvm_int 32);
-  crucible_precond {{i < 512}};
-  crucible_execute_func [crucible_term i];
-  ret <- crucible_fresh_var "ret" (llvm_int 32);
-  crucible_return (crucible_term ret);
-  crucible_postcond {{ ret <= i }};
+  i <- llvm_fresh_var "i" (llvm_int 32);
+  llvm_precond {{i < 512}};
+  llvm_execute_func [llvm_term i];
+  ret <- llvm_fresh_var "ret" (llvm_int 32);
+  llvm_return (llvm_term ret);
+  llvm_postcond {{ ret <= i }};
 };
 
 let main : TopLevel () = do {
-  x <- crucible_declare_ghost_state "x";
+  x <- llvm_declare_ghost_state "x";
   m <- llvm_load_module "test.bc";
-  f_ov <- crucible_llvm_unsafe_assume_spec m "f" (f_spec x);
+  f_ov <- llvm_unsafe_assume_spec m "f" (f_spec x);
   // This spec should probably use a different variable, but doesn't:
-  g_ov <- crucible_llvm_unsafe_assume_spec m "g" (g_spec x);
-  fails (crucible_llvm_verify m "h" [f_ov, g_ov] false h_spec z3);
+  g_ov <- llvm_unsafe_assume_spec m "g" (g_spec x);
+  fails (llvm_verify m "h" [f_ov, g_ov] false h_spec z3);
   print "done";
 };

--- a/intTests/test_intro_examples/ffs_bug.saw
+++ b/intTests/test_intro_examples/ffs_bug.saw
@@ -1,8 +1,8 @@
 set_base 16;
 m <- llvm_load_module "ffs.bc";
 print "Extracting functional models...";
-ref <- crucible_llvm_extract m "ffs_ref";
-bug <- crucible_llvm_extract m "ffs_bug";
+ref <- llvm_extract m "ffs_ref";
+bug <- llvm_extract m "ffs_bug";
 print "Trying to prove equivalence...";
 r <- time (prove abc {{ ref === bug }});
 print r;

--- a/intTests/test_intro_examples/ffs_bug_fail.saw
+++ b/intTests/test_intro_examples/ffs_bug_fail.saw
@@ -1,8 +1,8 @@
 set_base 16;
 m <- llvm_load_module "ffs.bc";
 print "Extracting functional models...";
-ref <- crucible_llvm_extract m "ffs_ref";
-bug <- crucible_llvm_extract m "ffs_bug";
+ref <- llvm_extract m "ffs_ref";
+bug <- llvm_extract m "ffs_bug";
 print "Checking for bug via random testing...";
 r <- time (prove (quickcheck 1000) {{ ref === bug }});
 print r;

--- a/intTests/test_intro_examples/ffs_eq.saw
+++ b/intTests/test_intro_examples/ffs_eq.saw
@@ -1,7 +1,7 @@
 m <- llvm_load_module "ffs.bc";
 print "Extracting functional models...";
-ref <- crucible_llvm_extract m "ffs_ref";
-imp <- crucible_llvm_extract m "ffs_imp";
+ref <- llvm_extract m "ffs_ref";
+imp <- llvm_extract m "ffs_imp";
 print "Comparing reference and implementation...";
 r <- time (prove abc {{ ref === imp }});
 print r;

--- a/intTests/test_intro_examples/ffs_extract.saw
+++ b/intTests/test_intro_examples/ffs_extract.saw
@@ -1,7 +1,7 @@
 m <- llvm_load_module "ffs.bc";
 
-ffs_imp_correct <- crucible_llvm_extract m "ffs_imp_correct";
-ffs_bug_correct <- crucible_llvm_extract m "ffs_bug_correct";
+ffs_imp_correct <- llvm_extract m "ffs_imp_correct";
+ffs_bug_correct <- llvm_extract m "ffs_bug_correct";
 
 set_base 16;
 print "Proving ffs_imp_correct always returns true...";

--- a/intTests/test_intro_examples/ffs_sat.saw
+++ b/intTests/test_intro_examples/ffs_sat.saw
@@ -1,7 +1,7 @@
 set_base 2;
 m <- llvm_load_module "ffs.bc";
 print "Extracting functional model...";
-imp <- crucible_llvm_extract m "ffs_imp";
+imp <- llvm_extract m "ffs_imp";
 print "Finding input for implementation that yields result of 4...";
 r <- time (sat abc {{ \x -> imp x == 4 }});
 print r;

--- a/intTests/test_intro_examples/swap-simpler.saw
+++ b/intTests/test_intro_examples/swap-simpler.saw
@@ -1,15 +1,15 @@
 m <- llvm_load_module "xor-swap.bc";
 let ptr_to_fresh nm ty = do {
-    x <- crucible_fresh_var nm ty;
-    p <- crucible_alloc ty;
-    crucible_points_to p (crucible_term x);
+    x <- llvm_fresh_var nm ty;
+    p <- llvm_alloc ty;
+    llvm_points_to p (llvm_term x);
     return (x, p);
 };
 let swap_spec = do {
     (x, xp) <- ptr_to_fresh "x" (llvm_int 32);
     (y, yp) <- ptr_to_fresh "y" (llvm_int 32);
-    crucible_execute_func [xp, yp];
-    crucible_points_to xp (crucible_term y);
-    crucible_points_to yp (crucible_term x);
+    llvm_execute_func [xp, yp];
+    llvm_points_to xp (llvm_term y);
+    llvm_points_to yp (llvm_term x);
 };
-crucible_llvm_verify m "swap_xor" [] true swap_spec abc;
+llvm_verify m "swap_xor" [] true swap_spec abc;

--- a/intTests/test_intro_examples/swap.saw
+++ b/intTests/test_intro_examples/swap.saw
@@ -3,17 +3,17 @@ xormod_bug <- llvm_load_module "xor-swap-bug.bc";
 directmod <- llvm_load_module "direct-swap.bc";
 
 let swap_spec = do {
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    y <- crucible_fresh_var "y" (llvm_int 32);
-    xp <- crucible_alloc (llvm_int 32);
-    yp <- crucible_alloc (llvm_int 32);
-    crucible_points_to xp (crucible_term x);
-    crucible_points_to yp (crucible_term y);
-    crucible_execute_func [xp, yp];
-    crucible_points_to xp (crucible_term y);
-    crucible_points_to yp (crucible_term x);
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    y <- llvm_fresh_var "y" (llvm_int 32);
+    xp <- llvm_alloc (llvm_int 32);
+    yp <- llvm_alloc (llvm_int 32);
+    llvm_points_to xp (llvm_term x);
+    llvm_points_to yp (llvm_term y);
+    llvm_execute_func [xp, yp];
+    llvm_points_to xp (llvm_term y);
+    llvm_points_to yp (llvm_term x);
 };
 
-crucible_llvm_verify xormod "swap_xor" [] true swap_spec abc;
-crucible_llvm_verify directmod "swap_direct" [] true swap_spec abc;
-crucible_llvm_verify xormod_bug "swap_xor" [] true swap_spec abc;
+llvm_verify xormod "swap_xor" [] true swap_spec abc;
+llvm_verify directmod "swap_direct" [] true swap_spec abc;
+llvm_verify xormod_bug "swap_xor" [] true swap_spec abc;

--- a/intTests/test_intro_examples/swap_extract.saw
+++ b/intTests/test_intro_examples/swap_extract.saw
@@ -2,7 +2,7 @@
 m <- llvm_load_module "swap-correct.bc";
 
 // Extract a formal model of the `swap_correct` property
-model <- crucible_llvm_extract m "swap_correct";
+model <- llvm_extract m "swap_correct";
 
 // Use the ABC prover to show that it always returns non-zero.
 thm <- prove_print abc {{ \x y -> model x y != 0 }};

--- a/intTests/test_issue521/test.saw
+++ b/intTests/test_issue521/test.saw
@@ -1,2 +1,2 @@
 m <- llvm_load_module "ptr.bc";
-fails (crucible_llvm_extract m "add");
+fails (llvm_extract m "add");

--- a/intTests/test_issue642/test.saw
+++ b/intTests/test_issue642/test.saw
@@ -8,30 +8,30 @@ bc <- llvm_load_module "test.bc";
 let i32 = llvm_int 32;
 
 foo_ov <-
-  crucible_llvm_verify bc "foo" [] false
+  llvm_verify bc "foo" [] false
     do {
-      crucible_alloc_global "glob";
-      x <- crucible_alloc i32;
-      crucible_execute_func [x];
-      crucible_return (crucible_term {{ 0 : [32] }});
+      llvm_alloc_global "glob";
+      x <- llvm_alloc i32;
+      llvm_execute_func [x];
+      llvm_return (llvm_term {{ 0 : [32] }});
     }
     z3;
 
 bar_ov1 <-
-  crucible_llvm_verify bc "bar" [] false
+  llvm_verify bc "bar" [] false
     do {
-      crucible_alloc_global "glob";
-      crucible_execute_func [];
-      crucible_return (crucible_term {{ 1 : [32] }});
+      llvm_alloc_global "glob";
+      llvm_execute_func [];
+      llvm_return (llvm_term {{ 1 : [32] }});
     }
     z3;
 
 fails (
-  crucible_llvm_verify bc "bar" [foo_ov] false
+  llvm_verify bc "bar" [foo_ov] false
     do {
-      crucible_alloc_global "glob";
-      crucible_execute_func [];
-      crucible_return (crucible_term {{ 0 : [32] }});
+      llvm_alloc_global "glob";
+      llvm_execute_func [];
+      llvm_return (llvm_term {{ 0 : [32] }});
     }
     z3
   );

--- a/intTests/test_llvm_alignment/test.saw
+++ b/intTests/test_llvm_alignment/test.saw
@@ -7,33 +7,33 @@ let i8 = llvm_int 8;
 let i64 = llvm_int 64;
 
 write_ov <-
-  crucible_llvm_verify bc "write" [] false
+  llvm_verify bc "write" [] false
     do {
-      p <- crucible_alloc i64;
-      x <- crucible_fresh_var "x" i64;
-      crucible_execute_func [p, crucible_term x];
-      crucible_points_to p (crucible_term x);
+      p <- llvm_alloc i64;
+      x <- llvm_fresh_var "x" i64;
+      llvm_execute_func [p, llvm_term x];
+      llvm_points_to p (llvm_term x);
     }
     z3;
 
 let write_unaligned_spec =
   do {
-    p <- crucible_alloc (llvm_array 16 i8);
-    b <- crucible_fresh_var "b" (llvm_array 16 i8);
-    x <- crucible_fresh_var "x" i64;
-    crucible_points_to p (crucible_term b);
-    crucible_execute_func [p, crucible_term x];
-    crucible_points_to p (crucible_term {{ take`{1} b # reverse (split x) # drop`{9} b }});
+    p <- llvm_alloc (llvm_array 16 i8);
+    b <- llvm_fresh_var "b" (llvm_array 16 i8);
+    x <- llvm_fresh_var "x" i64;
+    llvm_points_to p (llvm_term b);
+    llvm_execute_func [p, llvm_term x];
+    llvm_points_to p (llvm_term {{ take`{1} b # reverse (split x) # drop`{9} b }});
   };
 
 fails (
-  crucible_llvm_verify bc "write_unaligned" [] false
+  llvm_verify bc "write_unaligned" [] false
     write_unaligned_spec
     z3
   );
 
 fails (
-  crucible_llvm_verify bc "write_unaligned" [write_ov] false
+  llvm_verify bc "write_unaligned" [write_ov] false
     write_unaligned_spec
     z3
   );

--- a/intTests/test_llvm_global_field/test.saw
+++ b/intTests/test_llvm_global_field/test.saw
@@ -1,16 +1,16 @@
-// This test ensures that `crucible_field` can be used in conjunction
-// with `crucible_global`. It is a regression test for saw-script
+// This test ensures that `llvm_field` can be used in conjunction
+// with `llvm_global`. It is a regression test for saw-script
 // issue 742 (https://github.com/GaloisInc/saw-script/issues/742).
 
 bc <- llvm_load_module "test.bc";
 
-crucible_llvm_verify bc "set" [] false
+llvm_verify bc "set" [] false
   do {
-    crucible_alloc_global "the_pair";
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    y <- crucible_fresh_var "y" (llvm_int 32);
-    crucible_execute_func [crucible_term x, crucible_term y];
-    crucible_points_to (crucible_field (crucible_global "the_pair") "first") (crucible_term x);
-    crucible_points_to (crucible_field (crucible_global "the_pair") "second") (crucible_term y);
+    llvm_alloc_global "the_pair";
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    y <- llvm_fresh_var "y" (llvm_int 32);
+    llvm_execute_func [llvm_term x, llvm_term y];
+    llvm_points_to (llvm_field (llvm_global "the_pair") "first") (llvm_term x);
+    llvm_points_to (llvm_field (llvm_global "the_pair") "second") (llvm_term y);
   }
   z3;

--- a/intTests/test_llvm_non_fresh/test.saw
+++ b/intTests/test_llvm_non_fresh/test.saw
@@ -9,40 +9,40 @@ bc <- llvm_load_module "test.bc";
 let i64 = llvm_int 64;
 
 foo_ov <-
-  crucible_llvm_verify bc "foo" [] false
+  llvm_verify bc "foo" [] false
     do {
-      x <- crucible_alloc i64;
-      crucible_execute_func [x];
-      crucible_return x;
+      x <- llvm_alloc i64;
+      llvm_execute_func [x];
+      llvm_return x;
     }
     z3;
 
 fails (
-  crucible_llvm_verify bc "foo" [] false
+  llvm_verify bc "foo" [] false
     do {
-      x <- crucible_alloc i64;
-      crucible_execute_func [x];
-      y <- crucible_alloc i64;
-      crucible_return y;
+      x <- llvm_alloc i64;
+      llvm_execute_func [x];
+      y <- llvm_alloc i64;
+      llvm_return y;
     }
     z3
   );
 
 fails (
-  crucible_llvm_verify bc "bar" [foo_ov] false
+  llvm_verify bc "bar" [foo_ov] false
     do {
-      x <- crucible_alloc i64;
-      crucible_execute_func [x];
-      crucible_return (crucible_term {{ 0 : [32] }});
+      x <- llvm_alloc i64;
+      llvm_execute_func [x];
+      llvm_return (llvm_term {{ 0 : [32] }});
     }
     z3
   );
 
 bar_ov1 <-
-  crucible_llvm_verify bc "bar" [] false
+  llvm_verify bc "bar" [] false
     do {
-      x <- crucible_alloc i64;
-      crucible_execute_func [x];
-      crucible_return (crucible_term {{ 1 : [32] }});
+      x <- llvm_alloc i64;
+      llvm_execute_func [x];
+      llvm_return (llvm_term {{ 1 : [32] }});
     }
     z3;

--- a/intTests/test_llvm_return_global/test.saw
+++ b/intTests/test_llvm_return_global/test.saw
@@ -8,31 +8,31 @@ bc <- llvm_load_module "test.bc";
 let i64 = llvm_int 64;
 
 fails (
-  crucible_llvm_verify bc "foo" [] false
+  llvm_verify bc "foo" [] false
     do {
-      crucible_alloc_global "glob";
-      crucible_execute_func [];
-      x <- crucible_alloc i64;
-      crucible_return x;
+      llvm_alloc_global "glob";
+      llvm_execute_func [];
+      x <- llvm_alloc i64;
+      llvm_return x;
     }
     z3
   );
 
 /*
 bar_ov0 <-
-  crucible_llvm_verify bc "bar" [foo_ov] false
+  llvm_verify bc "bar" [foo_ov] false
     do {
-      crucible_execute_func [];
-      crucible_return (crucible_term {{ 0 : [32] }});
+      llvm_execute_func [];
+      llvm_return (llvm_term {{ 0 : [32] }});
     }
     z3;
 */
 
 bar_ov1 <-
-  crucible_llvm_verify bc "bar" [] false
+  llvm_verify bc "bar" [] false
     do {
-      crucible_alloc_global "glob";
-      crucible_execute_func [];
-      crucible_return (crucible_term {{ 1 : [32] }});
+      llvm_alloc_global "glob";
+      llvm_execute_func [];
+      llvm_return (llvm_term {{ 1 : [32] }});
     }
     z3;

--- a/intTests/test_llvm_return_null/test.saw
+++ b/intTests/test_llvm_return_null/test.saw
@@ -8,19 +8,19 @@ bc <- llvm_load_module "test.bc";
 let i64 = llvm_int 64;
 
 fails (
-  crucible_llvm_verify bc "foo" [] false
+  llvm_verify bc "foo" [] false
     do {
-      crucible_execute_func [];
-      x <- crucible_alloc i64;
-      crucible_return x;
+      llvm_execute_func [];
+      x <- llvm_alloc i64;
+      llvm_return x;
     }
     z3
   );
 
 bar_ov1 <-
-  crucible_llvm_verify bc "bar" [] false
+  llvm_verify bc "bar" [] false
     do {
-      crucible_execute_func [];
-      crucible_return (crucible_term {{ 1 : [32] }});
+      llvm_execute_func [];
+      llvm_return (llvm_term {{ 1 : [32] }});
     }
     z3;

--- a/intTests/test_llvm_unsound_alloc/unsound_alloc.saw
+++ b/intTests/test_llvm_unsound_alloc/unsound_alloc.saw
@@ -1,23 +1,23 @@
 MODULE <- llvm_load_module "unsound_alloc.bc";
 
 let foo_setup = do {
-  x <- crucible_alloc (llvm_int 32);
-  x_star <- crucible_fresh_var "x" (llvm_int 32);
-  crucible_points_to x (crucible_term x_star);
-  crucible_execute_func [x];
-  crucible_return (crucible_term {{ x_star + 1 : [32] }});
+  x <- llvm_alloc (llvm_int 32);
+  x_star <- llvm_fresh_var "x" (llvm_int 32);
+  llvm_points_to x (llvm_term x_star);
+  llvm_execute_func [x];
+  llvm_return (llvm_term {{ x_star + 1 : [32] }});
 };
-foo_spec <- crucible_llvm_verify MODULE "foo" [] false foo_setup z3;
+foo_spec <- llvm_verify MODULE "foo" [] false foo_setup z3;
 
 let bar_setup = do {
-  crucible_execute_func [];
-  crucible_return (crucible_term {{ 3 : [32] }});
+  llvm_execute_func [];
+  llvm_return (llvm_term {{ 3 : [32] }});
 };
 
 // the below line (without override) correctly fails
-// crucible_llvm_verify MODULE "bar" [] false bar_setup z3;
+// llvm_verify MODULE "bar" [] false bar_setup z3;
 
 // works, but shouldn't
-crucible_llvm_verify MODULE "bar" [foo_spec] false bar_setup z3;
+llvm_verify MODULE "bar" [foo_spec] false bar_setup z3;
 
 print "Should not have succeeded - unsound!";

--- a/intTests/test_llvm_unsound_global/unsound_global.saw
+++ b/intTests/test_llvm_unsound_global/unsound_global.saw
@@ -1,25 +1,25 @@
 MODULE <- llvm_load_module "unsound_global.bc";
 
 let foo_setup = do {
-  crucible_alloc_global "GLOBAL";
-  x <- crucible_fresh_var "x" (llvm_int 32);
-  crucible_execute_func [crucible_term x];
-  crucible_return (crucible_term {{ x + 1 : [32] }});
-  // crucible_points_to (crucible_elem (crucible_global "GLOBAL") 1) (crucible_term x);
+  llvm_alloc_global "GLOBAL";
+  x <- llvm_fresh_var "x" (llvm_int 32);
+  llvm_execute_func [llvm_term x];
+  llvm_return (llvm_term {{ x + 1 : [32] }});
+  // llvm_points_to (llvm_elem (llvm_global "GLOBAL") 1) (llvm_term x);
 };
-foo_spec <- crucible_llvm_verify MODULE "foo" [] false foo_setup z3;
+foo_spec <- llvm_verify MODULE "foo" [] false foo_setup z3;
 
 let bar_setup = do {
-  crucible_alloc_global "GLOBAL";
-  crucible_alloc_global "TEST";
-  crucible_execute_func [];
-  crucible_return (crucible_term {{ 2 : [32] }});
+  llvm_alloc_global "GLOBAL";
+  llvm_alloc_global "TEST";
+  llvm_execute_func [];
+  llvm_return (llvm_term {{ 2 : [32] }});
 };
 
 // the below line (without override) correctly fails
-// crucible_llvm_verify MODULE "bar" [] false bar_setup z3;
+// llvm_verify MODULE "bar" [] false bar_setup z3;
 
 // works, but shouldn't
-crucible_llvm_verify MODULE "bar" [foo_spec] false bar_setup z3;
+llvm_verify MODULE "bar" [foo_spec] false bar_setup z3;
 
 print "Should not have succeeded - unsound!";

--- a/intTests/test_llvm_x86_01/test.saw
+++ b/intTests/test_llvm_x86_01/test.saw
@@ -3,17 +3,17 @@ enable_experimental;
 m <- llvm_load_module "test.bc";
 
 let foo_setup = do {
-  ptr <- crucible_alloc (llvm_int 64);
-  val <- crucible_fresh_var "val" (llvm_int 64);
-  crucible_points_to ptr (crucible_term val);
-  j <- crucible_fresh_var "j" (llvm_int 64);
-  crucible_execute_func [ptr, crucible_term j];
-  val <- crucible_fresh_var "val'" (llvm_int 64);
-  crucible_points_to ptr (crucible_term val);
+  ptr <- llvm_alloc (llvm_int 64);
+  val <- llvm_fresh_var "val" (llvm_int 64);
+  llvm_points_to ptr (llvm_term val);
+  j <- llvm_fresh_var "j" (llvm_int 64);
+  llvm_execute_func [ptr, llvm_term j];
+  val <- llvm_fresh_var "val'" (llvm_int 64);
+  llvm_points_to ptr (llvm_term val);
 };
-foo_method_spec <- crucible_llvm_verify_x86 m "./test" "foo" [] false foo_setup w4;
+foo_method_spec <- llvm_verify_x86 m "./test" "foo" [] false foo_setup w4;
 
 let bar_setup = do {
-  crucible_execute_func [];
+  llvm_execute_func [];
 };
-crucible_llvm_verify m "bar" [foo_method_spec] false bar_setup z3;
+llvm_verify m "bar" [foo_method_spec] false bar_setup z3;

--- a/intTests/test_llvm_x86_02/test.saw
+++ b/intTests/test_llvm_x86_02/test.saw
@@ -3,12 +3,12 @@ enable_experimental;
 m <- llvm_load_module "test.bc";
 
 let increment_setup = do {
-  ptr <- crucible_alloc (llvm_int 64);
-  val <- crucible_fresh_var "val" (llvm_int 64);
-  crucible_points_to ptr (crucible_term val);
-  crucible_execute_func [ptr];
-  valprime <- crucible_fresh_var "val'" (llvm_int 64);
-  crucible_points_to ptr (crucible_term valprime);
-  crucible_postcond {{ valprime == val }};
+  ptr <- llvm_alloc (llvm_int 64);
+  val <- llvm_fresh_var "val" (llvm_int 64);
+  llvm_points_to ptr (llvm_term val);
+  llvm_execute_func [ptr];
+  valprime <- llvm_fresh_var "val'" (llvm_int 64);
+  llvm_points_to ptr (llvm_term valprime);
+  llvm_postcond {{ valprime == val }};
 };
-fails (crucible_llvm_verify_x86 m "./test" "increment" [] false increment_setup w4);
+fails (llvm_verify_x86 m "./test" "increment" [] false increment_setup w4);

--- a/intTests/test_llvm_x86_03/test.saw
+++ b/intTests/test_llvm_x86_03/test.saw
@@ -3,7 +3,7 @@ enable_experimental;
 m <- llvm_load_module "test.bc";
 
 let test_setup = do {
-  crucible_execute_func [];
-  crucible_return (crucible_term {{ 1 : [64] }});
+  llvm_execute_func [];
+  llvm_return (llvm_term {{ 1 : [64] }});
 };
-fails (crucible_llvm_verify_x86 m "./test" "foo" [] false test_setup w4);
+fails (llvm_verify_x86 m "./test" "foo" [] false test_setup w4);

--- a/intTests/test_llvm_x86_04/test.saw
+++ b/intTests/test_llvm_x86_04/test.saw
@@ -3,17 +3,17 @@ enable_experimental;
 m <- llvm_load_module "test.bc";
 
 let addvar_setup = do {
-  crucible_alloc_global "var";
-  var <- crucible_fresh_var "var" (llvm_int 64);
-  crucible_points_to (crucible_global "var") (crucible_term {{ 2 : [64] }});
+  llvm_alloc_global "var";
+  var <- llvm_fresh_var "var" (llvm_int 64);
+  llvm_points_to (llvm_global "var") (llvm_term {{ 2 : [64] }});
 
-  ptr <- crucible_alloc (llvm_int 64);
-  val <- crucible_fresh_var "val" (llvm_int 64);
-  crucible_points_to ptr (crucible_term val);
+  ptr <- llvm_alloc (llvm_int 64);
+  val <- llvm_fresh_var "val" (llvm_int 64);
+  llvm_points_to ptr (llvm_term val);
 
-  crucible_execute_func [ptr];
+  llvm_execute_func [ptr];
 
-  valprime <- crucible_fresh_var "_val" (llvm_int 64);
-  crucible_points_to ptr (crucible_term valprime);
+  valprime <- llvm_fresh_var "_val" (llvm_int 64);
+  llvm_points_to ptr (llvm_term valprime);
 };
-crucible_llvm_verify_x86 m "./test" "addvar" [] false addvar_setup w4;
+llvm_verify_x86 m "./test" "addvar" [] false addvar_setup w4;

--- a/intTests/test_llvm_x86_05/test.saw
+++ b/intTests/test_llvm_x86_05/test.saw
@@ -3,8 +3,8 @@ enable_experimental;
 m <- llvm_load_module "test.bc";
 
 let returntest_setup = do {
-  crucible_execute_func [];
+  llvm_execute_func [];
 
-  crucible_return (crucible_term {{ 42 : [32] }});
+  llvm_return (llvm_term {{ 42 : [32] }});
 };
-crucible_llvm_verify_x86 m "./test" "returntest" [] false returntest_setup w4;
+llvm_verify_x86 m "./test" "returntest" [] false returntest_setup w4;

--- a/intTests/test_llvm_x86_06/test.saw
+++ b/intTests/test_llvm_x86_06/test.saw
@@ -3,11 +3,11 @@ enable_experimental;
 m <- llvm_load_module "test.bc";
 
 let discoverytest_setup = do {
-  crucible_execute_func [];
+  llvm_execute_func [];
 };
 
-fails (crucible_llvm_verify_x86 m "./test" "discoverytest" [] false discoverytest_setup w4);
+fails (llvm_verify_x86 m "./test" "discoverytest" [] false discoverytest_setup w4);
 
 add_x86_preserved_reg "rax";
-crucible_llvm_verify_x86 m "./test" "discoverytest" [] false discoverytest_setup w4;
+llvm_verify_x86 m "./test" "discoverytest" [] false discoverytest_setup w4;
 default_x86_preserved_reg;

--- a/intTests/test_profiling/dotprod_struct.saw
+++ b/intTests/test_profiling/dotprod_struct.saw
@@ -1,32 +1,32 @@
 import "dotprod.cry";
 
 let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
+    p <- llvm_alloc ty;
+    llvm_points_to p v;
     return p;
 };
 
 let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
+    x <- llvm_fresh_var n ty;
+    p <- alloc_init ty (llvm_term x);
     return (x, p);
 };
 
 let dotprod_spec n = do {
-    let nt = crucible_term {{ `n : [32] }};
+    let nt = llvm_term {{ `n : [32] }};
     (xs, xsp) <- ptr_to_fresh "xs" (llvm_array n (llvm_int 32));
     (ys, ysp) <- ptr_to_fresh "ys" (llvm_array n (llvm_int 32));
-    let xval = crucible_struct [ xsp, nt ];
-    let yval = crucible_struct [ ysp, nt ];
+    let xval = llvm_struct_value [ xsp, nt ];
+    let yval = llvm_struct_value [ ysp, nt ];
     xp <- alloc_init (llvm_struct "struct.vec_t") xval;
     yp <- alloc_init (llvm_struct "struct.vec_t") yval;
-    crucible_execute_func [xp, yp];
-    crucible_return (crucible_term {{ dotprod xs ys }});
+    llvm_execute_func [xp, yp];
+    llvm_return (llvm_term {{ dotprod xs ys }});
 };
 
 m <- llvm_load_module "dotprod_struct.bc";
 
 enable_crucible_profiling "prof";
-dotprod_ov <- crucible_llvm_verify m "dotprod_struct" [] true (dotprod_spec 2) z3;
-crucible_llvm_verify m "dotprod_wrap" [dotprod_ov] true (dotprod_spec 2) z3;
+dotprod_ov <- llvm_verify m "dotprod_struct" [] true (dotprod_spec 2) z3;
+llvm_verify m "dotprod_wrap" [dotprod_ov] true (dotprod_spec 2) z3;
 disable_crucible_profiling;

--- a/intTests/test_sanitize/test.saw
+++ b/intTests/test_sanitize/test.saw
@@ -2,10 +2,10 @@ m_norm <- llvm_load_module "add-normal.bc";
 m_san <- llvm_load_module "add-sanitized.bc";
 
 let f_spec = do {
-    x <- crucible_fresh_var "x" (llvm_int 32);
-    y <- crucible_fresh_var "y" (llvm_int 32);
-    crucible_execute_func [crucible_term x, crucible_term y];
+    x <- llvm_fresh_var "x" (llvm_int 32);
+    y <- llvm_fresh_var "y" (llvm_int 32);
+    llvm_execute_func [llvm_term x, llvm_term y];
 };
 
-crucible_llvm_verify m_norm "f" [] false f_spec z3;
-fails (crucible_llvm_verify m_san "f" [] false f_spec z3);
+llvm_verify m_norm "f" [] false f_spec z3;
+fails (llvm_verify m_san "f" [] false f_spec z3);

--- a/saw-remote-api/src/SAWServer/LLVMVerify.hs
+++ b/saw-remote-api/src/SAWServer/LLVMVerify.hs
@@ -42,9 +42,9 @@ llvmVerifyAssume mode (VerifyParams modName fun lemmaNames checkSat contract scr
               VerifyContract -> do
                 lemmas <- mapM getLLVMMethodSpecIR lemmaNames
                 proofScript <- interpretProofScript script
-                tl $ crucible_llvm_verify mod fun lemmas checkSat setup proofScript
+                tl $ llvm_verify mod fun lemmas checkSat setup proofScript
               AssumeContract ->
-                tl $ crucible_llvm_unsafe_assume_spec mod fun setup
+                tl $ llvm_unsafe_assume_spec mod fun setup
             dropTask
             setServerVal lemmaName res
             ok
@@ -71,7 +71,7 @@ llvmVerifyX86 (X86VerifyParams modName objName fun globals _lemmaNames checkSat 
             proofScript <- interpretProofScript script
             fileReader <- getFileReader
             setup <- compileLLVMContract fileReader bic cenv <$> traverse getExpr contract
-            res <- tl $ crucible_llvm_verify_x86 mod objName fun allocs checkSat setup proofScript
+            res <- tl $ llvm_verify_x86 mod objName fun allocs checkSat setup proofScript
             dropTask
             setServerVal lemmaName res
             ok

--- a/src/SAWScript/AST.hs
+++ b/src/SAWScript/AST.hs
@@ -32,6 +32,7 @@ module SAWScript.AST
        , toLName
        , tMono, tForall, tTuple, tRecord, tArray, tFun
        , tString, tTerm, tType, tBool, tInt, tAIG, tCFG
+       , tJVMSpec, tLLVMSpec
        , tBlock, tContext, tVar
 
        , PrettyPrint(..), pShow, commaSepAll, prettyWholeModule
@@ -209,6 +210,8 @@ data TyCon
   | BlockCon
   | AIGCon
   | CFGCon
+  | JVMSpecCon
+  | LLVMSpecCon
   | ContextCon Context
   deriving (Eq, Show)
 
@@ -389,6 +392,8 @@ instance PrettyPrint TyCon where
     IntCon         -> "Int"
     AIGCon         -> "AIG"
     CFGCon         -> "CFG"
+    JVMSpecCon     -> "JVMSpec"
+    LLVMSpecCon    -> "LLVMSpec"
     BlockCon       -> "<Block>"
     ContextCon cxt -> pretty par cxt
 
@@ -459,6 +464,12 @@ tCFG = TyCon CFGCon []
 
 tInt :: Type
 tInt = TyCon IntCon []
+
+tJVMSpec :: Type
+tJVMSpec = TyCon JVMSpecCon []
+
+tLLVMSpec :: Type
+tLLVMSpec = TyCon LLVMSpecCon []
 
 tBlock :: Type -> Type -> Type
 tBlock c t = TyCon BlockCon [c,t]

--- a/src/SAWScript/AutoMatch.hs
+++ b/src/SAWScript/AutoMatch.hs
@@ -402,14 +402,14 @@ processResults (TaggedSourceFile leftLang  leftFile) (TaggedSourceFile rightLang
                   [SAWScript.StmtBind Unknown (SAWScript.PVar boundName Nothing) Nothing
                      (SAWScript.Application
                         (SAWScript.Application
-                           (SAWScript.Var . locate $ "crucible_llvm_extract")
+                           (SAWScript.Var . locate $ "llvm_extract")
                            (SAWScript.Var loadedModule))
                         (SAWScript.String function))]
                JVM ->
                   [SAWScript.StmtBind Unknown (SAWScript.PVar boundName Nothing) Nothing
                      (SAWScript.Application
                         (SAWScript.Application
-                           (SAWScript.Var . locate $ "crucible_java_extract")
+                           (SAWScript.Var . locate $ "java_extract")
                            (SAWScript.Var loadedModule))
                         (SAWScript.String function))]
 

--- a/src/SAWScript/AutoMatch.hs
+++ b/src/SAWScript/AutoMatch.hs
@@ -409,7 +409,7 @@ processResults (TaggedSourceFile leftLang  leftFile) (TaggedSourceFile rightLang
                   [SAWScript.StmtBind Unknown (SAWScript.PVar boundName Nothing) Nothing
                      (SAWScript.Application
                         (SAWScript.Application
-                           (SAWScript.Var . locate $ "java_extract")
+                           (SAWScript.Var . locate $ "jvm_extract")
                            (SAWScript.Var loadedModule))
                         (SAWScript.String function))]
 

--- a/src/SAWScript/Crucible/JVM/BuiltinsJVM.hs
+++ b/src/SAWScript/Crucible/JVM/BuiltinsJVM.hs
@@ -22,7 +22,7 @@ module SAWScript.Crucible.JVM.BuiltinsJVM
        (
          loadJavaClass           -- java_load_class: reads a class from the codebase
        , prepareClassTopLevel
-       , java_extract   --
+       , jvm_extract   --
        ) where
 
 import           Data.List (isPrefixOf)
@@ -135,8 +135,8 @@ prepareClassTopLevel str = do
 
 -- | Extract a JVM method to saw-core
 --
-java_extract :: J.Class -> String -> TopLevel TypedTerm
-java_extract c mname = do
+jvm_extract :: J.Class -> String -> TopLevel TypedTerm
+jvm_extract c mname = do
   sc <- getSharedContext
   cb <- getJavaCodebase
   opts <- getOptions

--- a/src/SAWScript/Crucible/JVM/BuiltinsJVM.hs
+++ b/src/SAWScript/Crucible/JVM/BuiltinsJVM.hs
@@ -22,7 +22,7 @@ module SAWScript.Crucible.JVM.BuiltinsJVM
        (
          loadJavaClass           -- java_load_class: reads a class from the codebase
        , prepareClassTopLevel
-       , crucible_java_extract   --
+       , java_extract   --
        ) where
 
 import           Data.List (isPrefixOf)
@@ -135,8 +135,8 @@ prepareClassTopLevel str = do
 
 -- | Extract a JVM method to saw-core
 --
-crucible_java_extract :: J.Class -> String -> TopLevel TypedTerm
-crucible_java_extract c mname = do
+java_extract :: J.Class -> String -> TopLevel TypedTerm
+java_extract c mname = do
   sc <- getSharedContext
   cb <- getJavaCodebase
   opts <- getOptions

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -25,36 +25,36 @@ Stability   : provisional
 
 module SAWScript.Crucible.LLVM.Builtins
     ( show_cfg
-    , crucible_execute_func
-    , crucible_return
-    , crucible_precond
-    , crucible_postcond
-    , crucible_llvm_cfg
-    , crucible_llvm_extract
-    , crucible_llvm_compositional_extract
-    , crucible_llvm_verify
-    , crucible_llvm_array_size_profile
+    , llvm_execute_func
+    , llvm_return
+    , llvm_precond
+    , llvm_postcond
+    , llvm_cfg
+    , llvm_extract
+    , llvm_compositional_extract
+    , llvm_verify
+    , llvm_array_size_profile
     , crucible_setup_val_to_typed_term
-    , crucible_spec_size
-    , crucible_spec_solvers
-    , crucible_ghost_value
-    , crucible_declare_ghost_state
-    , crucible_equal
-    , crucible_points_to
-    , crucible_conditional_points_to
-    , crucible_points_to_array_prefix
-    , crucible_fresh_pointer
-    , crucible_llvm_unsafe_assume_spec
-    , crucible_fresh_var
-    , crucible_fresh_cryptol_var
-    , crucible_alloc
-    , crucible_alloc_aligned
-    , crucible_alloc_readonly
-    , crucible_alloc_readonly_aligned
-    , crucible_alloc_with_size
-    , crucible_symbolic_alloc
-    , crucible_alloc_global
-    , crucible_fresh_expanded_val
+    , llvm_spec_size
+    , llvm_spec_solvers
+    , llvm_ghost_value
+    , llvm_declare_ghost_state
+    , llvm_equal
+    , llvm_points_to
+    , llvm_conditional_points_to
+    , llvm_points_to_array_prefix
+    , llvm_fresh_pointer
+    , llvm_unsafe_assume_spec
+    , llvm_fresh_var
+    , llvm_fresh_cryptol_var
+    , llvm_alloc
+    , llvm_alloc_aligned
+    , llvm_alloc_readonly
+    , llvm_alloc_readonly_aligned
+    , llvm_alloc_with_size
+    , llvm_symbolic_alloc
+    , llvm_alloc_global
+    , llvm_fresh_expanded_val
     , llvm_sizeof
 
     --
@@ -258,7 +258,7 @@ resolveSpecName nm =
     )
   else return (nm, Nothing)
 
-crucible_llvm_verify ::
+llvm_verify ::
   Some LLVMModule        ->
   String                 ->
   [SomeLLVM MS.CrucibleMethodSpecIR] ->
@@ -266,31 +266,31 @@ crucible_llvm_verify ::
   LLVMCrucibleSetupM ()      ->
   ProofScript SatResult  ->
   TopLevel (SomeLLVM MS.CrucibleMethodSpecIR)
-crucible_llvm_verify (Some lm) nm lemmas checkSat setup tactic =
+llvm_verify (Some lm) nm lemmas checkSat setup tactic =
   do lemmas' <- checkModuleCompatibility lm lemmas
      withMethodSpec checkSat lm nm setup $ \cc method_spec ->
        do (res_method_spec, _) <- verifyMethodSpec cc method_spec lemmas' checkSat tactic Nothing
           returnProof $ SomeLLVM res_method_spec
 
-crucible_llvm_unsafe_assume_spec ::
+llvm_unsafe_assume_spec ::
   Some LLVMModule  ->
   String          {- ^ Name of the function -} ->
   LLVMCrucibleSetupM () {- ^ Boundary specification -} ->
   TopLevel (SomeLLVM MS.CrucibleMethodSpecIR)
-crucible_llvm_unsafe_assume_spec (Some lm) nm setup =
+llvm_unsafe_assume_spec (Some lm) nm setup =
   withMethodSpec False lm nm setup $ \_ method_spec ->
   do printOutLnTop Info $
        unwords ["Assume override", (method_spec ^. csName)]
      returnProof $ SomeLLVM method_spec
 
-crucible_llvm_array_size_profile ::
+llvm_array_size_profile ::
   ProofScript SatResult  ->
   Some LLVMModule ->
   String ->
   [SomeLLVM MS.CrucibleMethodSpecIR] ->
   LLVMCrucibleSetupM () ->
   TopLevel [(String, [Crucible.FunctionProfile])]
-crucible_llvm_array_size_profile assume (Some lm) nm lemmas setup = do
+llvm_array_size_profile assume (Some lm) nm lemmas setup = do
   cell <- io $ newIORef (Map.empty :: Map Text.Text [Crucible.FunctionProfile])
   lemmas' <- checkModuleCompatibility lm lemmas
   withMethodSpec False lm nm setup $ \cc ms -> do
@@ -314,7 +314,7 @@ llvmURI symbol_name =
 llvmNameInfo :: String -> NameInfo
 llvmNameInfo symbol_name = ImportedName (llvmURI symbol_name) [ Text.pack symbol_name ]
 
-crucible_llvm_compositional_extract ::
+llvm_compositional_extract ::
   Some LLVMModule ->
   String ->
   String ->
@@ -323,7 +323,7 @@ crucible_llvm_compositional_extract ::
   LLVMCrucibleSetupM () ->
   ProofScript SatResult ->
   TopLevel (SomeLLVM MS.CrucibleMethodSpecIR)
-crucible_llvm_compositional_extract (Some lm) nm func_name lemmas checkSat setup tactic =
+llvm_compositional_extract (Some lm) nm func_name lemmas checkSat setup tactic =
   do lemmas' <- checkModuleCompatibility lm lemmas
      withMethodSpec checkSat lm nm setup $ \cc method_spec ->
        do let value_input_parameters = mapMaybe
@@ -342,7 +342,7 @@ crucible_llvm_compositional_extract (Some lm) nm func_name lemmas checkSat setup
             fail $ unlines
               [ "Unsupported input parameters:"
               , show unsupported_input_parameters
-              , "An input parameter must be bound by crucible_execute_func or crucible_points_to."
+              , "An input parameter must be bound by llvm_execute_func or llvm_points_to."
               ]
 
           let return_output_parameter =
@@ -365,7 +365,7 @@ crucible_llvm_compositional_extract (Some lm) nm func_name lemmas checkSat setup
             fail $ unlines
               [ "Unsupported output parameters:"
               , show unsupported_output_parameters
-              , "An output parameter must be bound by crucible_return or crucible_points_to."
+              , "An output parameter must be bound by llvm_return or llvm_points_to."
               ]
 
           (res_method_spec, post_override_state) <- verifyMethodSpec cc method_spec lemmas' checkSat tactic Nothing
@@ -419,7 +419,7 @@ crucible_llvm_compositional_extract (Some lm) nm func_name lemmas checkSat setup
           typed_extracted_func_const <- io $ mkTypedTerm shared_context extracted_func_const
           modify' $
             extendEnv
-              (Located func_name func_name $ PosInternal "crucible_llvm_compositional_extract")
+              (Located func_name func_name $ PosInternal "llvm_compositional_extract")
               Nothing
               Nothing
               (VTerm typed_extracted_func_const)
@@ -454,7 +454,7 @@ checkModuleCompatibility llvmModule = foldM step []
         Just Refl -> pure (lemma:accum)
 
 
--- -- | The real work of 'crucible_llvm_verify' and 'crucible_llvm_unsafe_assume_spec'.
+-- -- | The real work of 'llvm_verify' and 'llvm_unsafe_assume_spec'.
 withMethodSpec ::
   Bool {- ^ path sat -} ->
   LLVMModule arch ->
@@ -519,7 +519,7 @@ verifyMethodSpec cc methodSpec lemmas checkSat tactic asp =
      let sym = cc^.ccBackend
 
      profFile <- rwProfilingFile <$> getTopLevelRW
-     (writeFinalProfile, pfs) <- io $ Common.setupProfiling sym "crucible_llvm_verify" profFile
+     (writeFinalProfile, pfs) <- io $ Common.setupProfiling sym "llvm_verify" profFile
 
      -- set up the LLVM memory with a pristine heap
      let globals = cc^.ccLLVMGlobals
@@ -553,7 +553,7 @@ verifyMethodSpec cc methodSpec lemmas checkSat tactic asp =
      -- run the symbolic execution
      printOutLnTop Info $
        unwords ["Simulating", (methodSpec ^. csName) , "..."]
-     top_loc <- toW4Loc "crucible_llvm_verify" <$> getPosition
+     top_loc <- toW4Loc "llvm_verify" <$> getPosition
      (ret, globals3) <-
        io $ verifySimulate opts cc pfs methodSpec args assumes top_loc lemmas globals2 checkSat asp
 
@@ -683,16 +683,16 @@ checkSpecReturnType cc mspec =
 
 -- | Evaluate the precondition part of a Crucible method spec:
 --
--- * Allocate heap space for each 'crucible_alloc' statement.
+-- * Allocate heap space for each 'llvm_alloc' statement.
 --
--- * Record an equality precondition for each 'crucible_equal'
+-- * Record an equality precondition for each 'llvm_equal'
 -- statement.
 --
--- * Write to memory for each 'crucible_points_to' statement. (Writes
+-- * Write to memory for each 'llvm_points_to' statement. (Writes
 -- to already-initialized locations are transformed into equality
 -- preconditions.)
 --
--- * Evaluate the function arguments from the 'crucible_execute_func'
+-- * Evaluate the function arguments from the 'llvm_execute_func'
 -- statement.
 --
 -- Returns a tuple of (arguments, preconditions, pointer values,
@@ -716,7 +716,7 @@ verifyPrestate opts cc mspec globals =
      let lvar = Crucible.llvmMemVar (ccLLVMContext cc)
      let Just mem = Crucible.lookupGlobal lvar globals
 
-     -- Allocate LLVM memory for each 'crucible_alloc'
+     -- Allocate LLVM memory for each 'llvm_alloc'
      (env, mem') <- runStateT
        (Map.traverseWithKey (doAlloc cc) (mspec ^. MS.csPreState . MS.csAllocs))
        mem
@@ -829,7 +829,7 @@ resolveArguments cc mem mspec env = mapM resolveArg [0..(nArgs-1)]
 
 --------------------------------------------------------------------------------
 
--- | For each "crucible_global_alloc" in the method specification, allocate and
+-- | For each "llvm_global_alloc" in the method specification, allocate and
 -- register the appropriate memory.
 setupGlobalAllocs :: forall arch.
   (?lc :: Crucible.TypeContext, Crucible.HasPtrWidth (Crucible.ArchWidth arch)) =>
@@ -1269,7 +1269,7 @@ verifyPoststate cc mspec env0 globals ret =
       case (ret, mspec ^. MS.csRetValue) of
         (Just (rty,r), Just expect) -> matchArg opts sc cc mspec PostState r rty expect
         (Nothing     , Just _ )     ->
-          fail "verifyPoststate: unexpected crucible_return specification"
+          fail "verifyPoststate: unexpected llvm_return specification"
         _ -> return ()
 
 --------------------------------------------------------------------------------
@@ -1503,11 +1503,11 @@ extractFromLLVMCFG opts sc cc (Crucible.AnyCFG cfg) =
 
 --------------------------------------------------------------------------------
 
-crucible_llvm_extract ::
+llvm_extract ::
   Some LLVMModule ->
   String ->
   TopLevel TypedTerm
-crucible_llvm_extract (Some lm) fn_name =
+llvm_extract (Some lm) fn_name =
   do let ctx = modTrans lm ^. Crucible.transContext
      let ?lc = ctx^.Crucible.llvmTypeCtx
      let edef = findDefMaybeStatic (modAST lm) fn_name
@@ -1520,20 +1520,20 @@ crucible_llvm_extract (Some lm) fn_name =
                   NE.map (map L.typedType . L.defArgs) defs <>
                   NE.map (\d -> [L.defRetType d]) defs
             when (any L.isPointer defTypes) $
-              throwTopLevel "Pointer types are not supported by `crucible_llvm_extract`."
+              throwTopLevel "Pointer types are not supported by `llvm_extract`."
             when (any L.isAlias defTypes) $
-              throwTopLevel "Type aliases are not supported by `crucible_llvm_extract`."
+              throwTopLevel "Type aliases are not supported by `llvm_extract`."
        Left err -> throwTopLevel (displayVerifExceptionOpts opts err)
      setupLLVMCrucibleContext False lm $ \cc ->
        case Map.lookup (fromString fn_name) (Crucible.cfgMap (ccLLVMModuleTrans cc)) of
          Nothing  -> throwTopLevel $ unwords ["function", fn_name, "not found"]
          Just (_,cfg) -> io $ extractFromLLVMCFG opts sc cc cfg
 
-crucible_llvm_cfg ::
+llvm_cfg ::
   Some LLVMModule ->
   String ->
   TopLevel SAW_CFG
-crucible_llvm_cfg (Some lm) fn_name =
+llvm_cfg (Some lm) fn_name =
   do let ctx = modTrans lm ^. Crucible.transContext
      let ?lc = ctx^.Crucible.llvmTypeCtx
      setupLLVMCrucibleContext False lm $ \cc ->
@@ -1572,29 +1572,29 @@ checkMemTypeCompatibility loc t1 t2 =
 --------------------------------------------------------------------------------
 -- Setup builtins
 
-crucible_precond :: TypedTerm -> LLVMCrucibleSetupM ()
-crucible_precond term =
+llvm_precond :: TypedTerm -> LLVMCrucibleSetupM ()
+llvm_precond term =
   LLVMCrucibleSetupM $
-  do loc <- getW4Position "crucible_precond"
+  do loc <- getW4Position "llvm_precond"
      Setup.crucible_precond loc term
 
-crucible_postcond :: TypedTerm -> LLVMCrucibleSetupM ()
-crucible_postcond term =
+llvm_postcond :: TypedTerm -> LLVMCrucibleSetupM ()
+llvm_postcond term =
   LLVMCrucibleSetupM $
-  do loc <- getW4Position "crucible_postcond"
+  do loc <- getW4Position "llvm_postcond"
      Setup.crucible_postcond loc term
 
-crucible_return ::
+llvm_return ::
   AllLLVM MS.SetupValue ->
   LLVMCrucibleSetupM ()
-crucible_return val =
+llvm_return val =
   LLVMCrucibleSetupM $
   do Setup.crucible_return (getAllLLVM val)
 
-crucible_execute_func ::
+llvm_execute_func ::
   [AllLLVM MS.SetupValue] ->
   LLVMCrucibleSetupM ()
-crucible_execute_func args =
+llvm_execute_func args =
   LLVMCrucibleSetupM $ Setup.crucible_execute_func (map getAllLLVM args)
 
 getLLVMCrucibleContext :: CrucibleSetup (LLVM arch) (LLVMCrucibleContext arch)
@@ -1627,29 +1627,29 @@ cryptolTypeOfActual dl mt =
 
 -- | Generate a fresh variable term. The name will be used when
 -- pretty-printing the variable in debug output.
-crucible_fresh_var ::
+llvm_fresh_var ::
   String                  {- ^ variable name    -} ->
   L.Type                  {- ^ variable type    -} ->
   LLVMCrucibleSetupM TypedTerm {- ^ fresh typed term -}
-crucible_fresh_var name lty =
+llvm_fresh_var name lty =
   LLVMCrucibleSetupM $
   do cctx <- getLLVMCrucibleContext
      let ?lc = ccTypeCtx cctx
-     loc <- getW4Position "crucible_fresh_var"
+     loc <- getW4Position "llvm_fresh_var"
      lty' <- memTypeForLLVMType loc lty
      sc <- lift getSharedContext
      let dl = Crucible.llvmDataLayout (ccTypeCtx cctx)
      case cryptolTypeOfActual dl lty' of
-       Nothing -> throwCrucibleSetup loc $ "Unsupported type in crucible_fresh_var: " ++ show (L.ppType lty)
+       Nothing -> throwCrucibleSetup loc $ "Unsupported type in llvm_fresh_var: " ++ show (L.ppType lty)
        Just cty -> Setup.freshVariable sc name cty
 
-crucible_fresh_cryptol_var ::
+llvm_fresh_cryptol_var ::
   String ->
   Cryptol.Schema ->
   LLVMCrucibleSetupM TypedTerm
-crucible_fresh_cryptol_var name s =
+llvm_fresh_cryptol_var name s =
   LLVMCrucibleSetupM $
-  do loc <- getW4Position "crucible_fresh_var"
+  do loc <- getW4Position "llvm_fresh_var"
      case s of
        Cryptol.Forall [] [] ty ->
          do sc <- lift getSharedContext
@@ -1662,20 +1662,20 @@ crucible_fresh_cryptol_var name s =
 -- components of the LLVM type. Only the primitive types
 -- suitable for import as SAW core terms will be matched
 -- against fresh variables.
-crucible_fresh_expanded_val ::
+llvm_fresh_expanded_val ::
   L.Type         {- ^ variable type          -} ->
   LLVMCrucibleSetupM (AllLLVM SetupValue)
                  {- ^ elaborated setup value -}
-crucible_fresh_expanded_val lty =
+llvm_fresh_expanded_val lty =
   LLVMCrucibleSetupM $
   do sc <- lift getSharedContext
      cctx <- getLLVMCrucibleContext
      let ?lc = ccTypeCtx cctx
-     loc <- getW4Position "crucible_fresh_expanded_val"
+     loc <- getW4Position "llvm_fresh_expanded_val"
      lty' <- memTypeForLLVMType loc lty
      constructExpandedSetupValue cctx sc loc lty'
 
--- | See 'crucible_fresh_expanded_val'
+-- | See 'llvm_fresh_expanded_val'
 --
 -- This is the recursively-called worker function.
 constructExpandedSetupValue ::
@@ -1719,7 +1719,7 @@ constructExpandedSetupValue cc sc loc t =
     Crucible.VecType{}      -> failUnsupportedType "Vec"
     Crucible.X86_FP80Type{} -> failUnsupportedType "X86_FP80"
   where failUnsupportedType tyName = throwCrucibleSetup loc $ unwords
-          ["crucible_fresh_expanded_var: " ++ tyName ++ " not supported"]
+          ["llvm_fresh_expanded_var: " ++ tyName ++ " not supported"]
 
 
 memTypeForLLVMType ::
@@ -1760,13 +1760,13 @@ symTypeAlias :: Crucible.SymType -> Maybe Crucible.Ident
 symTypeAlias (Crucible.Alias i) = Just i
 symTypeAlias _ = Nothing
 
--- | Does the hard work for 'crucible_alloc', 'crucible_alloc_with_size',
---   'crucible_alloc_readonly', etc.
-crucible_alloc_internal ::
+-- | Does the hard work for 'llvm_alloc', 'llvm_alloc_with_size',
+--   'llvm_alloc_readonly', etc.
+llvm_alloc_internal ::
   L.Type  ->
   LLVMAllocSpec  ->
   CrucibleSetup (Crucible.LLVM arch) (AllLLVM SetupValue)
-crucible_alloc_internal lty spec =
+llvm_alloc_internal lty spec =
   do cctx <- getLLVMCrucibleContext
      let ?lc = ccTypeCtx cctx
      let ?dl = Crucible.llvmDataLayout ?lc
@@ -1778,16 +1778,16 @@ crucible_alloc_internal lty spec =
        Nothing -> return ()
      return (mkAllLLVM (SetupVar n))
 
-crucible_alloc_with_mutability_and_size ::
+llvm_alloc_with_mutability_and_size ::
   Crucible.Mutability    ->
   Maybe (Crucible.Bytes) ->
   Maybe Crucible.Alignment ->
   L.Type           ->
   LLVMCrucibleSetupM (AllLLVM SetupValue)
-crucible_alloc_with_mutability_and_size mut sz alignment lty =
+llvm_alloc_with_mutability_and_size mut sz alignment lty =
   LLVMCrucibleSetupM $
   do cctx <- getLLVMCrucibleContext
-     loc <- getW4Position "crucible_alloc"
+     loc <- getW4Position "llvm_alloc"
      memTy <- memTypeForLLVMType loc lty
      opts <- lift getOptions
 
@@ -1821,7 +1821,7 @@ crucible_alloc_with_mutability_and_size mut sz alignment lty =
               pure a
          Nothing -> pure $! memTyAlign
 
-     crucible_alloc_internal lty $
+     llvm_alloc_internal lty $
        LLVMAllocSpec
        { _allocSpecMut = mut
        , _allocSpecType = memTy
@@ -1831,40 +1831,40 @@ crucible_alloc_with_mutability_and_size mut sz alignment lty =
        , _allocSpecFresh = False
        }
 
-crucible_alloc ::
+llvm_alloc ::
   L.Type         ->
   LLVMCrucibleSetupM (AllLLVM SetupValue)
-crucible_alloc =
-  crucible_alloc_with_mutability_and_size Crucible.Mutable Nothing Nothing
+llvm_alloc =
+  llvm_alloc_with_mutability_and_size Crucible.Mutable Nothing Nothing
 
-crucible_alloc_aligned ::
+llvm_alloc_aligned ::
   Int            ->
   L.Type         ->
   LLVMCrucibleSetupM (AllLLVM SetupValue)
-crucible_alloc_aligned =
-  crucible_alloc_aligned_with_mutability Crucible.Mutable
+llvm_alloc_aligned =
+  llvm_alloc_aligned_with_mutability Crucible.Mutable
 
-crucible_alloc_readonly ::
+llvm_alloc_readonly ::
   L.Type         ->
   LLVMCrucibleSetupM (AllLLVM SetupValue)
-crucible_alloc_readonly =
-  crucible_alloc_with_mutability_and_size Crucible.Immutable Nothing Nothing
+llvm_alloc_readonly =
+  llvm_alloc_with_mutability_and_size Crucible.Immutable Nothing Nothing
 
-crucible_alloc_readonly_aligned ::
+llvm_alloc_readonly_aligned ::
   Int            ->
   L.Type         ->
   LLVMCrucibleSetupM (AllLLVM SetupValue)
-crucible_alloc_readonly_aligned =
-  crucible_alloc_aligned_with_mutability Crucible.Immutable
+llvm_alloc_readonly_aligned =
+  llvm_alloc_aligned_with_mutability Crucible.Immutable
 
-crucible_alloc_aligned_with_mutability ::
+llvm_alloc_aligned_with_mutability ::
   Crucible.Mutability ->
   Int ->
   L.Type ->
   LLVMCrucibleSetupM (AllLLVM SetupValue)
-crucible_alloc_aligned_with_mutability mut n lty =
+llvm_alloc_aligned_with_mutability mut n lty =
   do alignment <- LLVMCrucibleSetupM $ coerceAlignment n
-     crucible_alloc_with_mutability_and_size
+     llvm_alloc_with_mutability_and_size
        mut
        Nothing
        (Just alignment)
@@ -1874,39 +1874,39 @@ coerceAlignment :: Int -> CrucibleSetup (LLVM arch) Crucible.Alignment
 coerceAlignment n =
   case Crucible.toAlignment (Crucible.toBytes n) of
     Nothing ->
-      do loc <- getW4Position "crucible_alloc_aligned_with_mutability"
+      do loc <- getW4Position "llvm_alloc_aligned_with_mutability"
          throwCrucibleSetup loc $ unwords
-           [ "crucible_alloc_aligned/crucible_alloc_readonly_aligned:"
+           [ "llvm_alloc_aligned/llvm_alloc_readonly_aligned:"
            , "invalid non-power-of-2 alignment:"
            , show n
            ]
     Just alignment -> return alignment
 
-crucible_alloc_with_size ::
+llvm_alloc_with_size ::
   Int {-^ allocation size (in bytes) -} ->
   L.Type         ->
   LLVMCrucibleSetupM (AllLLVM SetupValue)
-crucible_alloc_with_size sz lty =
-  crucible_alloc_with_mutability_and_size
+llvm_alloc_with_size sz lty =
+  llvm_alloc_with_mutability_and_size
     Crucible.Mutable
     (Just (Crucible.toBytes sz))
     Nothing
     lty
 
-crucible_symbolic_alloc ::
+llvm_symbolic_alloc ::
   Bool ->
   Int ->
   Term ->
   LLVMCrucibleSetupM (AllLLVM SetupValue)
-crucible_symbolic_alloc ro align_bytes sz =
+llvm_symbolic_alloc ro align_bytes sz =
   LLVMCrucibleSetupM $
   do alignment <- coerceAlignment align_bytes
-     loc <- getW4Position "crucible_symbolic_alloc"
+     loc <- getW4Position "llvm_symbolic_alloc"
      sc <- lift getSharedContext
      sz_ty <- liftIO $ Cryptol.scCryptolType sc =<< scTypeOf sc sz
      when (Just 64 /= asCryptolBVType sz_ty) $
        throwCrucibleSetup loc $ unwords
-         [ "crucible_symbolic_alloc:"
+         [ "llvm_symbolic_alloc:"
          , "unexpected type of size term, expected [64], found"
          , Cryptol.pretty sz_ty
          ]
@@ -1929,20 +1929,20 @@ asCryptolBVType ty
     Cryptol.tIsNum n
   | otherwise = Nothing
 
-crucible_alloc_global ::
+llvm_alloc_global ::
   String         ->
   LLVMCrucibleSetupM ()
-crucible_alloc_global name =
+llvm_alloc_global name =
   LLVMCrucibleSetupM $
-  do loc <- getW4Position "crucible_alloc_global"
+  do loc <- getW4Position "llvm_alloc_global"
      Setup.addAllocGlobal . LLVMAllocGlobal loc $ L.Symbol name
 
-crucible_fresh_pointer ::
+llvm_fresh_pointer ::
   L.Type         ->
   LLVMCrucibleSetupM (AllLLVM SetupValue)
-crucible_fresh_pointer lty =
+llvm_fresh_pointer lty =
   LLVMCrucibleSetupM $
-  do loc <- getW4Position "crucible_fresh_pointer"
+  do loc <- getW4Position "llvm_fresh_pointer"
      memTy <- memTypeForLLVMType loc lty
      constructFreshPointer (llvmTypeAlias lty) loc memTy
 
@@ -1973,33 +1973,33 @@ constructFreshPointer mid loc memTy =
        Nothing -> return ()
      return (mkAllLLVM (SetupVar n))
 
-crucible_points_to ::
+llvm_points_to ::
   Bool {- ^ whether to check type compatibility -} ->
   AllLLVM SetupValue     ->
   AllLLVM SetupValue     ->
   LLVMCrucibleSetupM ()
-crucible_points_to typed =
-  crucible_points_to_internal typed Nothing
+llvm_points_to typed =
+  llvm_points_to_internal typed Nothing
 
-crucible_conditional_points_to ::
+llvm_conditional_points_to ::
   Bool {- ^ whether to check type compatibility -} ->
   TypedTerm ->
   AllLLVM SetupValue ->
   AllLLVM SetupValue ->
   LLVMCrucibleSetupM ()
-crucible_conditional_points_to typed cond =
-  crucible_points_to_internal typed (Just cond)
+llvm_conditional_points_to typed cond =
+  llvm_points_to_internal typed (Just cond)
 
-crucible_points_to_internal ::
+llvm_points_to_internal ::
   Bool {- ^ whether to check type compatibility -} ->
   Maybe TypedTerm ->
   AllLLVM SetupValue ->
   AllLLVM SetupValue ->
   LLVMCrucibleSetupM ()
-crucible_points_to_internal typed cond (getAllLLVM -> ptr) (getAllLLVM -> val) =
+llvm_points_to_internal typed cond (getAllLLVM -> ptr) (getAllLLVM -> val) =
   LLVMCrucibleSetupM $
   do cc <- getLLVMCrucibleContext
-     loc <- getW4Position "crucible_points_to"
+     loc <- getW4Position "llvm_points_to"
      Crucible.llvmPtrWidth (ccLLVMContext cc) $ \wptr -> Crucible.withPtrWidth wptr $
        do let ?lc = ccTypeCtx cc
           st <- get
@@ -2025,21 +2025,21 @@ crucible_points_to_internal typed cond (getAllLLVM -> ptr) (getAllLLVM -> val) =
           when typed (checkMemTypeCompatibility loc lhsTy valTy)
           Setup.addPointsTo (LLVMPointsTo loc cond ptr $ ConcreteSizeValue val)
 
-crucible_points_to_array_prefix ::
+llvm_points_to_array_prefix ::
   AllLLVM SetupValue ->
   TypedTerm ->
   TypedTerm ->
   LLVMCrucibleSetupM ()
-crucible_points_to_array_prefix (getAllLLVM -> ptr) arr sz =
+llvm_points_to_array_prefix (getAllLLVM -> ptr) arr sz =
   LLVMCrucibleSetupM $
   do cc <- getLLVMCrucibleContext
-     loc <- getW4Position "crucible_points_to_array_prefix"
+     loc <- getW4Position "llvm_points_to_array_prefix"
      case ttSchema sz of
        Cryptol.Forall [] [] ty
          | Just 64 == asCryptolBVType ty ->
            return ()
        _ -> throwCrucibleSetup loc $ unwords
-         [ "crucible_points_to_array_prefix:"
+         [ "llvm_points_to_array_prefix:"
          , "unexpected type of size term, expected [64], found"
          , Cryptol.pretty (ttSchema sz)
          ]
@@ -2066,14 +2066,14 @@ crucible_points_to_array_prefix (getAllLLVM -> ptr) arr sz =
             _ -> throwCrucibleSetup loc $ "lhs not a pointer type: " ++ show ptrTy
           Setup.addPointsTo (LLVMPointsTo loc Nothing ptr $ SymbolicSizeValue arr sz)
 
-crucible_equal ::
+llvm_equal ::
   AllLLVM SetupValue ->
   AllLLVM SetupValue ->
   LLVMCrucibleSetupM ()
-crucible_equal (getAllLLVM -> val1) (getAllLLVM -> val2) =
+llvm_equal (getAllLLVM -> val1) (getAllLLVM -> val2) =
   LLVMCrucibleSetupM $
   do cc <- getLLVMCrucibleContext
-     loc <- getW4Position "crucible_equal"
+     loc <- getW4Position "llvm_equal"
      st <- get
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
          nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
@@ -2088,28 +2088,28 @@ crucible_equal (getAllLLVM -> val1) (getAllLLVM -> val2) =
        ]
      Setup.addCondition (MS.SetupCond_Equal loc val1 val2)
 
-crucible_declare_ghost_state ::
+llvm_declare_ghost_state ::
   String         ->
   TopLevel Value
-crucible_declare_ghost_state name =
+llvm_declare_ghost_state name =
   do allocator <- getHandleAlloc
      global <- liftIO (Crucible.freshGlobalVar allocator (Text.pack name) knownRepr)
      return (VGhostVar global)
 
-crucible_ghost_value ::
+llvm_ghost_value ::
   MS.GhostGlobal ->
   TypedTerm ->
   LLVMCrucibleSetupM ()
-crucible_ghost_value ghost val = LLVMCrucibleSetupM $
-  do loc <- getW4Position "crucible_ghost_value"
+llvm_ghost_value ghost val = LLVMCrucibleSetupM $
+  do loc <- getW4Position "llvm_ghost_value"
      Setup.addCondition (MS.SetupCond_Ghost () loc ghost val)
 
-crucible_spec_solvers :: SomeLLVM (MS.CrucibleMethodSpecIR) -> [String]
-crucible_spec_solvers (SomeLLVM mir) =
+llvm_spec_solvers :: SomeLLVM (MS.CrucibleMethodSpecIR) -> [String]
+llvm_spec_solvers (SomeLLVM mir) =
   Set.toList $ solverStatsSolvers $ (view MS.csSolverStats) $ mir
 
-crucible_spec_size :: SomeLLVM MS.CrucibleMethodSpecIR -> Integer
-crucible_spec_size (SomeLLVM mir) =
+llvm_spec_size :: SomeLLVM MS.CrucibleMethodSpecIR -> Integer
+llvm_spec_size (SomeLLVM mir) =
   solverStatsGoalSize $ mir ^. MS.csSolverStats
 
 crucible_setup_val_to_typed_term ::

--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -1322,7 +1322,7 @@ learnPointsTo opts sc cc spec prepost (LLVMPointsTo loc maybe_cond ptr val) =
      case val of
        ConcreteSizeValue val' ->
          do memTy <- liftIO $ typeOfSetupValue cc tyenv nameEnv val'
-            -- In case the types are different (from crucible_points_to_untyped)
+            -- In case the types are different (from llvm_points_to_untyped)
             -- then the load type should be determined by the rhs.
             storTy <- Crucible.toStorableType memTy
             res <- liftIO $ Crucible.loadRaw sym mem ptr1 storTy alignment
@@ -1399,7 +1399,7 @@ stateCond :: PrePost -> String
 stateCond PreState = "precondition"
 stateCond PostState = "postcondition"
 
--- | Process a "crucible_equal" statement from the precondition
+-- | Process an @llvm_equal@ statement from the precondition
 -- section of the CrucibleSetup block.
 learnEqual ::
   Crucible.HasPtrWidth (Crucible.ArchWidth arch) =>
@@ -1419,7 +1419,7 @@ learnEqual opts sc cc spec loc prepost v1 v2 = do
   let name = "equality " ++ stateCond prepost
   addAssert p (Crucible.SimError loc (Crucible.AssertFailureSimError name ""))
 
--- | Process a "crucible_precond" statement from the precondition
+-- | Process an @llvm_precond@ statement from the precondition
 -- section of the CrucibleSetup block.
 learnPred ::
   SharedContext                                                       ->
@@ -1455,8 +1455,8 @@ instantiateExtResolveSAWSymBV sc cc w tm = do
 ------------------------------------------------------------------------
 
 -- | Invalidate all mutable memory that was allocated in the method spec
--- precondition, either through explicit calls to "crucible_alloc" or to
--- "crucible_alloc_global". As an optimization, a memory allocation that
+-- precondition, either through explicit calls to @llvm_alloc@ or to
+-- @llvm_alloc_global@. As an optimization, a memory allocation that
 -- is overwritten by a postcondition memory write is not invalidated.
 -- Return a map containing the overwritten memory allocations.
 invalidateMutableAllocs ::
@@ -1549,8 +1549,8 @@ invalidateMutableAllocs opts sc cc cs = do
 
 ------------------------------------------------------------------------
 
--- | Perform an allocation as indicated by a 'crucible_alloc' or
--- 'crucible_fresh_pointer' statement from the postcondition section.
+-- | Perform an allocation as indicated by an @llvm_alloc@ or
+-- @llvm_fresh_pointer@ statement from the postcondition section.
 executeAllocation ::
   (?lc :: Crucible.TypeContext, Crucible.HasPtrWidth (Crucible.ArchWidth arch)) =>
   Options                        ->
@@ -1630,7 +1630,7 @@ executePointsTo opts sc cc spec overwritten_allocs (LLVMPointsTo _loc cond ptr v
      let memVar = Crucible.llvmMemVar (ccLLVMContext cc)
      mem <- readGlobal memVar
 
-     -- In case the types are different (from crucible_points_to_untyped)
+     -- In case the types are different (from llvm_points_to_untyped)
      -- then the load type should be determined by the rhs.
      m <- OM (use setupValueSub)
      s <- OM (use termSub)
@@ -1729,7 +1729,7 @@ storePointsToValue opts cc env tyenv nameEnv base_mem maybe_cond ptr val maybe_i
 ------------------------------------------------------------------------
 
 
--- | Process a "crucible_equal" statement from the postcondition
+-- | Process an @llvm_equal@ statement from the postcondition
 -- section of the CrucibleSetup block.
 executeEqual ::
   Crucible.HasPtrWidth (Crucible.ArchWidth arch) =>
@@ -1746,7 +1746,7 @@ executeEqual opts sc cc spec v1 v2 = do
   p         <- liftIO (equalValsPred cc val1 val2)
   addAssume p
 
--- | Process a "crucible_postcond" statement from the postcondition
+-- | Process an @llvm_postcond@ statement from the postcondition
 -- section of the CrucibleSetup block.
 executePred ::
   SharedContext ->

--- a/src/SAWScript/Crucible/LLVM/ResolveSetupValue.hs
+++ b/src/SAWScript/Crucible/LLVM/ResolveSetupValue.hs
@@ -193,7 +193,7 @@ typeOfSetupValue' cc env nameEnv val =
       do memTys <- traverse (typeOfSetupValue cc env nameEnv) vs
          let si = Crucible.mkStructInfo dl packed memTys
          return (Crucible.StructType si)
-    SetupArray () [] -> fail "typeOfSetupValue: invalid empty crucible_array"
+    SetupArray () [] -> fail "typeOfSetupValue: invalid empty llvm_array_value"
     SetupArray () (v : vs) ->
       do memTy <- typeOfSetupValue cc env nameEnv v
          _memTys <- traverse (typeOfSetupValue cc env nameEnv) vs
@@ -204,7 +204,7 @@ typeOfSetupValue' cc env nameEnv val =
       typeOfSetupValue' cc env nameEnv (SetupElem () v i)
     SetupElem () v i ->
       do memTy <- typeOfSetupValue cc env nameEnv v
-         let msg = "typeOfSetupValue: crucible_elem requires pointer to struct or array, found " ++ show memTy
+         let msg = "typeOfSetupValue: llvm_elem requires pointer to struct or array, found " ++ show memTy
          case memTy of
            Crucible.PtrType symTy ->
              case let ?lc = lc in Crucible.asMemType symTy of
@@ -294,7 +294,7 @@ resolveSetupVal cc mem env tyenv nameEnv val = do
       resolveSetupVal cc mem env tyenv nameEnv (SetupElem () v i)
     SetupElem () v i ->
       do memTy <- typeOfSetupValue cc tyenv nameEnv v
-         let msg = "resolveSetupVal: crucible_elem requires pointer to struct or array, found " ++ show memTy
+         let msg = "resolveSetupVal: llvm_elem requires pointer to struct or array, found " ++ show memTy
          delta <- case memTy of
            Crucible.PtrType symTy ->
              case let ?lc = lc in Crucible.asMemType symTy of
@@ -315,7 +315,7 @@ resolveSetupVal cc mem env tyenv nameEnv val = do
              do delta' <- W4.bvLit sym (W4.bvWidth off) (Crucible.bytesToBV (W4.bvWidth off) delta)
                 off' <- W4.bvAdd sym off delta'
                 return (Crucible.LLVMValInt blk off')
-           _ -> fail "resolveSetupVal: crucible_elem requires pointer value"
+           _ -> fail "resolveSetupVal: llvm_elem requires pointer value"
     SetupNull () ->
       Crucible.ptrToPtrVal <$> Crucible.mkNullPointer sym Crucible.PtrWidth
     SetupGlobal () name ->

--- a/src/SAWScript/Crucible/LLVM/X86.hs
+++ b/src/SAWScript/Crucible/LLVM/X86.hs
@@ -23,7 +23,7 @@ Stability   : provisional
 {-# Language TemplateHaskell #-}
 
 module SAWScript.Crucible.LLVM.X86
-  ( crucible_llvm_verify_x86
+  ( llvm_verify_x86
   ) where
 
 import Control.Lens.TH (makeLenses)
@@ -220,7 +220,7 @@ cryptolUninterpreted _ nm _ xs = throwX86 $ mconcat
 -- | Verify that an x86_64 function (following the System V AMD64 ABI) conforms
 -- to an LLVM specification. This allows for compositional verification of LLVM
 -- functions that call x86_64 functions (but not the other way around).
-crucible_llvm_verify_x86 ::
+llvm_verify_x86 ::
   Some LLVMModule {- ^ Module to associate with method spec -} ->
   FilePath {- ^ Path to ELF file -} ->
   String {- ^ Function's symbol in ELF file -} ->
@@ -229,7 +229,7 @@ crucible_llvm_verify_x86 ::
   LLVMCrucibleSetupM () {- ^ Specification to verify against -} ->
   ProofScript SatResult {- ^ Tactic used to use when discharging goals -} ->
   TopLevel (SomeLLVM MS.CrucibleMethodSpecIR)
-crucible_llvm_verify_x86 (Some (llvmModule :: LLVMModule x)) path nm globsyms checkSat setup tactic
+llvm_verify_x86 (Some (llvmModule :: LLVMModule x)) path nm globsyms checkSat setup tactic
   | Just Refl <- testEquality (C.LLVM.X86Repr $ knownNat @64) . C.LLVM.llvmArch
                  $ modTrans llvmModule ^. C.LLVM.transContext = do
       let ?ptrWidth = knownNat @64

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1882,19 +1882,19 @@ primitives = Map.fromList
     , "information obtained from 'crucible_llvm_array_size_profile'."
     ]
 
-  , prim "skeleton_globals_pre" "ModuleSkeleton -> CrucibleSetup ()"
+  , prim "skeleton_globals_pre" "ModuleSkeleton -> LLVMSetup ()"
     (pureVal skeleton_globals_pre)
     Experimental
     [ "Allocate and initialize mutable globals from the given module skeleton."
     ]
 
-  , prim "skeleton_globals_post" "ModuleSkeleton -> CrucibleSetup ()"
+  , prim "skeleton_globals_post" "ModuleSkeleton -> LLVMSetup ()"
     (pureVal skeleton_globals_post)
     Experimental
     [ "Assert that all mutable globals from the given module skeleton are unchanged."
     ]
 
-  , prim "skeleton_prestate" "FunctionSkeleton -> CrucibleSetup SkeletonState"
+  , prim "skeleton_prestate" "FunctionSkeleton -> LLVMSetup SkeletonState"
     (pureVal skeleton_prestate)
     Experimental
     [ "Allocate and initialize the arguments of the given function skeleton."
@@ -1902,7 +1902,7 @@ primitives = Map.fromList
     , "so that preconditions can be imposed."
     ]
 
-  , prim "skeleton_poststate" "FunctionSkeleton -> SkeletonState -> CrucibleSetup SkeletonState"
+  , prim "skeleton_poststate" "FunctionSkeleton -> SkeletonState -> LLVMSetup SkeletonState"
     (pureVal skeleton_poststate)
     Experimental
     [ "Assert that pointer arguments of the given function skeleton remain"
@@ -1910,33 +1910,33 @@ primitives = Map.fromList
     , "be retrieved, so that postconditions can be imposed."
     ]
 
-  , prim "skeleton_arg_index" "SkeletonState -> Int -> CrucibleSetup Term"
+  , prim "skeleton_arg_index" "SkeletonState -> Int -> LLVMSetup Term"
     (pureVal skeleton_arg_index)
     Experimental
     [ "Retrieve the argument value at the given index from the given 'SkeletonState'."
     ]
 
-  , prim "skeleton_arg" "SkeletonState -> String -> CrucibleSetup Term"
+  , prim "skeleton_arg" "SkeletonState -> String -> LLVMSetup Term"
     (pureVal skeleton_arg)
     Experimental
     [ "Retrieve the argument value of the given name from the given 'SkeletonState'."
     ]
 
-  , prim "skeleton_arg_index_pointer" "SkeletonState -> Int -> CrucibleSetup SetupValue"
+  , prim "skeleton_arg_index_pointer" "SkeletonState -> Int -> LLVMSetup SetupValue"
     (pureVal skeleton_arg_index_pointer)
     Experimental
     [ "Retrieve the argument pointer at the given indexfrom the given 'SkeletonState'."
     , "Fails if the specified argument is not a pointer."
     ]
 
-  , prim "skeleton_arg_pointer" "SkeletonState -> String -> CrucibleSetup SetupValue"
+  , prim "skeleton_arg_pointer" "SkeletonState -> String -> LLVMSetup SetupValue"
     (pureVal skeleton_arg_pointer)
     Experimental
     [ "Retrieve the argument pointer of the given name from the given 'SkeletonState'."
     , "Fails if the specified argument is not a pointer."
     ]
 
-  , prim "skeleton_exec" "SkeletonState -> CrucibleSetup ()"
+  , prim "skeleton_exec" "SkeletonState -> LLVMSetup ()"
     (pureVal skeleton_exec)
     Experimental
     [ "Wrapper around 'crucible_execute_func' that passes the arguments initialized"
@@ -2124,7 +2124,7 @@ primitives = Map.fromList
     [ "Legacy alternative name for `llvm_extract`." ]
 
   , prim "llvm_compositional_extract"
-    "LLVMModule -> String -> String -> [CrucibleMethodSpec] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
+    "LLVMModule -> String -> String -> [LLVMSpec] -> Bool -> LLVMSetup () -> ProofScript SatResult -> TopLevel LLVMSpec"
     (pureVal llvm_compositional_extract)
     Experimental
     [ "Translate an LLVM function directly to a Term. The parameters of the"
@@ -2137,23 +2137,23 @@ primitives = Map.fromList
     , "`llvm_points_to`). For more flexibility, see `llvm_verify`."
     ]
   , prim "crucible_llvm_compositional_extract"
-    "LLVMModule -> String -> String -> [CrucibleMethodSpec] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
+    "LLVMModule -> String -> String -> [LLVMSpec] -> Bool -> LLVMSetup () -> ProofScript SatResult -> TopLevel LLVMSpec"
     (pureVal llvm_compositional_extract)
     Experimental
     [ "Legacy alternative name for `llvm_compositional_extract`." ]
 
-  , prim "llvm_fresh_var" "String -> LLVMType -> CrucibleSetup Term"
+  , prim "llvm_fresh_var" "String -> LLVMType -> LLVMSetup Term"
     (pureVal llvm_fresh_var)
     Current
     [ "Create a fresh symbolic variable for use within an LLVM"
     , "specification. The name is used only for pretty-printing."
     ]
-  , prim "crucible_fresh_var" "String -> LLVMType -> CrucibleSetup Term"
+  , prim "crucible_fresh_var" "String -> LLVMType -> LLVMSetup Term"
     (pureVal llvm_fresh_var)
     Current
     [ "Legacy alternative name for `llvm_fresh_var`." ]
 
-  , prim "llvm_fresh_cryptol_var" "String -> Type -> CrucibleSetup Term"
+  , prim "llvm_fresh_cryptol_var" "String -> Type -> LLVMSetup Term"
     (pureVal llvm_fresh_cryptol_var)
     Experimental
     [ "Create a fresh symbolic variable of the given Cryptol type for use"
@@ -2161,12 +2161,12 @@ primitives = Map.fromList
     , "pretty-printing. Unlike 'llvm_fresh_var', this can be used when"
     , "there isn't an appropriate LLVM type, such as the Cryptol Array type."
     ]
-  , prim "crucible_fresh_cryptol_var" "String -> Type -> CrucibleSetup Term"
+  , prim "crucible_fresh_cryptol_var" "String -> Type -> LLVMSetup Term"
     (pureVal llvm_fresh_cryptol_var)
     Experimental
     [ "Legacy alternative name for `llvm_fresh_cryptol_var`." ]
 
-  , prim "llvm_alloc" "LLVMType -> CrucibleSetup SetupValue"
+  , prim "llvm_alloc" "LLVMType -> LLVMSetup SetupValue"
     (pureVal llvm_alloc)
     Current
     [ "Declare that an object of the given type should be allocated in an"
@@ -2175,12 +2175,12 @@ primitives = Map.fromList
     , "After `llvm_execute_func`, it states that the function being"
     , "verified is expected to perform the allocation."
     ]
-  , prim "crucible_alloc" "LLVMType -> CrucibleSetup SetupValue"
+  , prim "crucible_alloc" "LLVMType -> LLVMSetup SetupValue"
     (pureVal llvm_alloc)
     Current
     [ "Legacy alternative name for `llvm_alloc`." ]
 
-  , prim "llvm_alloc_aligned" "Int -> LLVMType -> CrucibleSetup SetupValue"
+  , prim "llvm_alloc_aligned" "Int -> LLVMType -> LLVMSetup SetupValue"
     (pureVal llvm_alloc_aligned)
     Current
     [ "Declare that a memory region of the given type should be allocated in"
@@ -2188,12 +2188,12 @@ primitives = Map.fromList
     , "should be aligned to a multiple of the specified number of bytes (which"
     , "must be a power of 2)."
     ]
-  , prim "crucible_alloc_aligned" "Int -> LLVMType -> CrucibleSetup SetupValue"
+  , prim "crucible_alloc_aligned" "Int -> LLVMType -> LLVMSetup SetupValue"
     (pureVal llvm_alloc_aligned)
     Current
     [ "Legacy alternative name for `llvm_alloc_aligned`." ]
 
-  , prim "llvm_alloc_readonly" "LLVMType -> CrucibleSetup SetupValue"
+  , prim "llvm_alloc_readonly" "LLVMType -> LLVMSetup SetupValue"
     (pureVal llvm_alloc_readonly)
     Current
     [ "Declare that a read-only memory region of the given type should be"
@@ -2202,12 +2202,12 @@ primitives = Map.fromList
     , "allocated with `llvm_alloc_readonly` are allowed to alias other"
     , "read-only regions."
     ]
-  , prim "crucible_alloc_readonly" "LLVMType -> CrucibleSetup SetupValue"
+  , prim "crucible_alloc_readonly" "LLVMType -> LLVMSetup SetupValue"
     (pureVal llvm_alloc_readonly)
     Current
     [ "Legacy alternative name for `llvm_alloc_readonly`." ]
 
-  , prim "llvm_alloc_readonly_aligned" "Int -> LLVMType -> CrucibleSetup SetupValue"
+  , prim "llvm_alloc_readonly_aligned" "Int -> LLVMType -> LLVMSetup SetupValue"
     (pureVal llvm_alloc_readonly_aligned)
     Current
     [ "Declare that a read-only memory region of the given type should be"
@@ -2218,23 +2218,23 @@ primitives = Map.fromList
     , "regions allocated with `llvm_alloc_readonly_aligned` are allowed to"
     , "alias other read-only regions."
     ]
-  , prim "crucible_alloc_readonly_aligned" "Int -> LLVMType -> CrucibleSetup SetupValue"
+  , prim "crucible_alloc_readonly_aligned" "Int -> LLVMType -> LLVMSetup SetupValue"
     (pureVal llvm_alloc_readonly_aligned)
     Current
     [ "Legacy alternative name for `llvm_alloc_readonly_aligned`." ]
 
-  , prim "llvm_alloc_with_size" "Int -> LLVMType -> CrucibleSetup SetupValue"
+  , prim "llvm_alloc_with_size" "Int -> LLVMType -> LLVMSetup SetupValue"
     (pureVal llvm_alloc_with_size)
     Experimental
     [ "Like `llvm_alloc`, but with a user-specified size (given in bytes)."
     , "The specified size must be greater than the size of the LLVM type."
     ]
-  , prim "crucible_alloc_with_size" "Int -> LLVMType -> CrucibleSetup SetupValue"
+  , prim "crucible_alloc_with_size" "Int -> LLVMType -> LLVMSetup SetupValue"
     (pureVal llvm_alloc_with_size)
     Experimental
     [ "Legacy alternative name for `llvm_alloc_with_size`." ]
 
-  , prim "llvm_symbolic_alloc" "Bool -> Int -> Term -> CrucibleSetup SetupValue"
+  , prim "llvm_symbolic_alloc" "Bool -> Int -> Term -> LLVMSetup SetupValue"
     (pureVal llvm_symbolic_alloc)
     Current
     [ "Like `llvm_alloc`, but with a (symbolic) size instead of an LLVM type."
@@ -2242,36 +2242,36 @@ primitives = Map.fromList
     , "second argument specifies the alignment in bytes (which must be a power"
     , "of 2). The third argument specifies the size in bytes."
     ]
-  , prim "crucible_symbolic_alloc" "Bool -> Int -> Term -> CrucibleSetup SetupValue"
+  , prim "crucible_symbolic_alloc" "Bool -> Int -> Term -> LLVMSetup SetupValue"
     (pureVal llvm_symbolic_alloc)
     Current
     [ "Legacy alternative name for `llvm_symbolic_alloc`." ]
 
-  , prim "llvm_alloc_global" "String -> CrucibleSetup ()"
+  , prim "llvm_alloc_global" "String -> LLVMSetup ()"
     (pureVal llvm_alloc_global)
     Current
     [ "Declare that memory for the named global should be allocated in an"
     , "LLVM specification. This is done implicitly for immutable globals."
     , "A pointer to the allocated memory may be obtained using `llvm_global`."
     ]
-  , prim "crucible_alloc_global" "String -> CrucibleSetup ()"
+  , prim "crucible_alloc_global" "String -> LLVMSetup ()"
     (pureVal llvm_alloc_global)
     Current
     [ "Legacy alternative name for `llvm_alloc_global`." ]
 
-  , prim "llvm_fresh_pointer" "LLVMType -> CrucibleSetup SetupValue"
+  , prim "llvm_fresh_pointer" "LLVMType -> LLVMSetup SetupValue"
     (pureVal llvm_fresh_pointer)
     Current
     [ "Create a fresh pointer value for use in an LLVM specification."
     , "This works like `llvm_alloc` except that the pointer is not"
     , "required to point to allocated memory."
     ]
-  , prim "crucible_fresh_pointer" "LLVMType -> CrucibleSetup SetupValue"
+  , prim "crucible_fresh_pointer" "LLVMType -> LLVMSetup SetupValue"
     (pureVal llvm_fresh_pointer)
     Current
     [ "Legacy alternative name for `llvm_fresh_pointer`." ]
 
-  , prim "llvm_fresh_expanded_val" "LLVMType -> CrucibleSetup SetupValue"
+  , prim "llvm_fresh_expanded_val" "LLVMType -> LLVMSetup SetupValue"
     (pureVal llvm_fresh_expanded_val)
     Current
     [ "Create a compound type entirely populated with fresh symbolic variables."
@@ -2279,12 +2279,12 @@ primitives = Map.fromList
     , "explicitly setting each field or element to contain a fresh symbolic"
     , "variable."
     ]
-  , prim "crucible_fresh_expanded_val" "LLVMType -> CrucibleSetup SetupValue"
+  , prim "crucible_fresh_expanded_val" "LLVMType -> LLVMSetup SetupValue"
     (pureVal llvm_fresh_expanded_val)
     Current
     [ "Legacy alternative name for `llvm_fresh_expanded_val`." ]
 
-  , prim "llvm_points_to" "SetupValue -> SetupValue -> CrucibleSetup ()"
+  , prim "llvm_points_to" "SetupValue -> SetupValue -> LLVMSetup ()"
     (pureVal (llvm_points_to True))
     Current
     [ "Declare that the memory location indicated by the given pointer (first"
@@ -2295,12 +2295,12 @@ primitives = Map.fromList
     , "section (after `llvm_execute_func`), this specifies an assertion"
     , "about the final memory state after running the function."
     ]
-    , prim "crucible_points_to" "SetupValue -> SetupValue -> CrucibleSetup ()"
+    , prim "crucible_points_to" "SetupValue -> SetupValue -> LLVMSetup ()"
     (pureVal (llvm_points_to True))
     Current
     [ "Legacy alternative name for `llvm_points_to`." ]
 
-  , prim "llvm_conditional_points_to" "Term -> SetupValue -> SetupValue -> CrucibleSetup ()"
+  , prim "llvm_conditional_points_to" "Term -> SetupValue -> SetupValue -> LLVMSetup ()"
     (pureVal (llvm_conditional_points_to True))
     Current
     [ "Declare that the memory location indicated by the given pointer (second"
@@ -2312,36 +2312,36 @@ primitives = Map.fromList
     , "section (after `llvm_execute_func`), this specifies an assertion"
     , "about the final memory state after running the function."
     ]
-  , prim "crucible_conditional_points_to" "Term -> SetupValue -> SetupValue -> CrucibleSetup ()"
+  , prim "crucible_conditional_points_to" "Term -> SetupValue -> SetupValue -> LLVMSetup ()"
     (pureVal (llvm_conditional_points_to True))
     Current
     [ "Legacy alternative name for `llvm_conditional_points_to`." ]
 
-  , prim "llvm_points_to_untyped" "SetupValue -> SetupValue -> CrucibleSetup ()"
+  , prim "llvm_points_to_untyped" "SetupValue -> SetupValue -> LLVMSetup ()"
     (pureVal (llvm_points_to False))
     Current
     [ "A variant of `llvm_points_to` that does not check for compatibility"
     , "between the pointer type and the value type. This may be useful when"
     , "reading or writing a prefix of larger array, for example."
     ]
-  , prim "crucible_points_to_untyped" "SetupValue -> SetupValue -> CrucibleSetup ()"
+  , prim "crucible_points_to_untyped" "SetupValue -> SetupValue -> LLVMSetup ()"
     (pureVal (llvm_points_to False))
     Current
     [ "Legacy alternative name for `llvm_points_to`." ]
 
-  , prim "llvm_conditional_points_to_untyped" "Term -> SetupValue -> SetupValue -> CrucibleSetup ()"
+  , prim "llvm_conditional_points_to_untyped" "Term -> SetupValue -> SetupValue -> LLVMSetup ()"
     (pureVal (llvm_conditional_points_to False))
     Current
     [ "A variant of `llvm_conditional_points_to` that does not check for"
     , "compatibility between the pointer type and the value type. This may"
     , "be useful when reading or writing a prefix of larger array, for example."
     ]
-  , prim "crucible_conditional_points_to_untyped" "Term -> SetupValue -> SetupValue -> CrucibleSetup ()"
+  , prim "crucible_conditional_points_to_untyped" "Term -> SetupValue -> SetupValue -> LLVMSetup ()"
     (pureVal (llvm_conditional_points_to False))
     Current
     [ "Legacy alternative name for `llvm_conditional_points_to`." ]
 
-  , prim "llvm_points_to_array_prefix" "SetupValue -> Term -> Term -> CrucibleSetup ()"
+  , prim "llvm_points_to_array_prefix" "SetupValue -> Term -> Term -> LLVMSetup ()"
     (pureVal llvm_points_to_array_prefix)
     Experimental
     [ "Declare that the memory location indicated by the given pointer (first"
@@ -2353,12 +2353,12 @@ primitives = Map.fromList
     , "section (after `llvm_execute_func`), this specifies an assertion"
     , "about the final memory state after running the function."
     ]
-  , prim "crucible_points_to_array_prefix" "SetupValue -> Term -> Term -> CrucibleSetup ()"
+  , prim "crucible_points_to_array_prefix" "SetupValue -> Term -> Term -> LLVMSetup ()"
     (pureVal llvm_points_to_array_prefix)
     Experimental
     [ "Legacy alternative name for `llvm_points_to_array_prefix`." ]
 
-  , prim "llvm_equal" "SetupValue -> SetupValue -> CrucibleSetup ()"
+  , prim "llvm_equal" "SetupValue -> SetupValue -> LLVMSetup ()"
     (pureVal llvm_equal)
     Current
     [ "State that two LLVM values should be equal. Can be used as either a"
@@ -2366,66 +2366,66 @@ primitives = Map.fromList
     , "an `llvm_precond` or `llvm_postcond` statement which is an equality"
     , "predicate, but potentially more efficient."
     ]
-  , prim "crucible_equal" "SetupValue -> SetupValue -> CrucibleSetup ()"
+  , prim "crucible_equal" "SetupValue -> SetupValue -> LLVMSetup ()"
     (pureVal llvm_equal)
     Current
     [ "Legacy alternative name for `llvm_equal`." ]
 
-  , prim "llvm_precond" "Term -> CrucibleSetup ()"
+  , prim "llvm_precond" "Term -> LLVMSetup ()"
     (pureVal llvm_precond)
     Current
     [ "State that the given predicate is a pre-condition on execution of the"
     , "function being verified."
     ]
-  , prim "crucible_precond" "Term -> CrucibleSetup ()"
+  , prim "crucible_precond" "Term -> LLVMSetup ()"
     (pureVal llvm_precond)
     Current
     [ "Legacy alternative name for `llvm_precond`." ]
 
-  , prim "llvm_postcond" "Term -> CrucibleSetup ()"
+  , prim "llvm_postcond" "Term -> LLVMSetup ()"
     (pureVal llvm_postcond)
     Current
     [ "State that the given predicate is a post-condition of execution of the"
     , "function being verified."
     ]
-  , prim "crucible_postcond" "Term -> CrucibleSetup ()"
+  , prim "crucible_postcond" "Term -> LLVMSetup ()"
     (pureVal llvm_postcond)
     Current
     [ "Legacy alternative name for `llvm_postcond`." ]
 
-  , prim "llvm_execute_func" "[SetupValue] -> CrucibleSetup ()"
+  , prim "llvm_execute_func" "[SetupValue] -> LLVMSetup ()"
     (pureVal llvm_execute_func)
     Current
     [ "Specify the given list of values as the arguments of the function."
     ,  ""
     , "The `llvm_execute_func` statement also serves to separate the pre-state"
     , "section of the spec (before `llvm_execute_func`) from the post-state"
-    , "section (after `llvm_execute_func`). The effects of some CrucibleSetup"
+    , "section (after `llvm_execute_func`). The effects of some LLVMSetup"
     , "statements depend on whether they occur in the pre-state or post-state"
     , "section."
     ]
-  , prim "crucible_execute_func" "[SetupValue] -> CrucibleSetup ()"
+  , prim "crucible_execute_func" "[SetupValue] -> LLVMSetup ()"
     (pureVal llvm_execute_func)
     Current
     [ "Legacy alternative name for `llvm_execute_func`." ]
 
-  , prim "llvm_return" "SetupValue -> CrucibleSetup ()"
+  , prim "llvm_return" "SetupValue -> LLVMSetup ()"
     (pureVal llvm_return)
     Current
     [ "Specify the given value as the return value of the function. A"
     , "crucible_return statement is required if and only if the function"
     , "has a non-void return type." ]
-  , prim "crucible_return" "SetupValue -> CrucibleSetup ()"
+  , prim "crucible_return" "SetupValue -> LLVMSetup ()"
     (pureVal llvm_return)
     Current
     [ "Legacy alternative name for `llvm_return`." ]
 
   , prim "llvm_verify"
-    "LLVMModule -> String -> [CrucibleMethodSpec] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
+    "LLVMModule -> String -> [LLVMSpec] -> Bool -> LLVMSetup () -> ProofScript SatResult -> TopLevel LLVMSpec"
     (pureVal llvm_verify)
     Current
     [ "Verify the LLVM function named by the second parameter in the module"
-    , "specified by the first. The third parameter lists the CrucibleMethodSpec"
+    , "specified by the first. The third parameter lists the LLVMSpec"
     , "values returned by previous calls to use as overrides. The fourth (Bool)"
     , "parameter enables or disables path satisfiability checking. The fifth"
     , "describes how to set up the symbolic execution engine before verification."
@@ -2433,27 +2433,27 @@ primitives = Map.fromList
     , "verification conditions."
     ]
   , prim "crucible_llvm_verify"
-    "LLVMModule -> String -> [CrucibleMethodSpec] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
+    "LLVMModule -> String -> [LLVMSpec] -> Bool -> LLVMSetup () -> ProofScript SatResult -> TopLevel LLVMSpec"
     (pureVal llvm_verify)
     Current
     [ "Legacy alternative name for `llvm_verify`." ]
 
   , prim "llvm_unsafe_assume_spec"
-    "LLVMModule -> String -> CrucibleSetup () -> TopLevel CrucibleMethodSpec"
+    "LLVMModule -> String -> LLVMSetup () -> TopLevel LLVMSpec"
     (pureVal llvm_unsafe_assume_spec)
     Current
-    [ "Return a CrucibleMethodSpec corresponding to a CrucibleSetup block,"
+    [ "Return an LLVMSpec corresponding to an LLVMSetup block,"
     , "as would be returned by crucible_llvm_verify but without performing"
     , "any verification."
     ]
   , prim "crucible_llvm_unsafe_assume_spec"
-    "LLVMModule -> String -> CrucibleSetup () -> TopLevel CrucibleMethodSpec"
+    "LLVMModule -> String -> LLVMSetup () -> TopLevel LLVMSpec"
     (pureVal llvm_unsafe_assume_spec)
     Current
     [ "Legacy alternative name for `llvm_unsafe_assume_spec`." ]
 
   , prim "llvm_array_size_profile"
-    "LLVMModule -> String -> [CrucibleMethodSpec] -> CrucibleSetup () -> TopLevel [(String, [FunctionProfile])]"
+    "LLVMModule -> String -> [LLVMSpec] -> LLVMSetup () -> TopLevel [(String, [FunctionProfile])]"
     (pureVal $ llvm_array_size_profile assumeUnsat)
     Experimental
     [ "Symbolically execute the function named by the second parameter in"
@@ -2463,13 +2463,13 @@ primitives = Map.fromList
     , "it calls (recursively), to be passed to llvm_boilerplate."
     ]
   , prim "crucible_llvm_array_size_profile"
-    "LLVMModule -> String -> [CrucibleMethodSpec] -> CrucibleSetup () -> TopLevel [(String, [FunctionProfile])]"
+    "LLVMModule -> String -> [LLVMSpec] -> LLVMSetup () -> TopLevel [(String, [FunctionProfile])]"
     (pureVal $ llvm_array_size_profile assumeUnsat)
     Experimental
     [ "Legacy alternative name for `llvm_array_size_profile`." ]
 
   , prim "llvm_verify_x86"
-    "LLVMModule -> String -> String -> [(String, Int)] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
+    "LLVMModule -> String -> String -> [(String, Int)] -> Bool -> LLVMSetup () -> ProofScript SatResult -> TopLevel LLVMSpec"
     (pureVal llvm_verify_x86)
     Experimental
     [ "Verify an x86 function from an ELF file for use as an override in an"
@@ -2483,7 +2483,7 @@ primitives = Map.fromList
     , "that can be used as an override when verifying other LLVM functions."
     ]
   , prim "crucible_llvm_verify_x86"
-    "LLVMModule -> String -> String -> [(String, Int)] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
+    "LLVMModule -> String -> String -> [(String, Int)] -> Bool -> LLVMSetup () -> ProofScript SatResult -> TopLevel LLVMSpec"
     (pureVal llvm_verify_x86)
     Experimental
     [ "Legacy alternative name for `llvm_verify_x86`." ]
@@ -2626,34 +2626,34 @@ primitives = Map.fromList
     [ "Legacy alternative name for `llvm_declare_ghost_state`." ]
 
   , prim "llvm_ghost_value"
-    "Ghost -> Term -> CrucibleSetup ()"
+    "Ghost -> Term -> LLVMSetup ()"
     (pureVal llvm_ghost_value)
     Current
     [ "Specifies the value of a ghost variable. This can be used"
     , "in the pre- and post- conditions of a setup block."]
   , prim "crucible_ghost_value"
-    "Ghost -> Term -> CrucibleSetup ()"
+    "Ghost -> Term -> LLVMSetup ()"
     (pureVal llvm_ghost_value)
     Current
     [ "Legacy alternative name for `llvm_ghost_value`."]
 
-  , prim "llvm_spec_solvers"  "CrucibleMethodSpec -> [String]"
+  , prim "llvm_spec_solvers"  "LLVMSpec -> [String]"
     (\_ _ -> toValue llvm_spec_solvers)
     Current
     [ "Extract a list of all the solvers used when verifying the given method spec."
     ]
-  , prim "crucible_spec_solvers"  "CrucibleMethodSpec -> [String]"
+  , prim "crucible_spec_solvers"  "LLVMSpec -> [String]"
     (\_ _ -> toValue llvm_spec_solvers)
     Current
     [ "Legacy alternative name for `llvm_spec_solvers`." ]
 
-  , prim "llvm_spec_size"  "CrucibleMethodSpec -> Int"
+  , prim "llvm_spec_size"  "LLVMSpec -> Int"
     (\_ _ -> toValue llvm_spec_size)
     Current
     [ "Return a count of the combined size of all verification goals proved as part of"
     , "the given method spec."
     ]
-  , prim "crucible_spec_size"  "CrucibleMethodSpec -> Int"
+  , prim "crucible_spec_size"  "LLVMSpec -> Int"
     (\_ _ -> toValue llvm_spec_size)
     Current
     [ "Legacy alternative name for `llvm_spec_size`." ]
@@ -2760,12 +2760,12 @@ primitives = Map.fromList
     , "has a non-void return type." ]
 
   , prim "jvm_verify"
-    "JavaClass -> String -> [JVMMethodSpec] -> Bool -> JVMSetup () -> ProofScript SatResult -> TopLevel JVMMethodSpec"
+    "JavaClass -> String -> [JVMSpec] -> Bool -> JVMSetup () -> ProofScript SatResult -> TopLevel JVMSpec"
     (pureVal jvm_verify)
     Experimental
     [ "Verify the JVM method named by the second parameter in the class"
-    , "specified by the first. The third parameter lists the JVMMethodSpec"
-    , "values returned by previous calls to use as overrides. The fourth (Bool)"
+    , "specified by the first. The third parameter lists the JVMSpec values"
+    , "returned by previous calls to use as overrides. The fourth (Bool)"
     , "parameter enables or disables path satisfiability checking. The fifth"
     , "describes how to set up the symbolic execution engine before verification."
     , "And the last gives the script to use to prove the validity of the resulting"
@@ -2773,12 +2773,11 @@ primitives = Map.fromList
     ]
 
   , prim "jvm_unsafe_assume_spec"
-    "JavaClass -> String -> JVMSetup () -> TopLevel JVMMethodSpec"
+    "JavaClass -> String -> JVMSetup () -> TopLevel JVMSpec"
     (pureVal jvm_unsafe_assume_spec)
     Experimental
-    [ "Return a JVMMethodSpec corresponding to a JVMSetup block,"
-    , "as would be returned by jvm_verify but without performing any"
-    , "verification."
+    [ "Return a JVMSpec corresponding to a JVMSetup block, as would be"
+    , "returned by jvm_verify but without performing any verification."
     ]
 
   , prim "jvm_null"

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -2415,7 +2415,7 @@ primitives = Map.fromList
     [ "Specify the given value as the return value of the function. A"
     , "crucible_return statement is required if and only if the function"
     , "has a non-void return type." ]
-  , prim "llvm_return" "SetupValue -> CrucibleSetup ()"
+  , prim "crucible_return" "SetupValue -> CrucibleSetup ()"
     (pureVal llvm_return)
     Current
     [ "Legacy alternative name for `llvm_return`." ]

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1787,13 +1787,18 @@ primitives = Map.fromList
     [ "Convert a Java method to a Crucible CFG."
     ] -}
 
-  , prim "crucible_java_extract"  "JavaClass -> String -> TopLevel Term"
+  , prim "java_extract"  "JavaClass -> String -> TopLevel Term"
     (pureVal CJ.java_extract)
     Current
     [ "Translate a Java method directly to a Term. The parameters of the"
     , "Term will be the parameters of the Java method, and the return"
     , "value will be the return value of the method. Only methods with"
     , "scalar argument and return types are currently supported."
+    ]
+  , prim "crucible_java_extract"  "JavaClass -> String -> TopLevel Term"
+    (pureVal CJ.java_extract)
+    Current
+    [ "Legacy alternative name for `java_extract`."
     ]
 
   , prim "llvm_sizeof"         "LLVMModule -> LLVMType -> Int"
@@ -2104,226 +2109,318 @@ primitives = Map.fromList
     [ "Load a function from the given LLVM module into a Crucible CFG."
     ]
 
-  , prim "crucible_llvm_extract"  "LLVMModule -> String -> TopLevel Term"
+  , prim "llvm_extract"  "LLVMModule -> String -> TopLevel Term"
     (pureVal llvm_extract)
     Current
     [ "Translate an LLVM function directly to a Term. The parameters of the"
     , "Term will be the parameters of the LLVM function, and the return"
     , "value will be the return value of the functions. Only functions with"
     , "scalar argument and return types are currently supported. For more"
-    , "flexibility, see 'crucible_llvm_verify'."
+    , "flexibility, see 'llvm_verify'."
     ]
+  , prim "crucible_llvm_extract"  "LLVMModule -> String -> TopLevel Term"
+    (pureVal llvm_extract)
+    Current
+    [ "Legacy alternative name for `llvm_extract`." ]
 
-  , prim "crucible_llvm_compositional_extract"
+  , prim "llvm_compositional_extract"
     "LLVMModule -> String -> String -> [CrucibleMethodSpec] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
     (pureVal llvm_compositional_extract)
     Experimental
     [ "Translate an LLVM function directly to a Term. The parameters of the"
     , "Term are the input parameters of the LLVM function: the parameters"
-    , "passed by value (in the order given by `crucible_exec_func`), then"
+    , "passed by value (in the order given by `llvm_exec_func`), then"
     , "the parameters passed by reference (in the order given by"
-    , "`crucible_points_to`). The Term is the tuple consisting of the"
+    , "`llvm_points_to`). The Term is the tuple consisting of the"
     , "output parameters of the LLVM function: the return parameter, then"
     , "the parameters passed by reference (in the order given by"
-    , "`crucible_points_to`). For more flexibility, see"
-    , "`crucible_llvm_verify`."
+    , "`llvm_points_to`). For more flexibility, see `llvm_verify`."
     ]
+  , prim "crucible_llvm_compositional_extract"
+    "LLVMModule -> String -> String -> [CrucibleMethodSpec] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
+    (pureVal llvm_compositional_extract)
+    Experimental
+    [ "Legacy alternative name for `llvm_compositional_extract`." ]
 
+  , prim "llvm_fresh_var" "String -> LLVMType -> CrucibleSetup Term"
+    (pureVal llvm_fresh_var)
+    Current
+    [ "Create a fresh symbolic variable for use within an LLVM"
+    , "specification. The name is used only for pretty-printing."
+    ]
   , prim "crucible_fresh_var" "String -> LLVMType -> CrucibleSetup Term"
     (pureVal llvm_fresh_var)
     Current
-    [ "Create a fresh symbolic variable for use within a Crucible"
-    , "specification. The name is used only for pretty-printing."
-    ]
+    [ "Legacy alternative name for `llvm_fresh_var`." ]
 
-  , prim "crucible_fresh_cryptol_var" "String -> Type -> CrucibleSetup Term"
+  , prim "llvm_fresh_cryptol_var" "String -> Type -> CrucibleSetup Term"
     (pureVal llvm_fresh_cryptol_var)
     Experimental
     [ "Create a fresh symbolic variable of the given Cryptol type for use"
     , "within a Crucible specification. The given name is used only for"
-    , "pretty-printing. Unlike 'crucible_fresh_var', this can be used when"
+    , "pretty-printing. Unlike 'llvm_fresh_var', this can be used when"
     , "there isn't an appropriate LLVM type, such as the Cryptol Array type."
     ]
+  , prim "crucible_fresh_cryptol_var" "String -> Type -> CrucibleSetup Term"
+    (pureVal llvm_fresh_cryptol_var)
+    Experimental
+    [ "Legacy alternative name for `llvm_fresh_cryptol_var`." ]
 
+  , prim "llvm_alloc" "LLVMType -> CrucibleSetup SetupValue"
+    (pureVal llvm_alloc)
+    Current
+    [ "Declare that an object of the given type should be allocated in an"
+    , "LLVM specification. Before `llvm_execute_func`, this states that"
+    , "the function expects the object to be allocated before it runs."
+    , "After `llvm_execute_func`, it states that the function being"
+    , "verified is expected to perform the allocation."
+    ]
   , prim "crucible_alloc" "LLVMType -> CrucibleSetup SetupValue"
     (pureVal llvm_alloc)
     Current
-    [ "Declare that an object of the given type should be allocated in a"
-    , "Crucible specification. Before `crucible_execute_func`, this states"
-    , "that the function expects the object to be allocated before it runs."
-    , "After `crucible_execute_func`, it states that the function being"
-    , "verified is expected to perform the allocation."
-    ]
+    [ "Legacy alternative name for `llvm_alloc`." ]
 
-  , prim "crucible_alloc_aligned" "Int -> LLVMType -> CrucibleSetup SetupValue"
+  , prim "llvm_alloc_aligned" "Int -> LLVMType -> CrucibleSetup SetupValue"
     (pureVal llvm_alloc_aligned)
     Current
     [ "Declare that a memory region of the given type should be allocated in"
-    , "a Crucible specification, and also specify that the start of the region"
+    , "an LLVM specification, and also specify that the start of the region"
     , "should be aligned to a multiple of the specified number of bytes (which"
     , "must be a power of 2)."
     ]
+  , prim "crucible_alloc_aligned" "Int -> LLVMType -> CrucibleSetup SetupValue"
+    (pureVal llvm_alloc_aligned)
+    Current
+    [ "Legacy alternative name for `llvm_alloc_aligned`." ]
 
-  , prim "crucible_alloc_readonly" "LLVMType -> CrucibleSetup SetupValue"
+  , prim "llvm_alloc_readonly" "LLVMType -> CrucibleSetup SetupValue"
     (pureVal llvm_alloc_readonly)
     Current
     [ "Declare that a read-only memory region of the given type should be"
-    , "allocated in a Crucible specification. The function must not attempt"
-    , "to write to this memory region. Unlike `crucible_alloc`, regions"
-    , "allocated with `crucible_alloc_readonly` are allowed to alias other"
+    , "allocated in an LLVM specification. The function must not attempt"
+    , "to write to this memory region. Unlike `llvm_alloc`, regions"
+    , "allocated with `llvm_alloc_readonly` are allowed to alias other"
     , "read-only regions."
     ]
+  , prim "crucible_alloc_readonly" "LLVMType -> CrucibleSetup SetupValue"
+    (pureVal llvm_alloc_readonly)
+    Current
+    [ "Legacy alternative name for `llvm_alloc_readonly`." ]
 
-  , prim "crucible_alloc_readonly_aligned" "Int -> LLVMType -> CrucibleSetup SetupValue"
+  , prim "llvm_alloc_readonly_aligned" "Int -> LLVMType -> CrucibleSetup SetupValue"
     (pureVal llvm_alloc_readonly_aligned)
     Current
     [ "Declare that a read-only memory region of the given type should be"
-    , "a Crucible specification, and also specify that the start of the region"
-    , "should be aligned to a multiple of the specified number of bytes (which"
-    , "must be a power of 2). The function must not attempt to write to this"
-    , "memory region. Unlike `crucible_alloc`/`crucible_alloc_aligned`,"
-    , "regions allocated with `crucible_alloc_readonly_aligned` are allowed to"
+    , "allocated in an LLVM specification, and also specify that the start of"
+    , "the region should be aligned to a multiple of the specified number of"
+    , "bytes (which must be a power of 2). The function must not attempt to"
+    , "write to this memory region. Unlike `llvm_alloc`/`llvm_alloc_aligned`,"
+    , "regions allocated with `llvm_alloc_readonly_aligned` are allowed to"
     , "alias other read-only regions."
     ]
+  , prim "crucible_alloc_readonly_aligned" "Int -> LLVMType -> CrucibleSetup SetupValue"
+    (pureVal llvm_alloc_readonly_aligned)
+    Current
+    [ "Legacy alternative name for `llvm_alloc_readonly_aligned`." ]
 
+  , prim "llvm_alloc_with_size" "Int -> LLVMType -> CrucibleSetup SetupValue"
+    (pureVal llvm_alloc_with_size)
+    Experimental
+    [ "Like `llvm_alloc`, but with a user-specified size (given in bytes)."
+    , "The specified size must be greater than the size of the LLVM type."
+    ]
   , prim "crucible_alloc_with_size" "Int -> LLVMType -> CrucibleSetup SetupValue"
     (pureVal llvm_alloc_with_size)
     Experimental
-    [ "Like `crucible_alloc`, but with a user-specified size (given in bytes)."
-    , "The specified size must be greater than the size of the LLVM type."
-    ]
+    [ "Legacy alternative name for `llvm_alloc_with_size`." ]
 
+  , prim "llvm_symbolic_alloc" "Bool -> Int -> Term -> CrucibleSetup SetupValue"
+    (pureVal llvm_symbolic_alloc)
+    Current
+    [ "Like `llvm_alloc`, but with a (symbolic) size instead of an LLVM type."
+    , "The first argument specifies whether the allocation is read-only. The"
+    , "second argument specifies the alignment in bytes (which must be a power"
+    , "of 2). The third argument specifies the size in bytes."
+    ]
   , prim "crucible_symbolic_alloc" "Bool -> Int -> Term -> CrucibleSetup SetupValue"
     (pureVal llvm_symbolic_alloc)
     Current
-    [ "Like `crucible_alloc`, but with a (symbolic) size instead of"
-    , "a LLVM type. The first argument specifies whether the allocation is"
-    , "read-only. The second argument specifies the alignment in bytes (which"
-    , "must be a power of 2). The third argument specifies the size in bytes."
-    ]
+    [ "Legacy alternative name for `llvm_symbolic_alloc`." ]
 
+  , prim "llvm_alloc_global" "String -> CrucibleSetup ()"
+    (pureVal llvm_alloc_global)
+    Current
+    [ "Declare that memory for the named global should be allocated in an"
+    , "LLVM specification. This is done implicitly for immutable globals."
+    , "A pointer to the allocated memory may be obtained using `llvm_global`."
+    ]
   , prim "crucible_alloc_global" "String -> CrucibleSetup ()"
     (pureVal llvm_alloc_global)
     Current
-    [ "Declare that memory for the named global should be allocated in a"
-    , "Crucible specification. This is done implicitly for immutable globals."
-    , "A pointer to the allocated memory may be obtained using `crucible_global`."
-    ]
+    [ "Legacy alternative name for `llvm_alloc_global`." ]
 
+  , prim "llvm_fresh_pointer" "LLVMType -> CrucibleSetup SetupValue"
+    (pureVal llvm_fresh_pointer)
+    Current
+    [ "Create a fresh pointer value for use in an LLVM specification."
+    , "This works like `llvm_alloc` except that the pointer is not"
+    , "required to point to allocated memory."
+    ]
   , prim "crucible_fresh_pointer" "LLVMType -> CrucibleSetup SetupValue"
     (pureVal llvm_fresh_pointer)
     Current
-    [ "Create a fresh pointer value for use in a Crucible specification."
-    , "This works like `crucible_alloc` except that the pointer is not"
-    , "required to point to allocated memory."
-    ]
+    [ "Legacy alternative name for `llvm_fresh_pointer`." ]
 
-  , prim "crucible_fresh_expanded_val" "LLVMType -> CrucibleSetup SetupValue"
+  , prim "llvm_fresh_expanded_val" "LLVMType -> CrucibleSetup SetupValue"
     (pureVal llvm_fresh_expanded_val)
     Current
     [ "Create a compound type entirely populated with fresh symbolic variables."
     , "Equivalent to allocating a new struct or array of the given type and"
-    , "eplicitly setting each field or element to contain a fresh symbolic"
+    , "explicitly setting each field or element to contain a fresh symbolic"
     , "variable."
     ]
+  , prim "crucible_fresh_expanded_val" "LLVMType -> CrucibleSetup SetupValue"
+    (pureVal llvm_fresh_expanded_val)
+    Current
+    [ "Legacy alternative name for `llvm_fresh_expanded_val`." ]
 
-  , prim "crucible_points_to" "SetupValue -> SetupValue -> CrucibleSetup ()"
+  , prim "llvm_points_to" "SetupValue -> SetupValue -> CrucibleSetup ()"
     (pureVal (llvm_points_to True))
     Current
     [ "Declare that the memory location indicated by the given pointer (first"
     , "argument) contains the given value (second argument)."
     , ""
-    , "In the pre-state section (before crucible_execute_func) this specifies"
+    , "In the pre-state section (before `llvm_execute_func`) this specifies"
     , "the initial memory layout before function execution. In the post-state"
-    , "section (after crucible_execute_func), this specifies an assertion"
+    , "section (after `llvm_execute_func`), this specifies an assertion"
     , "about the final memory state after running the function."
     ]
+    , prim "crucible_points_to" "SetupValue -> SetupValue -> CrucibleSetup ()"
+    (pureVal (llvm_points_to True))
+    Current
+    [ "Legacy alternative name for `llvm_points_to`." ]
 
-  , prim "crucible_conditional_points_to" "Term -> SetupValue -> SetupValue -> CrucibleSetup ()"
+  , prim "llvm_conditional_points_to" "Term -> SetupValue -> SetupValue -> CrucibleSetup ()"
     (pureVal (llvm_conditional_points_to True))
     Current
     [ "Declare that the memory location indicated by the given pointer (second"
     , "argument) contains the given value (third argument) if the given"
     , "condition (first argument) holds."
     , ""
-    , "In the pre-state section (before crucible_execute_func) this specifies"
+    , "In the pre-state section (before `llvm_execute_func`) this specifies"
     , "the initial memory layout before function execution. In the post-state"
-    , "section (after crucible_execute_func), this specifies an assertion"
+    , "section (after `llvm_execute_func`), this specifies an assertion"
     , "about the final memory state after running the function."
     ]
+  , prim "crucible_conditional_points_to" "Term -> SetupValue -> SetupValue -> CrucibleSetup ()"
+    (pureVal (llvm_conditional_points_to True))
+    Current
+    [ "Legacy alternative name for `llvm_conditional_points_to`." ]
 
-  , prim "crucible_points_to_untyped" "SetupValue -> SetupValue -> CrucibleSetup ()"
+  , prim "llvm_points_to_untyped" "SetupValue -> SetupValue -> CrucibleSetup ()"
     (pureVal (llvm_points_to False))
     Current
-    [ "A variant of crucible_points_to that does not check for compatibility"
+    [ "A variant of `llvm_points_to` that does not check for compatibility"
     , "between the pointer type and the value type. This may be useful when"
     , "reading or writing a prefix of larger array, for example."
     ]
+  , prim "crucible_points_to_untyped" "SetupValue -> SetupValue -> CrucibleSetup ()"
+    (pureVal (llvm_points_to False))
+    Current
+    [ "Legacy alternative name for `llvm_points_to`." ]
 
-  , prim "crucible_conditional_points_to_untyped" "Term -> SetupValue -> SetupValue -> CrucibleSetup ()"
+  , prim "llvm_conditional_points_to_untyped" "Term -> SetupValue -> SetupValue -> CrucibleSetup ()"
     (pureVal (llvm_conditional_points_to False))
     Current
-    [ "A variant of crucible_conditional_points_to that does not check for"
+    [ "A variant of `llvm_conditional_points_to` that does not check for"
     , "compatibility between the pointer type and the value type. This may"
     , "be useful when reading or writing a prefix of larger array, for example."
     ]
+  , prim "crucible_conditional_points_to_untyped" "Term -> SetupValue -> SetupValue -> CrucibleSetup ()"
+    (pureVal (llvm_conditional_points_to False))
+    Current
+    [ "Legacy alternative name for `llvm_conditional_points_to`." ]
 
-  , prim "crucible_points_to_array_prefix" "SetupValue -> Term -> Term -> CrucibleSetup ()"
+  , prim "llvm_points_to_array_prefix" "SetupValue -> Term -> Term -> CrucibleSetup ()"
     (pureVal llvm_points_to_array_prefix)
     Experimental
     [ "Declare that the memory location indicated by the given pointer (first"
     , "argument) contains the prefix of the given array (second argument) of"
     , "the given size (third argument)."
     , ""
-    , "In the pre-state section (before crucible_execute_func) this specifies"
+    , "In the pre-state section (before `llvm_execute_func`) this specifies"
     , "the initial memory layout before function execution. In the post-state"
-    , "section (after crucible_execute_func), this specifies an assertion"
+    , "section (after `llvm_execute_func`), this specifies an assertion"
     , "about the final memory state after running the function."
     ]
+  , prim "crucible_points_to_array_prefix" "SetupValue -> Term -> Term -> CrucibleSetup ()"
+    (pureVal llvm_points_to_array_prefix)
+    Experimental
+    [ "Legacy alternative name for `llvm_points_to_array_prefix`." ]
 
+  , prim "llvm_equal" "SetupValue -> SetupValue -> CrucibleSetup ()"
+    (pureVal llvm_equal)
+    Current
+    [ "State that two LLVM values should be equal. Can be used as either a"
+    , "pre-condition or a post-condition. It is semantically equivalent to"
+    , "an `llvm_precond` or `llvm_postcond` statement which is an equality"
+    , "predicate, but potentially more efficient."
+    ]
   , prim "crucible_equal" "SetupValue -> SetupValue -> CrucibleSetup ()"
     (pureVal llvm_equal)
     Current
-    [ "State that two Crucible values should be equal. Can be used as either"
-    , "a pre-condition or a post-condition. It is semantically equivalent to"
-    , "a `crucible_precond` or `crucible_postcond` statement which is an"
-    , "equality predicate, but potentially more efficient."
-    ]
+    [ "Legacy alternative name for `llvm_equal`." ]
 
-  , prim "crucible_precond" "Term -> CrucibleSetup ()"
+  , prim "llvm_precond" "Term -> CrucibleSetup ()"
     (pureVal llvm_precond)
     Current
     [ "State that the given predicate is a pre-condition on execution of the"
     , "function being verified."
     ]
+  , prim "crucible_precond" "Term -> CrucibleSetup ()"
+    (pureVal llvm_precond)
+    Current
+    [ "Legacy alternative name for `llvm_precond`." ]
 
-  , prim "crucible_postcond" "Term -> CrucibleSetup ()"
+  , prim "llvm_postcond" "Term -> CrucibleSetup ()"
     (pureVal llvm_postcond)
     Current
     [ "State that the given predicate is a post-condition of execution of the"
     , "function being verified."
     ]
+  , prim "crucible_postcond" "Term -> CrucibleSetup ()"
+    (pureVal llvm_postcond)
+    Current
+    [ "Legacy alternative name for `llvm_postcond`." ]
 
-  , prim "crucible_execute_func" "[SetupValue] -> CrucibleSetup ()"
+  , prim "llvm_execute_func" "[SetupValue] -> CrucibleSetup ()"
     (pureVal llvm_execute_func)
     Current
     [ "Specify the given list of values as the arguments of the function."
     ,  ""
-    , "The crucible_execute_func statement also serves to separate the pre-state"
-    , "section of the spec (before crucible_execute_func) from the post-state"
-    , "section (after crucible_execute_func). The effects of some CrucibleSetup"
+    , "The `llvm_execute_func` statement also serves to separate the pre-state"
+    , "section of the spec (before `llvm_execute_func`) from the post-state"
+    , "section (after `llvm_execute_func`). The effects of some CrucibleSetup"
     , "statements depend on whether they occur in the pre-state or post-state"
     , "section."
     ]
+  , prim "crucible_execute_func" "[SetupValue] -> CrucibleSetup ()"
+    (pureVal llvm_execute_func)
+    Current
+    [ "Legacy alternative name for `llvm_execute_func`." ]
 
-  , prim "crucible_return" "SetupValue -> CrucibleSetup ()"
+  , prim "llvm_return" "SetupValue -> CrucibleSetup ()"
     (pureVal llvm_return)
     Current
     [ "Specify the given value as the return value of the function. A"
     , "crucible_return statement is required if and only if the function"
     , "has a non-void return type." ]
+  , prim "llvm_return" "SetupValue -> CrucibleSetup ()"
+    (pureVal llvm_return)
+    Current
+    [ "Legacy alternative name for `llvm_return`." ]
 
-  , prim "crucible_llvm_verify"
+  , prim "llvm_verify"
     "LLVMModule -> String -> [CrucibleMethodSpec] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
     (pureVal llvm_verify)
     Current
@@ -2335,8 +2432,13 @@ primitives = Map.fromList
     , "And the last gives the script to use to prove the validity of the resulting"
     , "verification conditions."
     ]
+  , prim "crucible_llvm_verify"
+    "LLVMModule -> String -> [CrucibleMethodSpec] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
+    (pureVal llvm_verify)
+    Current
+    [ "Legacy alternative name for `llvm_verify`." ]
 
-  , prim "crucible_llvm_unsafe_assume_spec"
+  , prim "llvm_unsafe_assume_spec"
     "LLVMModule -> String -> CrucibleSetup () -> TopLevel CrucibleMethodSpec"
     (pureVal llvm_unsafe_assume_spec)
     Current
@@ -2344,8 +2446,13 @@ primitives = Map.fromList
     , "as would be returned by crucible_llvm_verify but without performing"
     , "any verification."
     ]
+  , prim "crucible_llvm_unsafe_assume_spec"
+    "LLVMModule -> String -> CrucibleSetup () -> TopLevel CrucibleMethodSpec"
+    (pureVal llvm_unsafe_assume_spec)
+    Current
+    [ "Legacy alternative name for `llvm_unsafe_assume_spec`." ]
 
-  , prim "crucible_llvm_array_size_profile"
+  , prim "llvm_array_size_profile"
     "LLVMModule -> String -> [CrucibleMethodSpec] -> CrucibleSetup () -> TopLevel [(String, [FunctionProfile])]"
     (pureVal $ llvm_array_size_profile assumeUnsat)
     Experimental
@@ -2355,8 +2462,13 @@ primitives = Map.fromList
     , "referred to by pointer arguments for the function and all other functions"
     , "it calls (recursively), to be passed to llvm_boilerplate."
     ]
+  , prim "crucible_llvm_array_size_profile"
+    "LLVMModule -> String -> [CrucibleMethodSpec] -> CrucibleSetup () -> TopLevel [(String, [FunctionProfile])]"
+    (pureVal $ llvm_array_size_profile assumeUnsat)
+    Experimental
+    [ "Legacy alternative name for `llvm_array_size_profile`." ]
 
-  , prim "crucible_llvm_verify_x86"
+  , prim "llvm_verify_x86"
     "LLVMModule -> String -> String -> [(String, Int)] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
     (pureVal llvm_verify_x86)
     Experimental
@@ -2367,9 +2479,14 @@ primitives = Map.fromList
     , "specifies the names and sizes (in bytes) of global variables to"
     , "initialize, and the fifth whether to perform path satisfiability"
     , "checking. The last argument is the LLVM specification of the calling"
-    , "context against which to verify the function.Returns a method spec"
+    , "context against which to verify the function. Returns a method spec"
     , "that can be used as an override when verifying other LLVM functions."
     ]
+  , prim "crucible_llvm_verify_x86"
+    "LLVMModule -> String -> String -> [(String, Int)] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
+    (pureVal llvm_verify_x86)
+    Experimental
+    [ "Legacy alternative name for `llvm_verify_x86`." ]
 
   , prim "add_x86_preserved_reg" "String -> TopLevel ()"
     (pureVal add_x86_preserved_reg)
@@ -2381,67 +2498,112 @@ primitives = Map.fromList
     Current
     [ "Use the default set of callee-saved registers during x86 verification.." ]
 
-  , prim "crucible_array"
+  , prim "llvm_array_value"
     "[SetupValue] -> SetupValue"
     (pureVal CIR.anySetupArray)
     Current
     [ "Create a SetupValue representing an array, with the given list of"
     , "values as elements. The list must be non-empty." ]
+  , prim "crucible_array"
+    "[SetupValue] -> SetupValue"
+    (pureVal CIR.anySetupArray)
+    Current
+    [ "Legacy alternative name for `llvm_array_value`." ]
 
-  , prim "crucible_struct"
+  , prim "llvm_struct_value"
     "[SetupValue] -> SetupValue"
     (pureVal (CIR.anySetupStruct False))
     Current
     [ "Create a SetupValue representing a struct, with the given list of"
     , "values as elements." ]
+  , prim "crucible_struct"
+    "[SetupValue] -> SetupValue"
+    (pureVal (CIR.anySetupStruct False))
+    Current
+    [ "Legacy alternative name for `llvm_struct_value`." ]
 
-  , prim "crucible_packed_struct"
+  , prim "llvm_packed_struct_value"
     "[SetupValue] -> SetupValue"
     (pureVal (CIR.anySetupStruct True))
     Current
     [ "Create a SetupValue representing a packed struct, with the given"
     , "list of values as elements." ]
+  , prim "crucible_packed_struct"
+    "[SetupValue] -> SetupValue"
+    (pureVal (CIR.anySetupStruct True))
+    Current
+    [ "Legacy alternative name for `llvm_packed_struct_value`." ]
 
-  , prim "crucible_elem"
+  , prim "llvm_elem"
     "SetupValue -> Int -> SetupValue"
     (pureVal CIR.anySetupElem)
     Current
     [ "Turn a SetupValue representing a struct or array pointer into"
     , "a pointer to an element of the struct or array by field index." ]
+  , prim "crucible_elem"
+    "SetupValue -> Int -> SetupValue"
+    (pureVal CIR.anySetupElem)
+    Current
+    [ "Legacy alternative name for `llvm_elem`." ]
 
-  , prim "crucible_field"
+  , prim "llvm_field"
     "SetupValue -> String -> SetupValue"
     (pureVal CIR.anySetupField)
     Current
     [ "Turn a SetupValue representing a struct pointer into"
     , "a pointer to an element of the struct by field name." ]
+  , prim "crucible_field"
+    "SetupValue -> String -> SetupValue"
+    (pureVal CIR.anySetupField)
+    Current
+    [ "Legacy alternative name for `llvm_field`." ]
 
-  , prim "crucible_null"
+  , prim "llvm_null"
     "SetupValue"
     (pureVal CIR.anySetupNull)
     Current
     [ "A SetupValue representing a null pointer value." ]
+  , prim "crucible_null"
+    "SetupValue"
+    (pureVal CIR.anySetupNull)
+    Current
+    [ "Legacy alternative name for `llvm_null`." ]
 
-  , prim "crucible_global"
+  , prim "llvm_global"
     "String -> SetupValue"
     (pureVal CIR.anySetupGlobal)
     Current
     [ "Return a SetupValue representing a pointer to the named global."
     , "The String may be either the name of a global value or a function name." ]
+  , prim "crucible_global"
+    "String -> SetupValue"
+    (pureVal CIR.anySetupGlobal)
+    Current
+    [ "Legacy alternative name for `llvm_global`." ]
 
-  , prim "crucible_global_initializer"
+  , prim "llvm_global_initializer"
     "String -> SetupValue"
     (pureVal CIR.anySetupGlobalInitializer)
     Current
     [ "Return a SetupValue representing the value of the initializer of a named"
     , "global. The String should be the name of a global value."
     ]
+  , prim "crucible_global_initializer"
+    "String -> SetupValue"
+    (pureVal CIR.anySetupGlobalInitializer)
+    Current
+    [ "Legacy alternative name for `llvm_global_initializer`." ]
 
-  , prim "crucible_term"
+  , prim "llvm_term"
     "Term -> SetupValue"
     (pureVal CIR.anySetupTerm)
     Current
     [ "Construct a `SetupValue` from a `Term`." ]
+  , prim "crucible_term"
+    "Term -> SetupValue"
+    (pureVal CIR.anySetupTerm)
+    Current
+    [ "Legacy alternative name for `llvm_term`." ]
 
   , prim "crucible_setup_val_to_term"
     " SetupValue -> TopLevel Term"
@@ -2452,31 +2614,49 @@ primitives = Map.fromList
     ]
 
   -- Ghost state support
-  , prim "crucible_declare_ghost_state"
+  , prim "llvm_declare_ghost_state"
     "String -> TopLevel Ghost"
     (pureVal llvm_declare_ghost_state)
     Current
     [ "Allocates a unique ghost variable." ]
+  , prim "crucible_declare_ghost_state"
+    "String -> TopLevel Ghost"
+    (pureVal llvm_declare_ghost_state)
+    Current
+    [ "Legacy alternative name for `llvm_declare_ghost_state`." ]
 
-  , prim "crucible_ghost_value"
+  , prim "llvm_ghost_value"
     "Ghost -> Term -> CrucibleSetup ()"
     (pureVal llvm_ghost_value)
     Current
     [ "Specifies the value of a ghost variable. This can be used"
     , "in the pre- and post- conditions of a setup block."]
+  , prim "crucible_ghost_value"
+    "Ghost -> Term -> CrucibleSetup ()"
+    (pureVal llvm_ghost_value)
+    Current
+    [ "Legacy alternative name for `llvm_ghost_value`."]
 
-  , prim "crucible_spec_solvers"  "CrucibleMethodSpec -> [String]"
+  , prim "llvm_spec_solvers"  "CrucibleMethodSpec -> [String]"
     (\_ _ -> toValue llvm_spec_solvers)
     Current
     [ "Extract a list of all the solvers used when verifying the given method spec."
     ]
+  , prim "crucible_spec_solvers"  "CrucibleMethodSpec -> [String]"
+    (\_ _ -> toValue llvm_spec_solvers)
+    Current
+    [ "Legacy alternative name for `llvm_spec_solvers`." ]
 
-  , prim "crucible_spec_size"  "CrucibleMethodSpec -> Int"
+  , prim "llvm_spec_size"  "CrucibleMethodSpec -> Int"
     (\_ _ -> toValue llvm_spec_size)
     Current
     [ "Return a count of the combined size of all verification goals proved as part of"
     , "the given method spec."
     ]
+  , prim "crucible_spec_size"  "CrucibleMethodSpec -> Int"
+    (\_ _ -> toValue llvm_spec_size)
+    Current
+    [ "Legacy alternative name for `llvm_spec_size`." ]
 
     ---------------------------------------------------------------------
     -- Crucible/JVM commands

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1788,7 +1788,7 @@ primitives = Map.fromList
     ] -}
 
   , prim "crucible_java_extract"  "JavaClass -> String -> TopLevel Term"
-    (pureVal CJ.crucible_java_extract)
+    (pureVal CJ.java_extract)
     Current
     [ "Translate a Java method directly to a Term. The parameters of the"
     , "Term will be the parameters of the Java method, and the return"
@@ -2098,14 +2098,14 @@ primitives = Map.fromList
     ---------------------------------------------------------------------
     -- Crucible/LLVM interface
 
-  , prim "crucible_llvm_cfg"     "LLVMModule -> String -> TopLevel CFG"
-    (pureVal crucible_llvm_cfg)
+  , prim "llvm_cfg"     "LLVMModule -> String -> TopLevel CFG"
+    (pureVal llvm_cfg)
     Current
     [ "Load a function from the given LLVM module into a Crucible CFG."
     ]
 
   , prim "crucible_llvm_extract"  "LLVMModule -> String -> TopLevel Term"
-    (pureVal crucible_llvm_extract)
+    (pureVal llvm_extract)
     Current
     [ "Translate an LLVM function directly to a Term. The parameters of the"
     , "Term will be the parameters of the LLVM function, and the return"
@@ -2116,7 +2116,7 @@ primitives = Map.fromList
 
   , prim "crucible_llvm_compositional_extract"
     "LLVMModule -> String -> String -> [CrucibleMethodSpec] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
-    (pureVal crucible_llvm_compositional_extract)
+    (pureVal llvm_compositional_extract)
     Experimental
     [ "Translate an LLVM function directly to a Term. The parameters of the"
     , "Term are the input parameters of the LLVM function: the parameters"
@@ -2130,14 +2130,14 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_fresh_var" "String -> LLVMType -> CrucibleSetup Term"
-    (pureVal crucible_fresh_var)
+    (pureVal llvm_fresh_var)
     Current
     [ "Create a fresh symbolic variable for use within a Crucible"
     , "specification. The name is used only for pretty-printing."
     ]
 
   , prim "crucible_fresh_cryptol_var" "String -> Type -> CrucibleSetup Term"
-    (pureVal crucible_fresh_cryptol_var)
+    (pureVal llvm_fresh_cryptol_var)
     Experimental
     [ "Create a fresh symbolic variable of the given Cryptol type for use"
     , "within a Crucible specification. The given name is used only for"
@@ -2146,7 +2146,7 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_alloc" "LLVMType -> CrucibleSetup SetupValue"
-    (pureVal crucible_alloc)
+    (pureVal llvm_alloc)
     Current
     [ "Declare that an object of the given type should be allocated in a"
     , "Crucible specification. Before `crucible_execute_func`, this states"
@@ -2156,7 +2156,7 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_alloc_aligned" "Int -> LLVMType -> CrucibleSetup SetupValue"
-    (pureVal crucible_alloc_aligned)
+    (pureVal llvm_alloc_aligned)
     Current
     [ "Declare that a memory region of the given type should be allocated in"
     , "a Crucible specification, and also specify that the start of the region"
@@ -2165,7 +2165,7 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_alloc_readonly" "LLVMType -> CrucibleSetup SetupValue"
-    (pureVal crucible_alloc_readonly)
+    (pureVal llvm_alloc_readonly)
     Current
     [ "Declare that a read-only memory region of the given type should be"
     , "allocated in a Crucible specification. The function must not attempt"
@@ -2175,7 +2175,7 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_alloc_readonly_aligned" "Int -> LLVMType -> CrucibleSetup SetupValue"
-    (pureVal crucible_alloc_readonly_aligned)
+    (pureVal llvm_alloc_readonly_aligned)
     Current
     [ "Declare that a read-only memory region of the given type should be"
     , "a Crucible specification, and also specify that the start of the region"
@@ -2187,14 +2187,14 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_alloc_with_size" "Int -> LLVMType -> CrucibleSetup SetupValue"
-    (pureVal crucible_alloc_with_size)
+    (pureVal llvm_alloc_with_size)
     Experimental
     [ "Like `crucible_alloc`, but with a user-specified size (given in bytes)."
     , "The specified size must be greater than the size of the LLVM type."
     ]
 
   , prim "crucible_symbolic_alloc" "Bool -> Int -> Term -> CrucibleSetup SetupValue"
-    (pureVal crucible_symbolic_alloc)
+    (pureVal llvm_symbolic_alloc)
     Current
     [ "Like `crucible_alloc`, but with a (symbolic) size instead of"
     , "a LLVM type. The first argument specifies whether the allocation is"
@@ -2203,7 +2203,7 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_alloc_global" "String -> CrucibleSetup ()"
-    (pureVal crucible_alloc_global)
+    (pureVal llvm_alloc_global)
     Current
     [ "Declare that memory for the named global should be allocated in a"
     , "Crucible specification. This is done implicitly for immutable globals."
@@ -2211,7 +2211,7 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_fresh_pointer" "LLVMType -> CrucibleSetup SetupValue"
-    (pureVal crucible_fresh_pointer)
+    (pureVal llvm_fresh_pointer)
     Current
     [ "Create a fresh pointer value for use in a Crucible specification."
     , "This works like `crucible_alloc` except that the pointer is not"
@@ -2219,7 +2219,7 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_fresh_expanded_val" "LLVMType -> CrucibleSetup SetupValue"
-    (pureVal crucible_fresh_expanded_val)
+    (pureVal llvm_fresh_expanded_val)
     Current
     [ "Create a compound type entirely populated with fresh symbolic variables."
     , "Equivalent to allocating a new struct or array of the given type and"
@@ -2228,7 +2228,7 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_points_to" "SetupValue -> SetupValue -> CrucibleSetup ()"
-    (pureVal (crucible_points_to True))
+    (pureVal (llvm_points_to True))
     Current
     [ "Declare that the memory location indicated by the given pointer (first"
     , "argument) contains the given value (second argument)."
@@ -2240,7 +2240,7 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_conditional_points_to" "Term -> SetupValue -> SetupValue -> CrucibleSetup ()"
-    (pureVal (crucible_conditional_points_to True))
+    (pureVal (llvm_conditional_points_to True))
     Current
     [ "Declare that the memory location indicated by the given pointer (second"
     , "argument) contains the given value (third argument) if the given"
@@ -2253,7 +2253,7 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_points_to_untyped" "SetupValue -> SetupValue -> CrucibleSetup ()"
-    (pureVal (crucible_points_to False))
+    (pureVal (llvm_points_to False))
     Current
     [ "A variant of crucible_points_to that does not check for compatibility"
     , "between the pointer type and the value type. This may be useful when"
@@ -2261,7 +2261,7 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_conditional_points_to_untyped" "Term -> SetupValue -> SetupValue -> CrucibleSetup ()"
-    (pureVal (crucible_conditional_points_to False))
+    (pureVal (llvm_conditional_points_to False))
     Current
     [ "A variant of crucible_conditional_points_to that does not check for"
     , "compatibility between the pointer type and the value type. This may"
@@ -2269,7 +2269,7 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_points_to_array_prefix" "SetupValue -> Term -> Term -> CrucibleSetup ()"
-    (pureVal crucible_points_to_array_prefix)
+    (pureVal llvm_points_to_array_prefix)
     Experimental
     [ "Declare that the memory location indicated by the given pointer (first"
     , "argument) contains the prefix of the given array (second argument) of"
@@ -2282,7 +2282,7 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_equal" "SetupValue -> SetupValue -> CrucibleSetup ()"
-    (pureVal crucible_equal)
+    (pureVal llvm_equal)
     Current
     [ "State that two Crucible values should be equal. Can be used as either"
     , "a pre-condition or a post-condition. It is semantically equivalent to"
@@ -2291,21 +2291,21 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_precond" "Term -> CrucibleSetup ()"
-    (pureVal crucible_precond)
+    (pureVal llvm_precond)
     Current
     [ "State that the given predicate is a pre-condition on execution of the"
     , "function being verified."
     ]
 
   , prim "crucible_postcond" "Term -> CrucibleSetup ()"
-    (pureVal crucible_postcond)
+    (pureVal llvm_postcond)
     Current
     [ "State that the given predicate is a post-condition of execution of the"
     , "function being verified."
     ]
 
   , prim "crucible_execute_func" "[SetupValue] -> CrucibleSetup ()"
-    (pureVal crucible_execute_func)
+    (pureVal llvm_execute_func)
     Current
     [ "Specify the given list of values as the arguments of the function."
     ,  ""
@@ -2317,7 +2317,7 @@ primitives = Map.fromList
     ]
 
   , prim "crucible_return" "SetupValue -> CrucibleSetup ()"
-    (pureVal crucible_return)
+    (pureVal llvm_return)
     Current
     [ "Specify the given value as the return value of the function. A"
     , "crucible_return statement is required if and only if the function"
@@ -2325,7 +2325,7 @@ primitives = Map.fromList
 
   , prim "crucible_llvm_verify"
     "LLVMModule -> String -> [CrucibleMethodSpec] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
-    (pureVal crucible_llvm_verify)
+    (pureVal llvm_verify)
     Current
     [ "Verify the LLVM function named by the second parameter in the module"
     , "specified by the first. The third parameter lists the CrucibleMethodSpec"
@@ -2338,7 +2338,7 @@ primitives = Map.fromList
 
   , prim "crucible_llvm_unsafe_assume_spec"
     "LLVMModule -> String -> CrucibleSetup () -> TopLevel CrucibleMethodSpec"
-    (pureVal crucible_llvm_unsafe_assume_spec)
+    (pureVal llvm_unsafe_assume_spec)
     Current
     [ "Return a CrucibleMethodSpec corresponding to a CrucibleSetup block,"
     , "as would be returned by crucible_llvm_verify but without performing"
@@ -2347,7 +2347,7 @@ primitives = Map.fromList
 
   , prim "crucible_llvm_array_size_profile"
     "LLVMModule -> String -> [CrucibleMethodSpec] -> CrucibleSetup () -> TopLevel [(String, [FunctionProfile])]"
-    (pureVal $ crucible_llvm_array_size_profile assumeUnsat)
+    (pureVal $ llvm_array_size_profile assumeUnsat)
     Experimental
     [ "Symbolically execute the function named by the second parameter in"
     , "the module specified by the first. The fourth parameter may be used"
@@ -2358,7 +2358,7 @@ primitives = Map.fromList
 
   , prim "crucible_llvm_verify_x86"
     "LLVMModule -> String -> String -> [(String, Int)] -> Bool -> CrucibleSetup () -> ProofScript SatResult -> TopLevel CrucibleMethodSpec"
-    (pureVal crucible_llvm_verify_x86)
+    (pureVal llvm_verify_x86)
     Experimental
     [ "Verify an x86 function from an ELF file for use as an override in an"
     , "LLVM verification. The first argument specifies the LLVM module"
@@ -2454,25 +2454,25 @@ primitives = Map.fromList
   -- Ghost state support
   , prim "crucible_declare_ghost_state"
     "String -> TopLevel Ghost"
-    (pureVal crucible_declare_ghost_state)
+    (pureVal llvm_declare_ghost_state)
     Current
     [ "Allocates a unique ghost variable." ]
 
   , prim "crucible_ghost_value"
     "Ghost -> Term -> CrucibleSetup ()"
-    (pureVal crucible_ghost_value)
+    (pureVal llvm_ghost_value)
     Current
     [ "Specifies the value of a ghost variable. This can be used"
     , "in the pre- and post- conditions of a setup block."]
 
   , prim "crucible_spec_solvers"  "CrucibleMethodSpec -> [String]"
-    (\_ _ -> toValue crucible_spec_solvers)
+    (\_ _ -> toValue llvm_spec_solvers)
     Current
     [ "Extract a list of all the solvers used when verifying the given method spec."
     ]
 
   , prim "crucible_spec_size"  "CrucibleMethodSpec -> Int"
-    (\_ _ -> toValue crucible_spec_size)
+    (\_ _ -> toValue llvm_spec_size)
     Current
     [ "Return a count of the combined size of all verification goals proved as part of"
     , "the given method spec."

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1787,8 +1787,8 @@ primitives = Map.fromList
     [ "Convert a Java method to a Crucible CFG."
     ] -}
 
-  , prim "java_extract"  "JavaClass -> String -> TopLevel Term"
-    (pureVal CJ.java_extract)
+  , prim "jvm_extract"  "JavaClass -> String -> TopLevel Term"
+    (pureVal CJ.jvm_extract)
     Current
     [ "Translate a Java method directly to a Term. The parameters of the"
     , "Term will be the parameters of the Java method, and the return"
@@ -1796,9 +1796,9 @@ primitives = Map.fromList
     , "scalar argument and return types are currently supported."
     ]
   , prim "crucible_java_extract"  "JavaClass -> String -> TopLevel Term"
-    (pureVal CJ.java_extract)
+    (pureVal CJ.jvm_extract)
     Current
-    [ "Legacy alternative name for `java_extract`."
+    [ "Legacy alternative name for `jvm_extract`."
     ]
 
   , prim "llvm_sizeof"         "LLVMModule -> LLVMType -> Int"

--- a/src/SAWScript/Lexer.x
+++ b/src/SAWScript/Lexer.x
@@ -43,6 +43,7 @@ $codechar  = [$graphic $whitechar]
 @reservedid  = import|and|let|rec|in|do|if|then|else|as|hiding|typedef
              |CryptolSetup|JavaSetup|LLVMSetup|ProofScript|TopLevel|CrucibleSetup
              |Int|String|Term|Type|Bool|AIG|CFG
+             |CrucibleMethodSpec|LLVMSpec|JVMMethodSpec|JVMSpec
 
 @punct       = "," | ";" | "(" | ")" | ":" | "::" | "[" | "]" | "<-" | "->"
              | "=" | "{" | "}" | "." | "\"

--- a/src/SAWScript/Parser.y
+++ b/src/SAWScript/Parser.y
@@ -62,6 +62,10 @@ import Control.Exception
   'ProofScript'  { TReserved _ "ProofScript"    }
   'TopLevel'     { TReserved _ "TopLevel"       }
   'CrucibleSetup'{ TReserved _ "CrucibleSetup"  }
+  'CrucibleMethodSpec' { TReserved _ "CrucibleMethodSpec" }
+  'LLVMSpec'     { TReserved _ "LLVMSpec"       }
+  'JVMMethodSpec'{ TReserved _ "JVMMethodSpec"  }
+  'JVMSpec'      { TReserved _ "JVMSpec"        }
   'Bool'         { TReserved _ "Bool"           }
   'Int'          { TReserved _ "Int"            }
   'String'       { TReserved _ "String"         }
@@ -221,6 +225,10 @@ BaseType :: { Type }
  | 'Type'                               { LType (getPos $1) tType               }
  | 'AIG'                                { LType (getPos $1) tAIG                }
  | 'CFG' 				{ LType (getPos $1) tCFG                }
+ | 'CrucibleMethodSpec'			{ LType (getPos $1) tLLVMSpec           }
+ | 'LLVMSpec' 				{ LType (getPos $1) tLLVMSpec           }
+ | 'JVMMethodSpec'			{ LType (getPos $1) tJVMSpec            }
+ | 'JVMSpec' 				{ LType (getPos $1) tJVMSpec            }
  | '(' Type ')'                         { LType (maxSpan [$1, $3]) $2           }
  | '(' commas2(Type) ')'                { LType (maxSpan [$1, $3]) (tTuple $2)  }
  | '[' Type ']'                         { LType (maxSpan [$1, $3]) (tArray $2)  }
@@ -232,7 +240,7 @@ Context :: { Type }
  | 'LLVMSetup'                          { tContext LLVMSetup      }
  | 'ProofScript'                        { tContext ProofScript    }
  | 'TopLevel'                           { tContext TopLevel       }
- | 'CrucibleSetup'                      { tContext CrucibleSetup  }
+ | 'CrucibleSetup'                      { tContext LLVMSetup      }
  | name                                 { tVar (tokStr $1)        }
 
 -- Parameterized productions, most come directly from the Happy manual.


### PR DESCRIPTION
Add new saw-script function names without "crucible_" prefix.

LLVM-specific function names with the prefix "crucible_" have been switched to use the prefix "llvm_".

The original names remain in place, with documentation strings referring to the new names.