### PR TITLE
Re-enable all disabled integration tests in .github/ci.sh.

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -168,7 +168,6 @@ install_system_deps() {
 test_dist() {
   find_java
   pushd intTests
-  for t in test0019_jss_switch_statement test_crucible_jvm test_ecdsa test_issue108 test_tutorial1 test_tutorial2 test_tutorial_w4; do echo $t >> disabled_tests.txt; done
   env
   LOUD=true ./runtests.sh
   sh -c "! grep '<failure>' results.xml"


### PR DESCRIPTION
If there is a specific reason for any integration test to be
excluded from CI, the rationale for exclusion should be given
in a comment inside `disabled_tests.txt`.

Fixes #901.