### PR TITLE
Use correct link for GitHub Actions README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/GaloisInc/saw-script/workflows/Nightly%20Builds/badge.svg)](https://github.com/GaloisInc/saw-script/actions?query=workflow%3ANightly%20Builds)
+[![Build Status](https://github.com/GaloisInc/saw-script/workflows/Nightly%20Builds/badge.svg)](https://github.com/GaloisInc/saw-script/actions?query=event%3Aschedule)
 
 # SAWScript
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build Status](https://github.com/actions/GaloisInc/saw-script/workflows/.github/workflows/nightly.yml/badge.svg)
+[![Build Status](https://github.com/GaloisInc/saw-script/workflows/Nightly%20Builds/badge.svg)](https://github.com/GaloisInc/saw-script/actions?query=workflow%3ANightly%20Builds)
 
 # SAWScript
 


### PR DESCRIPTION
Currently, the GitHub Actions README badge doesn't display properly:

![saw-script](https://user-images.githubusercontent.com/2364661/115586169-4fa7ea80-a29a-11eb-992a-d363ae62ae42.png)

After this patch, it now looks like:

![saw-script2](https://user-images.githubusercontent.com/2364661/115586185-52a2db00-a29a-11eb-8961-a8bb125f97dc.png)