### PR TITLE
saw/Dockerfile: Install libreadline-dev in last stage

### DIFF
--- a/saw/Dockerfile
+++ b/saw/Dockerfile
@@ -60,7 +60,7 @@ RUN chown -R root:root /home/saw/rootfs
 
 FROM debian:buster-slim
 RUN apt-get update \
-    && apt-get install -y libgmp10 libgomp1 libffi6 wget libncurses5 unzip
+    && apt-get install -y libgmp10 libgomp1 libffi6 wget libncurses5 libreadline-dev unzip
 COPY --from=build /home/saw/rootfs /
 COPY --from=solvers /solvers/rootfs /
 RUN useradd -m saw && chown -R saw:saw /home/saw


### PR DESCRIPTION
This is necessary for `saw` commands that rely on `libreadline` to work, such as `write_cnf_external`.

Fixes #1211.