### PR TITLE
Update examples/java to use new JVM verification commands.

### DIFF
--- a/examples/java/alloc.saw
+++ b/examples/java/alloc.saw
@@ -1,11 +1,16 @@
-enable_deprecated;
-let alloc_spec = do {
-    java_var "dst" (java_array 10 java_int);
-    src <- java_var "src" (java_array 10 java_int);
-    java_allow_alloc;
-    java_ensure_eq "dst" src;
-    java_verify_tactic abc;
-};
+enable_experimental;
 
 c <- java_load_class "Alloc";
-java_verify c "alloc" [] alloc_spec;
+
+jvm_verify c "alloc" [] false
+  do {
+    this <- jvm_alloc_object "Alloc";
+    dst_ref <- jvm_alloc_array 10 java_int;
+    src_ref <- jvm_alloc_array 10 java_int;
+    src <- jvm_fresh_var "src" (java_array 10 java_int);
+    jvm_array_is src_ref src;
+    jvm_execute_func [this, dst_ref, src_ref];
+    jvm_array_is src_ref src;
+    jvm_array_is dst_ref src;
+  }
+  abc;

--- a/examples/java/arrayfield.saw
+++ b/examples/java/arrayfield.saw
@@ -1,12 +1,14 @@
-enable_deprecated;
-let init_spec = do {
-  a <- java_var "this.a" (java_array 5 java_int);
-  x <- java_var "x" java_int;
-  java_assert_eq "x" {{ 22 : [32] }};
-  java_ensure_eq "this.a" {{ [x, x, x, x, x] }};
-  java_allow_alloc;
-  java_verify_tactic abc;
-};
+enable_experimental;
 
 c <- java_load_class "ArrayField";
-java_verify c "init" [] init_spec;
+
+jvm_verify c "init" [] false
+  do {
+    this <- jvm_alloc_object "ArrayField";
+    x <- jvm_fresh_var "x" java_int;
+    jvm_execute_func [this, jvm_term x];
+    na <- jvm_alloc_array 5 java_int;
+    jvm_field_is this "a" na;
+    jvm_array_is na {{ [x, x, x, x, x] }};
+  }
+  abc;

--- a/examples/java/arrays.saw
+++ b/examples/java/arrays.saw
@@ -1,49 +1,69 @@
+enable_experimental;
+
+c <- java_load_class "ArrayTest";
+
+copy_ms <-
+jvm_verify c "copy" [] false
+  do {
+    this <- jvm_alloc_object "ArrayTest";
+    a_ref <- jvm_alloc_array 10 java_int;
+    b_ref <- jvm_alloc_array 10 java_int;
+    a <- jvm_fresh_var "a" (java_array 10 java_int);
+    jvm_array_is a_ref a;
+    jvm_execute_func [this, a_ref, b_ref];
+    jvm_array_is b_ref a;
+  }
+  abc;
+
+unit_ms <-
+jvm_verify c "unit" [] false
+  do {
+    this <- jvm_alloc_object "ArrayTest";
+    a_ref <- jvm_alloc_array 10 java_int;
+    jvm_execute_func [this, a_ref];
+    jvm_array_is a_ref {{ [1, 0, 0, 0, 0, 0, 0, 0, 0, 0] : [10][32] }};
+  }
+  abc;
+
+clear_ms <-
+jvm_verify c "clear" [] false
+  do {
+    this <- jvm_alloc_object "ArrayTest";
+    a_ref <- jvm_alloc_array 10 java_int;
+    jvm_execute_func [this, a_ref];
+    jvm_array_is a_ref {{ zero : [10][32] }};
+  }
+  abc;
+
+sum_ms <-
+jvm_verify c "sum" [] false
+  do {
+    this <- jvm_alloc_object "ArrayTest";
+    a_ref <- jvm_alloc_array 10 java_int;
+    a <- jvm_fresh_var "a" (java_array 10 java_int);
+    jvm_array_is a_ref a;
+    jvm_execute_func [this, a_ref];
+    jvm_return (jvm_term {{ sum a }});
+  }
+  abc;
+
+comp_ms <-
+jvm_verify c "comp" [unit_ms] false
+  do {
+    this <- jvm_alloc_object "ArrayTest";
+    a_ref <- jvm_alloc_array 10 java_int;
+    jvm_execute_func [this, a_ref];
+    jvm_array_is a_ref {{ [1, 0, 0, 0, 0, 0, 0, 0, 0, 0] : [10][32] }};
+  }
+  abc;
+
 enable_deprecated;
-let copy_setup : JavaSetup () = do {
-    a <- java_var "a" (java_array 10 java_int);
-    java_var "b" (java_array 10 java_int);
-    java_ensure_eq "b" {{ a : [10][32] }};
-    java_verify_tactic abc;
-};
-
-let unit_setup : JavaSetup () = do {
-    java_var "a" (java_array 10 java_int);
-    java_ensure_eq "a" {{ [1, 0, 0, 0, 0, 0, 0, 0, 0, 0] : [10][32] }};
-    java_verify_tactic abc;
-};
-
-let clear_setup : JavaSetup () = do {
-    java_requires_class "java.util.Arrays";
-    java_var "a" (java_array 10 java_int);
-    java_ensure_eq "a" {{ zero : [10][32] }};
-    java_verify_tactic abc;
-};
-
-let sum_setup : JavaSetup () = do {
-    a <- java_var "a" (java_array 10 java_int);
-    // Silly way to write it, but works as a test.
-    java_return {{ (a@0) + (a@1) + (a@2) + (a@3) + (a@4) +
-                   (a@5) + (a@6) + (a@7) + (a@8) + (a@9)  }};
-    java_verify_tactic abc;
-};
 
 let sum_setup' : JavaSetup () = do { java_var "a" (java_array 10 java_int); return (); };
 
 let id_setup : JavaSetup () = do { java_var "a" (java_array 10 java_int); return (); };
 
-let comp_setup : JavaSetup () = do {
-    java_var "a" (java_array 10 java_int);
-    java_ensure_eq "a" {{ [1, 0, 0, 0, 0, 0, 0, 0, 0, 0] : [10][32] }};
-    java_verify_tactic abc;
-};
-
 let main : TopLevel () = do {
-    c <- java_load_class "ArrayTest";
-    copy_ms <- java_verify c "copy" [] copy_setup;
-    unit_ms <- java_verify c "unit" [] unit_setup;
-    clear_ms <- java_verify c "clear" [] clear_setup;
-    sum_ms <- java_verify c "sum" [] sum_setup;
-    comp_ms <- java_verify c "comp" [unit_ms] comp_setup;
     print "Extracting model of sum, which has type:";
     sum_tm <- java_extract c "sum" sum_setup';
     id_tm <- java_extract c "arr_id" id_setup;

--- a/examples/java/arrays.saw
+++ b/examples/java/arrays.saw
@@ -57,6 +57,9 @@ jvm_verify c "comp" [unit_ms] false
   }
   abc;
 
+/*
+// FIXME: jvm_extract does not yet support array types for input/output.
+
 enable_deprecated;
 
 let sum_setup' : JavaSetup () = do { java_var "a" (java_array 10 java_int); return (); };
@@ -75,3 +78,4 @@ let main : TopLevel () = do {
     print {{ id_tm [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] }};
     print "Done.";
 };
+*/

--- a/examples/java/branchsat.saw
+++ b/examples/java/branchsat.saw
@@ -1,14 +1,15 @@
-enable_deprecated;
-let f_spec = do {
-   x <- java_var "x" java_int;
-   java_assert_eq "x" {{ 4:[32] }};
-   java_sat_branches true;
-   java_return {{ 6 : [32] }};
-   java_verify_tactic abc;
-};
+enable_experimental;
 
 c <- java_load_class "BranchTest";
+
+// FIXME: make this terminate with the symbolic precondition
 // The following will not terminate if the last parameter is `false`
-f <- java_symexec c "f" [("x", {{ 4:[32] }})] ["return"] true;
-print_term f;
-java_verify c "f" [] f_spec;
+jvm_verify c "f" [] true
+  do {
+    let x = {{ 6 : [32] }}; // FIXME
+    // x <- jvm_fresh_var "x" java_int;
+    // jvm_precond {{ x < 10 }};
+    jvm_execute_func [jvm_term x];
+    jvm_return (jvm_term {{ x * (x - 1) / 2 }});
+  }
+  abc;

--- a/examples/java/bytearray.saw
+++ b/examples/java/bytearray.saw
@@ -1,4 +1,11 @@
-enable_deprecated;
+enable_experimental;
 c <- java_load_class "ByteArray";
-t <- java_symexec c "id" [("x", {{ [1,2,3] : [3][8] }})] ["return"] false;
-print t;
+
+jvm_verify c "id" [] false
+  do {
+    this <- jvm_alloc_object "ByteArray";
+    xref <- jvm_alloc_array 10 java_byte;
+    jvm_execute_func [this, xref];
+    jvm_return xref;
+  }
+  abc;

--- a/examples/java/classtype.saw
+++ b/examples/java/classtype.saw
@@ -1,11 +1,12 @@
-enable_deprecated;
-let id_spec = do {
-    java_class_var "x" (java_class "java.lang.Object");
-    java_return {{ 0 : [32] }};
-    java_verify_tactic abc;
-};
+enable_experimental;
 
-let main = do {
-    c <- java_load_class "ClassType";
-    java_verify c "id" [] id_spec;
-};
+c <- java_load_class "ClassType";
+
+jvm_verify c "id" [] false
+  do {
+    this <- jvm_alloc_object "ClassType";
+    x_ref <- jvm_alloc_object "java.lang.Object";
+    jvm_execute_func [this, x_ref];
+    jvm_return (jvm_term {{ 0 : [32] }});
+  }
+  abc;

--- a/examples/java/fields.saw
+++ b/examples/java/fields.saw
@@ -1,35 +1,43 @@
-enable_deprecated;
-let setx_spec : JavaSetup () = do {
-    newx <- java_var "newx" java_int;
-    java_var "this.x" java_int;
-    java_ensure_eq "this.x" {{ newx : [32] }};
-    java_verify_tactic abc;
-};
+enable_experimental;
 
-let sety_spec : JavaSetup () = do {
-    newy <- java_var "newy" java_long;
-    java_var "this.y" java_long;
-    java_ensure_eq "this.y" {{ newy : [64] }};
-    java_verify_tactic abc;
-};
+c <- java_load_class "Fields";
 
-let unitx_spec : JavaSetup () = do {
-    java_var "this.x" java_int;
-    java_ensure_eq "this.x" {{ 1 : [32] }};
-    java_verify_tactic abc;
-};
+ms_setx <-
+jvm_verify c "setx" [] false
+  do {
+    this <- jvm_alloc_object "Fields";
+    newx <- jvm_fresh_var "newx" java_int;
+    jvm_execute_func [this, jvm_term newx];
+    jvm_field_is this "x" (jvm_term newx);
+  }
+  abc;
 
-let unity_spec : JavaSetup () = do {
-    java_var "this.y" java_long;
-    java_ensure_eq "this.y" {{ 1 : [64] }};
-    java_verify_tactic abc;
-};
+ms_sety <-
+jvm_verify c "sety" [] false
+  do {
+    this <- jvm_alloc_object "Fields";
+    newy <- jvm_fresh_var "newy" java_long;
+    jvm_execute_func [this, jvm_term newy];
+    jvm_field_is this "y" (jvm_term newy);
+  }
+  abc;
 
-let main : TopLevel () = do {
-    c <- java_load_class "Fields";
-    ms_setx <- java_verify c "setx" [] setx_spec;
-    ms_sety <- java_verify c "sety" [] sety_spec;
-    ms_unitx <- java_verify c "unitx" [] unitx_spec;
-    ms_unity <- java_verify c "unity" [] unity_spec;
-    print "Done.";
-};
+ms_unitx <-
+jvm_verify c "unitx" [] false
+  do {
+    this <- jvm_alloc_object "Fields";
+    jvm_execute_func [this];
+    jvm_field_is this "x" (jvm_term {{ 1 : [32] }});
+  }
+  abc;
+
+ms_unity <-
+jvm_verify c "unity" [] false
+  do {
+    this <- jvm_alloc_object "Fields";
+    jvm_execute_func [this];
+    jvm_field_is this "y" (jvm_term {{ 1 : [64] }});
+  }
+  abc;
+
+print "Done.";

--- a/examples/java/get.saw
+++ b/examples/java/get.saw
@@ -1,14 +1,15 @@
-enable_deprecated;
-let get_setup = do {
-    java_var "a" (java_array 4 java_int);
-    j <- java_var "j" java_int;
-    java_assert {{ 0 <= (j : [32]) /\ j <= 3 }};
-    java_modify "a";
-    java_return {{ j }};
-    java_verify_tactic abc;
-};
+enable_experimental;
 
-let main = do {
-    c <- java_load_class "Get";
-    java_verify c "get" [] get_setup;
-};
+c <- java_load_class "Get";
+
+jvm_verify c "get" [] false
+  do {
+    this <- jvm_alloc_object "Get";
+    a <- jvm_alloc_array 4 java_int;
+    j <- jvm_fresh_var "j" java_int;
+    jvm_precond {{ j <= 3 }};
+    jvm_execute_func [this, a, jvm_term j];
+    // TODO: Update spec to say `a` is modified but not specified
+    jvm_return (jvm_term {{ j }});
+  }
+  abc;

--- a/examples/java/java_add.saw
+++ b/examples/java/java_add.saw
@@ -1,21 +1,34 @@
-enable_deprecated;
-let setup (add : Term) : JavaSetup () = do {
-    x <- java_var "x" java_int;
-    y <- java_var "y" java_int;
-    java_return {{ add x y }};
-    java_verify_tactic (do { unfolding ["add"]; z3; });
-};
+enable_experimental;
 
-let setup' (add : Term) : JavaSetup () = do {
-    x <- java_var "x" java_int;
-    java_return {{ add x x }};
-    java_verify_tactic z3;
-};
+c <- java_load_class "Add";
 
-let main : TopLevel () = do {
-    c <- java_load_class "Add";
-    add <- define "add" {{ \x y -> (x : [32]) + y }};
-    ms <- java_verify c "add" [] (setup add);
-    ms' <- java_verify c "dbl" [ms] (setup' add);
-    print "Done.";
-};
+let {{
+  add : [32] -> [32] -> [32]
+  add x y = x + y
+}};
+
+ms <-
+  jvm_verify c "add" [] false
+    do {
+      this <- jvm_alloc_object "Add";
+      x <- jvm_fresh_var "x" java_int;
+      y <- jvm_fresh_var "y" java_int;
+      jvm_execute_func [this, jvm_term x, jvm_term y];
+      jvm_return (jvm_term {{ add x y }});
+    }
+    do {
+      unfolding ["add"];
+      z3;
+    };
+
+ms' <-
+  jvm_verify c "dbl" [ms] false
+    do {
+      this <- jvm_alloc_object "Add";
+      x <- jvm_fresh_var "x" java_int;
+      jvm_execute_func [this, jvm_term x];
+      jvm_return (jvm_term {{ add x x }});
+    }
+    z3;
+
+print "Done.";

--- a/examples/java/java_types.saw
+++ b/examples/java/java_types.saw
@@ -1,48 +1,71 @@
-enable_deprecated;
+enable_experimental;
 set_base 16;
 
 c <- java_load_class "JavaTypes";
 
-let set_spec fname ty = do {
-    x <- java_var "args[0]" ty;
-    java_var fname ty;
-    java_ensure_eq fname x;
-    java_verify_tactic abc;
-};
+let set_spec fname ty =
+  do {
+    this <- jvm_alloc_object "JavaTypes";
+    x <- jvm_fresh_var "x" ty;
+    jvm_execute_func [this, jvm_term x];
+    jvm_field_is this fname (jvm_term x);
+  };
 
-let get_spec fname ty = do {
-    x <- java_var fname ty;
-    java_return x;
-    java_verify_tactic abc;
-};
+let get_spec fname ty =
+  do {
+    this <- jvm_alloc_object "JavaTypes";
+    x <- jvm_fresh_var "x" ty;
+    jvm_field_is this fname (jvm_term x);
+    jvm_execute_func [this];
+    jvm_return (jvm_term x);
+  };
 
-let verify_get mname fname ty = java_verify c mname [] (get_spec fname ty);
-let verify_set mname fname ty = java_verify c mname [] (set_spec fname ty);
+let aset_spec fname len ty =
+  do {
+    this <- jvm_alloc_object "JavaTypes";
+    aref <- jvm_alloc_array len ty;
+    jvm_execute_func [this, aref];
+    jvm_field_is this fname aref;
+  };
 
-verify_set "bool_set"  "this.boolfld" java_bool;
-verify_set "byte_set"  "this.bfld" java_byte;
-verify_set "char_set"  "this.cfld" java_char;
-verify_set "short_set" "this.sfld" java_short;
-verify_set "int_set"   "this.ifld" java_int;
-verify_set "long_set"  "this.lfld" java_long;
+let aget_spec fname len ty =
+  do {
+    this <- jvm_alloc_object "JavaTypes";
+    aref <- jvm_alloc_array len ty;
+    jvm_field_is this fname aref;
+    jvm_execute_func [this];
+    jvm_return aref;
+  };
 
-verify_get "bool_get"  "this.boolfld" java_bool;
-verify_get "byte_get"  "this.bfld" java_byte;
-verify_get "char_get"  "this.cfld" java_char;
-verify_get "short_get" "this.sfld" java_short;
-verify_get "int_get"   "this.ifld" java_int;
-verify_get "long_get"  "this.lfld" java_long;
+let verify_set mname fname ty = jvm_verify c mname [] false (set_spec fname ty) abc;
+let verify_get mname fname ty = jvm_verify c mname [] false (get_spec fname ty) abc;
+let verify_aset mname fname n ty = jvm_verify c mname [] false (aset_spec fname n ty) abc;
+let verify_aget mname fname n ty = jvm_verify c mname [] false (aget_spec fname n ty) abc;
 
-verify_set "bool_aset"  "this.boolafld" (java_array 4 java_bool);
-verify_set "byte_aset"  "this.bafld" (java_array 4 java_byte);
-verify_set "char_aset"  "this.cafld" (java_array 4 java_char);
-verify_set "short_aset" "this.safld" (java_array 4 java_short);
-verify_set "int_aset"   "this.iafld" (java_array 4 java_int);
-verify_set "long_aset"  "this.lafld" (java_array 4 java_long);
+verify_set "bool_set"  "boolfld" java_bool;
+verify_set "byte_set"  "bfld" java_byte;
+verify_set "char_set"  "cfld" java_char;
+verify_set "short_set" "sfld" java_short;
+verify_set "int_set"   "ifld" java_int;
+verify_set "long_set"  "lfld" java_long;
 
-verify_get "bool_aget"  "this.boolafld" (java_array 4 java_bool);
-verify_get "byte_aget"  "this.bafld" (java_array 4 java_byte);
-verify_get "char_aget"  "this.cafld" (java_array 4 java_char);
-verify_get "short_aget" "this.safld" (java_array 4 java_short);
-verify_get "int_aget"   "this.iafld" (java_array 4 java_int);
-verify_get "long_aget"  "this.lafld" (java_array 4 java_long);
+verify_get "bool_get"  "boolfld" java_bool;
+verify_get "byte_get"  "bfld" java_byte;
+verify_get "char_get"  "cfld" java_char;
+verify_get "short_get" "sfld" java_short;
+verify_get "int_get"   "ifld" java_int;
+verify_get "long_get"  "lfld" java_long;
+
+verify_aset "bool_aset"  "boolafld" 4 java_bool;
+verify_aset "byte_aset"  "bafld" 4 java_byte;
+verify_aset "char_aset"  "cafld" 4 java_char;
+verify_aset "short_aset" "safld" 4 java_short;
+verify_aset "int_aset"   "iafld" 4 java_int;
+verify_aset "long_aset"  "lafld" 4 java_long;
+
+verify_aget "bool_aget"  "boolafld" 4 java_bool;
+verify_aget "byte_aget"  "bafld" 4 java_byte;
+verify_aget "char_aget"  "cafld" 4 java_char;
+verify_aget "short_aget" "safld" 4 java_short;
+verify_aget "int_aget"   "iafld" 4 java_int;
+verify_aget "long_aget"  "lafld" 4 java_long;

--- a/examples/java/javatoaig.saw
+++ b/examples/java/javatoaig.saw
@@ -1,4 +1,3 @@
-enable_deprecated;
 c <- java_load_class "Double";
 t <- jvm_extract c "f";
 print_term t;

--- a/examples/java/return.saw
+++ b/examples/java/return.saw
@@ -1,43 +1,38 @@
-enable_deprecated;
-let fill_spec = do {
-  x <- java_var "n" java_int;
-  java_var "return" (java_array 5 java_int);
-  java_assert_eq "n" {{ 22 : [32] }};
-  java_ensure_eq "return" {{ [x, x, x, x, x] }};
-  // This also works, and means the same thing.
-  // java_return {{ [x, x, x, x, x] }};
-  java_allow_alloc;
-  java_verify_tactic abc;
-};
-
-let newSimple_spec = do {
-  x <- java_var "x" java_int;
-  y <- java_var "y" java_int;
-  java_class_var "return" (java_class "SimpleObj");
-  java_var "return.x" java_int;
-  java_var "return.y" java_int;
-  java_assert_eq "x" {{ 43 : [32] }};
-  java_assert_eq "y" {{ 77 : [32] }};
-  java_ensure_eq "return.x" {{ x }};
-  java_ensure_eq "return.y" {{ y }};
-  java_allow_alloc;
-  java_verify_tactic abc;
-};
-
-let simpleWrap2_spec = do {
-  java_requires_class "SimpleObj";
-  x <- java_var "x" java_int;
-  y <- java_var "y" java_int;
-  java_assert_eq "x" {{ 43 : [32] }};
-  java_assert_eq "y" {{ 77 : [32] }};
-  java_return {{ 2 : [32] }};
-  java_allow_alloc;
-  java_verify_tactic abc;
-};
+enable_experimental;
 
 c <- java_load_class "Return";
-fill_ov <- java_verify c "fill" [] fill_spec;
-java_verify c "fillwrap" [fill_ov] fill_spec;
-newSimple_ov <- java_verify c "newSimple" [] newSimple_spec;
-java_verify c "newSimpleWrap" [newSimple_ov] newSimple_spec;
-java_verify c "newSimpleWrap2" [newSimple_ov] simpleWrap2_spec;
+
+let fill_spec =
+  do {
+    x <- jvm_fresh_var "x" java_int;
+    jvm_execute_func [jvm_term x];
+    aref <- jvm_alloc_array 5 java_int;
+    jvm_array_is aref {{ [x, x, x, x, x] }};
+    jvm_return aref;
+  };
+
+fill_ov <- jvm_verify c "fill" [] false fill_spec abc;
+jvm_verify c "fillwrap" [fill_ov] false fill_spec abc;
+
+let newSimple_spec =
+  do {
+    x <- jvm_fresh_var "x" java_int;
+    y <- jvm_fresh_var "y" java_int;
+    jvm_execute_func [jvm_term x, jvm_term y];
+    ref <- jvm_alloc_object "SimpleObj";
+    jvm_field_is ref "x" (jvm_term x);
+    jvm_field_is ref "y" (jvm_term y);
+    jvm_return ref;
+  };
+
+newSimple_ov <- jvm_verify c "newSimple" [] false newSimple_spec abc;
+jvm_verify c "newSimpleWrap" [newSimple_ov] false newSimple_spec abc;
+
+jvm_verify c "newSimpleWrap2" [newSimple_ov] false
+  do {
+    x <- jvm_fresh_var "x" java_int;
+    y <- jvm_fresh_var "y" java_int;
+    jvm_execute_func [jvm_term x, jvm_term y];
+    jvm_return (jvm_term {{ 2 : [32] }});
+  }
+  abc;

--- a/examples/java/returnsym.saw
+++ b/examples/java/returnsym.saw
@@ -1,4 +1,0 @@
-enable_deprecated;
-c <- java_load_class "Return";
-t <- java_symexec c "fill" [("n", {{ 22:[32] }})] ["return"] false;
-print_term t;

--- a/examples/java/staticfield.saw
+++ b/examples/java/staticfield.saw
@@ -1,20 +1,24 @@
-enable_deprecated;
-let setx_spec : JavaSetup () = do {
-    newx <- java_var "newx" java_int;
-    java_var "sfield.StaticField.x" java_int;
-    java_ensure_eq "sfield.StaticField.x" {{ newx : [32] }};
-    java_verify_tactic abc;
-};
+enable_experimental;
 
-let getx_spec : JavaSetup () = do {
-    x <- java_var "sfield.StaticField.x" java_int;
-    java_return {{ x : [32] }};
-    java_verify_tactic abc;
-};
+c <- java_load_class "sfield.StaticField";
 
-let main : TopLevel () = do {
-    c <- java_load_class "sfield.StaticField";
-    ms_setx <- java_verify c "setx" [] setx_spec;
-    ms_getx <- java_verify c "getx" [] getx_spec;
-    print "Done.";
-};
+ms_setx <-
+  jvm_verify c "setx" [] false
+    do {
+      newx <- jvm_fresh_var "newx" java_int;
+      jvm_execute_func [jvm_term newx];
+      jvm_static_field_is "sfield/StaticField.x" (jvm_term newx);
+    }
+    abc;
+
+ms_getx <-
+  jvm_verify c "getx" [] false
+    do {
+      x <- jvm_fresh_var "newx" java_int;
+      jvm_static_field_is "sfield/StaticField.x" (jvm_term x);
+      jvm_execute_func [];
+      jvm_return (jvm_term x);
+    }
+    abc;
+
+print "Done.";

--- a/src/SAWScript/Crucible/JVM/Builtins.hs
+++ b/src/SAWScript/Crucible/JVM/Builtins.hs
@@ -172,7 +172,6 @@ excludedClassName cname
 excludedRefs :: Set J.ClassName
 excludedRefs = Set.fromList
   [ "java/util/Comparator"
-  , "java/util/Arrays"
   , "java/lang/reflect/AccessibleObject"
   , "java/lang/reflect/AnnotatedElement"
   , "java/lang/invoke/SerializedLambda"


### PR DESCRIPTION
PR #1005 should wait for this PR to be completed and merged.

This PR updates most of the proof scripts in `examples/java` to use the new JVM verification commands instead of the old deprecated Java commands. I have avoided making any changes to the java code that is being verified.

We could merge this as is. However, there are still a couple of bits that are still using deprecated commands, and it would be nice to do something about them:
* `arrays.saw` uses `java_extract` on a non-static method that doesn't work with `jvm_extract`
* `branchsat.saw` uses `java_symexec`, which doesn't have a modern counterpart
* `bytearray.saw` uses `java_symexec`
* `returnsym.saw` uses `java_symexec`
