### PR TITLE
Stop printing "Valid" for every prove_print

### DIFF
--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -1016,8 +1016,9 @@ provePrintPrim script t = do
   (r, pstate) <- runStateT script (startProof goal)
   opts <- rwPPOpts <$> getTopLevelRW
   case finishProof pstate of
-    (_,Just thm) -> do printOutLnTop Info "Valid"
-                       SV.returnProof thm
+    (_,Just thm) -> do
+      printOutLnTop Debug $ "Valid: " ++ show (ppTerm (SV.sawPPOpts opts) $ ttTerm t)
+      SV.returnProof thm
     (_,Nothing) -> fail $ "prove: " ++ show (length (psGoals pstate)) ++ " unsolved subgoal(s)\n"
                      ++ SV.showsProofResult opts (SV.flipSatResult r) ""
 


### PR DESCRIPTION
After this change, `prove_print` will silently succeed when SAW's verbosity is less than "debug", and additionally print the term proved when verbosity is "debug".

The old behavior negatively impacts the readability of logs when many rewrite rules must be proved.