### PR TITLE
fix(rpc): tweak tests to avoid resource warnings

### DIFF
--- a/saw-remote-api/python/saw/commands.py
+++ b/saw-remote-api/python/saw/commands.py
@@ -43,8 +43,8 @@ class LLVMLoadModule(SAWCommand):
             connection
         )
 
-    def process_result(self, _res : Any) -> Any:
-        return None
+    def process_result(self, res : Any) -> Any:
+        return res
 
 class LLVMAssume(SAWCommand):
     def __init__(
@@ -83,8 +83,8 @@ class LLVMVerify(SAWCommand):
                   'lemma name': lemma_name}
         super(LLVMVerify, self).__init__('SAW/LLVM/verify', params, connection)
 
-    def process_result(self, _res : Any) -> Any:
-        return None
+    def process_result(self, res : Any) -> Any:
+        return res
 
 class Prove(SAWCommand):
     def __init__(

--- a/saw-remote-api/python/tests/saw/test_alloc_aligned.py
+++ b/saw-remote-api/python/tests/saw/test_alloc_aligned.py
@@ -61,16 +61,8 @@ class BufferCopySpec(Contract):
 
 
 class LLVMNestedStructTest(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        connect(reset_server=True)
-
-    @classmethod
-    def tearDownClass(self):
-        disconnect()
-
     def test_llvm_struct(self):
+        connect(reset_server=True)
         if __name__ == "__main__": view(LogResults())
 
         bcname = str(Path('tests','saw','test-files', 'alloc_aligned.bc'))

--- a/saw-remote-api/python/tests/saw/test_llvm_array_swap.py
+++ b/saw-remote-api/python/tests/saw/test_llvm_array_swap.py
@@ -19,16 +19,8 @@ class ArraySwapContract(Contract):
 
 
 class LLVMArraySwapTest(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        connect(reset_server=True)
-
-    @classmethod
-    def tearDownClass(self):
-        disconnect()
-
     def test_llvm_array_swap(self):
+        connect(reset_server=True)
         if __name__ == "__main__": view(LogResults())
         bcname = str(Path('tests','saw','test-files', 'llvm_array_swap.bc'))
         mod = llvm_load_module(bcname)

--- a/saw-remote-api/python/tests/saw/test_llvm_assert_null.py
+++ b/saw-remote-api/python/tests/saw/test_llvm_assert_null.py
@@ -21,16 +21,8 @@ class FContract2(Contract):
 
 
 class LLVMAssertNullTest(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        connect(reset_server=True)
-
-    @classmethod
-    def tearDownClass(self):
-        disconnect()
-
     def test_llvm_assert_null(self):
+        connect(reset_server=True)
         if __name__ == "__main__": view(LogResults())
         bcname = str(Path('tests','saw','test-files', 'llvm_assert_null.bc'))
         mod = llvm_load_module(bcname)

--- a/saw-remote-api/python/tests/saw/test_llvm_global.py
+++ b/saw-remote-api/python/tests/saw/test_llvm_global.py
@@ -15,16 +15,8 @@ class FContract(Contract):
 
 
 class LLVMGlobalTest(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        connect(reset_server=True)
-
-    @classmethod
-    def tearDownClass(self):
-        disconnect()
-
     def test_llvm_global(self):
+        connect(reset_server=True)
         if __name__ == "__main__": view(LogResults())
         bcname = str(Path('tests','saw','test-files', 'llvm_global.bc'))
         mod = llvm_load_module(bcname)

--- a/saw-remote-api/python/tests/saw/test_llvm_pointer.py
+++ b/saw-remote-api/python/tests/saw/test_llvm_pointer.py
@@ -18,15 +18,8 @@ class FContract(Contract):
 
 class LLVMPointerTest(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(self):
-        connect(reset_server=True)
-
-    @classmethod
-    def tearDownClass(self):
-        disconnect()
-
     def test_llvm_pointer(self):
+        connect(reset_server=True)
         if __name__ == "__main__": view(LogResults())
         bcname = str(Path('tests','saw','test-files', 'llvm_pointer.bc'))
         mod = llvm_load_module(bcname)

--- a/saw-remote-api/python/tests/saw/test_llvm_struct.py
+++ b/saw-remote-api/python/tests/saw/test_llvm_struct.py
@@ -47,17 +47,8 @@ class IdContract(Contract):
 
 
 class LLVMStructTest(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        connect(reset_server=True)
-
-    @classmethod
-    def tearDownClass(self):
-        disconnect()
-
-
     def test_llvm_struct(self):
+        connect(reset_server=True)
         if __name__ == "__main__": view(LogResults())
         bcname = str(Path('tests','saw','test-files', 'llvm_struct.bc'))
         mod = llvm_load_module(bcname)

--- a/saw-remote-api/python/tests/saw/test_llvm_struct_type.py
+++ b/saw-remote-api/python/tests/saw/test_llvm_struct_type.py
@@ -17,16 +17,8 @@ class FContract(Contract):
 
 
 class LLVMStructTest(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        connect(reset_server=True)
-
-    @classmethod
-    def tearDownClass(self):
-        disconnect()
-
     def test_llvm_struct(self):
+        connect(reset_server=True)
         if __name__ == "__main__": view(LogResults())
         bcname = str(Path('tests','saw','test-files', 'llvm_struct_type.bc'))
         mod = llvm_load_module(bcname)

--- a/saw-remote-api/python/tests/saw/test_nested_struct.py
+++ b/saw-remote-api/python/tests/saw/test_nested_struct.py
@@ -24,16 +24,8 @@ class FContract2(Contract):
         self.returns(b)
 
 class LLVMNestedStructTest(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        connect(reset_server=True)
-
-    @classmethod
-    def tearDownClass(self):
-        disconnect()
-
     def test_llvm_struct(self):
+        connect(reset_server=True)
         if __name__ == "__main__": view(LogResults())
 
         bcname = str(Path('tests','saw','test-files', 'nested_struct.bc'))

--- a/saw-remote-api/python/tests/saw/test_nested_struct2.py
+++ b/saw-remote-api/python/tests/saw/test_nested_struct2.py
@@ -26,16 +26,8 @@ class FContract2(Contract):
         self.returns(b)
 
 class LLVMNestedStructTest(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        connect(reset_server=True)
-
-    @classmethod
-    def tearDownClass(self):
-        disconnect()
-
     def test_llvm_struct(self):
+        connect(reset_server=True)
         if __name__ == "__main__": view(LogResults())
 
         bcname = str(Path('tests','saw','test-files', 'nested_struct.bc'))

--- a/saw-remote-api/python/tests/saw/test_points_to_at_type.py
+++ b/saw-remote-api/python/tests/saw/test_points_to_at_type.py
@@ -23,16 +23,8 @@ class FPointsToContract(Contract):
 
 
 class PointsToAtTypeTest(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        connect(reset_server=True)
-
-    @classmethod
-    def tearDownClass(self):
-        disconnect()
-
     def test_points_to_at_type(self):
+        connect(reset_server=True)
         if __name__ == "__main__": view(LogResults())
         bcname = str(Path('tests','saw','test-files', 'points_to_at_type.bc'))
         mod = llvm_load_module(bcname)

--- a/saw-remote-api/python/tests/saw/test_salsa20.py
+++ b/saw-remote-api/python/tests/saw/test_salsa20.py
@@ -121,16 +121,8 @@ class Salsa20CryptContract(Contract):
         self.points_to(m_p, cryptol("Salsa20_encrypt")((k, v, m)))
 
 class Salsa20EasyTest(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        connect(reset_server=True)
-
-    @classmethod
-    def tearDownClass(self):
-        disconnect()
-
     def test_salsa20(self):
+        connect(reset_server=True)
         if __name__ == "__main__": view(LogResults())
 
         bcname = str(Path('tests','saw','test-files', 'salsa20.bc'))

--- a/saw-remote-api/python/tests/saw/test_swap.py
+++ b/saw-remote-api/python/tests/saw/test_swap.py
@@ -23,17 +23,8 @@ class Swap(Contract):
 
 
 class SwapEasyTest(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        saw.connect(reset_server=True)
-
-    @classmethod
-    def tearDownClass(self):
-        saw.reset_server()
-        saw.disconnect()
-
     def test_swap(self):
+        saw.connect(reset_server=True)
 
         if __name__ == "__main__": saw.view(saw.LogResults())
         swap_bc = str(Path('tests','saw','test-files', 'swap.bc'))

--- a/saw-remote-api/python/tests/saw_low_level/test_llvm_assume.py
+++ b/saw-remote-api/python/tests/saw_low_level/test_llvm_assume.py
@@ -2,10 +2,10 @@ from pathlib import Path
 import saw
 from saw.proofscript import *
 import unittest
+import sys
 
 
 class LLVMAssumeTest(unittest.TestCase):
-
     def test_llvm_assume(self):
         c = saw.connection.connect(reset_server=True)
         if __name__ == "__main__": saw.view(saw.LogResults())
@@ -43,8 +43,7 @@ class LLVMAssumeTest(unittest.TestCase):
         prover = ProofScript([abc]).to_json()
         c.llvm_assume('m', 'seven', seven_contract, 'seven_ov').result()
         c.llvm_verify('m', 'addone', ['seven_ov'], False, addone_contract, prover, 'addone_ov').result()
-        c.reset_server()
-        c.disconnect()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/saw-remote-api/python/tests/saw_low_level/test_salsa20_low_level.py
+++ b/saw-remote-api/python/tests/saw_low_level/test_salsa20_low_level.py
@@ -10,6 +10,7 @@ from saw.proofscript import *
 class Salsa20LowLevelTest(unittest.TestCase):
     def test_salsa20(self):
         c = saw.connection.connect(reset_server=True)
+
         if __name__ == "__main__": saw.view(saw.LogResults())
 
         bcname = str(Path('tests','saw','test-files', 'salsa20.bc'))
@@ -215,7 +216,6 @@ class Salsa20LowLevelTest(unittest.TestCase):
         c.llvm_verify('m', 's20_hash', ['dr_ov'], False, hash_contract, prover, 'hash_ov').result()
         c.llvm_verify('m', 's20_expand32', ['hash_ov'], False, expand_contract, prover, 'expand_ov').result()
         c.llvm_verify('m', 's20_crypt32', ['expand_ov'], False, crypt_contract(63), prover, 'crypt_ov').result()
-        c.disconnect()
 
 if __name__ == "__main__":
     unittest.main()

--- a/saw-remote-api/python/tests/saw_low_level/test_seven.py
+++ b/saw-remote-api/python/tests/saw_low_level/test_seven.py
@@ -5,9 +5,7 @@ from saw.proofscript import *
 
 class SevenTest(unittest.TestCase):
     def test_seven(self):
-
         c = saw.connection.connect(reset_server=True)
-        c.reset()
         if __name__ == "__main__": saw.view(saw.LogResults())
 
         seven_bc = str(Path('tests','saw','test-files', 'seven.bc'))
@@ -29,7 +27,6 @@ class SevenTest(unittest.TestCase):
 
         prover = ProofScript([abc]).to_json()
         c.llvm_verify('m', 'seven', [], False, contract, prover, 'ok').result()
-        c.disconnect()
 
 if __name__ == "__main__":
     unittest.main()

--- a/saw-remote-api/python/tests/saw_low_level/test_swap_low_level.py
+++ b/saw-remote-api/python/tests/saw_low_level/test_swap_low_level.py
@@ -6,9 +6,7 @@ from saw.proofscript import *
 
 class SwapLowLevelTest(unittest.TestCase):
     def test_swap(self):
-
         c = saw.connection.connect(reset_server=True)
-        c.reset_server()
         if __name__ == "__main__": saw.view(saw.LogResults())
 
         swap_bc = str(Path('tests','saw','test-files', 'swap.bc'))
@@ -56,7 +54,6 @@ class SwapLowLevelTest(unittest.TestCase):
 
         prover = ProofScript([abc]).to_json()
         c.llvm_verify('m', 'swap', [], False, contract, prover, 'ok').result()
-        c.disconnect()
 
 
 if __name__ == "__main__":

--- a/saw-remote-api/python/tests/saw_low_level/test_trivial.py
+++ b/saw-remote-api/python/tests/saw_low_level/test_trivial.py
@@ -6,7 +6,6 @@ from saw.proofscript import *
 
 class TrivialTest(unittest.TestCase):
     def test_trivial(self):
-
         c = saw.connection.connect(reset_server=True)
         if __name__ == "__main__": saw.view(saw.LogResults())
 
@@ -33,7 +32,6 @@ class TrivialTest(unittest.TestCase):
 
         prover = ProofScript([abc]).to_json()
         c.llvm_verify('m', 'always_null', [], False, contract, prover, 'ok').result()
-        c.disconnect()
 
 
 if __name__ == "__main__":

--- a/saw-remote-api/scripts/run_rpc_tests.sh
+++ b/saw-remote-api/scripts/run_rpc_tests.sh
@@ -19,8 +19,11 @@ run_test poetry run mypy saw/
 
 export SAW_SERVER=$(which saw-remote-api)
 if [[ ! -x "$SAW_SERVER" ]]; then
-  echo "could not locate saw-remote-api executable - try executing with cabal v2-exec"
-  exit 1
+  export SAW_SERVER=$(cabal v2-exec which saw-remote-api)
+  if [[ ! -x "$SAW_SERVER" ]]; then
+    echo "could not locate saw-remote-api executable"
+    exit 1
+  fi
 fi
 
 echo "Running saw-remote-api tests..."


### PR DESCRIPTION
Prior to these changes the saw-remote-api python client unit tests were raising a lot of resource warnings (but seemed to work fine), e.g.:
```
ResourceWarning: Enable tracemalloc to get the object allocation traceback
./Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/subprocess.py:942: ResourceWarning: subprocess 20553 is still running
  _warn("subprocess %s is still running" % self.pid,
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/andrew/Repos/GRINDSTONE/saw-script/saw-remote-api/python/saw/__init__.py:193: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_INET6, type=SocketKind.SOCK_STREAM, proto=0, laddr=('::1', 62362, 0, 0), raddr=('::1', 62361, 0, 0)>
  __designated_connection = None
```

It appears this occurs when we manually shut down/disconnect from the server.

This PR removes the explicit disconnect code to avoid these warnings in the test suite. I intend to see if I can replicate these kinds of warnings with just the `argo-client` python package and then implement a proper fix at that level for instances where we do want to explicitly disconnect. (Perhaps every class implementing `ServerConnection` has to have a method to gracefully disconnect without warnings?).