### PR TITLE
Add support for `prove` command and more provers to RPC API

### DIFF
--- a/saw-remote-api/docs/SAW.rst
+++ b/saw-remote-api/docs/SAW.rst
@@ -264,7 +264,7 @@ SAW/prove (command)
   
 
 ``goal``
-  The term to interpret as a theorm and prove.
+  The goal to interpret as a theorm and prove.
   
   
 Attempt to prove the given term representing a theorem, given a proof script context.

--- a/saw-remote-api/docs/SAW.rst
+++ b/saw-remote-api/docs/SAW.rst
@@ -263,7 +263,7 @@ SAW/prove (command)
   
   
 
-``term``
+``goal``
   The term to interpret as a theorm and prove.
   
   

--- a/saw-remote-api/docs/old-Saw.rst
+++ b/saw-remote-api/docs/old-Saw.rst
@@ -269,10 +269,32 @@ A proof script is represented as a JSON object with a single field:
   containing a tag named ``tactic``, with any further fields determined by this tag. These tag values can be:
 
   ``use prover``
-    Apply an external prover to the goal. There is an additional field ``prover`` which is a JSON object
-    with a field ``name`` specifying what prover to use (one of ``abc``, ``cvc4``, ``rme``, ``yices``, or ``z3``),
-    and a field ``uninterpreted functions`` when ``name`` is one of ``cvc4``, ``yices``, or ``z3``. This
-    field is a list of names of functions taken as uninterpreted/abstract.
+    Apply an external prover to the goal. There is an additional field
+    ``prover`` which is a JSON object with a field ``name`` specifying
+    what prover to use, and an optional field ``uninterpreted
+    functions``. This second field is a list of names of functions taken
+    as uninterpreted/abstract. The ``name`` field can be one of the following:
+
+    * ``abc``: Default version of ABC (which may change)
+    * ``boolector``: Default version of Boolector (which may change)
+    * ``cvc4``: Default version of ABC (which may change); supports uninterpreted functions
+    * ``internal-abc``: Linked-in version of the ABC library
+    * ``mathsat``: Default version of MathSAT (which may change); supports uninterpreted functions
+    * ``rme``: Internal implementation of Reed-Muller Expansion
+    * ``sbv-abc``: ABC through SMT-Lib2 using the SBV library
+    * ``sbv-boolector``: Boolector through SMT-Lib2 using the SBV library
+    * ``sbv-cvc4``: CVC4 through SMT-Lib2 using the SBV library; supports uninterpreted functions
+    * ``sbv-mathsat``: MathSAT through SMT-Lib2 using the SBV library; supports uninterpreted functions
+    * ``sbv-yices``: Yices through SMT-Lib2 using the SBV library; supports uninterpreted functions
+    * ``sbv-z3``: Z3 through SMT-Lib2 using the SBV library; supports uninterpreted functions
+    * ``w4-abc-verilog``: ABC through Verilog using the What4 library
+    * ``w4-abc-smtlib``: ABC through SMT-Lib2 using the What4 library
+    * ``w4-boolector``: Boolector through SMT-Lib2 using the What4 library
+    * ``w4-cvc4``: CVC4 through SMT-Lib2 using the What4 library; supports uninterpreted functions
+    * ``w4-yices``: Yices through its native format using the What4 library; supports uninterpreted functions
+    * ``w4-z3``: Z3 through SMT-Lib2 using the What4 library; supports uninterpreted functions
+    * ``yices``: Default version of Yices (which may change); supports uninterpreted functions
+    * ``z3``: Default version of Z3 (which may change); supports uninterpreted functions
 
   ``unfold``
     Unfold terms in the context/goal. There is an additional field ``names``, a list of the names bound on
@@ -288,9 +310,8 @@ A proof script is represented as a JSON object with a single field:
   ``simplify``
     Simplify the context/goal. There is an additional field ``rules``, a name bound to a simpset on the server.
 
-  ``assume unsat``
-    Assume the goal is unsatisfiable, which in the current implementation of SAW should be interpreted as
-    assuming the property being checked to be true. This is likely to change in the future.
+  ``admit``
+    Admit the goal as valid without checking.
 
   ``trivial``
     States that the goal should be trivially true (either the constant ``True`` or a function that immediately

--- a/saw-remote-api/python/saw/__init__.py
+++ b/saw-remote-api/python/saw/__init__.py
@@ -59,9 +59,20 @@ class ProofResult(metaclass=ABCMeta):
     counterexample: Any
 
     def is_valid(self) -> bool:
+        """Returns @True@ in the case where the given proof goal is valid, or true for
+        all possible values of any symbolic variables that it contains. Returns
+        @False@ if the goal can possibly be false for any value of symbolic
+        variables it contains. In this latter case, the @get_counterexample@
+        function will return the variable values for which the goal evaluates
+        to false.
+        """
         return self.valid
 
     def get_counterexample(self) -> Any:
+        """In the case where @is_valid@ returns @False@, this function returns the
+        counterexample that provides the values for symbolic variables that
+        lead to it being false. If @is_valid@ returns @True@, returns @None@.
+        """
         return self.counterexample
 
 @dataclass
@@ -434,6 +445,11 @@ def llvm_verify(module: LLVMModule,
 
 def prove(goal: cryptoltypes.CryptolJSON,
           proof_script: proofscript.ProofScript) -> ProofResult:
+    """Atempts to prove that the expression given as the first argument, @goal@, is
+    true for all possible values of free symbolic variables. Uses the proof
+    script (potentially specifying an automated prover) provided by the second
+    argument.
+    """
     conn = __get_designated_connection()
     res = conn.prove(cryptoltypes.to_cryptol(goal),
                      proof_script.to_json()).result()

--- a/saw-remote-api/python/saw/__init__.py
+++ b/saw-remote-api/python/saw/__init__.py
@@ -8,6 +8,8 @@ import signal
 import atexit
 from distutils.spawn import find_executable
 
+import cryptol
+
 from cryptol import cryptoltypes
 from . import connection
 from argo_client.connection import ServerConnection
@@ -461,7 +463,8 @@ def prove(goal: cryptoltypes.CryptolJSON,
     else:
         raise ValueError("Unknown proof result " + str(res))
     if 'counterexample' in res:
-        pr.counterexample = res['counterexample']
+        pr.counterexample = [ (arg['name'], cryptol.from_cryptol_arg(arg['value']))
+                              for arg in res['counterexample'] ]
     return pr
 
 @atexit.register

--- a/saw-remote-api/python/saw/__init__.py
+++ b/saw-remote-api/python/saw/__init__.py
@@ -58,7 +58,7 @@ class VerificationResult(metaclass=ABCMeta):
 class ProofResult(metaclass=ABCMeta):
     goal: proofscript.ProofScript
     valid: bool
-    counterexample: Any
+    counterexample: Optional[Any]
 
     def is_valid(self) -> bool:
         """Returns @True@ in the case where the given proof goal is valid, or true for
@@ -465,6 +465,8 @@ def prove(goal: cryptoltypes.CryptolJSON,
     if 'counterexample' in res:
         pr.counterexample = [ (arg['name'], cryptol.from_cryptol_arg(arg['value']))
                               for arg in res['counterexample'] ]
+    else:
+        pr.counterexample = None
     return pr
 
 @atexit.register

--- a/saw-remote-api/python/saw/__init__.py
+++ b/saw-remote-api/python/saw/__init__.py
@@ -61,19 +61,19 @@ class ProofResult(metaclass=ABCMeta):
     counterexample: Optional[Any]
 
     def is_valid(self) -> bool:
-        """Returns @True@ in the case where the given proof goal is valid, or true for
+        """Returns `True` in the case where the given proof goal is valid, or true for
         all possible values of any symbolic variables that it contains. Returns
-        @False@ if the goal can possibly be false for any value of symbolic
-        variables it contains. In this latter case, the @get_counterexample@
+        `False` if the goal can possibly be false for any value of symbolic
+        variables it contains. In this latter case, the `get_counterexample`
         function will return the variable values for which the goal evaluates
         to false.
         """
         return self.valid
 
     def get_counterexample(self) -> Any:
-        """In the case where @is_valid@ returns @False@, this function returns the
+        """In the case where `is_valid` returns `False`, this function returns the
         counterexample that provides the values for symbolic variables that
-        lead to it being false. If @is_valid@ returns @True@, returns @None@.
+        lead to it being false. If `is_valid` returns `True`, returns `None`.
         """
         return self.counterexample
 
@@ -447,7 +447,7 @@ def llvm_verify(module: LLVMModule,
 
 def prove(goal: cryptoltypes.CryptolJSON,
           proof_script: proofscript.ProofScript) -> ProofResult:
-    """Atempts to prove that the expression given as the first argument, @goal@, is
+    """Atempts to prove that the expression given as the first argument, `goal`, is
     true for all possible values of free symbolic variables. Uses the proof
     script (potentially specifying an automated prover) provided by the second
     argument.

--- a/saw-remote-api/python/saw/__init__.py
+++ b/saw-remote-api/python/saw/__init__.py
@@ -8,6 +8,7 @@ import signal
 import atexit
 from distutils.spawn import find_executable
 
+from cryptol import cryptoltypes
 from . import connection
 from argo_client.connection import ServerConnection
 from . import llvm
@@ -421,6 +422,10 @@ def llvm_verify(module: LLVMModule,
 
     return result
 
+def prove(goal: cryptoltypes.CryptolJSON,
+          proof_script: Optional[proofscript.ProofScript] = None):
+    return __get_designated_connection().prove(cryptoltypes.to_cryptol(goal),
+                                               proof_script.to_json()).result()
 
 @atexit.register
 def script_exit() -> None:

--- a/saw-remote-api/python/saw/commands.py
+++ b/saw-remote-api/python/saw/commands.py
@@ -97,12 +97,7 @@ class Prove(SAWCommand):
         super(Prove, self).__init__('SAW/prove', params, connection)
 
     def process_result(self, res : Any) -> Any:
-        if res['status'] == 'valid':
-            return True
-        elif res['status'] == 'invalid':
-            return False
-        else:
-            raise ValueError("Unknown proof result " + str(res))
+        return res
 
 class SAWReset(argo.Notification):
     def __init__(self, connection : argo.HasProtocolState) -> None:

--- a/saw-remote-api/python/saw/commands.py
+++ b/saw-remote-api/python/saw/commands.py
@@ -1,5 +1,9 @@
 import argo_client.interaction as argo
+from typing import Any, Dict, List, Optional, Set, Union, overload
+
+from cryptol import cryptoltypes
 from . import exceptions
+from saw.proofscript import *
 
 from typing import Any, List
 
@@ -68,7 +72,7 @@ class LLVMVerify(SAWCommand):
             lemmas : List[str],
             check_sat : bool,
             setup : Any,
-            script : str,
+            script : ProofScript,
             lemma_name : str) -> None:
         params = {'module': module,
                   'function': function,
@@ -81,6 +85,24 @@ class LLVMVerify(SAWCommand):
 
     def process_result(self, _res : Any) -> Any:
         return None
+
+class Prove(SAWCommand):
+    def __init__(
+            self,
+            connection : argo.HasProtocolState,
+            goal : cryptoltypes.CryptolJSON,
+            script : ProofScript) -> None:
+        params = {'goal': goal,
+                  'script': script}
+        super(Prove, self).__init__('SAW/prove', params, connection)
+
+    def process_result(self, res : Any) -> Any:
+        if res['status'] == 'valid':
+            return True
+        elif res['status'] == 'invalid':
+            return False
+        else:
+            raise ValueError("Unknown proof result " + str(res))
 
 class SAWReset(argo.Notification):
     def __init__(self, connection : argo.HasProtocolState) -> None:

--- a/saw-remote-api/python/saw/connection.py
+++ b/saw-remote-api/python/saw/connection.py
@@ -161,7 +161,7 @@ class SAWConnection:
                     lemmas: List[str],
                     check_sat: bool,
                     contract: Any,
-                    script: Any,
+                    script: ProofScript,
                     lemma_name: str) -> Command:
         self.most_recent_result = \
             LLVMVerify(self, module, function, lemmas, check_sat, contract, script, lemma_name)
@@ -174,4 +174,8 @@ class SAWConnection:
                     lemma_name: str) -> Command:
         self.most_recent_result = \
             LLVMAssume(self, module, function, contract, lemma_name)
+        return self.most_recent_result
+
+    def prove(self, goal, proof_script):
+        self.most_recent_result = Prove(self, goal, proof_script)
         return self.most_recent_result

--- a/saw-remote-api/python/saw/connection.py
+++ b/saw-remote-api/python/saw/connection.py
@@ -176,6 +176,8 @@ class SAWConnection:
             LLVMAssume(self, module, function, contract, lemma_name)
         return self.most_recent_result
 
-    def prove(self, goal, proof_script):
+    def prove(self,
+              goal: cryptoltypes.CryptolJSON,
+              proof_script: ProofScript) -> Command:
         self.most_recent_result = Prove(self, goal, proof_script)
         return self.most_recent_result

--- a/saw-remote-api/python/saw/connection.py
+++ b/saw-remote-api/python/saw/connection.py
@@ -179,5 +179,10 @@ class SAWConnection:
     def prove(self,
               goal: cryptoltypes.CryptolJSON,
               proof_script: ProofScript) -> Command:
+        """Atempts to prove that the expression given as the first argument, @goal@, is
+        true for all possible values of free symbolic variables. Uses the proof
+        script (potentially specifying an automated prover) provided by the
+        second argument.
+        """
         self.most_recent_result = Prove(self, goal, proof_script)
         return self.most_recent_result

--- a/saw-remote-api/python/saw/proofscript.py
+++ b/saw-remote-api/python/saw/proofscript.py
@@ -23,7 +23,7 @@ class ABC_SBV(Prover):
 
 class Boolector(Prover):
   def to_json(self) -> Any:
-    return { "name": "w4-boolector" }
+    return { "name": "boolector" }
 
 class Boolector_SBV(Prover):
   def to_json(self) -> Any:

--- a/saw-remote-api/python/saw/proofscript.py
+++ b/saw-remote-api/python/saw/proofscript.py
@@ -61,9 +61,9 @@ class EvaluateGoal(ProofTactic):
 
 # TODO: add "simplify"
 
-class AssumeUnsat(ProofTactic):
+class Admit(ProofTactic):
   def to_json(self) -> Any:
-    return { "tactic": "assume unsat" }
+    return { "tactic": "admit" }
 
 class BetaReduceGoal(ProofTactic):
   def to_json(self) -> Any:

--- a/saw-remote-api/python/saw/proofscript.py
+++ b/saw-remote-api/python/saw/proofscript.py
@@ -9,6 +9,26 @@ class ABC(Prover):
   def to_json(self) -> Any:
     return { "name": "abc" }
 
+class ABC_Verilog(Prover):
+  def to_json(self) -> Any:
+    return { "name": "w4-abc-verilog" }
+
+class ABC_SMTLib(Prover):
+  def to_json(self) -> Any:
+    return { "name": "w4-abc-smtlib" }
+
+class ABC_SBV(Prover):
+  def to_json(self) -> Any:
+    return { "name": "sbv-abc" }
+
+class Boolector(Prover):
+  def to_json(self) -> Any:
+    return { "name": "w4-boolector" }
+
+class Boolector_SBV(Prover):
+  def to_json(self) -> Any:
+    return { "name": "sbv-boolector" }
+
 class RME(Prover):
   def to_json(self) -> Any:
     return { "name": "rme" }
@@ -23,15 +43,27 @@ class UnintProver(Prover):
 
 class CVC4(UnintProver):
   def __init__(self, unints : List[str]) -> None:
-    super().__init__("cvc4", unints)
+    super().__init__("w4-cvc4", unints)
 
 class Yices(UnintProver):
   def __init__(self, unints : List[str]) -> None:
-    super().__init__("yices", unints)
+    super().__init__("w4-yices", unints)
 
 class Z3(UnintProver):
   def __init__(self, unints : List[str]) -> None:
-    super().__init__("z3", unints)
+    super().__init__("w4-z3", unints)
+
+class CVC4_SBV(UnintProver):
+  def __init__(self, unints : List[str]) -> None:
+    super().__init__("sbv-cvc4", unints)
+
+class Yices_SBV(UnintProver):
+  def __init__(self, unints : List[str]) -> None:
+    super().__init__("sbv-yices", unints)
+
+class Z3_SBV(UnintProver):
+  def __init__(self, unints : List[str]) -> None:
+    super().__init__("sbv-z3", unints)
 
 class ProofTactic(metaclass=ABCMeta):
   @abstractmethod
@@ -81,7 +113,10 @@ class ProofScript:
     return { 'tactics': [t.to_json() for t in self.tactics] }
 
 abc = UseProver(ABC())
+abc_smtlib = UseProver(ABC_SMTLib())
+abc_verilog = UseProver(ABC_Verilog())
 rme = UseProver(RME())
+boolector = UseProver(Boolector())
 
 def cvc4(unints : List[str]) -> ProofTactic:
   return UseProver(CVC4(unints))

--- a/saw-remote-api/python/tests/saw/test_provers.py
+++ b/saw-remote-api/python/tests/saw/test_provers.py
@@ -1,4 +1,5 @@
 from cryptol import cryptoltypes
+from cryptol.bitvector import BV
 import saw
 from saw.proofscript import *
 
@@ -36,7 +37,7 @@ class ProverTest(unittest.TestCase):
         pr = saw.prove(simple_non_thm, ProofScript([z3([])]))
         self.assertFalse(pr.is_valid())
         cex = pr.get_counterexample()
-        self.assertEqual(cex[0]['value']['data'], '5')
+        self.assertEqual(cex, [('x', BV(8, 0x05))])
 
 
 if __name__ == "__main__":

--- a/saw-remote-api/python/tests/saw/test_provers.py
+++ b/saw-remote-api/python/tests/saw/test_provers.py
@@ -6,6 +6,9 @@ import unittest
 from pathlib import Path
 
 
+def cry(exp):
+    return cryptoltypes.CryptolLiteral(exp)
+
 class ProverTest(unittest.TestCase):
 
     @classmethod
@@ -21,13 +24,16 @@ class ProverTest(unittest.TestCase):
 
         if __name__ == "__main__": saw.view(saw.LogResults())
 
-        self.assertTrue(saw.prove(cryptoltypes.CryptolLiteral('True'), ProofScript([abc])))
-        self.assertTrue(saw.prove(cryptoltypes.CryptolLiteral('True'), ProofScript([yices([])])))
-        self.assertTrue(saw.prove(cryptoltypes.CryptolLiteral('True'), ProofScript([z3([])])))
+        simple_thm = cry('\(x:[8]) -> x != x+1')
+        self.assertTrue(saw.prove(simple_thm, ProofScript([abc])))
+        self.assertTrue(saw.prove(simple_thm, ProofScript([yices([])])))
+        self.assertTrue(saw.prove(simple_thm, ProofScript([z3([])])))
 
-        self.assertTrue(saw.prove(cryptoltypes.CryptolLiteral('True'), ProofScript([Admit()])))
+        self.assertTrue(saw.prove(simple_thm, ProofScript([Admit()])))
+        self.assertTrue(saw.prove(cry('True'), ProofScript([Trivial()])))
 
-        self.assertFalse(saw.prove(cryptoltypes.CryptolLiteral('False'), ProofScript([z3([])])))
+        simple_non_thm = cry('\(x:[8]) -> x == x+1')
+        self.assertFalse(saw.prove(simple_non_thm, ProofScript([z3([])])))
 
 
 if __name__ == "__main__":

--- a/saw-remote-api/python/tests/saw/test_provers.py
+++ b/saw-remote-api/python/tests/saw/test_provers.py
@@ -27,7 +27,6 @@ class ProverTest(unittest.TestCase):
 
         simple_thm = cry('\(x:[8]) -> x != x+1')
         self.assertTrue(saw.prove(simple_thm, ProofScript([abc])).is_valid())
-        self.assertTrue(saw.prove(simple_thm, ProofScript([yices([])])).is_valid())
         self.assertTrue(saw.prove(simple_thm, ProofScript([z3([])])).is_valid())
 
         self.assertTrue(saw.prove(simple_thm, ProofScript([Admit()])).is_valid())

--- a/saw-remote-api/python/tests/saw/test_provers.py
+++ b/saw-remote-api/python/tests/saw/test_provers.py
@@ -25,15 +25,18 @@ class ProverTest(unittest.TestCase):
         if __name__ == "__main__": saw.view(saw.LogResults())
 
         simple_thm = cry('\(x:[8]) -> x != x+1')
-        self.assertTrue(saw.prove(simple_thm, ProofScript([abc])))
-        self.assertTrue(saw.prove(simple_thm, ProofScript([yices([])])))
-        self.assertTrue(saw.prove(simple_thm, ProofScript([z3([])])))
+        self.assertTrue(saw.prove(simple_thm, ProofScript([abc])).is_valid())
+        self.assertTrue(saw.prove(simple_thm, ProofScript([yices([])])).is_valid())
+        self.assertTrue(saw.prove(simple_thm, ProofScript([z3([])])).is_valid())
 
-        self.assertTrue(saw.prove(simple_thm, ProofScript([Admit()])))
-        self.assertTrue(saw.prove(cry('True'), ProofScript([Trivial()])))
+        self.assertTrue(saw.prove(simple_thm, ProofScript([Admit()])).is_valid())
+        self.assertTrue(saw.prove(cry('True'), ProofScript([Trivial()])).is_valid())
 
-        simple_non_thm = cry('\(x:[8]) -> x == x+1')
-        self.assertFalse(saw.prove(simple_non_thm, ProofScript([z3([])])))
+        simple_non_thm = cry('\(x:[8]) -> x != 5')
+        pr = saw.prove(simple_non_thm, ProofScript([z3([])]))
+        self.assertFalse(pr.is_valid())
+        cex = pr.get_counterexample()
+        self.assertEqual(cex[0]['value']['data'], '5')
 
 
 if __name__ == "__main__":

--- a/saw-remote-api/python/tests/saw/test_provers.py
+++ b/saw-remote-api/python/tests/saw/test_provers.py
@@ -1,0 +1,34 @@
+from cryptol import cryptoltypes
+import saw
+from saw.proofscript import *
+
+import unittest
+from pathlib import Path
+
+
+class ProverTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        saw.connect(reset_server=True)
+
+    @classmethod
+    def tearDownClass(self):
+        saw.reset_server()
+        saw.disconnect()
+
+    def test_provers(self):
+
+        if __name__ == "__main__": saw.view(saw.LogResults())
+
+        self.assertTrue(saw.prove(cryptoltypes.CryptolLiteral('True'), ProofScript([abc])))
+        self.assertTrue(saw.prove(cryptoltypes.CryptolLiteral('True'), ProofScript([yices([])])))
+        self.assertTrue(saw.prove(cryptoltypes.CryptolLiteral('True'), ProofScript([z3([])])))
+
+        self.assertTrue(saw.prove(cryptoltypes.CryptolLiteral('True'), ProofScript([Admit()])))
+
+        self.assertFalse(saw.prove(cryptoltypes.CryptolLiteral('False'), ProofScript([z3([])])))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/saw-remote-api/src/SAWServer/ProofScript.hs
+++ b/saw-remote-api/src/SAWServer/ProofScript.hs
@@ -82,6 +82,7 @@ instance FromJSON Prover where
       case name of
         "abc"            -> pure ABC_Internal
         "internal-abc"   -> pure ABC_Internal
+        "boolector"      -> SBV_Boolector <$> unints
         "rme"            -> pure RME
         "sbv-abc"        -> pure SBV_ABC_SMTLib
         "sbv-boolector"  -> SBV_Boolector <$> unints

--- a/saw-remote-api/src/SAWServer/ProofScript.hs
+++ b/saw-remote-api/src/SAWServer/ProofScript.hs
@@ -10,9 +10,9 @@ module SAWServer.ProofScript
   ) where
 
 import Control.Applicative ( Alternative(empty) )
-import Control.Exception ( throw )
+import Control.Exception ( Exception, throw )
 import Control.Lens ( view )
-import Control.Monad (foldM)
+import Control.Monad (foldM, forM)
 import Control.Monad.IO.Class ( MonadIO(liftIO) )
 import Data.Aeson
     ( (.:), (.:?),
@@ -22,11 +22,12 @@ import Data.Aeson
       KeyValue((.=)),
       ToJSON(toJSON) )
 import Data.Maybe ( fromMaybe )
-import Data.Text (Text)
+import Data.Text (Text, pack)
+import Numeric (showHex)
 
 import qualified Argo
 import qualified Argo.Doc as Doc
-import CryptolServer.Data.Expression ( Expression, getCryptolExpr )
+import CryptolServer.Data.Expression ( Expression(..), Encoding(..), getCryptolExpr )
 import qualified SAWScript.Builtins as SB
 import qualified SAWScript.Value as SV
 import qualified SAWScript.Proof as PF
@@ -43,6 +44,8 @@ import SAWServer.CryptolExpression ( CryptolModuleException(..), getTypedTermOfC
 import SAWServer.Exceptions ( notASimpset )
 import SAWServer.OK ( OK, ok )
 import SAWServer.TopLevel ( tl )
+import Verifier.SAW.FiniteValue (FirstOrderValue(..))
+import Verifier.SAW.Name (ecName, toShortName)
 import Verifier.SAW.Rewriter (addSimp, emptySimpset)
 import Verifier.SAW.TermNet (merge)
 import Verifier.SAW.TypedTerm (TypedTerm(..))
@@ -177,25 +180,47 @@ instance Doc.DescribedParams (ProveParams cryptolExpr) where
        Doc.Paragraph [Doc.Text "The goal to interpret as a theorm and prove."])
     ]
 
---data CexValue = CexValue String TypedTerm
+data CexValue = CexValue Text Expression
 
 data ProveResult
   = ProofValid
-  | ProofInvalid -- [CexValue]
+  | ProofInvalid [CexValue]
+  | ProofUnknown
 
---instance ToJSON CexValue where
---  toJSON (CexValue n t) = object [ "name" .= n, "value" .= t ]
+instance ToJSON CexValue where
+  toJSON (CexValue n t) = object [ "name" .= n, "value" .= t ]
 
 instance ToJSON ProveResult where
   toJSON ProofValid = object [ "status" .= ("valid" :: Text)]
-  toJSON ProofInvalid {-cex-} =
-    object [ "status" .= ("invalid" :: Text) ] -- , "counterexample" .= cex]
+  toJSON ProofUnknown = object [ "status" .= ("unknown" :: Text)]
+  toJSON (ProofInvalid cex) =
+    object [ "status" .= ("invalid" :: Text), "counterexample" .= cex]
 
 
 proveDescr :: Doc.Block
 proveDescr =
   Doc.Paragraph [ Doc.Text "Attempt to prove the given term representing a"
                 , Doc.Text " theorem, given a proof script context."]
+
+exportFirstOrderExpression :: FirstOrderValue -> Either String Expression
+exportFirstOrderExpression fv =
+  case fv of
+    FOVBit b    -> return $ Bit b
+    FOVInt i    -> return $ Integer i
+    FOVIntMod m i -> return $ IntegerModulo i (toInteger m)
+    FOVWord w x -> return $ Num Hex (pack (showHex x "")) (toInteger w)
+    FOVVec _t vs -> Sequence <$> mapM exportFirstOrderExpression vs
+    FOVArray{}  -> Left "exportFirstOrderExpression: unsupported type: Array"
+    FOVTuple vs -> Tuple <$> mapM exportFirstOrderExpression vs
+    FOVRec _vm  -> Left "exportFirstOrderExpression: unsupported type: Record"
+
+
+data ProveException = ProveException String
+
+instance Show ProveException where
+    show (ProveException msg) = "Exception in `prove` command: " ++ msg
+
+instance Exception ProveException
 
 prove :: ProveParams Expression -> Argo.Command SAWState ProveResult
 prove params = do
@@ -211,9 +236,18 @@ prove params = do
   proofScript <- interpretProofScript (ppScript params)
   res <- tl $ SB.provePrim proofScript t
   case res of
-    PF.ValidProof{}      -> return ProofValid
-    PF.InvalidProof{}    -> return ProofInvalid
-    PF.UnfinishedProof{} -> return ProofInvalid
+    PF.ValidProof{} ->
+      return ProofValid
+    PF.InvalidProof _ cex _ ->
+      do cexVals <- forM cex $
+                      \(ec, v) ->
+                         do e <- case exportFirstOrderExpression v of
+                                   Left err -> throw $ ProveException err
+                                   Right e -> return e
+                            return $ CexValue (toShortName (ecName ec)) e
+         return $ ProofInvalid $ cexVals
+    PF.UnfinishedProof{} ->
+      return ProofUnknown
 
 interpretProofScript :: ProofScript -> Argo.Command SAWState (SV.ProofScript ())
 interpretProofScript (ProofScript ts) = go ts
@@ -248,4 +282,4 @@ interpretProofScript (ProofScript ts) = go ts
           ss <- getSimpset sn
           m <- go rest
           return (SB.simplifyGoal ss >> m)
-        go _ = error "malformed proof script"
+        go _ = throw $ ProveException "malformed proof script"

--- a/saw-remote-api/src/SAWServer/ProofScript.hs
+++ b/saw-remote-api/src/SAWServer/ProofScript.hs
@@ -84,25 +84,25 @@ instance FromJSON Prover where
       let unints = fromMaybe [] <$> o .:? "uninterpreted functions"
       case name of
         "abc"            -> pure ABC_Internal
-        "internal-abc"   -> pure ABC_Internal
         "boolector"      -> SBV_Boolector <$> unints
+        "cvc4"           -> SBV_CVC4  <$> unints
+        "internal-abc"   -> pure ABC_Internal
+        "mathsat"        -> SBV_MathSAT <$> unints
         "rme"            -> pure RME
         "sbv-abc"        -> pure SBV_ABC_SMTLib
         "sbv-boolector"  -> SBV_Boolector <$> unints
         "sbv-cvc4"       -> SBV_CVC4  <$> unints
-        "cvc4"           -> SBV_CVC4  <$> unints
         "sbv-mathsat"    -> SBV_MathSAT <$> unints
-        "mathsat"        -> SBV_MathSAT <$> unints
         "sbv-yices"      -> SBV_Yices <$> unints
-        "yices"          -> SBV_Yices <$> unints
         "sbv-z3"         -> SBV_Z3    <$> unints
-        "z3"             -> SBV_Z3    <$> unints
-        "w4-abc-verilog" -> pure W4_ABC_Verilog
         "w4-abc-smtlib"  -> pure W4_ABC_SMTLib
+        "w4-abc-verilog" -> pure W4_ABC_Verilog
         "w4-boolector"   -> W4_Boolector <$> unints
         "w4-cvc4"        -> W4_CVC4   <$> unints
         "w4-yices"       -> W4_Yices  <$> unints
         "w4-z3"          -> W4_Z3     <$> unints
+        "yices"          -> SBV_Yices <$> unints
+        "z3"             -> SBV_Z3    <$> unints
         _                -> empty
 
 instance FromJSON ProofTactic where

--- a/saw-remote-api/src/SAWServer/ProofScript.hs
+++ b/saw-remote-api/src/SAWServer/ProofScript.hs
@@ -10,7 +10,10 @@ module SAWServer.ProofScript
   ) where
 
 import Control.Applicative ( Alternative(empty) )
+import Control.Exception ( throw )
+import Control.Lens ( view )
 import Control.Monad (foldM)
+import Control.Monad.IO.Class ( MonadIO(liftIO) )
 import Data.Aeson
     ( (.:), (.:?),
       withObject,
@@ -18,11 +21,12 @@ import Data.Aeson
       FromJSON(parseJSON),
       KeyValue((.=)),
       ToJSON(toJSON) )
-import Data.Maybe (maybeToList)
+import Data.Maybe ( fromMaybe )
 import Data.Text (Text)
 
 import qualified Argo
 import qualified Argo.Doc as Doc
+import CryptolServer.Data.Expression ( Expression, getCryptolExpr )
 import qualified SAWScript.Builtins as SB
 import qualified SAWScript.Value as SV
 import qualified SAWScript.Proof as PF
@@ -33,7 +37,9 @@ import SAWServer
       setServerVal,
       getServerVal,
       getSimpset,
-      getTerm )
+      sawBIC,
+      sawTopLevelRW)
+import SAWServer.CryptolExpression ( CryptolModuleException(..), getTypedTermOfCExp )
 import SAWServer.Exceptions ( notASimpset )
 import SAWServer.OK ( OK, ok )
 import SAWServer.TopLevel ( tl )
@@ -63,7 +69,7 @@ data ProofTactic
   | BetaReduceGoal
   | EvaluateGoal [String]
   | Simplify ServerName
-  | AssumeUnsat
+  | Admit
   | Trivial
 
 newtype ProofScript = ProofScript [ProofTactic]
@@ -72,7 +78,7 @@ instance FromJSON Prover where
   parseJSON =
     withObject "prover" $ \o -> do
       (name :: String) <- o .: "name"
-      let unints = maybeToList <$> o .:? "uninterpreted functions"
+      let unints = fromMaybe [] <$> o .:? "uninterpreted functions"
       case name of
         "abc"            -> pure ABC_Internal
         "internal-abc"   -> pure ABC_Internal
@@ -105,7 +111,7 @@ instance FromJSON ProofTactic where
         "beta reduce goal" -> pure BetaReduceGoal
         "evalute goal"     -> EvaluateGoal <$> o .: "uninterpreted functions"
         "simplify"         -> Simplify <$> o .: "rules"
-        "assume unsat"     -> pure AssumeUnsat
+        "admit"            -> pure Admit
         "trivial"          -> pure Trivial
         _                  -> empty
 
@@ -150,24 +156,24 @@ makeSimpset params = do
   setServerVal (ssResult params) ss
   ok
 
-data ProveParams =
+data ProveParams cryptolExpr =
   ProveParams
-  { ppScript   :: ProofScript
-  , ppTermName :: ServerName
+  { ppScript :: ProofScript
+  , ppGoal   :: cryptolExpr
   }
 
-instance FromJSON ProveParams where
+instance (FromJSON cryptolExpr) => FromJSON (ProveParams cryptolExpr) where
   parseJSON =
     withObject "SAW/prove params" $ \o ->
     ProveParams <$> o .: "script"
-                <*> o .: "term"
+                <*> o .: "goal"
 
-instance Doc.DescribedParams ProveParams where
+instance Doc.DescribedParams (ProveParams cryptolExpr) where
   parameterFieldDescription =
     [ ("script",
        Doc.Paragraph [Doc.Text "Script to use to prove the term."])
-    , ("term",
-       Doc.Paragraph [Doc.Text "The term to interpret as a theorm and prove."])
+    , ("goal",
+       Doc.Paragraph [Doc.Text "The goal to interpret as a theorm and prove."])
     ]
 
 --data CexValue = CexValue String TypedTerm
@@ -190,9 +196,17 @@ proveDescr =
   Doc.Paragraph [ Doc.Text "Attempt to prove the given term representing a"
                 , Doc.Text " theorem, given a proof script context."]
 
-prove :: ProveParams -> Argo.Command SAWState ProveResult
+prove :: ProveParams Expression -> Argo.Command SAWState ProveResult
 prove params = do
-  t <- getTerm (ppTermName params)
+  state <- Argo.getState
+  fileReader <- Argo.getFileReader
+  let cenv = SV.rwCryptol (view sawTopLevelRW state)
+      bic = view sawBIC state
+  cexp <- getCryptolExpr (ppGoal params)
+  (eterm, warnings) <- liftIO $ getTypedTermOfCExp fileReader (SV.biSharedContext bic) cenv cexp
+  t <- case eterm of
+         Right (t, _) -> return t -- TODO: report warnings
+         Left err -> throw $ CryptolModuleException err warnings
   proofScript <- interpretProofScript (ppScript params)
   res <- tl $ SB.provePrim proofScript t
   case res of
@@ -219,7 +233,7 @@ interpretProofScript (ProofScript ts) = go ts
             W4_Yices unints       -> return $ SB.w4_unint_yices unints
             W4_Z3 unints          -> return $ SB.w4_unint_z3 unints
         go [Trivial]                  = return $ SB.trivial
-        go [AssumeUnsat]              = return $ SB.assumeUnsat
+        go [Admit]                    = return $ SB.assumeUnsat -- TODO: admit
         go (BetaReduceGoal : rest)    = do
           m <- go rest
           return (SB.beta_reduce_goal >> m)


### PR DESCRIPTION
This adds a new command, `prove`, to the remote API, and a `ProofResult` type in Python to hold its results. It also adds support for a wider range of provers to the server and Python client.
