### PR TITLE
Embed JVMSetupError inside TopLevelException datatype.

### DIFF
--- a/src/SAWScript/Crucible/JVM/Builtins.hs
+++ b/src/SAWScript/Crucible/JVM/Builtins.hs
@@ -98,6 +98,7 @@ import Verifier.SAW.TypedTerm
 
 import Verifier.SAW.Simulator.What4.ReturnTrip
 
+import SAWScript.Exceptions
 import SAWScript.Proof
 import SAWScript.Prover.SolverStats
 import SAWScript.TopLevel
@@ -813,7 +814,9 @@ data JVMSetupError
   | JVMReturnUnexpected J.Type -- found
   | JVMReturnTypeMismatch J.Type J.Type -- expected, found
 
-instance X.Exception JVMSetupError
+instance X.Exception JVMSetupError where
+  toException = topLevelExceptionToException
+  fromException = topLevelExceptionFromException
 
 instance Show JVMSetupError where
   show err =


### PR DESCRIPTION
This means that JVMSetupError exceptions can now be caught by
the standard TopLevelException handlers, and get shown with
the expected stack traces in the saw-script REPL.

This is done using a new existentially-typed `SomeTopLevelException`
constructor, as recommended by the Control.Exception documentation.

Fixes #1021.