### PR TITLE
Eschew -Weverything in favor of -Wall

### DIFF
--- a/saw-remote-api/saw-remote-api.cabal
+++ b/saw-remote-api/saw-remote-api.cabal
@@ -26,16 +26,7 @@ flag builtin-abc
 
 common warnings
   ghc-options:
-    -Weverything
-    -Wno-missing-exported-signatures
-    -Wno-missing-import-lists
-    -Wno-missed-specialisations
-    -Wno-all-missed-specialisations
-    -Wno-unsafe
-    -Wno-safe
-    -Wno-missing-local-signatures
-    -Wno-monomorphism-restriction
-    -Wno-implicit-prelude
+    -Wall
     -Wno-orphans
 
 common deps


### PR DESCRIPTION
`-Weverything` enables absolutely every single warning that GHC has in its arsenal, which is usually too much. As discussed in #1083, this replaces `-Weverything` in favor of `-Wall`, which enables a more reasonable subset of warnings. This means that we don't have to explicitly disable as many warnings (which would otherwise be enabled by `-Weverything`) as before.

Fixes #1083.