### PR TITLE
saw-core-sbv: Handle zero-width bitvectors properly in counterexamples.

### DIFF
--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -667,6 +667,7 @@ data Labeler
    = BoolLabel String
    | IntegerLabel String
    | WordLabel String
+   | ZeroWidthWordLabel
    | VecLabel (Vector Labeler)
    | TupleLabel (Vector Labeler)
    | RecLabel (Map FieldName Labeler)
@@ -684,7 +685,7 @@ newVars FOTInt = nextId <&> \s-> (IntegerLabel s, vInteger <$> existsSInteger s)
 newVars (FOTIntMod n) = nextId <&> \s-> (IntegerLabel s, VIntMod n <$> existsSInteger s)
 newVars (FOTVec n FOTBit) =
   if n == 0
-    then nextId <&> \s-> (WordLabel s, return (vWord (literalSWord 0 0)))
+    then pure (ZeroWidthWordLabel, pure (vWord (literalSWord 0 0)))
     else nextId <&> \s-> (WordLabel s, vWord <$> existsSWord s (fromIntegral n))
 newVars (FOTVec n tp) = do
   (labels, vals) <- V.unzip <$> V.replicateM (fromIntegral n) (newVars tp)
@@ -717,6 +718,8 @@ getLabels ls d args
 
   getLabel (WordLabel s)    = FOVWord (cvKind cv) (cvToInteger cv)
     where cv = d Map.! s
+
+  getLabel ZeroWidthWordLabel = FOVWord 0 0
 
   getLabel (VecLabel ns)
     | V.null ns = error "getLabel of empty vector"


### PR DESCRIPTION
Fixes #1182.

N.B. The fix uses exactly the same technique that we were already using in the saw-core-what4 backend: https://github.com/GaloisInc/saw-script/blob/7b8c134a1a2fad07620af1f17b246d3012744e80/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs#L995-L996