### PR TITLE
Better printing of Cryptol errors in saw-remote-api

### DIFF
--- a/saw-remote-api/src/SAWServer/CryptolExpression.hs
+++ b/saw-remote-api/src/SAWServer/CryptolExpression.hs
@@ -6,8 +6,10 @@ module SAWServer.CryptolExpression
  ( getCryptolExpr
  , getTypedTerm
  , getTypedTermOfCExp
+ , CryptolModuleException(..)
  ) where
 
+import Control.Exception (Exception)
 import Control.Lens ( view )
 import Control.Monad.IO.Class ( MonadIO(liftIO) )
 import qualified Data.ByteString as B
@@ -15,7 +17,7 @@ import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
 
 import Cryptol.Eval (EvalOpts(..))
-import Cryptol.ModuleSystem (ModuleRes, ModuleInput(..))
+import Cryptol.ModuleSystem (ModuleError, ModuleInput(..), ModuleRes, ModuleWarning)
 import Cryptol.ModuleSystem.Base (genInferInput, getPrimMap, noPat, rename)
 import Cryptol.ModuleSystem.Env (ModuleEnv, meSolverConfig)
 import Cryptol.ModuleSystem.Interface (noIfaceParams)
@@ -108,3 +110,10 @@ runInferOutput out =
     InferFailed nm warns errs ->
       do typeCheckWarnings nm warns
          typeCheckingFailed nm errs
+
+data CryptolModuleException = CryptolModuleException
+  { cmeError    :: ModuleError
+  , cmeWarnings :: [ModuleWarning]
+  } deriving Show
+
+instance Exception CryptolModuleException


### PR DESCRIPTION
This is a first stab at improving the state of affairs observed in #1128. Before, we had:

```
Running: cabal new-exec --verbose=0 saw-remote-api socket
⚠️  Failed to verify: lemma_FPointsToContract (defined at bug.py:34):
error: Cryptol error: RenamerErrors (FromModule (ModName "<interactive>")) [UnboundExpr (Located {srcRange = Range {from = Position {line = 1, col = 1}, to = Position {line = 1, col = 2}, source = ""}, thing = UnQual (Ident False "x")}) <NameDisp>,UnboundExpr (Located {srcRange = Range {from = Position {line = 1, col = 5}, to = Position {line = 1, col = 6}, source = ""}, thing = UnQual (Ident False "x")}) <NameDisp>]
CallStack (from HasCallStack):
  error, called at src/SAWServer/LLVMCrucibleSetup.hs:175:24 in saw-remote-api-0.1.0.0-inplace:SAWServer.LLVMCrucibleSetup
Traceback (most recent call last):
  File "bug.py", line 34, in <module>
    result = llvm_verify(mod, "f", FPointsToContract())
  File "/home/rscott/Documents/Hacking/Haskell/sandbox/saw-script/galois-py-toolkit/saw/__init__.py", line 396, in llvm_verify
    raise result.exception from None
  File "/home/rscott/Documents/Hacking/Haskell/sandbox/saw-script/galois-py-toolkit/saw/__init__.py", line 361, in llvm_verify
    conn.llvm_assume(module.server_name,
  File "/home/rscott/Documents/Hacking/Haskell/sandbox/saw-script/galois-py-toolkit/virtenv/lib/python3.8/site-packages/argo_client/interaction.py", line 163, in result
    return self.process_result(self._result_and_state_and_out_err()[0])
  File "/home/rscott/Documents/Hacking/Haskell/sandbox/saw-script/galois-py-toolkit/virtenv/lib/python3.8/site-packages/argo_client/interaction.py", line 148, in _result_and_state_and_out_err
    raise self.process_error(exception)
saw.exceptions.VerificationError: error: Cryptol error: RenamerErrors (FromModule (ModName "<interactive>")) [UnboundExpr (Located {srcRange = Range {from = Position {line = 1, col = 1}, to = Position {line = 1, col = 2}, source = ""}, thing = UnQual (Ident False "x")}) <NameDisp>,UnboundExpr (Located {srcRange = Range {from = Position {line = 1, col = 5}, to = Position {line = 1, col = 6}, source = ""}, thing = UnQual (Ident False "x")}) <NameDisp>]
CallStack (from HasCallStack):
  error, called at src/SAWServer/LLVMCrucibleSetup.hs:175:24 in saw-remote-api-0.1.0.0-inplace:SAWServer.LLVMCrucibleSetup
🛑  The goal failed to verify.
```

Now, we have:

```
Running: cabal new-exec --verbose=0 saw-remote-api socket
Traceback (most recent call last):
  File "bug.py", line 34, in <module>
    result = llvm_verify(mod, "f", FPointsToContract())
  File "/home/rscott/Documents/Hacking/Haskell/sandbox/saw-script/galois-py-toolkit/saw/__init__.py", line 381, in llvm_verify
    raise err from None
  File "/home/rscott/Documents/Hacking/Haskell/sandbox/saw-script/galois-py-toolkit/saw/__init__.py", line 346, in llvm_verify
    stdout = res.stdout()
  File "/home/rscott/Documents/Hacking/Haskell/sandbox/saw-script/galois-py-toolkit/virtenv/lib/python3.8/site-packages/argo_client/interaction.py", line 167, in stdout
    return self._result_and_state_and_out_err()[2]
  File "/home/rscott/Documents/Hacking/Haskell/sandbox/saw-script/galois-py-toolkit/virtenv/lib/python3.8/site-packages/argo_client/interaction.py", line 148, in _result_and_state_and_out_err
    raise self.process_error(exception)
  File "/home/rscott/Documents/Hacking/Haskell/sandbox/saw-script/galois-py-toolkit/saw/commands.py", line 8, in process_error
    return exceptions.make_saw_exception(ae)
  File "/home/rscott/Documents/Hacking/Haskell/sandbox/saw-script/galois-py-toolkit/saw/exceptions.py", line 42, in make_saw_exception
    raise ae
argo_client.interaction.ArgoException: [error] at :1:1--1:2 Value not in scope: x
[error] at :1:5--1:6 Value not in scope: x {'warnings': [], 'source': 'module name <interactive>', 'errors': ['[error] at :1:1--1:2 Value not in scope: x', '[error] at :1:5--1:6 Value not in scope: x']}
🔶 No goal results logged.
```

There's obviously some room for improvement still (it still prints a `{'warnings': ... }` dictionary, and the errors lack filenames), but I wanted to submit this now to get @pnwamk's feedback.