### PR TITLE
Reimplement `refreshTerms` to register names in the naming environment.

### DIFF
--- a/src/SAWScript/Crucible/JVM/Override.hs
+++ b/src/SAWScript/Crucible/JVM/Override.hs
@@ -381,8 +381,8 @@ refreshTerms sc ss =
      OM (termSub %= Map.union extension)
   where
     freshenTerm (TypedExtCns _cty ec) =
-      do new <- liftIO $ do i <- scFreshGlobalVar sc
-                            scExtCns sc (EC i (ecName ec) (ecType ec))
+      do ec' <- liftIO $ scFreshEC sc (toShortName (ecName ec)) (ecType ec)
+         new <- liftIO $ scExtCns sc ec'
          return (ecVarIndex ec, new)
 
 ------------------------------------------------------------------------

--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -709,8 +709,8 @@ refreshTerms sc ss =
      OM (termSub %= Map.union extension)
   where
     freshenTerm (TypedExtCns _cty ec) =
-      do new <- liftIO $ do i <- scFreshGlobalVar sc
-                            scExtCns sc (EC i (ecName ec) (ecType ec))
+      do ec' <- liftIO $ scFreshEC sc (toShortName (ecName ec)) (ecType ec)
+         new <- liftIO $ scExtCns sc ec'
          return (ecVarIndex ec, new)
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #869.