### PR TITLE
Update crucible submodule and adapt to GaloisInc/crucible#658.

### DIFF
--- a/src/SAWScript/Crucible/LLVM/CrucibleLLVM.hs
+++ b/src/SAWScript/Crucible/LLVM/CrucibleLLVM.hs
@@ -35,6 +35,7 @@ module SAWScript.Crucible.LLVM.CrucibleLLVM
   , EndianForm(..)
     -- * Re-exports from "Lang.Crucible.LLVM.Extension"
   , ArchWidth
+  , LLVMArch
     -- * Re-exports from "Lang.Crucible.LLVM.Intrinsics"
   , LLVM
   , llvmTypeCtx
@@ -142,7 +143,7 @@ import Lang.Crucible.LLVM.DataLayout
    integerAlignment, floatAlignment, fromAlignment, intWidthSize, ptrBitwidth)
 
 import Lang.Crucible.LLVM.Extension
-  (ArchWidth)
+  (ArchWidth, LLVMArch)
 
 import Lang.Crucible.LLVM.Intrinsics
   (LLVM, register_llvm_overrides, llvmIntrinsicTypes)

--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -101,7 +101,6 @@ import qualified What4.ProgramLoc as W4
 import qualified What4.Symbol as W4
 
 import qualified SAWScript.Crucible.LLVM.CrucibleLLVM as Crucible
-import           SAWScript.Crucible.LLVM.CrucibleLLVM (LLVM)
 
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.NatRepr
@@ -162,7 +161,7 @@ ppSetupValueAsLLVMVal ::
   LLVMCrucibleContext arch ->
   SharedContext {- ^ context for constructing SAW terms -} ->
   MS.CrucibleMethodSpecIR (LLVM arch) {- ^ for name and typing environments -} ->
-  SetupValue (Crucible.LLVM arch) ->
+  SetupValue (LLVM arch) ->
   OverrideMatcher (LLVM arch) w (PP.Doc ann)
 ppSetupValueAsLLVMVal opts cc sc spec setupval = do
   (_memTy, llvmval) <- resolveSetupValueLLVM opts cc sc spec setupval
@@ -177,7 +176,7 @@ mkStructuralMismatch ::
   SharedContext {- ^ context for constructing SAW terms -} ->
   MS.CrucibleMethodSpecIR (LLVM arch) {- ^ for name and typing environments -} ->
   Crucible.LLVMVal Sym {- ^ the value from the simulator -} ->
-  SetupValue (Crucible.LLVM arch)           {- ^ the value from the spec -} ->
+  SetupValue (LLVM arch)           {- ^ the value from the spec -} ->
   Crucible.MemType     {- ^ the expected type -} ->
   OverrideMatcher (LLVM arch) w (OverrideFailureReason (LLVM arch))
 mkStructuralMismatch _opts cc _sc spec llvmval setupval memTy =
@@ -219,7 +218,7 @@ notEqual ::
   LLVMCrucibleContext arch ->
   SharedContext {- ^ context for constructing SAW terms -} ->
   MS.CrucibleMethodSpecIR (LLVM arch) {- ^ for name and typing environments -} ->
-  SetupValue (Crucible.LLVM arch)           {- ^ the value from the spec -} ->
+  SetupValue (LLVM arch)           {- ^ the value from the spec -} ->
   Crucible.LLVMVal Sym {- ^ the value from the simulator -} ->
   OverrideMatcher (LLVM arch) w Crucible.SimError
 notEqual cond opts loc cc sc spec expected actual = do
@@ -375,7 +374,7 @@ methodSpecHandler ::
   [MS.CrucibleMethodSpecIR (LLVM arch)]
     {- ^ specification for current function override  -} ->
   Crucible.FnHandle args ret {- ^ the handle for this function -} ->
-  Crucible.OverrideSim (SAWCruciblePersonality Sym) Sym (Crucible.LLVM arch) rtp args ret
+  Crucible.OverrideSim (SAWCruciblePersonality Sym) Sym Crucible.LLVM rtp args ret
      (Crucible.RegValue Sym ret)
 methodSpecHandler opts sc cc top_loc css h = do
   let fnName = head css ^. csName
@@ -909,13 +908,13 @@ matchPointsTos opts sc cc spec prepost = go False []
     checkPointsTo :: PointsTo (LLVM arch) -> OverrideMatcher (LLVM arch) md Bool
     checkPointsTo (LLVMPointsTo _loc _ p _) = checkSetupValue p
 
-    checkSetupValue :: SetupValue (Crucible.LLVM arch) -> OverrideMatcher (LLVM arch) md Bool
+    checkSetupValue :: SetupValue (LLVM arch) -> OverrideMatcher (LLVM arch) md Bool
     checkSetupValue v =
       do m <- OM (use setupValueSub)
          return (all (`Map.member` m) (setupVars v))
 
     -- Compute the set of variable identifiers in a 'SetupValue'
-    setupVars :: SetupValue (Crucible.LLVM arch) -> Set AllocIndex
+    setupVars :: SetupValue (LLVM arch) -> Set AllocIndex
     setupVars v =
       case v of
         SetupVar i                 -> Set.singleton i
@@ -1060,7 +1059,7 @@ matchArg ::
   Crucible.LLVMVal Sym
                      {- ^ concrete simulation value             -} ->
   Crucible.MemType   {- ^ expected memory type                  -} ->
-  SetupValue (Crucible.LLVM arch)         {- ^ expected specification value          -} ->
+  SetupValue (LLVM arch)         {- ^ expected specification value          -} ->
   OverrideMatcher (LLVM arch) md ()
 
 matchArg opts sc cc cs prepost actual expectedTy expected = do
@@ -1436,8 +1435,8 @@ learnEqual ::
   MS.CrucibleMethodSpecIR (LLVM arch)                             ->
   W4.ProgramLoc                                    ->
   PrePost                                          ->
-  SetupValue (Crucible.LLVM arch)       {- ^ first value to compare  -} ->
-  SetupValue (Crucible.LLVM arch)       {- ^ second value to compare -} ->
+  SetupValue (LLVM arch)       {- ^ first value to compare  -} ->
+  SetupValue (LLVM arch)       {- ^ second value to compare -} ->
   OverrideMatcher (LLVM arch) md ()
 learnEqual opts sc cc spec loc prepost v1 v2 = do
   (_, val1) <- resolveSetupValueLLVM opts cc sc spec v1
@@ -1766,8 +1765,8 @@ executeEqual ::
   SharedContext                                    ->
   LLVMCrucibleContext arch                           ->
   MS.CrucibleMethodSpecIR (LLVM arch)                             ->
-  SetupValue (Crucible.LLVM arch)       {- ^ first value to compare  -} ->
-  SetupValue (Crucible.LLVM arch)       {- ^ second value to compare -} ->
+  SetupValue (LLVM arch)       {- ^ first value to compare  -} ->
+  SetupValue (LLVM arch)       {- ^ second value to compare -} ->
   OverrideMatcher (LLVM arch) md ()
 executeEqual opts sc cc spec v1 v2 = do
   (_, val1) <- resolveSetupValueLLVM opts cc sc spec v1
@@ -1852,7 +1851,7 @@ resolveSetupValue ::
   SharedContext        ->
   MS.CrucibleMethodSpecIR (LLVM arch) ->
   Crucible.TypeRepr tp ->
-  SetupValue (Crucible.LLVM arch)           ->
+  SetupValue (LLVM arch)           ->
   OverrideMatcher (LLVM arch) md (Crucible.MemType, Crucible.RegValue Sym tp)
 resolveSetupValue opts cc sc spec tp sval =
   do (memTy, lval) <- resolveSetupValueLLVM opts cc sc spec sval

--- a/src/SAWScript/Crucible/LLVM/ResolveSetupValue.hs
+++ b/src/SAWScript/Crucible/LLVM/ResolveSetupValue.hs
@@ -84,7 +84,7 @@ resolveSetupValueInfo ::
   LLVMCrucibleContext wptr            {- ^ crucible context  -} ->
   Map AllocIndex LLVMAllocSpec {- ^ allocation types  -} ->
   Map AllocIndex Crucible.Ident   {- ^ allocation type names -} ->
-  SetupValue (Crucible.LLVM arch)                      {- ^ pointer to struct -} ->
+  SetupValue (LLVM arch)                      {- ^ pointer to struct -} ->
   L.Info                          {- ^ field index       -}
 resolveSetupValueInfo cc env nameEnv v =
   case v of
@@ -113,7 +113,7 @@ resolveSetupFieldIndex ::
   LLVMCrucibleContext arch {- ^ crucible context  -} ->
   Map AllocIndex LLVMAllocSpec {- ^ allocation types  -} ->
   Map AllocIndex Crucible.Ident   {- ^ allocation type names -} ->
-  SetupValue (Crucible.LLVM arch) {- ^ pointer to struct -} ->
+  SetupValue (LLVM arch) {- ^ pointer to struct -} ->
   String                          {- ^ field name        -} ->
   Maybe Int                       {- ^ field index       -}
 resolveSetupFieldIndex cc env nameEnv v n =
@@ -137,7 +137,7 @@ resolveSetupFieldIndexOrFail ::
   LLVMCrucibleContext arch {- ^ crucible context  -} ->
   Map AllocIndex LLVMAllocSpec {- ^ allocation types  -} ->
   Map AllocIndex Crucible.Ident   {- ^ allocation type names -} ->
-  SetupValue (Crucible.LLVM arch) {- ^ pointer to struct -} ->
+  SetupValue (LLVM arch) {- ^ pointer to struct -} ->
   String                          {- ^ field name        -} ->
   m Int                           {- ^ field index       -}
 resolveSetupFieldIndexOrFail cc env nameEnv v n =
@@ -160,7 +160,7 @@ typeOfSetupValue ::
   LLVMCrucibleContext arch ->
   Map AllocIndex LLVMAllocSpec ->
   Map AllocIndex Crucible.Ident ->
-  SetupValue (Crucible.LLVM arch) ->
+  SetupValue (LLVM arch) ->
   m Crucible.MemType
 typeOfSetupValue cc env nameEnv val =
   do let ?lc = ccTypeCtx cc
@@ -171,7 +171,7 @@ typeOfSetupValue' :: forall m arch.
   LLVMCrucibleContext arch ->
   Map AllocIndex LLVMAllocSpec ->
   Map AllocIndex Crucible.Ident ->
-  SetupValue (Crucible.LLVM arch) ->
+  SetupValue (LLVM arch) ->
   m Crucible.MemType
 typeOfSetupValue' cc env nameEnv val =
   case val of
@@ -265,7 +265,7 @@ resolveSetupElemIndexOrFail ::
   LLVMCrucibleContext arch {- ^ crucible context  -} ->
   Map AllocIndex LLVMAllocSpec {- ^ allocation types  -} ->
   Map AllocIndex Crucible.Ident   {- ^ allocation type names -} ->
-  SetupValue (Crucible.LLVM arch) {- ^ base pointer -} ->
+  SetupValue (LLVM arch) {- ^ base pointer -} ->
   Int                             {- ^ element index -} ->
   m Crucible.Bytes                {- ^ element offset -}
 resolveSetupElemIndexOrFail cc env nameEnv v i = do
@@ -298,7 +298,7 @@ resolveSetupVal :: forall arch.
   Map AllocIndex (LLVMPtr (Crucible.ArchWidth arch)) ->
   Map AllocIndex LLVMAllocSpec ->
   Map AllocIndex Crucible.Ident ->
-  SetupValue (Crucible.LLVM arch) ->
+  SetupValue (LLVM arch) ->
   IO LLVMVal
 resolveSetupVal cc mem env tyenv nameEnv val = do
   case val of

--- a/src/SAWScript/Crucible/LLVM/X86.hs
+++ b/src/SAWScript/Crucible/LLVM/X86.hs
@@ -76,9 +76,10 @@ import qualified SAWScript.Crucible.Common.Override as O
 import qualified SAWScript.Crucible.Common.Setup.Type as Setup
 
 import SAWScript.Crucible.LLVM.Builtins
-import SAWScript.Crucible.LLVM.MethodSpecIR
+import SAWScript.Crucible.LLVM.MethodSpecIR hiding (LLVM)
 import SAWScript.Crucible.LLVM.ResolveSetupValue
 import qualified SAWScript.Crucible.LLVM.Override as LO
+import qualified SAWScript.Crucible.LLVM.MethodSpecIR as LMS (LLVM)
 
 import qualified What4.Config as W4
 import qualified What4.Expr as W4
@@ -126,7 +127,7 @@ import qualified Data.ElfEdit as Elf
 -- ** Utility type synonyms and functions
 
 type LLVMArch = C.LLVM.X86 64
-type LLVM = C.LLVM.LLVM LLVMArch
+type LLVM = LMS.LLVM LLVMArch
 type LLVMOverrideMatcher = O.OverrideMatcher LLVM
 type Regs = Assignment (C.RegValue' Sym) (Macaw.MacawCrucibleRegTypes Macaw.X86_64)
 type Register = Macaw.X86Reg (Macaw.BVType 64)
@@ -526,7 +527,7 @@ buildMethodSpec lm nm loc checkSat setup =
     (mtargs, mtret) <- case (,) <$> mapM (llvmTypeToMemType lc) args <*> mapM (llvmTypeToMemType lc) ret of
       Left err -> fail err
       Right x -> pure x
-    let initialMethodSpec = MS.makeCrucibleMethodSpecIR @(C.LLVM.LLVM (C.LLVM.X86 64))
+    let initialMethodSpec = MS.makeCrucibleMethodSpecIR @LLVM
           methodId mtargs mtret programLoc lm
     view Setup.csMethodSpec <$> execStateT (runLLVMCrucibleSetupM setup)
       (Setup.makeCrucibleSetupState cc initialMethodSpec)

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -158,7 +158,7 @@ data AIGProxy where
   AIGProxy :: (Typeable l, Typeable g, AIG.IsAIG l g) => AIG.Proxy l g -> AIGProxy
 
 data SAW_CFG where
-  LLVM_CFG :: Crucible.AnyCFG (Crucible.LLVM arch) -> SAW_CFG
+  LLVM_CFG :: Crucible.AnyCFG Crucible.LLVM -> SAW_CFG
   JVM_CFG :: Crucible.AnyCFG JVM -> SAW_CFG
 
 data BuiltinContext = BuiltinContext { biSharedContext :: SharedContext
@@ -560,7 +560,7 @@ newtype LLVMCrucibleSetupM a =
     { runLLVMCrucibleSetupM ::
         forall arch.
         (?lc :: Crucible.TypeContext, Crucible.HasPtrWidth (Crucible.ArchWidth arch)) =>
-        CrucibleSetup (Crucible.LLVM arch) a
+        CrucibleSetup (CMSLLVM.LLVM arch) a
     }
   deriving Functor
 


### PR DESCRIPTION
This crucible PR removed the `arch` parameter from the `LLVM`
language-extension datatype. The type families defined in
`SAWScript.Crucible.Common.MethodSpec` had been using Crucible's
`LLVM arch` type as an index type, while making use of the `arch`
parameter. Now that Crucible's `LLVM` type has no `arch` parameter,
we can no longer use the same type as an index to the MethodSpec
types, so now we define our own `LLVM arch` type to use instead.