### PR TITLE
Reimplement `extendEnv` using the usual SharedTerm API.

### DIFF
--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -419,12 +419,16 @@ llvm_compositional_extract (Some lm) nm func_name lemmas checkSat setup tactic =
                 MS.csPostState . MS.csPointsTos .~ extracted_post_state_points_tos
 
           typed_extracted_func_const <- io $ mkTypedTerm shared_context extracted_func_const
-          modify' $
-            extendEnv
+          rw <- getTopLevelRW
+          rw' <-
+            liftIO $
+            extendEnv shared_context
               (Located func_name func_name $ PosInternal "llvm_compositional_extract")
               Nothing
               Nothing
               (VTerm typed_extracted_func_const)
+              rw
+          putTopLevelRW rw'
 
           return $ SomeLLVM extracted_method_spec
 

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -51,7 +51,6 @@ import qualified Data.Map as M
 import Data.Map ( Map )
 import Data.Set ( Set )
 import Data.Text (Text, pack, unpack)
-import qualified Data.Vector as Vector
 import Data.Parameterized.Some
 import Data.Typeable
 import GHC.Generics (Generic, Generic1)
@@ -84,7 +83,6 @@ import Verifier.SAW.SharedTerm hiding (PPOpts(..), defaultPPOpts,
                                        ppTerm, scPrettyTerm)
 import qualified Verifier.SAW.SharedTerm as SAWCorePP (PPOpts(..), defaultPPOpts,
                                                        ppTerm, scPrettyTerm)
-import Verifier.SAW.TypedAST hiding (PPOpts(..), defaultPPOpts, ppTerm)
 import Verifier.SAW.TypedTerm
 
 import qualified Verifier.SAW.Simulator.Concrete as Concrete
@@ -501,51 +499,47 @@ maybeInsert :: Ord k => k -> Maybe a -> Map k a -> Map k a
 maybeInsert _ Nothing m = m
 maybeInsert k (Just x) m = M.insert k x m
 
-extendEnv :: SS.LName -> Maybe SS.Schema -> Maybe String -> Value -> TopLevelRW -> TopLevelRW
-extendEnv x mt md v rw =
-  rw { rwValues  = M.insert name v (rwValues rw)
-     , rwTypes   = maybeInsert name mt (rwTypes rw)
-     , rwDocs    = maybeInsert (SS.getVal name) md (rwDocs rw)
-     , rwCryptol = ce'
-     }
+extendEnv ::
+  SharedContext ->
+  SS.LName -> Maybe SS.Schema -> Maybe String -> Value -> TopLevelRW -> IO TopLevelRW
+extendEnv sc x mt md v rw =
+  do ce' <-
+       case v of
+         VTerm t ->
+           pure $ CEnv.bindTypedTerm (ident, t) ce
+         VType s ->
+           pure $ CEnv.bindType (ident, s) ce
+         VInteger n ->
+           pure $ CEnv.bindInteger (ident, n) ce
+         VCryptolModule m ->
+           pure $ CEnv.bindCryptolModule (modname, m) ce
+         VString s ->
+           do tt <- typedTermOfString sc s
+              pure $ CEnv.bindTypedTerm (ident, tt) ce
+         _ ->
+           pure ce
+     pure $
+      rw { rwValues  = M.insert name v (rwValues rw)
+         , rwTypes   = maybeInsert name mt (rwTypes rw)
+         , rwDocs    = maybeInsert (SS.getVal name) md (rwDocs rw)
+         , rwCryptol = ce'
+         }
   where
     name = x
     ident = T.packIdent (SS.getOrig x)
     modname = T.packModName [pack (SS.getOrig x)]
     ce = rwCryptol rw
-    ce' = case v of
-            VTerm t
-              -> CEnv.bindTypedTerm (ident, t) ce
-            VType s
-              -> CEnv.bindType (ident, s) ce
-            VInteger n
-              -> CEnv.bindInteger (ident, n) ce
-            VCryptolModule m
-              -> CEnv.bindCryptolModule (modname, m) ce
-            VString s
-              -> CEnv.bindTypedTerm (ident, typedTermOfString s) ce
-            _ -> ce
 
-typedTermOfString :: String -> TypedTerm
-typedTermOfString cs = TypedTerm schema trm
-  where
-    nat :: Integer -> Term
-    nat n = Unshared (FTermF (NatLit (fromInteger n)))
-    bvNat :: Term
-    bvNat = Unshared (FTermF (GlobalDef "Prelude.bvNat"))
-    bvNat8 :: Term
-    bvNat8 = Unshared (App bvNat (nat 8))
-    encodeChar :: Char -> Term
-    encodeChar c = Unshared (App bvNat8 (nat (toInteger (fromEnum c))))
-    vecT :: Term
-    vecT = Unshared (FTermF (GlobalDef "Prelude.Vec"))
-    boolT :: Term
-    boolT = Unshared (FTermF (GlobalDef "Prelude.Bool"))
-    byteT :: Term
-    byteT = Unshared (App (Unshared (App vecT (nat 8))) boolT)
-    trm :: Term
-    trm = Unshared (FTermF (ArrayValue byteT (Vector.fromList (map encodeChar cs))))
-    schema = Cryptol.Forall [] [] (Cryptol.tString (length cs))
+typedTermOfString :: SharedContext -> String -> IO TypedTerm
+typedTermOfString sc str =
+  do let schema = Cryptol.Forall [] [] (Cryptol.tString (length str))
+     bvNat <- scGlobalDef sc "Prelude.bvNat"
+     bvNat8 <- scApply sc bvNat =<< scNat sc 8
+     byteT <- scBitvector sc 8
+     let scChar c = scApply sc bvNat8 =<< scNat sc (fromIntegral (fromEnum c))
+     ts <- traverse scChar str
+     trm <- scVector sc byteT ts
+     pure (TypedTerm schema trm)
 
 
 -- Other SAWScript Monads ------------------------------------------------------


### PR DESCRIPTION
Function `extendEnv` is a part of the saw-script interpreter.
Redefining it avoids a dependency on the internal details of the
saw-core term representation, allowing us to make changes to it.