### PR TITLE
Increase the timeouts for tests, given that some of them are now semi-regularly surpassing 40 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,7 +192,7 @@ jobs:
         working-directory: s2nTests
         run: |
           docker-compose pull
-          grep -h '^FROM' "$f" docker/*.dockerfile | sort -u | awk '{print $2}' | xargs -n1 -P8 docker pull
+          grep -h '^FROM' docker/*.dockerfile | sort -u | awk '{print $2}' | xargs -n1 -P8 docker pull
 
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,7 @@ jobs:
 
   s2n-tests:
     name: "Test s2n proofs"
-    timeout-minutes: 40
+    timeout-minutes: 60
     needs: build
     runs-on: ubuntu-latest
     strategy:
@@ -190,10 +190,17 @@ jobs:
 
       - shell: bash
         working-directory: s2nTests
-        run: docker-compose pull
+        run: |
+          docker-compose pull
+          grep -h '^FROM' "$f" docker/*.dockerfile | sort -u | awk '{print $2}' | xargs -n1 -P8 docker pull
 
-      - uses: satackey/action-docker-layer-caching@v0.0.8
+      - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
+
+      - shell: bash
+        name: "make s2n"
+        working-directory: s2nTests
+        run: docker-compose build s2n
 
       - shell: bash
         name: "s2n tests: ${{ matrix.s2n-target }}"


### PR DESCRIPTION
Most ideally, we would split out `awslc` and `blst` into a finer level of granularity and try to target an overall average of 15 minutes max per test. But for now, this will at least get things working again until we make that change.