### PR TITLE
cabal.project: Remove unneeded allow-newer=uuid:random

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -33,5 +33,3 @@ packages:
     deps/argo/tasty-script-exitcode
     deps/argo/python
     deps/cryptol/cryptol-remote-api
-
-allow-newer: uuid:random


### PR DESCRIPTION
`uuid-1.3.12` and later allow building with the latest Hackage release of `random` at the time of writing (`random-1.2.0`), making this line in the `cabal.project` file unnecessary.