### PR TITLE
Switch jvm-parser package to use prettyprinter library.

### DIFF
--- a/src/SAWScript/Crucible/JVM/MethodSpecIR.hs
+++ b/src/SAWScript/Crucible/JVM/MethodSpecIR.hs
@@ -68,10 +68,6 @@ type instance MS.TypeName CJ.JVM = JIdent
 
 type instance MS.ExtType CJ.JVM = J.Type
 
--- TODO: remove when jvm-parser switches to prettyprinter
-instance PPL.Pretty J.Type where
-  pretty = PPL.viaShow
-
 --------------------------------------------------------------------------------
 -- *** JVMMethodId
 

--- a/src/SAWScript/JavaPretty.hs
+++ b/src/SAWScript/JavaPretty.hs
@@ -53,7 +53,7 @@ prettyField :: Field -> Doc ann
 prettyField f = hsep $
   [ viaShow (fieldVisibility f) ] ++
   attrs ++
-  [ viaShow (ppType (fieldType f)) -- TODO: Ick. Different PPs.
+  [ ppType (fieldType f)
   , pretty (fieldName f)
   ]
   where attrs = concat
@@ -67,12 +67,11 @@ prettyMethod :: Method -> Doc ann
 prettyMethod m =
   hsep $
   (if methodIsStatic m then ["static"] else []) ++
-  [ maybe "void" prettyType ret
+  [ maybe "void" ppType ret
   , pretty name
-  , (parens . commas . map prettyType) params
+  , (parens . commas . map ppType) params
   ]
   where (MethodKey name params ret) = methodKey m
-        prettyType = viaShow . ppType -- TODO: Ick.
 
 commas :: [Doc ann] -> Doc ann
 commas = sep . punctuate comma


### PR DESCRIPTION
This PR includes GaloisInc/jvm-parser#8, which should be merged first.

Fixes #951.