### PR TITLE
saw-remote-api: Parse optional fields with (.:?) instead of (.:)

### DIFF
--- a/saw-remote-api/src/SAWServer/Data/Contract.hs
+++ b/saw-remote-api/src/SAWServer/Data/Contract.hs
@@ -13,7 +13,7 @@ module SAWServer.Data.Contract
   ) where
 
 import Control.Applicative
-import Data.Aeson (FromJSON(..), withObject, withText, (.:))
+import Data.Aeson (FromJSON(..), withObject, withText, (.:), (.:?))
 import Data.Text (Text)
 
 import SAWScript.Crucible.LLVM.Builtins (CheckPointsToType(..))
@@ -71,18 +71,18 @@ data CheckAgainstTag
 instance (FromJSON ty, FromJSON cryptolExpr) => FromJSON (PointsTo ty cryptolExpr) where
   parseJSON =
     withObject "Points-to relationship" $ \o ->
-      PointsTo <$> o .: "pointer"
-               <*> o .: "points to"
-               <*> o .: "check points to type"
-               <*> o .: "condition"
+      PointsTo <$> o .:  "pointer"
+               <*> o .:  "points to"
+               <*> o .:? "check points to type"
+               <*> o .:? "condition"
 
 instance FromJSON ty => FromJSON (Allocated ty) where
   parseJSON =
     withObject "allocated thing" $ \o ->
-      Allocated <$> o .: "server name"
-                <*> o .: "type"
-                <*> o .: "mutable"
-                <*> o .: "alignment"
+      Allocated <$> o .:  "server name"
+                <*> o .:  "type"
+                <*> o .:  "mutable"
+                <*> o .:? "alignment"
 
 instance FromJSON ty => FromJSON (ContractVar ty) where
   parseJSON =
@@ -94,16 +94,16 @@ instance FromJSON ty => FromJSON (ContractVar ty) where
 instance (FromJSON ty, FromJSON e) => FromJSON (Contract ty e) where
   parseJSON =
     withObject "contract" $ \o ->
-    Contract <$> o .: "pre vars"
-             <*> o .: "pre conds"
-             <*> o .: "pre allocated"
-             <*> o .: "pre points tos"
-             <*> o .: "argument vals"
-             <*> o .: "post vars"
-             <*> o .: "post conds"
-             <*> o .: "post allocated"
-             <*> o .: "post points tos"
-             <*> o .: "return val"
+    Contract <$> o .:  "pre vars"
+             <*> o .:  "pre conds"
+             <*> o .:  "pre allocated"
+             <*> o .:  "pre points tos"
+             <*> o .:  "argument vals"
+             <*> o .:  "post vars"
+             <*> o .:  "post conds"
+             <*> o .:  "post allocated"
+             <*> o .:  "post points tos"
+             <*> o .:? "return val"
 
 instance FromJSON CheckAgainstTag where
   parseJSON =


### PR DESCRIPTION
Doing so allows omitting optional fields to be parsed as `Nothing` instead of failing outright.

Fixes #1096.