### PR TITLE
Skip a rewriting step in `resolveSAWSymBV` to improve performance.

### DIFF
--- a/src/SAWScript/Crucible/JVM/ResolveSetupValue.hs
+++ b/src/SAWScript/Crucible/JVM/ResolveSetupValue.hs
@@ -43,7 +43,6 @@ import qualified What4.BaseTypes as W4
 import qualified What4.Interface as W4
 import qualified What4.ProgramLoc as W4
 
-import Verifier.SAW.Rewriter
 import Verifier.SAW.SharedTerm
 import Verifier.SAW.TypedTerm
 
@@ -69,7 +68,6 @@ import SAWScript.Crucible.Common
 import SAWScript.Crucible.Common.MethodSpec (AllocIndex(..))
 
 import SAWScript.Panic
-import SAWScript.Prover.Rewrite
 import SAWScript.Crucible.JVM.MethodSpecIR
 import qualified SAWScript.Crucible.Common.MethodSpec as MS
 
@@ -250,10 +248,7 @@ resolveBitvectorTerm ::
 resolveBitvectorTerm sym w tm =
   do st <- sawCoreState sym
      let sc = saw_ctx st
-     --ss <- basic_ss sc
-     --tm' <- rewriteSharedTerm sc ss tm
-     let tm' = tm
-     mx <- case getAllExts tm' of
+     mx <- case getAllExts tm of
              -- concretely evaluate if it is a closed term
              [] ->
                do modmap <- scGetModuleMap sc
@@ -262,15 +257,13 @@ resolveBitvectorTerm sym w tm =
              _ -> return Nothing
      case mx of
        Just x  -> W4.bvLit sym w (BV.mkBV w x)
-       Nothing -> bindSAWTerm sym st (W4.BaseBVRepr w) tm'
+       Nothing -> bindSAWTerm sym st (W4.BaseBVRepr w) tm
 
 resolveBoolTerm :: Sym -> Term -> IO (W4.Pred Sym)
 resolveBoolTerm sym tm =
   do st <- sawCoreState sym
      let sc = saw_ctx st
-     ss <- basic_ss sc
-     tm' <- rewriteSharedTerm sc ss tm
-     mx <- case getAllExts tm' of
+     mx <- case getAllExts tm of
              -- concretely evaluate if it is a closed term
              [] ->
                do modmap <- scGetModuleMap sc
@@ -279,7 +272,7 @@ resolveBoolTerm sym tm =
              _ -> return Nothing
      case mx of
        Just x  -> return (W4.backendPred sym x)
-       Nothing -> bindSAWTerm sym st W4.BaseBoolRepr tm'
+       Nothing -> bindSAWTerm sym st W4.BaseBoolRepr tm
 
 toJVMType :: Cryptol.TValue -> Maybe J.Type
 toJVMType tp =

--- a/src/SAWScript/Crucible/LLVM/ResolveSetupValue.hs
+++ b/src/SAWScript/Crucible/LLVM/ResolveSetupValue.hs
@@ -393,17 +393,15 @@ resolveSAWSymBV cc w tm =
   do let sym = cc^.ccBackend
      st <- sawCoreState sym
      let sc = saw_ctx st
-     let ss = cc^.ccBasicSS
-     tm' <- rewriteSharedTerm sc ss tm
-     mx <- case getAllExts tm' of
+     mx <- case getAllExts tm of
              [] -> do
                -- Evaluate in SBV to test whether 'tm' is a concrete value
-               sbv <- SBV.toWord =<< SBV.sbvSolveBasic sc Map.empty mempty tm'
+               sbv <- SBV.toWord =<< SBV.sbvSolveBasic sc Map.empty mempty tm
                return (SBV.svAsInteger sbv)
              _ -> return Nothing
      case mx of
        Just x  -> W4.bvLit sym w (BV.mkBV w x)
-       Nothing -> bindSAWTerm sym st (W4.BaseBVRepr w) tm'
+       Nothing -> bindSAWTerm sym st (W4.BaseBVRepr w) tm
 
 resolveSAWTerm ::
   Crucible.HasPtrWidth (Crucible.ArchWidth arch) =>


### PR DESCRIPTION
This is a test to see whether the rewriting step during LLVM verification is really necessary.

EDIT: It looks like all the CI tests pass just fine; the simplification pass was totally unnecessary. Note that the corresponding call to the simplifier during JVM verification was already removed in ed9ed43621a676a2114d8e5d741ceb535c653398.

This change seems to speed up various CI scripts (s2n, blst, etc.) by something on the order of 10%.