### PR TITLE
Add new pretty-printer precedence level for comma-separated lists.

### DIFF
--- a/saw-core/src/Verifier/SAW/Term/Pretty.hs
+++ b/saw-core/src/Verifier/SAW/Term/Pretty.hs
@@ -114,12 +114,12 @@ depthAllowed _ _ = True
 
 -- | Precedence levels, each of which corresponds to a parsing nonterminal
 data Prec
-  = PrecNone   -- ^ Nonterminal 'Term' or "sepBy(Term, ',')"
-  | PrecTerm   -- ^ Nonterminal 'Term'
-  | PrecLambda -- ^ Nonterminal 'LTerm'
-  | PrecProd   -- ^ Nonterminal 'ProdTerm'
-  | PrecApp    -- ^ Nonterminal 'AppTerm'
-  | PrecArg    -- ^ Nonterminal 'AtomTerm'
+  = PrecCommas -- ^ Nonterminal @sepBy(Term, \',\')@
+  | PrecTerm   -- ^ Nonterminal @Term@
+  | PrecLambda -- ^ Nonterminal @LTerm@
+  | PrecProd   -- ^ Nonterminal @ProdTerm@
+  | PrecApp    -- ^ Nonterminal @AppTerm@
+  | PrecArg    -- ^ Nonterminal @AtomTerm@
   deriving (Eq, Ord)
 
 -- | Test if the first precedence "contains" the second, meaning that terms at
@@ -337,7 +337,7 @@ ppLetBlock defs body =
 
 -- | Pretty-print pairs as "(x, y)"
 ppPair :: Prec -> SawDoc -> SawDoc -> SawDoc
-ppPair prec x y = ppParensPrec prec PrecNone (group (vcat [x <> pretty ',', y]))
+ppPair prec x y = ppParensPrec prec PrecCommas (group (vcat [x <> pretty ',', y]))
 
 -- | Pretty-print pair types as "x * y"
 ppPairType :: Prec -> SawDoc -> SawDoc -> SawDoc
@@ -417,7 +417,7 @@ ppFlatTermF prec tf =
     Primitive ec  -> annotate PrimitiveStyle <$> ppBestName (ecName ec)
     UnitValue     -> return "(-empty-)"
     UnitType      -> return "#(-empty-)"
-    PairValue x y -> ppPair prec <$> ppTerm' PrecTerm x <*> ppTerm' PrecNone y
+    PairValue x y -> ppPair prec <$> ppTerm' PrecTerm x <*> ppTerm' PrecCommas y
     PairType x y  -> ppPairType prec <$> ppTerm' PrecApp x <*> ppTerm' PrecProd y
     PairLeft t    -> ppProj "1" <$> ppTerm' PrecArg t
     PairRight t   -> ppProj "2" <$> ppTerm' PrecArg t

--- a/saw-core/src/Verifier/SAW/Term/Pretty.hs
+++ b/saw-core/src/Verifier/SAW/Term/Pretty.hs
@@ -119,23 +119,13 @@ data Prec
   | PrecProd   -- ^ Nonterminal 'ProductTerm'
   | PrecApp    -- ^ Nonterminal 'AppTerm'
   | PrecArg    -- ^ Nonterminal 'AtomTerm'
+  deriving (Eq, Ord)
 
 -- | Test if the first precedence "contains" the second, meaning that terms at
 -- the latter precedence level can be printed in the context of the former
 -- without parentheses.
---
--- NOTE: we write this explicitly here, instead of generating it from an 'Ord'
--- instance, so that readers of this code understand it and know what it is.
 precContains :: Prec -> Prec -> Bool
-precContains _ PrecArg = True
-precContains PrecArg _ = False
-precContains _ PrecApp = True
-precContains PrecApp _ = False
-precContains _ PrecProd = True
-precContains PrecProd _ = False
-precContains _ PrecLambda = True
-precContains PrecLambda _ = False
-precContains PrecNone PrecNone = True
+precContains x y = x <= y
 
 -- | Optionally print parentheses around a document, iff the incoming, outer
 -- precedence (listed first) contains (as in 'precContains') the required


### PR DESCRIPTION
This lets us print pair values using infix ',' with parens in the right places.

Fixes #1147.