### PR TITLE
Proof conventions

### DIFF
--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -580,6 +580,7 @@ satExternal doCNF execName args = withFirstGoal $ tacticSolve $ \g -> do
   let cnfName = goalType g ++ show (goalNum g) ++ ".cnf"
   (path, fh) <- openTempFile "." cnfName
   hClose fh -- Yuck. TODO: allow writeCNF et al. to work on handles.
+
   let args' = map replaceFileName args
       replaceFileName "%f" = path
       replaceFileName a = a

--- a/src/SAWScript/Crucible/JVM/Builtins.hs
+++ b/src/SAWScript/Crucible/JVM/Builtins.hs
@@ -268,9 +268,9 @@ verifyObligations cc mspec tactic assumes asserts =
      let nm = mspec ^. csMethodName
      stats <- forM (zip [(0::Int)..] asserts) $ \(n, (msg, assert)) -> do
        goal   <- io $ scImplies sc assume assert
-       goal'  <- io $ scEqTrue sc goal
+       goal'  <- io $ predicateToProp sc Universal [] goal
        let goalname = concat [nm, " (", takeWhile (/= '\n') msg, ")"]
-           proofgoal = ProofGoal n "vc" goalname (Prop goal')
+           proofgoal = ProofGoal n "vc" goalname goal'
        r      <- evalStateT tactic (startProof proofgoal)
        case r of
          Unsat stats -> return stats

--- a/src/SAWScript/Crucible/JVM/Builtins.hs
+++ b/src/SAWScript/Crucible/JVM/Builtins.hs
@@ -268,7 +268,7 @@ verifyObligations cc mspec tactic assumes asserts =
      let nm = mspec ^. csMethodName
      stats <- forM (zip [(0::Int)..] asserts) $ \(n, (msg, assert)) -> do
        goal   <- io $ scImplies sc assume assert
-       goal'  <- io $ predicateToProp sc Universal [] goal
+       goal'  <- io $ predicateToProp sc Universal goal
        let goalname = concat [nm, " (", takeWhile (/= '\n') msg, ")"]
            proofgoal = ProofGoal n "vc" goalname goal'
        r      <- evalStateT tactic (startProof proofgoal)

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -751,7 +751,7 @@ assumptionsContainContradiction ::
   TopLevel Bool
 assumptionsContainContradiction cc tactic assumptions =
   do
-     proofGoal <- io $
+     pgl <- io $
       do
          let sym = cc^.ccBackend
          st <- Common.sawCoreState sym
@@ -762,7 +762,7 @@ assumptionsContainContradiction cc tactic assumptions =
          goal  <- scImplies sc assume =<< toSC sym st (W4.falsePred sym)
          goal' <- predicateToProp sc Universal [] goal
          return $ ProofGoal 0 "vc" "vacuousness check" goal'
-     evalStateT tactic (startProof proofGoal) >>= \case
+     evalStateT tactic (startProof pgl) >>= \case
        Unsat _stats -> return True
        SatMulti _stats _vals -> return False
 

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -598,9 +598,9 @@ verifyObligations cc mspec tactic assumes asserts =
      stats <-
        forM (zip [(0::Int)..] asserts) $ \(n, (msg, assert)) ->
        do goal   <- io $ scImplies sc assume assert
-          goal'  <- io $ scEqTrue sc goal
+          goal'  <- io $ predicateToProp sc Universal [] goal
           let goalname = concat [nm, " (", takeWhile (/= '\n') msg, ")"]
-              proofgoal = ProofGoal n "vc" goalname (Prop goal')
+              proofgoal = ProofGoal n "vc" goalname goal'
           r <- evalStateT tactic (startProof proofgoal)
           case r of
             Unsat stats -> return stats
@@ -760,8 +760,8 @@ assumptionsContainContradiction cc tactic assumptions =
          assume <- scAndList sc (toListOf (folded . Crucible.labeledPred) assumptions)
          -- implies falsehood
          goal  <- scImplies sc assume =<< toSC sym st (W4.falsePred sym)
-         goal' <- scEqTrue sc goal
-         return $ ProofGoal 0 "vc" "vacuousness check" (Prop goal')
+         goal' <- predicateToProp sc Universal [] goal
+         return $ ProofGoal 0 "vc" "vacuousness check" goal'
      evalStateT tactic (startProof proofGoal) >>= \case
        Unsat _stats -> return True
        SatMulti _stats _vals -> return False

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -598,7 +598,7 @@ verifyObligations cc mspec tactic assumes asserts =
      stats <-
        forM (zip [(0::Int)..] asserts) $ \(n, (msg, assert)) ->
        do goal   <- io $ scImplies sc assume assert
-          goal'  <- io $ predicateToProp sc Universal [] goal
+          goal'  <- io $ predicateToProp sc Universal goal
           let goalname = concat [nm, " (", takeWhile (/= '\n') msg, ")"]
               proofgoal = ProofGoal n "vc" goalname goal'
           r <- evalStateT tactic (startProof proofgoal)
@@ -760,7 +760,7 @@ assumptionsContainContradiction cc tactic assumptions =
          assume <- scAndList sc (toListOf (folded . Crucible.labeledPred) assumptions)
          -- implies falsehood
          goal  <- scImplies sc assume =<< toSC sym st (W4.falsePred sym)
-         goal' <- predicateToProp sc Universal [] goal
+         goal' <- predicateToProp sc Universal goal
          return $ ProofGoal 0 "vc" "vacuousness check" goal'
      evalStateT tactic (startProof pgl) >>= \case
        Unsat _stats -> return True

--- a/src/SAWScript/Proof.hs
+++ b/src/SAWScript/Proof.hs
@@ -56,7 +56,6 @@ module SAWScript.Proof
 
   , Quantification(..)
   , predicateToProp
-  , propToPredicate
 
   , ProofState
   , psTimeout
@@ -438,16 +437,6 @@ predicateToProp sc quant = loop []
                     scPi sc x xT t3
            Prop <$> toPi argTs t
 
--- | Turn a pi type with an @EqTrue@ result into a lambda term with a
--- boolean result type. This function exists to interface the new
--- pi-type proof goals with older proof tactic implementations that
--- expect the old lambda-term representation.
-propToPredicate :: SharedContext -> Prop -> IO Term
-propToPredicate sc (Prop goal) =
-  do let (args, t1) = asPiList goal
-     case asEqTrue t1 of
-       Just t2 -> scLambdaList sc args t2
-       Nothing -> fail $ "propToPredicate: expected EqTrue, actual " ++ show t1
 
 -- | A ProofState represents a sequent, where the collection of goals
 -- implies the conclusion.

--- a/src/SAWScript/Proof.hs
+++ b/src/SAWScript/Proof.hs
@@ -465,7 +465,7 @@ checkEvidence sc = check mempty
     checkApply hyps (Prop p) (e:es)
       | Just (_lnm, tp, body) <- asPi p
       , looseVars body == emptyBitSet
-      = do check hyps e (Prop tp) -- TODO, check that tp is a prop
+      = do check hyps e =<< termToProp sc tp
            checkApply hyps (Prop body) es
       | otherwise = fail $ unlines
            [ "Apply evidence mismatch: non-function or dependent function"

--- a/src/SAWScript/Proof.hs
+++ b/src/SAWScript/Proof.hs
@@ -33,6 +33,7 @@ module SAWScript.Proof
   , thmProp
   , thmStats
   , thmEvidence
+  , validateTheorem
 
   , Evidence(..)
   , checkEvidence
@@ -50,10 +51,6 @@ module SAWScript.Proof
 
   , ProofGoal(..)
   , withFirstGoal
-  , goalApply
-  , goalIntro
-  , goalAssume
-  , goalInsert
 
   , Tactic
   , tacticIntro
@@ -197,10 +194,20 @@ data Theorem =
   , _thmStats :: SolverStats
   , _thmEvidence :: Evidence
   }
+  | LocalAssumption Prop
+
+validateTheorem :: SharedContext -> Theorem -> IO ()
+validateTheorem _sc (LocalAssumption p) =
+   fail $ unlines
+     [ "Illegal use of unbound local hypothesis"
+     , showTerm (unProp p)
+     ]
+validateTheorem sc Theorem{ _thmProp = p, _thmEvidence = e } =
+   checkEvidence sc e p
 
 data Evidence
   = ProofTerm Term
-  | LocalAssumption Prop
+  | LocalAssumptionEvidence Prop
   | SolverEvidence SolverStats Prop
   | Admitted Prop
   | QuickcheckEvidence Integer Prop
@@ -215,13 +222,16 @@ data Evidence
   | EvalEvidence (Set VarIndex) Evidence
 
 thmProp :: Theorem -> Prop
-thmProp thm = _thmProp thm
+thmProp (LocalAssumption p) = p
+thmProp Theorem{ _thmProp = p } = p
 
 thmStats :: Theorem -> SolverStats
-thmStats thm = _thmStats thm
+thmStats (LocalAssumption _) = mempty
+thmStats Theorem{ _thmStats = stats } = stats
 
 thmEvidence :: Theorem -> Evidence
-thmEvidence thm = _thmEvidence thm
+thmEvidence (LocalAssumption p) = LocalAssumptionEvidence p
+thmEvidence Theorem{ _thmEvidence = e } = e
 
 impossibleEvidence :: [Evidence] -> IO Evidence
 impossibleEvidence _ = fail "impossibleEvidence: attempted to check an impossible proof!"
@@ -246,22 +256,27 @@ proofByTerm :: SharedContext -> Term -> IO Theorem
 proofByTerm sc prf =
   do ty <- scTypeOf sc prf
      p  <- termToProp sc ty
-     return (Theorem p mempty (ProofTerm prf))
+     return
+       Theorem
+       { _thmProp      = p
+       , _thmStats     = mempty
+       , _thmEvidence  = ProofTerm prf
+       }
 
 admitTheorem :: Prop -> Theorem
 admitTheorem p =
   Theorem
-  { _thmProp     = p
-  , _thmStats    = solverStats "ADMITTED" (propSize p)
-  , _thmEvidence = Admitted p
+  { _thmProp      = p
+  , _thmStats     = solverStats "ADMITTED" (propSize p)
+  , _thmEvidence  = Admitted p
   }
 
 solverTheorem :: Prop -> SolverStats -> Theorem
 solverTheorem p stats =
   Theorem
-  { _thmProp     = p
-  , _thmStats    = stats
-  , _thmEvidence = SolverEvidence stats p
+  { _thmProp      = p
+  , _thmStats     = stats
+  , _thmEvidence  = SolverEvidence stats p
   }
 
 -- | A @ProofGoal@ contains a proposition to be proved, along with
@@ -336,7 +351,7 @@ propToPredicate sc (Prop goal) =
 data ProofState =
   ProofState
   { _psGoals :: [ProofGoal]
-  , _psConcl :: ProofGoal
+  , _psConcl :: Prop
   , _psStats :: SolverStats
   , _psTimeout :: Maybe Integer
   , _psEvidence :: [Evidence] -> IO Evidence
@@ -351,7 +366,7 @@ psGoals = _psGoals
 -- | Verify that the given evidence in fact supports
 --   the given proposition.
 checkEvidence :: SharedContext -> Evidence -> Prop -> IO ()
-checkEvidence sc e0 p0 = check mempty e0 p0
+checkEvidence sc = check mempty
   where
     checkApply _hyps (Prop p) [] = return p
     checkApply hyps (Prop p) (e:es)
@@ -364,29 +379,34 @@ checkEvidence sc e0 p0 = check mempty e0 p0
            , showTerm p
            ]
 
+    checkTheorem :: Set Term -> Theorem -> IO ()
+    checkTheorem hyps (LocalAssumption p) =
+       unless (Set.member (unProp p) hyps) $ fail $ unlines
+          [ "Attempt to reference a local hypothesis that is not in scope"
+          , showTerm (unProp p)
+          ]
+    checkTheorem _hyps Theorem{} = return ()
+
     check :: Set Term -> Evidence -> Prop -> IO ()
     check hyps e p@(Prop ptm) = case e of
       ProofTerm tm ->
         do ty <- scTypeCheckError sc tm
            ok <- scConvertible sc False ptm ty
-           if ok then return () else
-             fail $ unlines
+           unless ok $ fail $ unlines
                [ "Proof term does not prove the required proposition"
                , showTerm ptm
                , showTerm tm
                ]
 
-      LocalAssumption (Prop l) ->
-        if Set.member l hyps then return () else
-          fail $ unlines
+      LocalAssumptionEvidence (Prop l) ->
+        unless (Set.member l hyps) $ fail $ unlines
              [ "Illegal use of local hypothesis"
              , showTerm l
              ]
 
-      SolverEvidence _ (Prop p') ->
+      SolverEvidence _stats (Prop p') ->
         do ok <- scConvertible sc False ptm p'
-           if ok then return () else
-             fail $ unlines
+           unless ok $ fail $ unlines
                [ "Solver proof does not prove the required proposition"
                , showTerm ptm
                , showTerm p'
@@ -394,25 +414,22 @@ checkEvidence sc e0 p0 = check mempty e0 p0
 
       Admitted (Prop p') ->
         do ok <- scConvertible sc False ptm p'
-           if ok then return () else
-             fail $ unlines
+           unless ok $ fail $ unlines
                [ "Admitted proof does not match the required proposition"
                , showTerm ptm
                , showTerm p'
                ]
 
-      QuickcheckEvidence _ (Prop p') ->
+      QuickcheckEvidence _n (Prop p') ->
         do ok <- scConvertible sc False ptm p'
-           if ok then return () else
-             fail $ unlines
+           unless ok $ fail $ unlines
                [ "Quickcheck evidence does not match the required proposition"
                , showTerm ptm
                , showTerm p'
                ]
 
       TrivialEvidence ->
-        if propIsTrivial p then return () else
-          fail $ unlines
+        unless (propIsTrivial p) $ fail $ unlines
             [ "Proposition is not trivial"
             , showTerm ptm
             ]
@@ -428,17 +445,18 @@ checkEvidence sc e0 p0 = check mempty e0 p0
                check hyps e2 p2
 
       ApplyEvidence thm es ->
-        do p' <- checkApply hyps (thmProp thm) es
+        do checkTheorem hyps thm
+           p' <- checkApply hyps (thmProp thm) es
            ok <- scConvertible sc False ptm p'
-           if ok then return () else
-             fail $ unlines
+           unless ok $ fail $ unlines
                [ "Apply evidence does not match the required proposition"
                , showTerm ptm
                , showTerm p'
                ]
 
       CutEvidence thm e' ->
-        do p' <- scFun sc (unProp (thmProp thm)) ptm
+        do checkTheorem hyps thm
+           p' <- scFun sc (unProp (thmProp thm)) ptm
            check hyps e' (Prop p')
 
       UnfoldEvidence vars e' ->
@@ -458,14 +476,16 @@ checkEvidence sc e0 p0 = check mempty e0 p0
           Nothing -> fail $ unlines ["Assume evidence expected function prop", showTerm ptm]
           Just (_lnm, ty, body) ->
             do ok <- scConvertible sc False ty p'
-               if ok && looseVars body == emptyBitSet then
-                 check (Set.insert p' hyps) e' p
-               else
-                 fail $ unlines
+               unless ok $ fail $ unlines
                    [ "Assume evidence types do not match"
                    , showTerm ty
                    , showTerm p'
                    ]
+               unless (looseVars body == emptyBitSet) $ fail $ unlines
+                   [ "Assume evidence cannot be used on a dependent propsition"
+                   , showTerm ptm
+                   ]
+               check (Set.insert p' hyps) e' (Prop body)
 
       ForallEvidence tt e' ->
         case asPi ptm of
@@ -473,14 +493,13 @@ checkEvidence sc e0 p0 = check mempty e0 p0
           Just (_lnm, ty, body) ->
             do ty' <- scTypeOf sc (ttTerm tt)
                ok <- scConvertible sc False ty ty'
-               if ok then
-                 do body' <- instantiateVar sc 0 (ttTerm tt) body
-                    check hyps e' (Prop body')
-               else
-                 fail $ unlines ["Forall evidence types do not match"
-                                , showTerm (ttTerm tt)
-                                , showTerm ty
-                                ]
+               unless ok $ fail $ unlines
+                 ["Forall evidence types do not match"
+                 , showTerm (ttTerm tt)
+                 , showTerm ty
+                 ]
+               body' <- instantiateVar sc 0 (ttTerm tt) body
+               check hyps e' (Prop body')
 
 rewriteEvidence :: Simpset -> [Evidence] -> IO Evidence
 rewriteEvidence ss [e] = pure (RewriteEvidence ss e)
@@ -506,15 +525,19 @@ setProofTimeout :: Integer -> ProofState -> ProofState
 setProofTimeout to ps = ps { _psTimeout = Just to }
 
 startProof :: ProofGoal -> ProofState
-startProof g = ProofState [g] g mempty Nothing passthroughEvidence
+startProof g = ProofState [g] (goalProp g) mempty Nothing passthroughEvidence
 
 finishProof :: SharedContext -> ProofState -> IO (SolverStats, Maybe Theorem)
 finishProof sc (ProofState gs concl stats _ checkEv) =
   case gs of
     [] ->
       do e <- checkEv []
-         checkEvidence sc e (goalProp concl)
-         let thm = Theorem (goalProp concl) stats e
+         checkEvidence sc e concl
+         let thm = Theorem
+                   { _thmProp = concl
+                   , _thmStats = stats
+                   , _thmEvidence = e
+                   }
          pure (stats, Just thm)
     _ : _ ->
          pure (stats, Nothing)
@@ -542,25 +565,6 @@ propToSATQuery sc (Prop goal) =
        Just t2 ->
 -}
 
-
--- TODO: unsound?
-goalAssume :: ProofGoal -> IO (Maybe (Theorem, ProofGoal))
-goalAssume goal =
-  case asPi (unProp (goalProp goal)) of
-    Just (_nm, tp, body)
-      | looseVars body == emptyBitSet ->
-          do let goal' = goal{ goalProp = Prop body }
-             let p     = Prop tp
-             let thm'  = Theorem p mempty (LocalAssumption p)
-             return (Just (thm', goal'))
-
-    _ -> return Nothing
-
-goalInsert :: SharedContext -> Theorem -> ProofGoal -> IO ProofGoal
-goalInsert sc thm goal =
-  do body' <- scFun sc (unProp (thmProp thm)) (unProp (goalProp goal))
-     let goal' = goal{ goalProp = Prop body' }
-     return goal'
 
 goalIntro :: SharedContext -> String -> ProofGoal -> IO (Maybe (TypedTerm, ProofGoal))
 goalIntro sc s goal =
@@ -614,13 +618,20 @@ tacticIntro sc nm goal =
 
 tacticAssume :: (F.MonadFail m, MonadIO m) => SharedContext -> Tactic m Theorem
 tacticAssume _sc goal =
-  liftIO (goalAssume goal) >>= \case
-    Nothing -> fail "assume tactic failed: not a function, or a dependent function"
-    Just (thm, goal') -> return (thm, mempty, [goal'], assumeEvidence (thmProp thm))
+  case asPi (unProp (goalProp goal)) of
+    Just (_nm, tp, body)
+      | looseVars body == emptyBitSet ->
+          do let goal' = goal{ goalProp = Prop body }
+             let p     = Prop tp
+             let thm'  = LocalAssumption p
+             return (thm', mempty, [goal'], assumeEvidence p)
+
+    _ -> fail "assume tactic failed: not a function, or a dependent function"
 
 tacticCut :: (F.MonadFail m, MonadIO m) => SharedContext -> Theorem -> Tactic m ()
 tacticCut sc thm goal =
-  do goal' <- liftIO (goalInsert sc thm goal)
+  do body' <- liftIO (scFun sc (unProp (thmProp thm)) (unProp (goalProp goal)))
+     let goal' = goal{ goalProp = Prop body' }
      return ((), mempty, [goal'], cutEvidence thm)
 
 tacticApply :: (F.MonadFail m, MonadIO m) => SharedContext -> Theorem -> Tactic m ()

--- a/src/SAWScript/Proof.hs
+++ b/src/SAWScript/Proof.hs
@@ -5,17 +5,150 @@ License     : BSD3
 Maintainer  : huffman
 Stability   : provisional
 -}
-module SAWScript.Proof where
 
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module SAWScript.Proof
+  ( Prop
+  , splitProp
+  , unfoldProp
+  , simplifyProp
+  , evalProp
+  , betaReduceProp
+  , falseProp
+  , termToProp
+  , propToTerm
+  , propToRewriteRule
+  , propIsTrivial
+  , propSize
+  , prettyProp
+  , ppProp
+
+  , Theorem(..)
+
+  , ProofGoal(..)
+  , goalApply
+  , goalIntro
+  , goalAssume
+  , goalInsert
+
+  , Quantification(..)
+  , makeProofGoal
+  , predicateToProp
+  , propToPredicate
+  , ProofState(..)
+  , startProof
+  , finishProof
+  ) where
+
+import           Data.Maybe (fromMaybe)
+import qualified Data.Map as Map
+import           Data.Set (Set)
+import           Data.Text (Text)
+import qualified Data.Text as Text
+
+import Verifier.SAW.Prelude (scApplyPrelude_False)
 import Verifier.SAW.Recognizer
+import Verifier.SAW.Rewriter
 import Verifier.SAW.SharedTerm
+import Verifier.SAW.TypedAST
+import Verifier.SAW.TypedTerm
+import Verifier.SAW.Term.Pretty (SawDoc)
+
 import SAWScript.Prover.SolverStats
+import SAWScript.Crucible.Common as Common
+import qualified Verifier.SAW.Simulator.What4 as W4Sim
+import qualified Verifier.SAW.Simulator.What4.ReturnTrip as W4Sim
 
 -- | A proposition is a saw-core type (i.e. a term of type @sort n@
 -- for some @n@). In particular, this includes any pi type whose
 -- result type is a proposition. The argument of a pi type represents
 -- a universally quantified variable.
-newtype Prop = Prop { unProp :: Term }
+newtype Prop = Prop Term
+
+unProp :: Prop -> Term
+unProp (Prop tm) = tm
+
+-- TODO, check that the given term has a type that is a sort
+termToProp :: SharedContext -> Term -> IO Prop
+termToProp _sc tm = pure (Prop tm)
+
+propToTerm :: SharedContext -> Prop -> IO Term
+propToTerm _sc (Prop tm) = pure tm
+
+propToRewriteRule :: SharedContext -> Prop -> IO (Maybe (RewriteRule))
+propToRewriteRule _sc (Prop tm) =
+  case ruleOfProp tm of
+    Nothing -> pure Nothing
+    Just r  -> pure (Just r)
+
+splitProp :: SharedContext -> Prop -> IO (Maybe (Prop, Prop))
+splitProp sc (Prop p) =
+  do let (vars, body) = asPiList p
+     case (isGlobalDef "Prelude.and" <@> return <@> return) =<< asEqTrue body of
+       Nothing -> pure Nothing
+       Just (_ :*: p1 :*: p2) ->
+         do t1 <- scPiList sc vars =<< scEqTrue sc p1
+            t2 <- scPiList sc vars =<< scEqTrue sc p2
+            return (Just (Prop t1,Prop t2))
+
+unfoldProp :: SharedContext -> Set VarIndex -> Prop -> IO Prop
+unfoldProp sc unints (Prop tm) =
+  do tm' <- scUnfoldConstantSet sc True unints tm
+     return (Prop tm')
+
+simplifyProp :: SharedContext -> Simpset -> Prop -> IO Prop
+simplifyProp sc ss (Prop tm) =
+  do tm' <- rewriteSharedTerm sc ss tm
+     return (Prop tm')
+
+evalProp :: SharedContext -> Set VarIndex -> Prop -> IO Prop
+evalProp sc unints (Prop p) =
+  do let (args, body) = asPiList p
+
+     body' <-
+       case asEqTrue body of
+         Just t -> pure t
+         Nothing -> fail "goal_eval: expected EqTrue"
+
+     ecs <- traverse (\(nm, ty) -> scFreshEC sc (Text.unpack nm) ty) args
+     vars <- traverse (scExtCns sc) ecs
+     t0 <- instantiateVarList sc 0 (reverse vars) body'
+
+     sym <- Common.newSAWCoreBackend sc
+     st <- Common.sawCoreState sym
+     (_names, (_mlabels, p')) <- W4Sim.w4Eval sym st sc mempty unints t0
+     t1 <- W4Sim.toSC sym st p'
+
+     t2 <- scEqTrue sc t1
+     -- turn the free variables we generated back into pi-bound variables
+     t3 <- scGeneralizeExts sc ecs t2
+     return (Prop t3)
+
+betaReduceProp :: SharedContext -> Prop -> IO Prop
+betaReduceProp sc (Prop tm) =
+  do tm' <- betaNormalize sc tm
+     return (Prop tm')
+
+falseProp :: SharedContext -> IO Prop
+falseProp sc = Prop <$> (scEqTrue sc =<< scApplyPrelude_False sc)
+
+propSize :: Prop -> Integer
+propSize (Prop tm) = scSharedSize tm
+
+propIsTrivial :: Prop -> Bool
+propIsTrivial (Prop tm) = checkTrue tm
+  where
+    checkTrue :: Term -> Bool
+    checkTrue (asPiList -> (_, asEqTrue -> Just (asBool -> Just True))) = True
+    checkTrue _ = False
+
+prettyProp :: PPOpts -> Prop -> String
+prettyProp opts (Prop tm) = scPrettyTerm opts tm
+
+ppProp :: PPOpts -> Prop -> SawDoc
+ppProp opts (Prop tm) = ppTerm opts tm
 
 -- | A theorem is a proposition which has been wrapped in a
 -- constructor indicating that it has already been proved.
@@ -109,3 +242,71 @@ finishProof (ProofState gs concl stats _) =
   case gs of
     []    -> (stats, Just (Theorem (goalProp concl) stats))
     _ : _ -> (stats, Nothing)
+
+{-
+propToSATQuery :: SharedContext -> Prop -> IO SATQuery
+propToSATQuery sc (Prop goal) =
+  do let (args, t1) = asPiList goal
+     case asEqTrue t1 of
+       Nothing -> fail $ "propToSATQuery: expected EqTrue, actual " ++ show t1
+       Just t2 ->
+-}
+
+
+-- TODO: unsound?
+goalAssume :: ProofGoal -> IO (Maybe (Theorem, ProofGoal))
+goalAssume goal =
+  case asPi (unProp (goalProp goal)) of
+    Just (_nm, tp, body)
+      | looseVars body == emptyBitSet ->
+          let goal' = goal{ goalProp = Prop body }
+           in return (Just (Theorem (Prop tp) mempty, goal'))
+
+    _ -> return Nothing
+
+goalInsert :: SharedContext -> Theorem -> ProofGoal -> IO ProofGoal
+goalInsert sc (Theorem t _stats) goal =
+  do body' <- scFun sc (unProp t) (unProp (goalProp goal))
+     let goal' = goal{ goalProp = Prop body' }
+     return goal'
+
+goalIntro :: SharedContext -> String -> ProofGoal -> IO (Maybe (TypedTerm, ProofGoal))
+goalIntro sc s goal =
+  case asPi (unProp (goalProp goal)) of
+    Nothing -> pure Nothing
+    Just (nm, tp, body) ->
+      do let name = if null s then Text.unpack nm else s
+         x <- scFreshGlobal sc name tp
+         tt <- mkTypedTerm sc x
+         body' <- instantiateVar sc 0 x body
+         let goal' = goal { goalProp = Prop body' }
+         return (Just (tt, goal'))
+
+goalApply :: SharedContext -> Theorem -> ProofGoal -> IO (Maybe [ProofGoal])
+goalApply sc (Theorem rule _stats) goal = applyFirst (asPiLists (unProp rule))
+  where
+    applyFirst [] = pure Nothing
+    applyFirst ((ruleArgs, ruleConcl) : rest) =
+      do result <- scMatch sc ruleConcl (unProp (goalProp goal))
+         case result of
+           Nothing -> applyFirst rest
+           Just inst ->
+             do let inst' = [ Map.lookup i inst | i <- take (length ruleArgs) [0..] ]
+                dummy <- scUnitType sc
+                let mkNewGoals (Nothing : mts) ((_, prop) : args) =
+                      do c0 <- instantiateVarList sc 0 (map (fromMaybe dummy) mts) prop
+                         cs <- mkNewGoals mts args
+                         return (Prop c0 : cs)
+                    mkNewGoals (Just _ : mts) (_ : args) =
+                      mkNewGoals mts args
+                    mkNewGoals _ _ = return []
+                newgoalterms <- mkNewGoals inst' (reverse ruleArgs)
+                let newgoals = reverse [ goal { goalProp = t } | t <- newgoalterms ]
+                return (Just newgoals)
+
+    asPiLists :: Term -> [([(Text, Term)], Term)]
+    asPiLists t =
+      case asPi t of
+        Nothing -> [([], t)]
+        Just (nm, tp, body) ->
+          [ ((nm, tp) : args, concl) | (args, concl) <- asPiLists body ] ++ [([], t)]

--- a/src/SAWScript/Proof.hs
+++ b/src/SAWScript/Proof.hs
@@ -127,7 +127,7 @@ propToRewriteRule _sc (Prop tm) =
     Just r  -> pure (Just r)
 
 -- | Attempt to split a conjunctive proposition into two propositions,
---   such that a proof of both return propositions is equivalant to
+--   such that a proof of both return propositions is equivalent to
 --   a proof of the original.
 splitProp :: SharedContext -> Prop -> IO (Maybe (Prop, Prop))
 splitProp sc (Prop p) =
@@ -192,7 +192,7 @@ falseProp sc = Prop <$> (scEqTrue sc =<< scApplyPrelude_False sc)
 propSize :: Prop -> Integer
 propSize (Prop tm) = scSharedSize tm
 
--- | Test if the given proposition is trivally true.  This holds
+-- | Test if the given proposition is trivially true.  This holds
 --   just when the proposition is a (possibly empty) sequence of
 --   Pi-types followed by an @EqTrue@ proposition for a
 --   concretely-true boolean value.
@@ -225,7 +225,7 @@ data Theorem =
       -- This constructor is used to construct "hypothetical" theorems that
       -- are intended to be used in local scopes when proving implications.
 
--- | Check that the proported theorem is valid.
+-- | Check that the purported theorem is valid.
 --
 --   This checks that the given theorem object does not correspond
 --   to a local assumption that has been leaked from its scope,
@@ -264,7 +264,7 @@ data Evidence
 
     -- | This type of evidence is produced when the given proposition
     --   has been randomly tested against input vectors in the style
-    --   of quickcheck.  The included number is the number of sucessfully
+    --   of quickcheck.  The included number is the number of successfully
     --   passed test vectors.
   | QuickcheckEvidence Integer Prop
 
@@ -273,7 +273,7 @@ data Evidence
     --   user's direction.
   | Admitted Prop
 
-    -- | This type of evidence is produced when a given propisition is trivally
+    -- | This type of evidence is produced when a given proposition is trivially
     --   true.
   | TrivialEvidence
 
@@ -302,7 +302,7 @@ data Evidence
   | CutEvidence Theorem Evidence
 
     -- | This type of evidence is used to modify a goal to prove via rewriting.
-    --   The goal to prove is rewriten by the given simpset; then the provided
+    --   The goal to prove is rewritten by the given simpset; then the provided
     --   evidence is used to check the modified goal.
   | RewriteEvidence Simpset Evidence
 
@@ -367,7 +367,7 @@ proofByTerm sc prf =
 
 -- | Construct a theorem directly from a proposition and evidence
 --   for that proposition.  The evidence will be validated to
---   check that it supports the given propsition; if not, an
+--   check that it supports the given proposition; if not, an
 --   error will be raised.
 constructTheorem :: SharedContext -> Prop -> Evidence -> IO Theorem
 constructTheorem sc p e =
@@ -575,7 +575,7 @@ checkEvidence sc = check mempty
                    , showTerm p'
                    ]
                unless (looseVars body == emptyBitSet) $ fail $ unlines
-                   [ "Assume evidence cannot be used on a dependent propsition"
+                   [ "Assume evidence cannot be used on a dependent proposition"
                    , showTerm ptm
                    ]
                check (Set.insert p' hyps) e' (Prop body)
@@ -874,7 +874,7 @@ tacticSolve f = Tactic \gl ->
 
 -- | Attempt to simplify a proof goal via computation, rewriting or similar.
 --   The tactic should return a new proposition to prove and a method for
---   transferring evidence for the modifed proposition into a evidence for
+--   transferring evidence for the modified proposition into a evidence for
 --   the original goal.
 tacticChange :: Monad m => (ProofGoal -> m (Prop, Evidence -> Evidence)) -> Tactic m ()
 tacticChange f = Tactic \gl ->

--- a/src/SAWScript/Prover/ABC.hs
+++ b/src/SAWScript/Prover/ABC.hs
@@ -1,6 +1,23 @@
-module SAWScript.Prover.ABC (proveABC) where
+module SAWScript.Prover.ABC
+  ( proveABC
+  , w4AbcVerilog
+  , abcSatExternal
+  ) where
 
+import Control.Monad (unless)
+import Control.Monad.IO.Class
+import Data.Char (isSpace)
+import Data.List (isPrefixOf)
+import qualified Data.Map as Map
+import Data.Maybe
+import           Data.Set (Set)
 import qualified Data.Text as Text
+import Text.Read (readMaybe)
+
+import System.Directory
+import System.IO
+import System.IO.Temp (emptySystemTempFile)
+import System.Process (readProcessWithExitCode)
 
 import qualified Data.AIG as AIG
 
@@ -9,9 +26,15 @@ import           Verifier.SAW.Name
 import           Verifier.SAW.SharedTerm
 import qualified Verifier.SAW.Simulator.BitBlast as BBSim
 
-import SAWScript.Proof(Prop, propToSATQuery, propSize)
+import SAWScript.Proof(Prop, propToSATQuery, propSize, goalProp, ProofGoal, goalType, goalNum)
 import SAWScript.Prover.SolverStats (SolverStats, solverStats)
+import qualified SAWScript.Prover.Exporter as Exporter
 import SAWScript.Prover.Util (liftCexBB)
+
+-- crucible-jvm
+-- TODO, very weird import
+import Lang.JVM.ProcessUtils (readProcessExitIfFailure)
+
 
 -- | Bit-blast a proposition and check its validity using ABC.
 proveABC ::
@@ -28,6 +51,7 @@ proveABC proxy sc goal =
           res <- getModel nms fts =<< AIG.checkSat be lit
           let stats = solverStats "ABC" (propSize goal)
           return (res, stats)
+
 
 getModel ::
   Show name =>
@@ -53,3 +77,115 @@ getModel argNames shapes satRes =
 
     AIG.SatUnknown -> fail "Unknown result from ABC"
 
+
+w4AbcVerilog :: MonadIO m =>
+  Set VarIndex ->
+  SharedContext ->
+  Bool ->
+  Prop ->
+  m (Maybe [(String, FirstOrderValue)], SolverStats)
+w4AbcVerilog unints sc _hashcons goal = liftIO $
+       -- Create temporary files
+    do let tpl = "abc_verilog.v"
+           tplCex = "abc_verilog.cex"
+       tmp <- emptySystemTempFile tpl
+       tmpCex <- emptySystemTempFile tplCex
+
+       satq <- propToSATQuery sc unints goal
+       (argNames, argTys) <- Exporter.writeVerilogSAT sc tmp satq
+
+       -- Run ABC and remove temporaries
+       let execName = "abc"
+           args = ["-q", "%read " ++ tmp ++"; %blast; &sweep -C 5000; &syn4; &cec -m; write_aiger_cex " ++ tmpCex]
+       (_out, _err) <- readProcessExitIfFailure execName args
+       cexText <- readFile tmpCex
+       removeFile tmp
+       removeFile tmpCex
+
+       -- Parse and report results
+       let stats = solverStats "abc_verilog" (propSize goal)
+       res <- if all isSpace cexText
+              then return Nothing
+                      -- NB: reverse bits to get bit-order convention right
+              else do bits <- reverse <$> parseAigerCex cexText
+                      case liftCexBB (reverse argTys) bits of
+                        Left parseErr -> fail parseErr
+                        Right vs -> return $ Just model
+                          where model = zip argNames (map toFirstOrderValue (reverse vs))
+       return (res, stats)
+
+parseAigerCex :: String -> IO [Bool]
+parseAigerCex text =
+  case lines text of
+    [_, cex] ->
+      case words cex of
+        [bits, _] -> mapM bitToBool bits
+        _ -> fail $ "invalid counterexample line: " ++ cex
+    _ -> fail $ "invalid counterexample text: " ++ text
+  where
+    bitToBool '0' = return False
+    bitToBool '1' = return True
+    bitToBool c   = fail ("invalid bit: " ++ [c])
+
+
+abcSatExternal :: MonadIO m =>
+  (AIG.IsAIG l g) =>
+  AIG.Proxy l g ->
+  SharedContext ->
+  Bool ->
+  String ->
+  [String] ->
+  ProofGoal ->
+  m (Maybe [(String,FirstOrderValue)], SolverStats)
+abcSatExternal proxy sc doCNF execName args g = liftIO $
+  do satq <- propToSATQuery sc mempty (goalProp g)
+     let cnfName = goalType g ++ show (goalNum g) ++ ".cnf"
+     (path, fh) <- openTempFile "." cnfName
+     hClose fh -- Yuck. TODO: allow writeCNF et al. to work on handles.
+
+     let args' = map replaceFileName args
+         replaceFileName "%f" = path
+         replaceFileName a = a
+
+     BBSim.withBitBlastedSATQuery proxy sc mempty satq $ \be l shapes -> do
+       variables <- (if doCNF then AIG.writeCNF else writeAIGWithMapping) be l path
+       (_ec, out, err) <- readProcessWithExitCode execName args' ""
+       removeFile path
+       unless (null err) $
+         print $ unlines ["Standard error from SAT solver:", err]
+       let ls = lines out
+           sls = filter ("s " `isPrefixOf`) ls
+           vls = filter ("v " `isPrefixOf`) ls
+       let stats = solverStats ("external SAT:" ++ execName) (propSize (goalProp g))
+       case (sls, vls) of
+         (["s SATISFIABLE"], _) -> do
+           let bs = parseDimacsSolution variables vls
+           let r = liftCexBB (map snd shapes) bs
+               argNames = map (Text.unpack . toShortName . ecName . fst) shapes
+           case r of
+             Left msg -> fail $ "Can't parse counterexample: " ++ msg
+             Right vs
+               | length argNames == length vs -> do
+                 return (Just (zip argNames (map toFirstOrderValue vs)), stats)
+               | otherwise -> fail $ unwords ["external SAT results do not match expected arguments", show argNames, show vs]
+         (["s UNSATISFIABLE"], []) ->
+           return (Nothing, stats)
+         _ -> fail $ "Unexpected result from SAT solver:\n" ++ out
+
+parseDimacsSolution :: [Int]    -- ^ The list of CNF variables to return
+                    -> [String] -- ^ The value lines from the solver
+                    -> [Bool]
+parseDimacsSolution vars ls = map lkup vars
+  where
+    vs :: [Int]
+    vs = concatMap (filter (/= 0) . mapMaybe readMaybe . tail . words) ls
+    varToPair n | n < 0 = (-n, False)
+                | otherwise = (n, True)
+    assgnMap = Map.fromList (map varToPair vs)
+    lkup v = Map.findWithDefault False v assgnMap
+
+writeAIGWithMapping :: AIG.IsAIG l g => g s -> l s -> FilePath -> IO [Int]
+writeAIGWithMapping be l path = do
+  nins <- AIG.inputCount be
+  AIG.writeAiger path (AIG.Network be [l])
+  return [1..nins]

--- a/src/SAWScript/Prover/Exporter.hs
+++ b/src/SAWScript/Prover/Exporter.hs
@@ -67,6 +67,7 @@ import qualified Verifier.SAW.Simulator.BitBlast as BBSim
 import qualified Verifier.SAW.Simulator.Value as Sim
 import qualified Verifier.SAW.Simulator.What4 as W4Sim
 import qualified Verifier.SAW.Simulator.SBV as SBV
+import qualified Verifier.SAW.Simulator.What4 as W
 
 import qualified Verifier.SAW.UntypedAST as Un
 
@@ -224,11 +225,9 @@ writeSMTLib2 sc f satq = io $
 writeSMTLib2What4 :: SharedContext -> FilePath -> SATQuery -> TopLevel ()
 writeSMTLib2What4 sc f satq = io $
   do sym <- W4.newExprBuilder W4.FloatRealRepr St globalNonceGenerator
-     term <- satQueryAsTerm sc satq
-     (_, _, (_,lit)) <- prepWhat4 sym sc (satUninterp satq) term
+     (_argNames, _labels, lit) <- W.w4Solve sym sc satq
      withFile f WriteMode $ \h ->
        writeDefaultSMT2 () "Offline SMTLib2" defaultWriteSMTLIB2Features sym h [lit]
-
 
 writeCore :: FilePath -> Term -> TopLevel ()
 writeCore path t = io $ writeFile path (scWriteExternal t)

--- a/src/SAWScript/Prover/Exporter.hs
+++ b/src/SAWScript/Prover/Exporter.hs
@@ -72,8 +72,8 @@ import SAWScript.Crucible.Common
 import SAWScript.Proof (Prop, propSize, propToTerm, predicateToProp, Quantification(..), propToPredicate)
 import SAWScript.Prover.SolverStats
 import SAWScript.Prover.Util
-import SAWScript.Prover.What4
 import SAWScript.Prover.SBV (prepNegatedSBV)
+import SAWScript.Prover.What4
 import SAWScript.Value
 
 import qualified What4.Interface as W4

--- a/src/SAWScript/Prover/Exporter.hs
+++ b/src/SAWScript/Prover/Exporter.hs
@@ -6,11 +6,12 @@
 {-# Language FlexibleContexts #-}
 {-# Language TypeApplications #-}
 module SAWScript.Prover.Exporter
-  ( proveWithExporter
-  , adaptExporter
+  ( proveWithSATExporter
+  , proveWithPropExporter
 
     -- * External formats
   , writeAIG
+  , writeAIG_SAT
   , writeSAIG
   , writeSAIGInferLatches
   , writeAIGComputedLatches
@@ -20,8 +21,6 @@ module SAWScript.Prover.Exporter
   , writeSMTLib2What4
   , write_smtlib2
   , write_smtlib2_w4
-  , writeUnintSMTLib2
-  , writeUnintSMTLib2What4
   , writeCoqCryptolPrimitivesForSAWCore
   , writeCoqCryptolModule
   , writeCoqSAWCorePrelude
@@ -29,6 +28,7 @@ module SAWScript.Prover.Exporter
   , writeCoqProp
   , writeCore
   , writeVerilog
+  , writeVerilogSAT
   , write_verilog
   , writeCoreProp
 
@@ -57,7 +57,8 @@ import Verifier.SAW.ExternalFormat(scWriteExternal)
 import Verifier.SAW.FiniteValue
 import Verifier.SAW.Module (emptyModule, moduleDecls)
 import Verifier.SAW.Prelude (preludeModule)
-import Verifier.SAW.Recognizer (asPi, asPiList, asEqTrue)
+import Verifier.SAW.Recognizer (asPi)
+import Verifier.SAW.SATQuery
 import Verifier.SAW.SharedTerm as SC
 import qualified Verifier.SAW.Translation.Coq as Coq
 import Verifier.SAW.TypedAST (mkModuleName)
@@ -65,55 +66,57 @@ import Verifier.SAW.TypedTerm
 import qualified Verifier.SAW.Simulator.BitBlast as BBSim
 import qualified Verifier.SAW.Simulator.Value as Sim
 import qualified Verifier.SAW.Simulator.What4 as W4Sim
+import qualified Verifier.SAW.Simulator.SBV as SBV
 
 import qualified Verifier.SAW.UntypedAST as Un
 
 import SAWScript.Crucible.Common
-import SAWScript.Proof (Prop, propSize, propToTerm, predicateToProp, Quantification(..), propToPredicate)
+import SAWScript.Proof (Prop, propSize, propToTerm, predicateToSATQuery, propToSATQuery)
 import SAWScript.Prover.SolverStats
 import SAWScript.Prover.Util
-import SAWScript.Prover.SBV (prepNegatedSBV)
 import SAWScript.Prover.What4
 import SAWScript.Value
 
-import qualified What4.Interface as W4
 import qualified What4.Expr.Builder as W4
 import What4.Protocol.SMTLib2 (writeDefaultSMT2)
 import What4.Protocol.VerilogWriter (exprVerilog)
 import What4.Solver.Adapter
 import qualified What4.SWord as W4Sim
 
-proveWithExporter ::
+proveWithSATExporter ::
+  (SharedContext -> FilePath -> SATQuery -> TopLevel ()) ->
+  Set VarIndex ->
+  String ->
+  Prop ->
+  TopLevel SolverStats
+proveWithSATExporter exporter unintSet path goal =
+  do sc <- getSharedContext
+     satq <- io $ propToSATQuery sc unintSet goal
+     exporter sc path satq
+     let stats = solverStats ("offline: "++ path) (propSize goal)
+     return stats
+
+
+proveWithPropExporter ::
   (SharedContext -> FilePath -> Prop -> TopLevel ()) ->
   String ->
   Prop ->
   TopLevel SolverStats
-proveWithExporter exporter path goal =
+proveWithPropExporter exporter path goal =
   do sc <- getSharedContext
      exporter sc path goal
      let stats = solverStats ("offline: "++ path) (propSize goal)
      return stats
 
--- | Converts an old-style exporter (which expects to take a predicate
--- as an argument) into a new-style one (which takes a pi-type proposition).
-adaptExporter ::
-  (SharedContext -> FilePath -> Term -> TopLevel ()) ->
-  (SharedContext -> FilePath -> Prop -> TopLevel ())
-adaptExporter exporter sc path goal =
-  -- TODO, move this into Proof.hs
-  do (args, concl) <- asPiList <$> io (propToTerm sc goal)
-     p <-
-       case asEqTrue concl of
-         Just p -> return p
-         Nothing -> throwTopLevel "adaptExporter: expected EqTrue"
-     p' <- io $ scNot sc p -- is this right?
-     t <- io $ scLambdaList sc args p'
-     exporter sc path t
-
 --------------------------------------------------------------------------------
 
--- | Write a @Term@ representing a theorem or an arbitrary
--- function to an AIG file.
+writeAIG_SAT :: (AIG.IsAIG l g) => AIG.Proxy l g -> SharedContext -> FilePath -> SATQuery -> TopLevel ()
+writeAIG_SAT proxy sc f satq = io $
+  do t  <- satQueryAsTerm sc satq
+     BBSim.withBitBlastedPred proxy sc mempty t $ \g l _vars -> do
+       AIG.writeAiger f (AIG.Network g [l])
+
+-- | Write a @Term@ representing a an arbitrary function to an AIG file.
 writeAIG :: (AIG.IsAIG l g) => AIG.Proxy l g -> SharedContext -> FilePath -> Term -> TopLevel ()
 writeAIG proxy sc f t = do
   io $ do
@@ -175,31 +178,18 @@ writeAIGComputedLatches ::
 writeAIGComputedLatches proxy sc file term numLatches =
   writeSAIG proxy sc file term numLatches
 
-writeCNF :: (AIG.IsAIG l g) => AIG.Proxy l g -> SharedContext -> FilePath -> Term -> TopLevel ()
-writeCNF proxy sc f t = do
-  AIG.Network be ls <- io $ bitblastPrim proxy sc t
-  case ls of
-    [l] -> do
-      _ <- io $ AIG.writeCNF be l f
-      return ()
-    _ -> throwTopLevel "writeCNF: non-boolean term"
+writeCNF :: (AIG.IsAIG l g) => AIG.Proxy l g -> SharedContext -> FilePath -> SATQuery -> TopLevel ()
+writeCNF proxy sc f satq = io $
+  do t  <- satQueryAsTerm sc satq
+     _ <- BBSim.withBitBlastedPred proxy sc mempty t $ \g l _vars -> AIG.writeCNF g l f
+     return ()
 
 write_cnf :: SharedContext -> FilePath -> TypedTerm -> TopLevel ()
 write_cnf sc f (TypedTerm schema t) = do
   liftIO $ checkBooleanSchema schema
   AIGProxy proxy <- getProxy
-  writeCNF proxy sc f t
-
--- | Write a proposition to an SMT-Lib version 2 file. Because @Prop@ is
--- assumed to have universally quantified variables, it will be negated.
-writeSMTLib2 :: SharedContext -> FilePath -> Prop -> TopLevel ()
-writeSMTLib2 sc f t = writeUnintSMTLib2 mempty sc f t
-
--- | Write a proposition to an SMT-Lib version 2 file. Because @Prop@ is
--- assumed to have universally quantified variables, it will be negated.
--- This version uses What4 instead of SBV.
-writeSMTLib2What4 :: SharedContext -> FilePath -> Prop -> TopLevel ()
-writeSMTLib2What4 sc f t = writeUnintSMTLib2What4 mempty sc f t
+  satq <- io (predicateToSATQuery sc mempty t)
+  writeCNF proxy sc f satq
 
 -- | Write a @Term@ representing a predicate (i.e. a monomorphic
 -- function returning a boolean) to an SMT-Lib version 2 file. The goal
@@ -208,8 +198,8 @@ writeSMTLib2What4 sc f t = writeUnintSMTLib2What4 mempty sc f t
 write_smtlib2 :: SharedContext -> FilePath -> TypedTerm -> TopLevel ()
 write_smtlib2 sc f (TypedTerm schema t) = do
   io $ checkBooleanSchema schema
-  p <- io $ predicateToProp sc Existential [] t
-  writeSMTLib2 sc f p
+  satq <- io $ predicateToSATQuery sc mempty t
+  writeSMTLib2 sc f satq
 
 -- | Write a @Term@ representing a predicate (i.e. a monomorphic
 -- function returning a boolean) to an SMT-Lib version 2 file. The goal
@@ -218,37 +208,38 @@ write_smtlib2 sc f (TypedTerm schema t) = do
 write_smtlib2_w4 :: SharedContext -> FilePath -> TypedTerm -> TopLevel ()
 write_smtlib2_w4 sc f (TypedTerm schema t) = do
   io $ checkBooleanSchema schema
-  p <- io $ predicateToProp sc Existential [] t
-  writeUnintSMTLib2What4 mempty sc f p
+  satq <- io $ predicateToSATQuery sc mempty t
+  writeSMTLib2What4 sc f satq
 
--- | Write a proposition to an SMT-Lib version 2 file, treating some
--- constants as uninterpreted. Because @Prop@ is assumed to have
--- universally quantified variables, it will be negated.
-writeUnintSMTLib2 :: Set VarIndex -> SharedContext -> FilePath -> Prop -> TopLevel ()
-writeUnintSMTLib2 unintSet sc f p = io $
-  do (_, _, l) <- prepNegatedSBV sc unintSet p
+-- | Write a SAT query to an SMT-Lib version 2 file.
+writeSMTLib2 :: SharedContext -> FilePath -> SATQuery -> TopLevel ()
+writeSMTLib2 sc f satq = io $
+  do (_, _, l) <- SBV.sbvSATQuery sc mempty satq
      let isSat = True -- l is encoded as an existential formula
      txt <- SBV.generateSMTBenchmark isSat l
      writeFile f txt
 
--- | Write a proposition to an SMT-Lib version 2 file, treating some
--- constants as uninterpreted. Because @Prop@ is assumed to have
--- universally quantified variables, it will be negated. This version
--- uses What4 instead of SBV.
-writeUnintSMTLib2What4 :: Set VarIndex -> SharedContext -> FilePath -> Prop -> TopLevel ()
-writeUnintSMTLib2What4 unints sc f goal = io $
+-- | Write a SAT query an SMT-Lib version 2 file.
+-- This version uses What4 instead of SBV.
+writeSMTLib2What4 :: SharedContext -> FilePath -> SATQuery -> TopLevel ()
+writeSMTLib2What4 sc f satq = io $
   do sym <- W4.newExprBuilder W4.FloatRealRepr St globalNonceGenerator
-     term <- propToPredicate sc goal
-     (_, _, (_,lit0)) <- prepWhat4 sym sc unints term
-     lit <- W4.notPred sym lit0 -- for symmetry with `prepNegatedSBV` above
+     term <- satQueryAsTerm sc satq
+     (_, _, (_,lit)) <- prepWhat4 sym sc (satUninterp satq) term
      withFile f WriteMode $ \h ->
        writeDefaultSMT2 () "Offline SMTLib2" defaultWriteSMTLIB2Features sym h [lit]
+
 
 writeCore :: FilePath -> Term -> TopLevel ()
 writeCore path t = io $ writeFile path (scWriteExternal t)
 
 write_verilog :: SharedContext -> FilePath -> Term -> TopLevel ()
 write_verilog sc path t = io $ writeVerilog sc path t
+
+writeVerilogSAT :: SharedContext -> FilePath -> SATQuery -> TopLevel ()
+writeVerilogSAT sc path satq = io $
+  do t <- satQueryAsTerm sc satq
+     writeVerilog sc path t
 
 writeVerilog :: SharedContext -> FilePath -> Term -> IO ()
 writeVerilog sc path t = do

--- a/src/SAWScript/Prover/MRSolver.hs
+++ b/src/SAWScript/Prover/MRSolver.hs
@@ -281,7 +281,7 @@ mrProvable bool_prop =
      path_prop <- mrPathCondition <$> get
      bool_prop' <- liftSC2 scImplies path_prop bool_prop
      sc <- mrSC <$> get
-     prop <- liftIO (predicateToProp sc Universal [] bool_prop')
+     prop <- liftIO (predicateToProp sc Universal bool_prop')
      (smt_res, _) <- liftSC1 (SBV.proveUnintSBV smt_conf mempty timeout) prop
      case smt_res of
        Just _ -> return False

--- a/src/SAWScript/Prover/MRSolver.hs
+++ b/src/SAWScript/Prover/MRSolver.hs
@@ -21,7 +21,7 @@ import Verifier.SAW.Term.Functor
 import Verifier.SAW.SharedTerm
 import Verifier.SAW.Recognizer
 
-import SAWScript.Proof (Prop(..))
+import SAWScript.Proof (predicateToProp, Quantification(..))
 import qualified SAWScript.Prover.SBV as SBV
 
 import Prelude
@@ -280,8 +280,9 @@ mrProvable bool_prop =
      timeout <- mrSMTTimeout <$> get
      path_prop <- mrPathCondition <$> get
      bool_prop' <- liftSC2 scImplies path_prop bool_prop
-     prop <- liftSC1 scEqTrue bool_prop'
-     (smt_res, _) <- liftSC1 (SBV.proveUnintSBV smt_conf mempty timeout) (Prop prop)
+     sc <- mrSC <$> get
+     prop <- liftIO (predicateToProp sc Universal [] bool_prop')
+     (smt_res, _) <- liftSC1 (SBV.proveUnintSBV smt_conf mempty timeout) prop
      case smt_res of
        Just _ -> return False
        Nothing -> return True

--- a/src/SAWScript/Prover/What4.hs
+++ b/src/SAWScript/Prover/What4.hs
@@ -122,7 +122,7 @@ setupWhat4_solver solver sym unintSet sc goal =
   do
      -- symbolically evaluate
      satq <- propToSATQuery sc unintSet goal
-     (argNames, bvs, lit) <- W.w4Solve sym sc satq
+     (argNames, _argTys, bvs, lit) <- W.w4Solve sym sc satq
 
      extendConfig (solver_adapter_config_options solver)
                   (getConfiguration sym)

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -280,9 +280,9 @@ showsPrecValue opts p v =
     VTopLevel {} -> showString "<<TopLevel>>"
     VSimpset ss -> showString (showSimpset opts ss)
     VProofScript {} -> showString "<<proof script>>"
-    VTheorem (Theorem (Prop t) _stats) ->
+    VTheorem (Theorem t _stats) ->
       showString "Theorem " .
-      showParen True (showString (SAWCorePP.scPrettyTerm opts' t))
+      showParen True (showString (prettyProp opts' t))
     VLLVMCrucibleSetup{} -> showString "<<Crucible Setup>>"
     VLLVMCrucibleSetupValue{} -> showString "<<Crucible SetupValue>>"
     VLLVMCrucibleMethodSpec{} -> showString "<<Crucible MethodSpec>>"

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -334,7 +334,7 @@ tupleLookupValue _ _ = error "tupleLookupValue"
 
 evaluate :: SharedContext -> Term -> IO Concrete.CValue
 evaluate sc t =
-  (\modmap -> Concrete.evalSharedTerm modmap mempty t) <$>
+  (\modmap -> Concrete.evalSharedTerm modmap mempty mempty t) <$>
   scGetModuleMap sc
 
 evaluateTypedTerm :: SharedContext -> TypedTerm -> IO C.Value

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -280,9 +280,9 @@ showsPrecValue opts p v =
     VTopLevel {} -> showString "<<TopLevel>>"
     VSimpset ss -> showString (showSimpset opts ss)
     VProofScript {} -> showString "<<proof script>>"
-    VTheorem (Theorem t _stats) ->
+    VTheorem thm ->
       showString "Theorem " .
-      showParen True (showString (prettyProp opts' t))
+      showParen True (showString (prettyProp opts' (thmProp thm)))
     VLLVMCrucibleSetup{} -> showString "<<Crucible Setup>>"
     VLLVMCrucibleSetupValue{} -> showString "<<Crucible SetupValue>>"
     VLLVMCrucibleMethodSpec{} -> showString "<<Crucible MethodSpec>>"

--- a/src/SAWScript/VerificationSummary.hs
+++ b/src/SAWScript/VerificationSummary.hs
@@ -73,7 +73,7 @@ thmToJSON thm = object [
     ("type" .= ("property" :: String))
     , ("loc" .= ("unknown" :: String)) -- TODO: Theorem has no attached location information
     , ("status" .= (statusString $ thmStats thm))
-    , ("term" .= (show $ PP.ppTerm PP.defaultPPOpts $ unProp $ thmProp thm))
+    , ("term" .= (show $ ppProp PP.defaultPPOpts $ thmProp thm))
   ]
 
 statusString :: SolverStats -> String
@@ -134,7 +134,7 @@ prettyVerificationSummary vs@(VerificationSummary jspecs lspecs thms) =
         vsep [ if Set.null (solverStatsSolvers (thmStats t))
                then "Axiom:"
                else "Theorem:"
-             , code (indent 2 (PP.ppTerm PP.defaultPPOpts (unProp (thmProp t))))
+             , code (indent 2 (ppProp PP.defaultPPOpts (thmProp t)))
              , ""
              ]
       prettySolvers ss =

--- a/src/SAWScript/VerificationSummary.hs
+++ b/src/SAWScript/VerificationSummary.hs
@@ -50,7 +50,7 @@ vsVerifSolvers vs =
 
 vsTheoremSolvers :: VerificationSummary -> Set.Set String
 vsTheoremSolvers = Set.unions . map getSolvers . vsTheorems
-  where getSolvers (Theorem _ ss) = solverStatsSolvers ss
+  where getSolvers thm = solverStatsSolvers (thmStats thm)
 
 vsAllSolvers :: VerificationSummary -> Set.Set String
 vsAllSolvers vs = Set.union (vsVerifSolvers vs) (vsTheoremSolvers vs)

--- a/src/SAWScript/X86.hs
+++ b/src/SAWScript/X86.hs
@@ -540,7 +540,7 @@ data Goal = Goal
 
 -- | The proposition that needs proving (i.e., assumptions imply conclusion)
 gGoal :: SharedContext -> Goal -> IO Prop
-gGoal sc g0 = predicateToProp sc Universal [] =<< go (gAssumes g)
+gGoal sc g0 = predicateToProp sc Universal =<< go (gAssumes g)
   where
   g = g0 { gAssumes = mapMaybe skip (gAssumes g0) }
 


### PR DESCRIPTION
Start refactoring some of the core SAWScript proof primitives.  This strengthens the abstractions surrounding these soundness-critical operations and paves the way to rework some of the underlying data representations in a safe way.