### PR TITLE
Test0023

### DIFF
--- a/intTests/test0023_java_assert_false/test.saw
+++ b/intTests/test0023_java_assert_false/test.saw
@@ -1,9 +1,13 @@
-enable_deprecated;
+enable_experimental;
 c <- java_load_class "Test0023";
-fails
-  (java_verify c "id" [] do {
-    x <- java_var "x" java_int;
-    java_assert {{ x > 5 }};
-    java_return {{ 6 : [32] }};
-    java_verify_tactic abc;
-  });
+fails (
+  jvm_verify c "id" [] false
+    do {
+      this <- jvm_alloc_object "Test0023";
+      x <- jvm_fresh_var "x" java_int;
+      jvm_precond {{ x > 5 }};
+      jvm_execute_func [this, jvm_term x];
+      jvm_return (jvm_term {{ 6 : [32] }});
+    }
+    abc
+  );

--- a/intTests/test0023_java_assert_false/test.saw
+++ b/intTests/test0023_java_assert_false/test.saw
@@ -1,8 +1,9 @@
 enable_deprecated;
 c <- java_load_class "Test0023";
-java_verify c "id" [] do {
+fails
+  (java_verify c "id" [] do {
     x <- java_var "x" java_int;
     java_assert {{ x > 5 }};
     java_return {{ 6 : [32] }};
     java_verify_tactic abc;
-};
+  });

--- a/intTests/test0023_java_assert_false/test.sh
+++ b/intTests/test0023_java_assert_false/test.sh
@@ -1,7 +1,1 @@
-#!/bin/sh
-
-if ! $SAW side.saw ; then
-    exit 0
-else
-    exit 1
-fi
+$SAW test.saw


### PR DESCRIPTION
This updates `test0023_java_assert_false` to use the new JVM verification commands. This should be merged in before #1005, in order to get the test suite ready for the removal of the old commands.