### PR TITLE
Recursor refactor

### DIFF
--- a/cryptol-saw-core/cryptol-saw-core.cabal
+++ b/cryptol-saw-core/cryptol-saw-core.cabal
@@ -39,6 +39,7 @@ library
     saw-core-what4,
     what4,
     sbv,
+    transformers,
     vector,
     text,
     executable-path,

--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -1577,7 +1577,7 @@ asCryptolTypeValue v =
       case C.tIsTuple t2 of
         Just ts -> return (C.tTuple (t1 : ts))
         Nothing -> return (C.tTuple [t1, t2])
-    SC.VPiType v1 f -> do
+    SC.VPiType _nm v1 f -> do
       case v1 of
         -- if we see that the parameter is a Cryptol.Num, it's a
         -- pretty good guess that it originally was a

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -45,6 +45,7 @@ import Verifier.SAW.TypedAST
 import qualified Verifier.SAW.Simulator.Concrete as Concrete
 import qualified Verifier.SAW.Prim as Prim
 import qualified Verifier.SAW.Recognizer as R
+import Verifier.SAW.Utils (panic)
 
 import qualified Data.AIG as AIG
 
@@ -296,19 +297,21 @@ lazyMux be muxFn c tm fm
       f <- fm
       muxFn c t f
 
-muxBVal :: AIG.IsAIG l g => g s -> l s -> BValue (l s) -> BValue (l s) -> IO (BValue (l s))
+muxBVal :: AIG.IsAIG l g => g s -> TValue (BitBlast (l s)) -> l s -> BValue (l s) -> BValue (l s) -> IO (BValue (l s))
 muxBVal be = Prims.muxValue (prims be)
 
 muxInt :: a -> Integer -> Integer -> IO Integer
 muxInt _ x y = if x == y then return x else fail $ "muxBVal: VInt " ++ show (x, y)
 
-muxBExtra :: AIG.IsAIG l g => g s -> l s -> BExtra (l s) -> BExtra (l s) -> IO (BExtra (l s))
-muxBExtra be c x y =
+muxBExtra :: AIG.IsAIG l g => g s ->
+  TValue (BitBlast (l s)) -> l s -> BExtra (l s) -> BExtra (l s) -> IO (BExtra (l s))
+muxBExtra be (VDataType "Prelude.Stream" [TValue tp]) c x y =
   do let f i = do xi <- lookupBStream (VExtra x) i
                   yi <- lookupBStream (VExtra y) i
-                  muxBVal be c xi yi
+                  muxBVal be tp c xi yi
      r <- newIORef Map.empty
      return (BStream f r)
+muxBExtra _ tp _ _ _ = panic "AIG: muxBExtra" ["Type mismatch", show tp]
 
 -- | Barrel-shifter algorithm. Takes a list of bits in big-endian order.
 genShift ::
@@ -396,13 +399,13 @@ mkStreamOp =
 -- streamGet :: (a :: sort 0) -> Stream a -> Nat -> a;
 streamGetOp :: AIG.IsAIG l g => g s -> BValue (l s)
 streamGetOp be =
-  constFun $
+  strictFun $ \(toTValue -> tp) -> return $
   strictFun $ \xs -> return $
   strictFun $ \case
     VNat n -> lookupBStream xs n
     VBVToNat _ w ->
        do bs <- toWord w
-          AIG.muxInteger (lazyMux be (muxBVal be)) ((2 ^ AIG.length bs) - 1) bs (lookupBStream xs)
+          AIG.muxInteger (lazyMux be (muxBVal be tp)) ((2 ^ AIG.length bs) - 1) bs (lookupBStream xs)
     v -> fail (unlines ["Verifier.SAW.Simulator.BitBlast.streamGetOp", "Expected Nat value", show v])
 
 

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -151,7 +151,7 @@ bvShiftOp bvOp natOp =
   strictFun $ \y ->
     case y of
       VNat n   -> return (vWord (natOp x n))
-      VToNat v -> fmap vWord (bvOp x =<< toWord v)
+      VBVToNat _ v -> fmap vWord (bvOp x =<< toWord v)
       _        -> error $ unwords ["Verifier.SAW.Simulator.BitBlast.shiftOp", show y]
 
 lvSShr :: LitVector l -> Natural -> LitVector l
@@ -400,7 +400,7 @@ streamGetOp be =
   strictFun $ \xs -> return $
   strictFun $ \case
     VNat n -> lookupBStream xs n
-    VToNat w ->
+    VBVToNat _ w ->
        do bs <- toWord w
           AIG.muxInteger (lazyMux be (muxBVal be)) ((2 ^ AIG.length bs) - 1) bs (lookupBStream xs)
     v -> fail (unlines ["Verifier.SAW.Simulator.BitBlast.streamGetOp", "Expected Nat value", show v])

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -449,7 +449,7 @@ bitBlastBasic :: AIG.IsAIG l g
               -> Term
               -> IO (BValue (l s))
 bitBlastBasic be m addlPrims ecMap t = do
-  let neutral nt = fail ("bitBlastBasic: could not evaluate neutral term: " ++ show nt)
+  let neutral _env nt = fail ("bitBlastBasic: could not evaluate neutral term: " ++ show nt)
   cfg <- Sim.evalGlobal m (Map.union (beConstMap be) (addlPrims be))
          (bitBlastExtCns ecMap)
          (const Nothing)

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -514,11 +514,12 @@ withBitBlastedTerm proxy sc addlPrims t c = AIG.withNewGraph proxy $ \be -> do
 
 asFiniteType :: SharedContext -> Term -> IO FiniteType
 asFiniteType sc t =
-  scGetModuleMap sc >>= \modmap ->
-  case asFiniteTypeValue (Concrete.evalSharedTerm modmap Map.empty Map.empty t) of
-    Just ft -> return ft
-    Nothing ->
-      fail $ "asFiniteType: unsupported type " ++ scPrettyTerm defaultPPOpts t
+  do modmap <- scGetModuleMap sc
+     tm <- Concrete.evalSharedTerm modmap Map.empty Map.empty t
+     case asFiniteTypeValue tm of
+       Just ft -> return ft
+       Nothing ->
+         fail $ "asFiniteType: unsupported type " ++ scPrettyTerm defaultPPOpts t
 
 processVar ::
   (ExtCns Term, FirstOrderType) ->

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -446,9 +446,11 @@ bitBlastBasic :: AIG.IsAIG l g
               -> Term
               -> IO (BValue (l s))
 bitBlastBasic be m addlPrims ecMap t = do
+  let neutral nt = fail ("bitBlastBasic: could not evaluate neutral term: " ++ show nt)
   cfg <- Sim.evalGlobal m (Map.union (beConstMap be) (addlPrims be))
          (bitBlastExtCns ecMap)
          (const Nothing)
+         neutral
   Sim.evalSharedTerm cfg t
 
 bitBlastExtCns ::

--- a/saw-core-coq/src/Verifier/SAW/Translation/Coq/Term.hs
+++ b/saw-core-coq/src/Verifier/SAW/Translation/Coq/Term.hs
@@ -238,8 +238,7 @@ flatTermFToExpr tf = -- traceFTermF "flatTermFToExpr" tf $
          Coq.App rect_var <$> mapM translateTerm args
 
     RecursorApp rec indices termEliminated ->
-      do rec' <- flatTermFToExpr (Recursor rec)
-         --rec' <- translateTerm rec
+      do rec' <- translateTerm rec
          let args = indices ++ [termEliminated]
          Coq.App rec' <$> mapM translateTerm args
 

--- a/saw-core-coq/src/Verifier/SAW/Translation/Coq/Term.hs
+++ b/saw-core-coq/src/Verifier/SAW/Translation/Coq/Term.hs
@@ -218,7 +218,7 @@ flatTermFToExpr tf = -- traceFTermF "flatTermFToExpr" tf $
     DataTypeApp n is as -> translateIdentWithArgs n (is ++ as)
     CtorApp n is as -> translateIdentWithArgs n (is ++ as)
     -- TODO: support this next!
-    RecursorApp d parameters motive eliminators indices termEliminated ->
+    RecursorApp (CompiledRecursor d parameters motive eliminators) indices termEliminated ->
       do maybe_d_trans <- translateIdentToIdent d
          rect_var <- case maybe_d_trans of
            Just i -> return $ Coq.Var (show i ++ "_rect")

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -350,7 +350,7 @@ bvShiftOp bvOp natOp =
     case y of
       VNat i | j < toInteger (maxBound :: Int) -> return (vWord (natOp x (fromInteger j)))
         where j = toInteger i `min` toInteger (intSizeOf x)
-      VToNat v -> fmap (vWord . bvOp x) (toWord v)
+      VBVToNat _ v -> fmap (vWord . bvOp x) (toWord v)
       _        -> error $ unwords ["Verifier.SAW.Simulator.SBV.bvShiftOp", show y]
 
 -- bvShl : (w : Nat) -> Vec w Bool -> Nat -> Vec w Bool;
@@ -383,7 +383,7 @@ intToNatOp =
       Nothing ->
         let z  = svInteger KUnbounded 0
             i' = svIte (svLessThan i z) z i
-         in pure (VToNat (VInt i'))
+         in pure (VIntToNat (VInt i'))
 
 -- primitive natToInt :: Nat -> Integer;
 natToIntOp :: SValue
@@ -497,7 +497,7 @@ streamGetOp =
   strictFun $ \xs -> return $
   strictFun $ \case
     VNat n -> lookupSStream xs n
-    VToNat w ->
+    VBVToNat _ w ->
       do ilv <- toWord w
          selectV (lazyMux muxBVal) ((2 ^ intSizeOf ilv) - 1) (lookupSStream xs) ilv
     v -> Prims.panic "SBV.streamGetOp" ["Expected Nat value", show v]

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -271,7 +271,7 @@ flattenSValue nm v = do
         VIntMod 0 si              -> return ([si], "")
         VIntMod n si              -> return ([svRem si (svInteger KUnbounded (toInteger n))], "")
         VWord sw                  -> return (if intSizeOf sw > 0 then [sw] else [], "")
-        VCtorApp i (V.toList->ts) -> do (xss, ss) <- unzip <$> traverse (force >=> flattenSValue nm) ts
+        VCtorApp i ps ts          -> do (xss, ss) <- unzip <$> traverse (force >=> flattenSValue nm) (ps++ts)
                                         return (concat xss, "_" ++ identName i ++ concat ss)
         VNat n                    -> return ([], "_" ++ show n)
         TValue (suffixTValue -> Just s)
@@ -581,7 +581,7 @@ sbvSolveBasic sc addlPrims unintSet t = do
   let uninterpreted ec
         | Set.member (ecVarIndex ec) unintSet = Just (extcns ec)
         | otherwise                           = Nothing
-  let neutral nt = fail ("sbvSolveBasic: could not evaluate neutral term: " ++ show nt)
+  let neutral _env nt = fail ("sbvSolveBasic: could not evaluate neutral term: " ++ show nt)
   cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted neutral
   Sim.evalSharedTerm cfg t
 
@@ -658,7 +658,7 @@ sbvSATQuery sc addlPrims query =
           let uninterpreted ec
                 | Set.member (ecVarIndex ec) unintSet = Just (mkUninterp ec)
                 | otherwise                           = Nothing
-          let neutral nt = fail ("sbvSATQuery: could not evaluate neutral term: " ++ show nt)
+          let neutral _env nt = fail ("sbvSATQuery: could not evaluate neutral term: " ++ show nt)
 
           cfg  <- liftIO (Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted neutral)
           bval <- liftIO (Sim.evalSharedTerm cfg t)

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -274,7 +274,7 @@ flattenSValue nm v = do
         VNat n                    -> return ([], "_" ++ show n)
         TValue (suffixTValue -> Just s)
                                   -> return ([], s)
-        VFun _ -> fail $ "Cannot create uninterpreted higher-order function " ++ show nm
+        VFun _ _ -> fail $ "Cannot create uninterpreted higher-order function " ++ show nm
         _ -> fail $ "Cannot create uninterpreted function " ++ show nm ++ " with argument " ++ show v
 
 vWord :: SWord -> SValue
@@ -585,7 +585,7 @@ sbvSolveBasic sc addlPrims unintSet t = do
 parseUninterpreted :: [SVal] -> String -> TValue SBV -> IO SValue
 parseUninterpreted cws nm ty =
   case ty of
-    (VPiType _ f)
+    (VPiType _ _ f)
       -> return $
          strictFun $ \x -> do
            (cws', suffix) <- flattenSValue nm x

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -578,7 +578,8 @@ sbvSolveBasic sc addlPrims unintSet t = do
   let uninterpreted ec
         | Set.member (ecVarIndex ec) unintSet = Just (extcns ec)
         | otherwise                           = Nothing
-  cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted
+  let neutral nt = fail ("sbvSolveBasic: could not evaluate neutral term: " ++ show nt)
+  cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted neutral
   Sim.evalSharedTerm cfg t
 
 parseUninterpreted :: [SVal] -> String -> TValue SBV -> IO SValue
@@ -654,8 +655,9 @@ sbvSATQuery sc addlPrims query =
           let uninterpreted ec
                 | Set.member (ecVarIndex ec) unintSet = Just (mkUninterp ec)
                 | otherwise                           = Nothing
+          let neutral nt = fail ("sbvSATQuery: could not evaluate neutral term: " ++ show nt)
 
-          cfg  <- liftIO (Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted)
+          cfg  <- liftIO (Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted neutral)
           bval <- liftIO (Sim.evalSharedTerm cfg t)
 
           case bval of

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -55,6 +55,9 @@ module Verifier.SAW.Simulator.What4
 
   , valueToSymExpr
   , symExprToValue
+
+  , w4ReplaceUninterp
+  , UnintApp(..)
   ) where
 
 
@@ -65,6 +68,7 @@ import Data.Bits
 import Data.IORef
 import Data.List (genericTake)
 import Data.Map (Map)
+import Data.Maybe (fromMaybe)
 import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -84,11 +88,12 @@ import Numeric.Natural (Natural)
 import qualified Verifier.SAW.Recognizer as R
 import qualified Verifier.SAW.Simulator as Sim
 import qualified Verifier.SAW.Simulator.Prims as Prims
+import Verifier.SAW.Term.Functor
 import Verifier.SAW.SATQuery
 import Verifier.SAW.SharedTerm
 import Verifier.SAW.Simulator.Value
 import Verifier.SAW.FiniteValue (FirstOrderType(..), FirstOrderValue(..))
-import Verifier.SAW.TypedAST (FieldName, ModuleMap, identName, toShortName)
+import Verifier.SAW.TypedAST (ModuleMap)
 
 -- what4
 import qualified What4.Expr.Builder as B
@@ -1126,6 +1131,113 @@ w4EvalBasic sym st sc m addlPrims ref unintSet t =
            | otherwise                           = Nothing
      cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted
      Sim.evalSharedTerm cfg t
+
+
+w4ReplaceUninterp ::
+  forall n st fs.
+  B.ExprBuilder n st fs ->
+  SAWCoreState n ->
+  SharedContext ->
+  ModuleMap ->
+  Map Ident (SValue (B.ExprBuilder n st fs)) {- ^ additional primitives -} ->
+  IORef (SymFnCache (B.ExprBuilder n st fs)) {- ^ cache for uninterpreted function symbols -} ->
+  Set VarIndex {- ^ 'unints' Constants in this list are kept uninterpreted -} ->
+  Term {- ^ term to simulate -} ->
+  IO (SValue (B.ExprBuilder n st fs), ReplaceUninterpMap n)
+w4ReplaceUninterp sym st sc mmap addlPrims ref unintSet t =
+  do mapref <- newIORef mempty
+     let extcns tf ec@(EC ix nm ty)
+           | Set.member ix unintSet = replaceUninterp sc sym st mapref ec
+           | otherwise =
+               do trm <- ArgTermConst <$> scTermF sc tf
+                  parseUninterpretedSAW sym st sc ref trm
+                     (mkUnintApp (Text.unpack (toShortName nm) ++ "_" ++ show ix)) ty
+     let uninterpreted _tf ec
+           | Set.member (ecVarIndex ec) unintSet = Just (replaceUninterp sc sym st mapref ec)
+           | otherwise                           = Nothing
+     cfg <- Sim.evalGlobal' mmap (constMap sym `Map.union` addlPrims) extcns uninterpreted
+     t' <- Sim.evalSharedTerm cfg t
+     m' <- readIORef mapref
+     return (t',m')
+
+type ReplaceUninterpMap n = Map VarIndex [(ExtCns Term, UnintApp (B.Expr n))]
+
+replaceUninterp ::
+  forall n st fs.
+  SharedContext ->
+  B.ExprBuilder n st fs ->
+  SAWCoreState n ->
+  IORef (ReplaceUninterpMap n) ->
+  ExtCns (TValue (What4 (B.ExprBuilder n st fs))) ->
+  IO (SValue (B.ExprBuilder n st fs))
+replaceUninterp sc sym scst mapref ec =
+    do let app0 = mkUnintApp (Text.unpack (toShortName (ecName ec)))
+       loop app0 (ecType ec)
+  where
+    recordApp :: ExtCns Term -> UnintApp (B.Expr n) -> IO ()
+    recordApp ec' app =
+      modifyIORef mapref (Map.alter (Just . ((ec',app):) . fromMaybe []) (ecVarIndex ec))
+
+    base ::
+      UnintApp (SymExpr (B.ExprBuilder n st fs)) ->
+      TValue (What4 (B.ExprBuilder n st fs)) ->
+      W.BaseTypeRepr btp ->
+      IO (B.Expr n btp)
+
+    base app@(UnintApp nm _args _tys) ty bty =
+      -- Make a fresh uninterepted constant to stand for the result of applying
+      -- this function, remember the arguments that were applied
+      do tyterm <- termOfTValue sc ty
+         ec' <- scFreshEC sc nm tyterm
+         recordApp ec' app
+
+         ecterm' <- scFlatTermF sc (ExtCns ec')
+         bindSAWTerm sym scst bty ecterm'
+
+    loop ::
+      UnintApp (SymExpr (B.ExprBuilder n st fs)) ->
+      TValue (What4 (B.ExprBuilder n st fs)) ->
+      IO (SValue (B.ExprBuilder n st fs))
+    loop app ty =
+      case ty of
+        VPiType _t1 f ->
+          return $
+          strictFun $ \x -> do
+           app' <- applyUnintApp sym app x
+           t2 <- f (ready x)
+           loop app' t2
+
+        VBoolType -> VBool <$> base app ty BaseBoolRepr
+
+        VIntType -> VInt  <$> base app ty BaseIntegerRepr
+
+        -- 0 width bitvector is a constant
+        VVecType 0 VBoolType -> return $ VWord ZBV
+
+        VVecType n VBoolType
+          | Just (Some (PosNat w)) <- somePosNat n ->
+          (VWord . DBV) <$> base app ty (BaseBVRepr w)
+
+        VVecType n ety | n >= 0 ->
+          do let mkElem i =
+                   do let app' = suffixUnintApp ("_a" ++ show i) app
+                      loop app' ety
+             xs <- traverse mkElem (genericTake n [(0::Integer) ..])
+             return (VVector (V.fromList (map ready xs)))
+
+        VArrayType ity ety
+          | Just (Some idx_repr) <- valueAsBaseType ity
+          , Just (Some elm_repr) <- valueAsBaseType ety
+          -> (VArray . SArray) <$> base app ty (BaseArrayRepr (Ctx.Empty Ctx.:> idx_repr) elm_repr)
+
+        VUnitType -> return VUnit
+
+        VPairType ty1 ty2 ->
+          do x1 <- loop (suffixUnintApp "_L" app) ty1
+             x2 <- loop (suffixUnintApp "_R" app) ty2
+             return (VPair (ready x1) (ready x2))
+
+        _ -> fail $ "could not extract uninterpreted symbol of type " ++ show ty
 
 
 -- | Evaluate a saw-core term to a What4 value for the purposes of

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -738,7 +738,7 @@ parseUninterpreted ::
   TValue (What4 sym) -> IO (SValue sym)
 parseUninterpreted sym ref app ty =
   case ty of
-    VPiType _ f
+    VPiType _ _ f
       -> return $
          strictFun $ \x -> do
            app' <- applyUnintApp sym app x
@@ -859,7 +859,7 @@ applyUnintApp sym app0 v =
     VNat n                    -> return (suffixUnintApp ("_" ++ show n) app0)
     TValue (suffixTValue -> Just s)
                               -> return (suffixUnintApp s app0)
-    VFun _ ->
+    VFun _ _ ->
       fail $
       "Cannot create uninterpreted higher-order function " ++
       show (stringOfUnintApp app0)
@@ -898,7 +898,7 @@ w4Solve sym sc satq =
 argTypes :: IsSymExprBuilder sym => TValue (What4 sym) -> IO [TValue (What4 sym)]
 argTypes v =
   case v of
-    VPiType v1 f ->
+    VPiType _nm v1 f ->
       do x <- delay (fail "argTypes: unsupported dependent SAW-Core type")
          v2 <- f x
          vs <- argTypes v2
@@ -1204,7 +1204,7 @@ replaceUninterp sc sym scst mapref ec =
       IO (SValue (B.ExprBuilder n st fs))
     loop app ty =
       case ty of
-        VPiType _t1 f ->
+        VPiType _nm _t1 f ->
           return $
           strictFun $ \x -> do
            app' <- applyUnintApp sym app x
@@ -1295,7 +1295,7 @@ parseUninterpretedSAW ::
   IO (SValue (B.ExprBuilder n st fs))
 parseUninterpretedSAW sym st sc ref trm app ty =
   case ty of
-    VPiType t1 f
+    VPiType _nm t1 f
       -> return $
          strictFun $ \x -> do
            app' <- applyUnintApp sym app x

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -594,9 +594,10 @@ arrayConstant ::
   W.IsSymExprBuilder sym =>
   sym ->
   TValue (What4 sym) ->
+  TValue (What4 sym) ->
   SValue sym ->
   IO (SArray sym)
-arrayConstant sym ity elm
+arrayConstant sym ity _elTy elm
   | Just (Some idx_repr) <- valueAsBaseType ity
   , Just (Some elm_expr) <- valueToSymExpr elm =
     SArray <$> W.constantArray sym (Ctx.Empty Ctx.:> idx_repr) elm_expr
@@ -679,7 +680,8 @@ w4SolveBasic sym sc addlPrims ecMap ref unintSet t =
      let uninterpreted ec
            | Set.member (ecVarIndex ec) unintSet = Just (extcns ec)
            | otherwise                           = Nothing
-     cfg <- Sim.evalGlobal m (constMap sym `Map.union` addlPrims) extcns uninterpreted
+     let neutral nt = fail ("w4SolveBasic: could not evaluate neutral term: " ++ show nt)
+     cfg <- Sim.evalGlobal m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral
      Sim.evalSharedTerm cfg t
 
 
@@ -1129,7 +1131,8 @@ w4EvalBasic sym st sc m addlPrims ref unintSet t =
      let uninterpreted tf ec
            | Set.member (ecVarIndex ec) unintSet = Just (extcns tf ec)
            | otherwise                           = Nothing
-     cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted
+     let neutral nt = fail ("w4EvalBasic: could not evaluate neutral term: " ++ show nt)
+     cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral
      Sim.evalSharedTerm cfg t
 
 
@@ -1155,7 +1158,8 @@ w4ReplaceUninterp sym st sc mmap addlPrims ref unintSet t =
      let uninterpreted _tf ec
            | Set.member (ecVarIndex ec) unintSet = Just (replaceUninterp sc sym st mapref ec)
            | otherwise                           = Nothing
-     cfg <- Sim.evalGlobal' mmap (constMap sym `Map.union` addlPrims) extcns uninterpreted
+     let neutral nt = fail ("w4ReplaceUninterp: could not evaluate neutral term: " ++ show nt)
+     cfg <- Sim.evalGlobal' mmap (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral
      t' <- Sim.evalSharedTerm cfg t
      m' <- readIORef mapref
      return (t',m')
@@ -1263,8 +1267,9 @@ w4SimulatorEval sym st sc m addlPrims ref constantFilter t =
               parseUninterpretedSAW sym st sc ref trm (mkUnintApp (Text.unpack (toShortName nm) ++ "_" ++ show ix)) ty
      let uninterpreted _tf ec =
           if constantFilter ec then Nothing else Just (X.throwIO (NeutralTermEx (ecName ec)))
+     let neutral nt = fail ("w4SimulatorEval: could not evaluate neutral term: " ++ show nt)
      res <- X.try $ do
-              cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted
+              cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral
               Sim.evalSharedTerm cfg t
      case res of
        Left (NeutralTermEx nmi) -> pure (Left nmi)

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -523,13 +523,13 @@ mkStreamOp =
 -- streamGet :: (a :: sort 0) -> Stream a -> Nat -> a;
 streamGetOp :: forall sym. Sym sym => sym -> SValue sym
 streamGetOp sym =
-  constFun $
+  strictFun $ \(toTValue -> tp) -> return $
   strictFun $ \xs -> return $
   strictFun $ \case
     VNat n -> lookupSStream xs n
     VBVToNat _ w ->
       do ilv <- toWord sym w
-         selectV sym (lazyMux @sym (muxBVal sym)) ((2 ^ SW.bvWidth ilv) - 1) (lookupSStream xs) ilv
+         selectV sym (lazyMux @sym (muxBVal sym tp)) ((2 ^ SW.bvWidth ilv) - 1) (lookupSStream xs) ilv
     v -> Prims.panic "streamGetOp" ["Expected Nat value", show v]
 
 lookupSStream :: SValue sym -> Natural -> IO (SValue sym)
@@ -544,17 +544,18 @@ lookupSStream _ _ = fail "expected Stream"
 
 
 muxBVal :: forall sym. Sym sym =>
-  sym -> SBool sym -> SValue sym -> SValue sym -> IO (SValue sym)
+  sym -> TValue (What4 sym) -> SBool sym -> SValue sym -> SValue sym -> IO (SValue sym)
 muxBVal sym = Prims.muxValue (prims sym)
 
 muxWhat4Extra :: forall sym. Sym sym =>
-  sym -> SBool sym -> What4Extra sym -> What4Extra sym -> IO (What4Extra sym)
-muxWhat4Extra sym c x y =
+  sym -> TValue (What4 sym) -> SBool sym -> What4Extra sym -> What4Extra sym -> IO (What4Extra sym)
+muxWhat4Extra sym (VDataType "Prelude.Stream" [TValue tp]) c x y =
   do let f i = do xi <- lookupSStream (VExtra x) i
                   yi <- lookupSStream (VExtra y) i
-                  muxBVal sym c xi yi
+                  muxBVal sym tp c xi yi
      r <- newIORef Map.empty
      return (SStream f r)
+muxWhat4Extra _ tp _ _ _ = panic "muxWhat4Extra" ["Type mismatch", show tp]
 
 
 -- | Lifts a strict mux operation to a lazy mux

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -340,7 +340,7 @@ intToNatOp sym =
         do z <- W.intLit sym 0
            pneg <- W.intLt sym i z
            i' <- W.intIte sym pneg z i
-           pure (VToNat (VInt i'))
+           pure (VIntToNat (VInt i'))
 
 -- primitive natToInt :: Nat -> Integer;
 natToIntOp :: forall sym. Sym sym => sym -> SValue sym
@@ -415,7 +415,7 @@ bvShiftOp sym bvOp natOp =
     case y of
       VNat i   -> VWord <$> natOp x j
         where j = toInteger i `min` SW.bvWidth x
-      VToNat v -> VWord <$> (bvOp x =<< toWord sym v)
+      VBVToNat _ v -> VWord <$> (bvOp x =<< toWord sym v)
       _        -> error $ unwords ["Verifier.SAW.Simulator.What4.bvShiftOp", show y]
 
 -- bvShl : (w : Nat) -> Vec w Bool -> Nat -> Vec w Bool;
@@ -527,7 +527,7 @@ streamGetOp sym =
   strictFun $ \xs -> return $
   strictFun $ \case
     VNat n -> lookupSStream xs n
-    VToNat w ->
+    VBVToNat _ w ->
       do ilv <- toWord sym w
          selectV sym (lazyMux @sym (muxBVal sym)) ((2 ^ SW.bvWidth ilv) - 1) (lookupSStream xs) ilv
     v -> Prims.panic "streamGetOp" ["Expected Nat value", show v]

--- a/saw-core/saw-core.cabal
+++ b/saw-core/saw-core.cabal
@@ -76,6 +76,7 @@ library
      Verifier.SAW.SCTypeCheck
      Verifier.SAW.Simulator
      Verifier.SAW.Simulator.Concrete
+     Verifier.SAW.Simulator.TermModel
      Verifier.SAW.Simulator.MonadLazy
      Verifier.SAW.Simulator.Prims
      Verifier.SAW.Simulator.RME

--- a/saw-core/src/Verifier/SAW/Conversion.hs
+++ b/saw-core/src/Verifier/SAW/Conversion.hs
@@ -686,10 +686,10 @@ at_bvNat = globalConv "Prelude.at" Prim.at_bv
 atWithDefault_bvNat :: Conversion
 atWithDefault_bvNat =
   Conversion $
-  (\(_ :*: n :*: a :*: d :*: x :*: i) ->
-    if fromIntegral i < width x then mkBool (Prim.at_bv n a x i) else return d) <$>
+  (\(_ :*: _n :*: _a :*: d :*: x :*: i) ->
+    if fromIntegral i < width x then mkBool (Prim.at_bv x i) else return d) <$>
   (asGlobalDef "Prelude.atWithDefault" <:>
-   defaultMatcher <:> defaultMatcher <:> asAny <:> asBvNatLit <:> asAnyNatLit)
+   asAny <:> asAny <:> asAny <:> asBvNatLit <:> asAnyNatLit)
 
 take_bvNat :: Conversion
 take_bvNat = globalConv "Prelude.take" Prim.take_bv

--- a/saw-core/src/Verifier/SAW/Conversion.hs
+++ b/saw-core/src/Verifier/SAW/Conversion.hs
@@ -686,10 +686,10 @@ at_bvNat = globalConv "Prelude.at" Prim.at_bv
 atWithDefault_bvNat :: Conversion
 atWithDefault_bvNat =
   Conversion $
-  (\(_ :*: _n :*: _a :*: d :*: x :*: i) ->
-    if fromIntegral i < width x then mkBool (Prim.at_bv x i) else return d) <$>
+  (\(_ :*: n :*: a :*: d :*: x :*: i) ->
+    if fromIntegral i < width x then mkBool (Prim.at_bv n a x i) else return d) <$>
   (asGlobalDef "Prelude.atWithDefault" <:>
-   asAny <:> asAny <:> asAny <:> asBvNatLit <:> asAnyNatLit)
+   defaultMatcher <:> defaultMatcher <:> asAny <:> asBvNatLit <:> asAnyNatLit)
 
 take_bvNat :: Conversion
 take_bvNat = globalConv "Prelude.take" Prim.take_bv

--- a/saw-core/src/Verifier/SAW/Module.hs
+++ b/saw-core/src/Verifier/SAW/Module.hs
@@ -146,19 +146,26 @@ data Ctor =
     --
     -- where the @ps@ are the parameters and the @ix@s are the indices of
     -- datatype @d@
-  , ctorIotaReduction :: Term
-    -- ^ Cached result of one step of iota reduction of the term
+  , ctorIotaReduction ::
+       [Term] {- ^ data type parameters -} ->
+       Term   {- ^ elimination motive -} ->
+       [(Ident,Term)] {- ^ constructor eliminators -} ->
+       [Term] {- ^ constructor arguments -} ->
+       IO Term
+    -- ^ Cached functon for computing the result of one step of iota
+    --   reduction of the term
     --
     -- > RecursorApp d params p_ret elims ixs (c params args)
     --
     -- where @params@, @p_ret@, @elims@, and @args@ are distinct free variables,
     -- in that order, so that the last @arg@ is the most recently-bound
-    -- variable, i.e., has deBruijn index 0. This means that an iota reduction
-    -- of the above recursor application can be performed by substituting the
-    -- concrete parameters, eliminators, and constructor arguments into the
-    -- 'Term' stored in 'ctorIotaReduction'. Note that we are assuming that the
-    -- @elims@ are in the same order as they are listed in the corresponding
-    -- 'DataType' for this constructor.
+    -- variable, i.e., has deBruijn index 0.  This means that an iota reduction
+    -- of the above recursor application can be performed by passing the
+    -- concrete parameters, eliminators, and constructor arguments to this function.
+    -- Note that we are assuming that the @elims@ are in the same order as they are
+    -- listed in the corresponding 'DataType' for this constructor.
+
+  , ctorIotaTemplate :: Term
   }
 
 -- | Return the number of parameters of a constructor

--- a/saw-core/src/Verifier/SAW/Module.hs
+++ b/saw-core/src/Verifier/SAW/Module.hs
@@ -147,8 +147,7 @@ data Ctor =
     -- where the @ps@ are the parameters and the @ix@s are the indices of
     -- datatype @d@
   , ctorIotaReduction ::
-       [Term] {- ^ data type parameters -} ->
-       Term   {- ^ elimination motive -} ->
+       Term   {- ^ eliminator term -} ->
        Map Ident Term {- ^ constructor eliminators -} ->
        [Term] {- ^ constructor arguments -} ->
        IO Term

--- a/saw-core/src/Verifier/SAW/Module.hs
+++ b/saw-core/src/Verifier/SAW/Module.hs
@@ -149,7 +149,7 @@ data Ctor =
   , ctorIotaReduction ::
        [Term] {- ^ data type parameters -} ->
        Term   {- ^ elimination motive -} ->
-       [(Ident,Term)] {- ^ constructor eliminators -} ->
+       Map Ident Term {- ^ constructor eliminators -} ->
        [Term] {- ^ constructor arguments -} ->
        IO Term
     -- ^ Cached functon for computing the result of one step of iota

--- a/saw-core/src/Verifier/SAW/Prelude.hs
+++ b/saw-core/src/Verifier/SAW/Prelude.hs
@@ -39,7 +39,8 @@ scEq :: SharedContext -> Term -> Term -> IO Term
 scEq sc x y = do
   xty <- scTypeOf sc x
   mmap <- scGetModuleMap sc
-  case asFirstOrderTypeValue (evalSharedTerm mmap mempty mempty xty) of
+  tm <- evalSharedTerm mmap mempty mempty xty
+  case asFirstOrderTypeValue tm of
     Just fot -> scDecEq sc fot (Just (x,y))
     Nothing  -> fail ("scEq: expected first order type, but got: " ++ showTerm xty)
 

--- a/saw-core/src/Verifier/SAW/Prim.hs
+++ b/saw-core/src/Verifier/SAW/Prim.hs
@@ -56,6 +56,16 @@ signed (BV w x)
 bvAt :: BitVector -> Int -> Bool
 bvAt (BV w x) i = testBit x (w - 1 - i)
 
+-- | Conversion from list of bits to integer (big-endian)
+bvToInteger :: Vector Bool -> Integer
+bvToInteger = V.foldl' (\x b -> if b then 2*x+1 else 2*x) 0
+
+unpackBitVector :: BitVector -> Vector Bool
+unpackBitVector x = V.generate (width x) (bvAt x)
+
+packBitVector :: Vector Bool -> BitVector
+packBitVector v = BV (V.length v) (bvToInteger v)
+
 ------------------------------------------------------------
 -- Primitive operations
 

--- a/saw-core/src/Verifier/SAW/Prim.hs
+++ b/saw-core/src/Verifier/SAW/Prim.hs
@@ -273,6 +273,36 @@ lg2rem n = (k+1, 2*d+r)
   where (q, r) = n `divMod` 2
         (k, d) = lg2rem q
 
+------------------------------------------------------------
+-- BitVector shift/rotate
+
+bvRotateL :: BitVector -> Integer -> BitVector
+bvRotateL (BV w x) i = bv w ((x `shiftL` j) .|. (x `shiftR` (w - j)))
+  where j = fromInteger (i `mod` toInteger w)
+
+bvRotateR :: BitVector -> Integer -> BitVector
+bvRotateR w i = bvRotateL w (- i)
+
+bvShiftL ::
+  Bool {- ^ bit value to shift in -} ->
+  BitVector {- ^ value to shift -} ->
+  Integer {- ^ amount to shift by -} ->
+  BitVector
+bvShiftL c (BV w x) i = bv w ((x `shiftL` j) .|. c')
+  where c' = if c then (1 `shiftL` j) - 1 else 0
+        j = fromInteger (i `min` toInteger w)
+
+bvShiftR ::
+  Bool {- ^ bit value to shift in -} ->
+  BitVector {- ^ value to shift -} ->
+  Integer {- ^ amount to shift by -} ->
+  BitVector
+bvShiftR c (BV w x) i = bv w (c' .|. (x `shiftR` j))
+  where c' = if c then (full `shiftL` (w - j)) .&. full else 0
+        full = (1 `shiftL` w) - 1
+        j = fromInteger (i `min` toInteger w)
+
+
 ----------------------------------------
 -- Errors
 

--- a/saw-core/src/Verifier/SAW/Prim.hs
+++ b/saw-core/src/Verifier/SAW/Prim.hs
@@ -105,51 +105,49 @@ upd _ _ (Vec t v) i e = Vec t (v V.// [(i, e)])
 ----------------------------------------
 -- Bitvector operations
 
--- bvNat : (n : Nat) -> Nat -> Vec n Bool;
 bvNat :: Int -> Integer -> BitVector
 bvNat w x = bv w x
 
--- bvAdd : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
-bvAdd, bvSub, bvMul :: Natural -> BitVector -> BitVector -> BitVector
-bvAdd _ (BV w x) (BV _ y) = bv w (x + y)
-bvSub _ (BV w x) (BV _ y) = bv w (x - y)
-bvMul _ (BV w x) (BV _ y) = bv w (x * y)
+bvAdd, bvSub, bvMul :: BitVector -> BitVector -> BitVector
+bvAdd (BV w x) (BV _ y) = bv w (x + y)
+bvSub (BV w x) (BV _ y) = bv w (x - y)
+bvMul (BV w x) (BV _ y) = bv w (x * y)
 
-bvNeg :: Natural -> BitVector -> BitVector
-bvNeg _ x@(BV w _) = bv w $ negate $ signed x
+bvNeg :: BitVector -> BitVector
+bvNeg x@(BV w _) = bv w $ negate $ signed x
 
-bvAnd, bvOr, bvXor :: Int -> BitVector -> BitVector -> BitVector
-bvAnd _ (BV w x) (BV _ y) = BV w (x .&. y)
-bvOr  _ (BV w x) (BV _ y) = BV w (x .|. y)
-bvXor _ (BV w x) (BV _ y) = BV w (x `xor` y)
+bvAnd, bvOr, bvXor :: BitVector -> BitVector -> BitVector
+bvAnd (BV w x) (BV _ y) = BV w (x .&. y)
+bvOr  (BV w x) (BV _ y) = BV w (x .|. y)
+bvXor (BV w x) (BV _ y) = BV w (x `xor` y)
 
-bvNot :: Int -> BitVector -> BitVector
-bvNot _ (BV w x) = BV w (x `xor` bitMask w)
+bvNot :: BitVector -> BitVector
+bvNot (BV w x) = BV w (x `xor` bitMask w)
 
 bvEq, bvult, bvule, bvugt, bvuge, bvsgt, bvsge, bvslt, bvsle
-    :: Int -> BitVector -> BitVector -> Bool
-bvEq  _ x y = unsigned x == unsigned y
-bvugt _ x y = unsigned x >  unsigned y
-bvuge _ x y = unsigned x >= unsigned y
-bvult _ x y = unsigned x <  unsigned y
-bvule _ x y = unsigned x <= unsigned y
-bvsgt _ x y = signed x >  signed y
-bvsge _ x y = signed x >= signed y
-bvslt _ x y = signed x <  signed y
-bvsle _ x y = signed x <= signed y
+    :: BitVector -> BitVector -> Bool
+bvEq  x y = unsigned x == unsigned y
+bvugt x y = unsigned x >  unsigned y
+bvuge x y = unsigned x >= unsigned y
+bvult x y = unsigned x <  unsigned y
+bvule x y = unsigned x <= unsigned y
+bvsgt x y = signed x >  signed y
+bvsge x y = signed x >= signed y
+bvslt x y = signed x <  signed y
+bvsle x y = signed x <= signed y
 
-bvPopcount :: Int -> BitVector -> BitVector
-bvPopcount _ (BV w x) = BV w (toInteger (popCount x))
+bvPopcount :: BitVector -> BitVector
+bvPopcount (BV w x) = BV w (toInteger (popCount x))
 
-bvCountLeadingZeros :: Int -> BitVector -> BitVector
-bvCountLeadingZeros _ (BV w x) = BV w (toInteger (go 0))
+bvCountLeadingZeros :: BitVector -> BitVector
+bvCountLeadingZeros (BV w x) = BV w (toInteger (go 0))
  where
  go !i
    | i < w && testBit x (w - i - 1) == False = go (i+1)
    | otherwise = i
 
-bvCountTrailingZeros :: Int -> BitVector -> BitVector
-bvCountTrailingZeros _ (BV w x) = BV w (toInteger (go 0))
+bvCountTrailingZeros :: BitVector -> BitVector
+bvCountTrailingZeros (BV w x) = BV w (toInteger (go 0))
  where
  go !i
    | i < w && testBit x i == False = go (i+1)
@@ -164,8 +162,8 @@ bvCountTrailingZeros _ (BV w x) = BV w (toInteger (go 0))
 
 -- | @at@ specialized to BitVector (big-endian)
 -- at :: (n :: Nat) -> (a :: sort 0) -> Vec n a -> Nat -> a;
-at_bv :: Int -> () -> BitVector -> Natural -> Bool
-at_bv _ _ x i = testBit (unsigned x) (width x - 1 - fromIntegral i)
+at_bv :: BitVector -> Natural -> Bool
+at_bv x i = testBit (unsigned x) (width x - 1 - fromIntegral i)
 
 -- | @set@ specialized to BitVector (big-endian)
 -- set :: (n :: Nat) -> (a :: sort 0) -> Vec n a -> Fin n -> a -> Vec n a;
@@ -175,48 +173,48 @@ at_bv _ _ x i = testBit (unsigned x) (width x - 1 - fromIntegral i)
 
 -- | @append@ specialized to BitVector (big-endian)
 -- append :: (m n :: Nat) -> (a :: sort 0) -> Vec m a -> Vec n a -> Vec (addNat m n) a;
-append_bv :: Int -> Int -> () -> BitVector -> BitVector -> BitVector
-append_bv _ _ _ (BV m x) (BV n y) = BV (m + n) (shiftL x n .|. y)
+append_bv :: BitVector -> BitVector -> BitVector
+append_bv (BV m x) (BV n y) = BV (m + n) (shiftL x n .|. y)
 -- little-endian version:
 -- append_bv _ _ _ (BV m x) (BV n y) = BV (m + n) (x .|. shiftL y m)
 
 -- bvToNat : (n : Nat) -> Vec n Bool -> Nat;
-bvToNat :: Int -> BitVector -> Integer
-bvToNat _ (BV _ x) = x
+bvToNat :: BitVector -> Integer
+bvToNat (BV _ x) = x
 
 -- bvAddWithCarry : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool * Vec n Bool;
-bvAddWithCarry :: Int -> BitVector -> BitVector -> (Bool, BitVector)
-bvAddWithCarry _ (BV w x) (BV _ y) = (testBit z w, bv w z)
+bvAddWithCarry :: BitVector -> BitVector -> (Bool, BitVector)
+bvAddWithCarry (BV w x) (BV _ y) = (testBit z w, bv w z)
     where z = x + y
 
-bvUDiv :: Int -> BitVector -> BitVector -> Maybe BitVector
-bvUDiv _ (BV w x) (BV _ y)
+bvUDiv :: BitVector -> BitVector -> Maybe BitVector
+bvUDiv (BV w x) (BV _ y)
   | y == 0    = Nothing
   | otherwise = Just (bv w (x `quot` y))
 
-bvURem :: Int -> BitVector -> BitVector -> Maybe BitVector
-bvURem _ (BV w x) (BV _ y)
+bvURem :: BitVector -> BitVector -> Maybe BitVector
+bvURem (BV w x) (BV _ y)
   | y == 0    = Nothing
   | otherwise = Just (bv w (x `rem` y))
 
-bvSDiv :: Int -> BitVector -> BitVector -> Maybe BitVector
-bvSDiv _ x y
+bvSDiv :: BitVector -> BitVector -> Maybe BitVector
+bvSDiv x y
   | unsigned y == 0 = Nothing
   | otherwise       = Just (bv (width x) (signed x `quot` signed y))
 
-bvSRem :: Int -> BitVector -> BitVector -> Maybe BitVector
-bvSRem _ x y
+bvSRem :: BitVector -> BitVector -> Maybe BitVector
+bvSRem x y
   | unsigned y == 0 = Nothing
   | otherwise       = Just (bv (width x) (signed x `rem` signed y))
 
-bvShl :: Int -> BitVector -> Int -> BitVector
-bvShl _ (BV w x) i = bv w (x `shiftL` i)
+bvShl :: BitVector -> Int -> BitVector
+bvShl (BV w x) i = bv w (x `shiftL` i)
 
-bvShr :: Int -> BitVector -> Int -> BitVector
-bvShr _ (BV w x) i = bv w (x `shiftR` i)
+bvShr :: BitVector -> Int -> BitVector
+bvShr (BV w x) i = bv w (x `shiftR` i)
 
-bvSShr :: Int -> BitVector -> Int -> BitVector
-bvSShr _ x i = bv (width x) (signed x `shiftR` i)
+bvSShr :: BitVector -> Int -> BitVector
+bvSShr x i = bv (width x) (signed x `shiftR` i)
 
 -- bvTrunc : (m n : Nat) -> Vec (addNat m n) Bool -> Vec n Bool;
 bvTrunc :: Int -> Int -> BitVector -> BitVector
@@ -232,21 +230,21 @@ bvSExt m n x = bv (m + n + 1) (signed x)
 
 -- | @take@ specialized to BitVector (big-endian)
 -- take :: (a :: sort 0) -> (m n :: Nat) -> Vec (addNat m n) a -> Vec m a;
-take_bv :: () -> Int -> Int -> BitVector -> BitVector
-take_bv _ m n (BV _ x) = bv m (x `shiftR` n)
+take_bv :: Int -> Int -> BitVector -> BitVector
+take_bv m n (BV _ x) = bv m (x `shiftR` n)
 -- little-endian version:
--- take_bv _ m _ (BV _ x) = bv m x
+-- take_bv m _ (BV _ x) = bv m x
 
 -- | @vDrop@ specialized to BitVector (big-endian)
 -- drop :: (a :: sort 0) -> (m n :: Nat) -> Vec (addNat m n) a -> Vec n a;
-drop_bv :: () -> Int -> Int -> BitVector -> BitVector
-drop_bv _ _ n (BV _ x) = bv n x
+drop_bv :: Int -> Int -> BitVector -> BitVector
+drop_bv _ n (BV _ x) = bv n x
 -- little-endian version:
 -- drop_bv _ m n (BV _ x) = BV n (x `shiftR` m)
 
 -- | @slice@ specialized to BitVector
-slice_bv :: () -> Int -> Int -> Int -> BitVector -> BitVector
-slice_bv _ _ n o (BV _ x) = bv n (shiftR x o)
+slice_bv :: Int -> Int -> Int -> BitVector -> BitVector
+slice_bv _ n o (BV _ x) = bv n (shiftR x o)
 -- little-endian version:
 -- slice_bv _ i n _ (BV _ x) = bv n (shiftR x i)
 

--- a/saw-core/src/Verifier/SAW/Prim.hs
+++ b/saw-core/src/Verifier/SAW/Prim.hs
@@ -115,49 +115,51 @@ upd _ _ (Vec t v) i e = Vec t (v V.// [(i, e)])
 ----------------------------------------
 -- Bitvector operations
 
+-- bvNat : (n : Nat) -> Nat -> Vec n Bool;
 bvNat :: Int -> Integer -> BitVector
 bvNat w x = bv w x
 
-bvAdd, bvSub, bvMul :: BitVector -> BitVector -> BitVector
-bvAdd (BV w x) (BV _ y) = bv w (x + y)
-bvSub (BV w x) (BV _ y) = bv w (x - y)
-bvMul (BV w x) (BV _ y) = bv w (x * y)
+-- bvAdd : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
+bvAdd, bvSub, bvMul :: Natural -> BitVector -> BitVector -> BitVector
+bvAdd _ (BV w x) (BV _ y) = bv w (x + y)
+bvSub _ (BV w x) (BV _ y) = bv w (x - y)
+bvMul _ (BV w x) (BV _ y) = bv w (x * y)
 
-bvNeg :: BitVector -> BitVector
-bvNeg x@(BV w _) = bv w $ negate $ signed x
+bvNeg :: Natural -> BitVector -> BitVector
+bvNeg _ x@(BV w _) = bv w $ negate $ signed x
 
-bvAnd, bvOr, bvXor :: BitVector -> BitVector -> BitVector
-bvAnd (BV w x) (BV _ y) = BV w (x .&. y)
-bvOr  (BV w x) (BV _ y) = BV w (x .|. y)
-bvXor (BV w x) (BV _ y) = BV w (x `xor` y)
+bvAnd, bvOr, bvXor :: Int -> BitVector -> BitVector -> BitVector
+bvAnd _ (BV w x) (BV _ y) = BV w (x .&. y)
+bvOr  _ (BV w x) (BV _ y) = BV w (x .|. y)
+bvXor _ (BV w x) (BV _ y) = BV w (x `xor` y)
 
-bvNot :: BitVector -> BitVector
-bvNot (BV w x) = BV w (x `xor` bitMask w)
+bvNot :: Int -> BitVector -> BitVector
+bvNot _ (BV w x) = BV w (x `xor` bitMask w)
 
 bvEq, bvult, bvule, bvugt, bvuge, bvsgt, bvsge, bvslt, bvsle
-    :: BitVector -> BitVector -> Bool
-bvEq  x y = unsigned x == unsigned y
-bvugt x y = unsigned x >  unsigned y
-bvuge x y = unsigned x >= unsigned y
-bvult x y = unsigned x <  unsigned y
-bvule x y = unsigned x <= unsigned y
-bvsgt x y = signed x >  signed y
-bvsge x y = signed x >= signed y
-bvslt x y = signed x <  signed y
-bvsle x y = signed x <= signed y
+    :: Int -> BitVector -> BitVector -> Bool
+bvEq  _ x y = unsigned x == unsigned y
+bvugt _ x y = unsigned x >  unsigned y
+bvuge _ x y = unsigned x >= unsigned y
+bvult _ x y = unsigned x <  unsigned y
+bvule _ x y = unsigned x <= unsigned y
+bvsgt _ x y = signed x >  signed y
+bvsge _ x y = signed x >= signed y
+bvslt _ x y = signed x <  signed y
+bvsle _ x y = signed x <= signed y
 
-bvPopcount :: BitVector -> BitVector
-bvPopcount (BV w x) = BV w (toInteger (popCount x))
+bvPopcount :: Int -> BitVector -> BitVector
+bvPopcount _ (BV w x) = BV w (toInteger (popCount x))
 
-bvCountLeadingZeros :: BitVector -> BitVector
-bvCountLeadingZeros (BV w x) = BV w (toInteger (go 0))
+bvCountLeadingZeros :: Int -> BitVector -> BitVector
+bvCountLeadingZeros _ (BV w x) = BV w (toInteger (go 0))
  where
  go !i
    | i < w && testBit x (w - i - 1) == False = go (i+1)
    | otherwise = i
 
-bvCountTrailingZeros :: BitVector -> BitVector
-bvCountTrailingZeros (BV w x) = BV w (toInteger (go 0))
+bvCountTrailingZeros :: Int -> BitVector -> BitVector
+bvCountTrailingZeros _ (BV w x) = BV w (toInteger (go 0))
  where
  go !i
    | i < w && testBit x i == False = go (i+1)
@@ -172,8 +174,8 @@ bvCountTrailingZeros (BV w x) = BV w (toInteger (go 0))
 
 -- | @at@ specialized to BitVector (big-endian)
 -- at :: (n :: Nat) -> (a :: sort 0) -> Vec n a -> Nat -> a;
-at_bv :: BitVector -> Natural -> Bool
-at_bv x i = testBit (unsigned x) (width x - 1 - fromIntegral i)
+at_bv :: Int -> () -> BitVector -> Natural -> Bool
+at_bv _ _ x i = testBit (unsigned x) (width x - 1 - fromIntegral i)
 
 -- | @set@ specialized to BitVector (big-endian)
 -- set :: (n :: Nat) -> (a :: sort 0) -> Vec n a -> Fin n -> a -> Vec n a;
@@ -183,48 +185,48 @@ at_bv x i = testBit (unsigned x) (width x - 1 - fromIntegral i)
 
 -- | @append@ specialized to BitVector (big-endian)
 -- append :: (m n :: Nat) -> (a :: sort 0) -> Vec m a -> Vec n a -> Vec (addNat m n) a;
-append_bv :: BitVector -> BitVector -> BitVector
-append_bv (BV m x) (BV n y) = BV (m + n) (shiftL x n .|. y)
+append_bv :: Int -> Int -> () -> BitVector -> BitVector -> BitVector
+append_bv _ _ _ (BV m x) (BV n y) = BV (m + n) (shiftL x n .|. y)
 -- little-endian version:
 -- append_bv _ _ _ (BV m x) (BV n y) = BV (m + n) (x .|. shiftL y m)
 
 -- bvToNat : (n : Nat) -> Vec n Bool -> Nat;
-bvToNat :: BitVector -> Integer
-bvToNat (BV _ x) = x
+bvToNat :: Int -> BitVector -> Integer
+bvToNat _ (BV _ x) = x
 
 -- bvAddWithCarry : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool * Vec n Bool;
-bvAddWithCarry :: BitVector -> BitVector -> (Bool, BitVector)
-bvAddWithCarry (BV w x) (BV _ y) = (testBit z w, bv w z)
+bvAddWithCarry :: Int -> BitVector -> BitVector -> (Bool, BitVector)
+bvAddWithCarry _ (BV w x) (BV _ y) = (testBit z w, bv w z)
     where z = x + y
 
-bvUDiv :: BitVector -> BitVector -> Maybe BitVector
-bvUDiv (BV w x) (BV _ y)
+bvUDiv :: Int -> BitVector -> BitVector -> Maybe BitVector
+bvUDiv _ (BV w x) (BV _ y)
   | y == 0    = Nothing
   | otherwise = Just (bv w (x `quot` y))
 
-bvURem :: BitVector -> BitVector -> Maybe BitVector
-bvURem (BV w x) (BV _ y)
+bvURem :: Int -> BitVector -> BitVector -> Maybe BitVector
+bvURem _ (BV w x) (BV _ y)
   | y == 0    = Nothing
   | otherwise = Just (bv w (x `rem` y))
 
-bvSDiv :: BitVector -> BitVector -> Maybe BitVector
-bvSDiv x y
+bvSDiv :: Int -> BitVector -> BitVector -> Maybe BitVector
+bvSDiv _ x y
   | unsigned y == 0 = Nothing
   | otherwise       = Just (bv (width x) (signed x `quot` signed y))
 
-bvSRem :: BitVector -> BitVector -> Maybe BitVector
-bvSRem x y
+bvSRem :: Int -> BitVector -> BitVector -> Maybe BitVector
+bvSRem _ x y
   | unsigned y == 0 = Nothing
   | otherwise       = Just (bv (width x) (signed x `rem` signed y))
 
-bvShl :: BitVector -> Int -> BitVector
-bvShl (BV w x) i = bv w (x `shiftL` i)
+bvShl :: Int -> BitVector -> Int -> BitVector
+bvShl _ (BV w x) i = bv w (x `shiftL` i)
 
-bvShr :: BitVector -> Int -> BitVector
-bvShr (BV w x) i = bv w (x `shiftR` i)
+bvShr :: Int -> BitVector -> Int -> BitVector
+bvShr _ (BV w x) i = bv w (x `shiftR` i)
 
-bvSShr :: BitVector -> Int -> BitVector
-bvSShr x i = bv (width x) (signed x `shiftR` i)
+bvSShr :: Int -> BitVector -> Int -> BitVector
+bvSShr _ x i = bv (width x) (signed x `shiftR` i)
 
 -- bvTrunc : (m n : Nat) -> Vec (addNat m n) Bool -> Vec n Bool;
 bvTrunc :: Int -> Int -> BitVector -> BitVector
@@ -240,21 +242,21 @@ bvSExt m n x = bv (m + n + 1) (signed x)
 
 -- | @take@ specialized to BitVector (big-endian)
 -- take :: (a :: sort 0) -> (m n :: Nat) -> Vec (addNat m n) a -> Vec m a;
-take_bv :: Int -> Int -> BitVector -> BitVector
-take_bv m n (BV _ x) = bv m (x `shiftR` n)
+take_bv :: () -> Int -> Int -> BitVector -> BitVector
+take_bv _ m n (BV _ x) = bv m (x `shiftR` n)
 -- little-endian version:
--- take_bv m _ (BV _ x) = bv m x
+-- take_bv _ m _ (BV _ x) = bv m x
 
 -- | @vDrop@ specialized to BitVector (big-endian)
 -- drop :: (a :: sort 0) -> (m n :: Nat) -> Vec (addNat m n) a -> Vec n a;
-drop_bv :: Int -> Int -> BitVector -> BitVector
-drop_bv _ n (BV _ x) = bv n x
+drop_bv :: () -> Int -> Int -> BitVector -> BitVector
+drop_bv _ _ n (BV _ x) = bv n x
 -- little-endian version:
 -- drop_bv _ m n (BV _ x) = BV n (x `shiftR` m)
 
 -- | @slice@ specialized to BitVector
-slice_bv :: Int -> Int -> Int -> BitVector -> BitVector
-slice_bv _ n o (BV _ x) = bv n (shiftR x o)
+slice_bv :: () -> Int -> Int -> Int -> BitVector -> BitVector
+slice_bv _ _ n o (BV _ x) = bv n (shiftR x o)
 -- little-endian version:
 -- slice_bv _ i n _ (BV _ x) = bv n (shiftR x i)
 

--- a/saw-core/src/Verifier/SAW/Recognizer.hs
+++ b/saw-core/src/Verifier/SAW/Recognizer.hs
@@ -273,11 +273,10 @@ asDataTypeParams t = do DataTypeApp c ps args <- asFTermF t; return (c,ps,args)
 asDataType :: Recognizer Term (Ident, [Term])
 asDataType t = do DataTypeApp c ps args <- asFTermF t; return (c,ps ++ args)
 
-asRecursorApp :: Recognizer Term (Ident,[Term],Term,
-                                               [(Ident,Term)],[Term],Term)
+asRecursorApp :: Recognizer Term (CompiledRecursor Term, [Term], Term)
 asRecursorApp t =
-  do RecursorApp d params p_ret cs_fs ixs arg <- asFTermF t;
-     return (d, params, p_ret, cs_fs, ixs, arg)
+  do RecursorApp rec ixs arg <- asFTermF t
+     return (rec, ixs, arg)
 
 isDataType :: Ident -> Recognizer [Term] a -> Recognizer Term a
 isDataType i p t = do

--- a/saw-core/src/Verifier/SAW/Recognizer.hs
+++ b/saw-core/src/Verifier/SAW/Recognizer.hs
@@ -42,6 +42,7 @@ module Verifier.SAW.Recognizer
   , asDataType
   , asDataTypeParams
   , asRecursorApp
+  , asRecursorType
   , isDataType
   , asNat
   , asBvNat
@@ -273,9 +274,15 @@ asDataTypeParams t = do DataTypeApp c ps args <- asFTermF t; return (c,ps,args)
 asDataType :: Recognizer Term (Ident, [Term])
 asDataType t = do DataTypeApp c ps args <- asFTermF t; return (c,ps ++ args)
 
+asRecursorType :: Recognizer Term (Ident, [Term], Term, Term)
+asRecursorType t =
+  do RecursorType d ps motive motive_ty <- asFTermF t
+     return (d,ps,motive,motive_ty)
+
 asRecursorApp :: Recognizer Term (CompiledRecursor Term, [Term], Term)
 asRecursorApp t =
   do RecursorApp rec ixs arg <- asFTermF t
+     --Recursor rec' <- asFTermF rec
      return (rec, ixs, arg)
 
 isDataType :: Ident -> Recognizer [Term] a -> Recognizer Term a

--- a/saw-core/src/Verifier/SAW/Recognizer.hs
+++ b/saw-core/src/Verifier/SAW/Recognizer.hs
@@ -282,8 +282,8 @@ asRecursorType t =
 asRecursorApp :: Recognizer Term (CompiledRecursor Term, [Term], Term)
 asRecursorApp t =
   do RecursorApp rec ixs arg <- asFTermF t
-     --Recursor rec' <- asFTermF rec
-     return (rec, ixs, arg)
+     Recursor rec' <- asFTermF rec
+     return (rec', ixs, arg)
 
 isDataType :: Ident -> Recognizer [Term] a -> Recognizer Term a
 isDataType i p t = do

--- a/saw-core/src/Verifier/SAW/Recognizer.hs
+++ b/saw-core/src/Verifier/SAW/Recognizer.hs
@@ -279,11 +279,11 @@ asRecursorType t =
   do RecursorType d ps motive motive_ty <- asFTermF t
      return (d,ps,motive,motive_ty)
 
-asRecursorApp :: Recognizer Term (CompiledRecursor Term, [Term], Term)
+asRecursorApp :: Recognizer Term (Term, CompiledRecursor Term, [Term], Term)
 asRecursorApp t =
   do RecursorApp rec ixs arg <- asFTermF t
-     Recursor rec' <- asFTermF rec
-     return (rec', ixs, arg)
+     Recursor crec <- asFTermF rec
+     return (rec, crec, ixs, arg)
 
 isDataType :: Ident -> Recognizer [Term] a -> Recognizer Term a
 isDataType i p t = do

--- a/saw-core/src/Verifier/SAW/Rewriter.hs
+++ b/saw-core/src/Verifier/SAW/Rewriter.hs
@@ -678,6 +678,9 @@ rewriteSharedTermTypeSafe sc ss t0 =
           -- a term to become ill-typed
           CtorApp{}        -> return ftf
           DataTypeApp{}    -> return ftf -- could treat same as CtorApp
+
+          RecursorType{}   -> return ftf
+          Recursor{}       -> return ftf
           RecursorApp{}    -> return ftf -- could treat same as CtorApp
 
           RecordType{}     -> traverse rewriteAll ftf

--- a/saw-core/src/Verifier/SAW/SCTypeCheck.hs
+++ b/saw-core/src/Verifier/SAW/SCTypeCheck.hs
@@ -165,6 +165,7 @@ data TCError
   | DeclError Text String
   | ErrorPos Pos TCError
   | ErrorCtx LocalName Term TCError
+  | ExpectedRecursor TypedTerm
 
 -- | Throw a type-checking error
 throwTCError :: TCError -> TCM a
@@ -230,7 +231,7 @@ prettyTCError e = runReader (helper e) ([], Nothing) where
     ppWithPos [ return ("Type of constant " ++ show n), ishow rty
               , return "doesn't match declared type", ishow ty ]
   helper (MalformedRecursor trm reason) =
-      ppWithPos [ return "Malformed recursor application",
+      ppWithPos [ return "Malformed recursor",
                   ishow trm, return reason ]
   helper (DeclError nm reason) =
     ppWithPos [ return ("Malformed declaration for " ++ show nm), return reason ]
@@ -238,6 +239,8 @@ prettyTCError e = runReader (helper e) ([], Nothing) where
     local (\(ctx,_) -> (ctx, Just p)) $ helper err
   helper (ErrorCtx x _ err) =
     local (\(ctx,p) -> (x:ctx, p)) $ helper err
+  helper (ExpectedRecursor ttm) =
+    ppWithPos [ return "Expected recursor value", ishow (typedVal ttm), ishow (typedType ttm)]
 
   ishow :: Term -> PPErrM String
   ishow tm =
@@ -477,8 +480,27 @@ instance TypeInfer (FlatTermF TypedTerm) where
        -- t' <- typeCheckWHNF t
        foldM applyPiTyped (ctorType ctor) (params ++ args)
 
+  typeInfer (RecursorType d ps motive _mty) =
+    do s <- inferRecursorType d ps motive
+       liftTCM scSort s
+
+  typeInfer (Recursor rec) =
+    inferRecursor rec
+
   typeInfer (RecursorApp rec ixs arg) =
-    inferRecursorApp rec ixs arg
+    do let motive   = typedVal (recursorMotive rec)
+       let motiveTy = typedType (recursorMotive rec)
+
+       -- Apply the indices to the type of the motive
+       -- to check the types of the `ixs` and `arg`, and
+       -- ensure that the result is fully applied
+       _s <- ensureSort =<< foldM applyPiTyped motiveTy (ixs ++ [arg])
+    
+       -- return the type (p_ret ixs arg)
+       liftTCM scTypeCheckWHNF =<<
+         liftTCM scApplyAll motive (map typedVal (ixs ++ [arg]))
+
+    --inferRecursorApp rec ixs arg
 
   typeInfer (RecordType elems) =
     -- NOTE: record types are always predicative, i.e., non-Propositional, so we
@@ -561,19 +583,97 @@ areConvertible :: Term -> Term -> TCM Bool
 areConvertible t1 t2 = liftTCM scConvertibleEval scTypeCheckWHNF True t1 t2
 
 
+inferRecursorType ::
+  Ident       {- ^ data type name -} ->
+  [TypedTerm] {- ^ data type parameters -} ->
+  TypedTerm   {- ^ elimination motive -} ->
+  TCM Sort
+inferRecursorType d params motive =
+  do maybe_dt <- liftTCM scFindDataType d
+     dt <- case maybe_dt of
+       Just dt -> return dt
+       Nothing -> throwTCError $ NoSuchDataType d
+
+     let mk_err str =
+           MalformedRecursor
+           (Unshared $ fmap typedVal $ FTermF $
+             Recursor (CompiledRecursor d params motive mempty))
+            str
+
+     -- Check that the params have the correct types by making sure
+     -- they correspond to the input types of dt
+     unless (length params == length (dtParams dt)) $
+       throwTCError $ mk_err "Incorrect number of parameters"
+     _ <- foldM applyPiTyped (dtType dt) params
+
+     -- Get the type of p_ret and make sure that it is of the form
+     --
+     -- (ix1::Ix1) -> .. -> (ixn::Ixn) -> d params ixs -> s
+     --
+     -- for some allowed sort s, where the Ix are the indices of of dt
+     motive_srt <-
+       case asPiList (typedType motive) of
+         (_, (asSort -> Just s)) -> return s
+         _ -> throwTCError $ mk_err "Motive function should return a sort"
+     motive_req <-
+       liftTCM scRecursorRetTypeType dt (map typedVal params) motive_srt
+     -- Technically this is an equality test, not a subtype test, but we
+     -- use the precise sort used in the motive, so they are the same, and
+     -- checkSubtype is handy...
+     checkSubtype motive motive_req
+     unless (allowedElimSort dt motive_srt)  $
+       throwTCError $ mk_err "Disallowed propositional elimination"
+
+     return motive_srt
+
+
+inferRecursor ::
+  CompiledRecursor TypedTerm ->
+  TCM Term
+inferRecursor rec =
+  do let mk_err str =
+           MalformedRecursor
+            (Unshared $ fmap typedVal $ FTermF $ Recursor rec)
+            str
+
+     let d      = recursorDataType rec
+     let params = recursorParams rec
+     let motive = recursorMotive rec
+     let cs_fs  = recursorElims rec
+
+     -- Check that the parameters and motive are correct for the given
+     -- data type
+     _s <- inferRecursorType d params motive
+
+     -- Check that the elimination functions each have the right types, and
+     -- that we have exactly one for each constructor of dt
+     cs_fs_tps <-
+       liftTCM scRecursorElimTypes d (map typedVal params) (typedVal motive)
+     case map fst (Map.toList cs_fs) \\ map fst cs_fs_tps of
+       [] -> return ()
+       cs -> throwTCError $ mk_err ("Extra constructors: " ++ show cs)
+     forM_ cs_fs_tps $ \(c,req_tp) ->
+       case Map.lookup c cs_fs of
+         Nothing ->
+           throwTCError $ mk_err ("Missing constructor: " ++ show c)
+         Just f -> checkSubtype f req_tp
+
+     -- return the type of this recursor
+     liftTCM scFlatTermF
+       (RecursorType d (map typedVal params) (typedVal motive) (typedType motive))
+
+
 inferAndCompileRecursor ::
   Ident       {- ^ data type name -} ->
   [TypedTerm] {- ^ data type parameters -} ->
   TypedTerm   {- ^ elimination motive -} ->
-  [(Ident,TypedTerm)] {- ^ constructor eliminators -} ->
+  Map Ident TypedTerm {- ^ constructor eliminators -} ->
   TCM (CompiledRecursor TypedTerm)
 inferAndCompileRecursor d params p_ret cs_fs =
   do let mk_err str =
            MalformedRecursor
            (Unshared $ fmap typedVal $ FTermF $
-             RecursorApp (CompiledRecursor d params p_ret cs_fs)
-             []
-             (TypedTerm (Unshared (FTermF (UnitValue))) (Unshared (FTermF (UnitType)))))
+             Recursor (CompiledRecursor d params p_ret cs_fs))
             str
      maybe_dt <- liftTCM scFindDataType d
      dt <- case maybe_dt of
@@ -608,11 +708,11 @@ inferAndCompileRecursor d params p_ret cs_fs =
      -- that we have exactly one for each constructor of dt
      cs_fs_tps <-
        liftTCM scRecursorElimTypes d (map typedVal params) (typedVal p_ret)
-     case map fst cs_fs \\ map fst cs_fs_tps of
+     case map fst (Map.toList cs_fs) \\ map fst cs_fs_tps of
        [] -> return ()
        cs -> throwTCError $ mk_err ("Extra constructors: " ++ show cs)
      forM_ cs_fs_tps $ \(c,req_tp) ->
-       case lookup c cs_fs of
+       case Map.lookup c cs_fs of
          Nothing ->
            throwTCError $ mk_err ("Missing constructor: " ++ show c)
          Just f -> checkSubtype f req_tp
@@ -626,20 +726,22 @@ inferAndCompileRecursor d params p_ret cs_fs =
          }
 
 -- | Infer the type of a recursor application
-inferRecursorApp ::
-  CompiledRecursor TypedTerm ->
+_inferRecursorApp ::
+  TypedTerm   {- ^ recursor term -} ->
   [TypedTerm] {- ^ data type indices -} ->
   TypedTerm   {- ^ recursor argument -} ->
   TCM Term
-inferRecursorApp rec ixs arg =
-  do let motive   = typedVal (recursorMotive rec)
-     let motiveTy = typedType (recursorMotive rec)
-
-     -- Apply the indices to the type of the motive
-     -- to check the types of the `ixs` and `arg`, and
-     -- ensure that the result is fully applied
-     _s <- ensureSort =<< foldM applyPiTyped motiveTy (ixs ++ [arg])
-
-     -- return the type (p_ret ixs arg)
-     liftTCM scTypeCheckWHNF =<<
-       liftTCM scApplyAll motive (map typedVal (ixs ++ [arg]))
+_inferRecursorApp rec ixs arg =
+  do recty <- typeCheckWHNF (typedType rec)
+     case asRecursorType recty of
+       Nothing -> throwTCError (ExpectedRecursor rec)
+       Just (_d, _ps, motive, motiveTy) -> do
+    
+         -- Apply the indices to the type of the motive
+         -- to check the types of the `ixs` and `arg`, and
+         -- ensure that the result is fully applied
+         _s <- ensureSort =<< foldM applyPiTyped motiveTy (ixs ++ [arg])
+    
+         -- return the type (p_ret ixs arg)
+         liftTCM scTypeCheckWHNF =<<
+           liftTCM scApplyAll motive (map typedVal (ixs ++ [arg]))

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -1970,7 +1970,7 @@ scBvSDiv sc n x y = scGlobalApply sc "Prelude.bvSDiv" [n, x, y]
 --
 -- > bvLg2 : (n : Nat) -> Vec n Bool -> Vec n Bool;
 scBvLg2 :: SharedContext -> Term -> Term -> IO Term
-scBvLg2 sc n x = scGlobalApply sc "Prelide.bvLg2" [n, x]
+scBvLg2 sc n x = scGlobalApply sc "Prelude.bvLg2" [n, x]
 
 -- | Create a term applying the population count bitvector primitive.
 --

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -213,6 +213,7 @@ module Verifier.SAW.SharedTerm
   , scBvShl, scBvShr, scBvSShr
   , scBvUExt, scBvSExt
   , scBvTrunc
+  , scBvLg2
   , scBvPopcount
   , scBvCountLeadingZeros
   , scBvCountTrailingZeros
@@ -222,6 +223,7 @@ module Verifier.SAW.SharedTerm
   , scArrayConstant
   , scArrayLookup
   , scArrayUpdate
+  , scArrayEq
     -- ** Utilities
 --  , scTrue
 --  , scFalse
@@ -1933,6 +1935,12 @@ scBvSRem sc n x y = scGlobalApply sc "Prelude.bvSRem" [n, x, y]
 scBvSDiv :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvSDiv sc n x y = scGlobalApply sc "Prelude.bvSDiv" [n, x, y]
 
+-- | Create a term applying the lg2 bitvector primitive.
+--
+-- > bvLg2 : (n : Nat) -> Vec n Bool -> Vec n Bool;
+scBvLg2 :: SharedContext -> Term -> Term -> IO Term
+scBvLg2 sc n x = scGlobalApply sc "Prelide.bvLg2" [n, x]
+
 -- | Create a term applying the population count bitvector primitive.
 --
 -- > bvPopcount : (n : Nat) -> Vec n Bool -> Vec n Bool;
@@ -2096,14 +2104,14 @@ scUpdBvFun sc n a f i v = scGlobalApply sc "Prelude.updBvFun" [n, a, f, i, v]
 scArrayType :: SharedContext -> Term -> Term -> IO Term
 scArrayType sc a b = scGlobalApply sc "Prelude.Array" [a, b]
 
--- Create a term computing a constant array, given an index type, element type,
+-- | Create a term computing a constant array, given an index type, element type,
 -- and element (all as 'Term's).
 --
 -- > arrayConstant : (a b : sort 0) -> b -> (Array a b);
 scArrayConstant :: SharedContext -> Term -> Term -> Term -> IO Term
 scArrayConstant sc a b e = scGlobalApply sc "Prelude.arrayConstant" [a, b, e]
 
--- Create a term computing the value at a particular index of an array.
+-- | Create a term computing the value at a particular index of an array.
 --
 -- > arrayLookup : (a b : sort 0) -> (Array a b) -> a -> b;
 scArrayLookup :: SharedContext -> Term -> Term -> Term -> Term -> IO Term
@@ -2114,6 +2122,12 @@ scArrayLookup sc a b f i = scGlobalApply sc "Prelude.arrayLookup" [a, b, f, i]
 -- > arrayUpdate : (a b : sort 0) -> (Array a b) -> a -> b -> (Array a b);
 scArrayUpdate :: SharedContext -> Term -> Term -> Term -> Term -> Term -> IO Term
 scArrayUpdate sc a b f i e = scGlobalApply sc "Prelude.arrayUpdate" [a, b, f, i, e]
+
+-- | Create a term computing the equality of two arrays.
+--
+-- > arrayEq : (a b : sort 0) -> (Array a b) -> (Array a b) -> Bool;
+scArrayEq :: SharedContext -> Term -> Term -> Term -> Term -> IO Term
+scArrayEq sc a b x y = scGlobalApply sc "Prelude.arrayEq" [a, b, x, y]
 
 ------------------------------------------------------------
 -- | The default instance of the SharedContext operations.

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -812,8 +812,8 @@ scWhnf sc t0 =
     reapply t (ElimProj i) = scRecordSelect sc t i
     reapply t (ElimPair i) = scPairSelector sc t i
     reapply t (ElimRecursor rec ixs) =
-      do --rectm <- scFlatTermF sc (Recursor rec)
-         scFlatTermF sc (RecursorApp rec ixs t)
+      do rectm <- scFlatTermF sc (Recursor rec)
+         scFlatTermF sc (RecursorApp rectm ixs t)
 
     tryDef :: (?cache :: Cache IO TermIndex Term) =>
               Ident -> [WHNFElim] -> Def -> IO Term
@@ -998,15 +998,12 @@ scTypeOf' sc env t0 = State.evalStateT (memo t0) Map.empty
                           (recursorMotive rec)
                           mty
         RecursorApp rec ixs arg ->
-          lift $ scApplyAll sc (recursorMotive rec) (ixs ++ [arg])
-
-{-
           do tp <- (liftIO . scWhnf sc) =<< memo rec
              case asRecursorType tp of
                Just (_d, _ps, motive, _motivety) ->
                  lift $ scApplyAll sc motive (ixs ++ [arg])
                _ -> fail "Expected recursor type in recursor application"
--}
+
         RecordType elems ->
           do max_s <- maximum <$> mapM (sort . snd) elems
              lift $ scSort sc max_s

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -710,7 +710,7 @@ scReduceRecursor sc rec crec c args =
   do ctor <- scRequireCtor sc c
      -- The ctorIotaReduction field caches the result of iota reduction, which
      -- we just substitute into to perform the reduction
-     ctorIotaReduction ctor rec (recursorElims crec) args
+     ctorIotaReduction ctor rec (fmap fst $ recursorElims crec) args
 
 --------------------------------------------------------------------------------
 -- Reduction to head-normal form

--- a/saw-core/src/Verifier/SAW/Simulator.hs
+++ b/saw-core/src/Verifier/SAW/Simulator.hs
@@ -299,8 +299,13 @@ evalRecursorApp modmap lam ps p_ret cs_fs (VNat 0) =
 evalRecursorApp modmap lam ps p_ret cs_fs (VNat i) =
   evalRecursorApp modmap lam ps p_ret cs_fs
   (VCtorApp "Prelude.Succ" (V.singleton $ ready $ VNat $ i-1))
-evalRecursorApp _modmap _lam _ps _p_ret _cs_fs (VToNat _bv) =
-  panic $ "evalRecursorApp: VToNat!"
+
+evalRecursorApp _modmap _lam _ps _p_ret _cs_fs (VBVToNat _ _bv) =
+  panic $ "evalRecursorApp: VBVToNat!"
+
+evalRecursorApp _modmap _lam _ps _p_ret _cs_fs (VIntToNat _i) =
+  panic $ "evalRecursorApp: VIntToNat!"
+
 evalRecursorApp _ _ _ _ _ v =
   panic $ "evalRecursorApp: non-constructor value: " ++ show v
 

--- a/saw-core/src/Verifier/SAW/Simulator.hs
+++ b/saw-core/src/Verifier/SAW/Simulator.hs
@@ -124,14 +124,14 @@ evalTermF :: forall l. (VMonadLazy l, Show (Extra l)) =>
 evalTermF cfg lam recEval tf env =
   case tf of
     App t1 t2               -> recEval t1 >>= \case
-                                 VFun f ->
+                                 VFun _ f ->
                                    do x <- recEvalDelay t2
                                       f x
                                  _ -> simNeutral cfg (NeutralApp (NeutralBox t1) t2)
 
-    Lambda _ _ t            -> return $ VFun (\x -> lam t (x : env))
-    Pi _ t1 t2              -> do v <- toTValue <$> recEval t1
-                                  return $ TValue $ VPiType v (\x -> toTValue <$> lam t2 (x : env))
+    Lambda nm _ t           -> return $ VFun nm (\x -> lam t (x : env))
+    Pi nm t1 t2             -> do v <- toTValue <$> recEval t1
+                                  return $ TValue $ VPiType nm v (\x -> toTValue <$> lam t2 (x : env))
     LocalVar i              -> force (env !! i)
     Constant ec t           -> do ec' <- traverse (fmap toTValue . recEval) ec
                                   maybe (recEval t) id (simConstant cfg tf ec')

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -364,6 +364,7 @@ streamGetOp =
   pureFun $ \xs ->
   strictFun $ \case
     VNat n -> return $ IntTrie.apply (toStream xs) (toInteger n)
-    VToNat w -> return $ IntTrie.apply (toStream xs) (unsigned (toWord w))
+    VIntToNat (VInt i) -> return $ IntTrie.apply (toStream xs) i
+    VBVToNat _ w -> return $ IntTrie.apply (toStream xs) (unsigned (toWord w))
     n -> Prims.panic "Verifier.SAW.Simulator.Concrete.streamGetOp"
                ["Expected Nat value", show n]

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -23,17 +23,11 @@ module Verifier.SAW.Simulator.Concrete
        , runIdentity
        ) where
 
---import Control.Applicative
---import Control.Monad (zipWithM, (<=<))
 import Control.Monad.Identity
-import Data.Bits
 import Data.IntTrie (IntTrie)
 import qualified Data.IntTrie as IntTrie
 import Data.Map (Map)
 import qualified Data.Map as Map
---import Data.Traversable
-import Data.Vector (Vector)
-import qualified Data.Vector as V
 
 import Verifier.SAW.Prim (BitVector(..), signed, bv, bvNeg)
 import qualified Verifier.SAW.Prim as Prim
@@ -45,15 +39,14 @@ import Verifier.SAW.SharedTerm
 
 ------------------------------------------------------------
 
--- type ExtCnsEnv = VarIndex -> String -> CValue
-
 -- | Evaluator for shared terms.
 evalSharedTerm :: ModuleMap -> Map Ident CValue -> Map VarIndex CValue -> Term -> CValue
 evalSharedTerm m addlPrims ecVals t =
   runIdentity $ do
-    cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns (const Nothing)
+    cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns (const Nothing) neutral
     Sim.evalSharedTerm cfg t
   where
+    neutral nt = return $ Prim.userError $ "Cannot evaluate neutral term\n" ++ show nt
     extcns ec =
       case Map.lookup (ecVarIndex ec) ecVals of
         Just v  -> return v
@@ -88,7 +81,7 @@ vWord x = VWord x
 
 toWord :: CValue -> BitVector
 toWord (VWord x) = x
-toWord (VVector vv) = packBitVector (fmap (toBool . runIdentity . force) vv)
+toWord (VVector vv) = Prim.packBitVector (fmap (toBool . runIdentity . force) vv)
 toWord x = error $ unwords ["Verifier.SAW.Simulator.Concrete.toWord", show x]
 
 vStream :: IntTrie CValue -> CValue
@@ -97,20 +90,6 @@ vStream x = VExtra (CStream x)
 toStream :: CValue -> IntTrie CValue
 toStream (VExtra (CStream x)) = x
 toStream x = error $ unwords ["Verifier.SAW.Simulator.Concrete.toStream", show x]
-
-{-
-flattenBValue :: CValue -> BitVector
-flattenBValue (VExtra (BBool l)) = return (AIG.replicate 1 l)
-flattenBValue (VWord lv) = return lv
-flattenBValue (VExtra (CStream _ _)) = error "Verifier.SAW.Simulator.Concrete.flattenBValue: CStream"
-flattenBValue (VVector vv) =
-  AIG.concat <$> traverse (flattenBValue <=< force) (V.toList vv)
-flattenBValue (VTuple vv) =
-  AIG.concat <$> traverse (flattenBValue <=< force) (V.toList vv)
-flattenBValue (VRecord m) =
-  AIG.concat <$> traverse (flattenBValue <=< force) (Map.elems m)
-flattenBValue _ = error $ unwords ["Verifier.SAW.Simulator.Concrete.flattenBValue: unsupported value"]
--}
 
 wordFun :: (BitVector -> CValue) -> CValue
 wordFun f = pureFun (\x -> f (toWord x))
@@ -146,8 +125,8 @@ prims :: Prims.BasePrims Concrete
 prims =
   Prims.BasePrims
   { Prims.bpAsBool  = Just
-  , Prims.bpUnpack  = pure1 unpackBitVector
-  , Prims.bpPack    = pure1 packBitVector
+  , Prims.bpUnpack  = pure1 Prim.unpackBitVector
+  , Prims.bpPack    = pure1 Prim.packBitVector
   , Prims.bpBvAt    = pure2 Prim.bvAt
   , Prims.bpBvLit   = pure2 Prim.bv
   , Prims.bpBvSize  = Prim.width
@@ -192,14 +171,14 @@ prims =
   , Prims.bpBvuge  = pure2 Prim.bvuge
   , Prims.bpBvugt  = pure2 Prim.bvugt
     -- Bitvector shift/rotate
-  , Prims.bpBvRolInt = pure2 bvRotateL
-  , Prims.bpBvRorInt = pure2 bvRotateR
-  , Prims.bpBvShlInt = pure3 bvShiftL
-  , Prims.bpBvShrInt = pure3 bvShiftR
-  , Prims.bpBvRol    = pure2 (\x y -> bvRotateL x (unsigned y))
-  , Prims.bpBvRor    = pure2 (\x y -> bvRotateR x (unsigned y))
-  , Prims.bpBvShl    = pure3 (\b x y -> bvShiftL b x (unsigned y))
-  , Prims.bpBvShr    = pure3 (\b x y -> bvShiftR b x (unsigned y))
+  , Prims.bpBvRolInt = pure2 Prim.bvRotateL
+  , Prims.bpBvRorInt = pure2 Prim.bvRotateR
+  , Prims.bpBvShlInt = pure3 Prim.bvShiftL
+  , Prims.bpBvShrInt = pure3 Prim.bvShiftR
+  , Prims.bpBvRol    = pure2 (\x y -> Prim.bvRotateL x (unsigned y))
+  , Prims.bpBvRor    = pure2 (\x y -> Prim.bvRotateR x (unsigned y))
+  , Prims.bpBvShl    = pure3 (\b x y -> Prim.bvShiftL b x (unsigned y))
+  , Prims.bpBvShr    = pure3 (\b x y -> Prim.bvShiftR b x (unsigned y))
     -- Bitvector misc
   , Prims.bpBvPopcount = pure1 Prim.bvPopcount
   , Prims.bpBvCountLeadingZeros = pure1 Prim.bvCountLeadingZeros
@@ -282,27 +261,6 @@ intToBvOp =
     VWord $
      if n >= 0 then bv (fromIntegral n) x
                else bvNeg $ bv (fromIntegral n) $ negate x
-
-------------------------------------------------------------
--- BitVector operations
-
-bvRotateL :: BitVector -> Integer -> BitVector
-bvRotateL (BV w x) i = Prim.bv w ((x `shiftL` j) .|. (x `shiftR` (w - j)))
-  where j = fromInteger (i `mod` toInteger w)
-
-bvRotateR :: BitVector -> Integer -> BitVector
-bvRotateR w i = bvRotateL w (- i)
-
-bvShiftL :: Bool -> BitVector -> Integer -> BitVector
-bvShiftL c (BV w x) i = Prim.bv w ((x `shiftL` j) .|. c')
-  where c' = if c then (1 `shiftL` j) - 1 else 0
-        j = fromInteger (i `min` toInteger w)
-
-bvShiftR :: Bool -> BitVector -> Integer -> BitVector
-bvShiftR c (BV w x) i = Prim.bv w (c' .|. (x `shiftR` j))
-  where c' = if c then (full `shiftL` (w - j)) .&. full else 0
-        full = (1 `shiftL` w) - 1
-        j = fromInteger (i `min` toInteger w)
 
 ------------------------------------------------------------
 

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -44,7 +44,7 @@ evalSharedTerm m addlPrims ecVals t = do
     cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns (const Nothing) neutral
     Sim.evalSharedTerm cfg t
   where
-    neutral nt = return $ Prim.userError $ "Cannot evaluate neutral term\n" ++ show nt
+    neutral _env nt = return $ Prim.userError $ "Cannot evaluate neutral term\n" ++ show nt
     extcns ec =
       case Map.lookup (ecVarIndex ec) ecVals of
         Just v  -> return v

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -161,8 +161,8 @@ prims =
   , Prims.bpBvAt    = pure2 Prim.bvAt
   , Prims.bpBvLit   = pure2 Prim.bv
   , Prims.bpBvSize  = Prim.width
-  , Prims.bpBvJoin  = pure2 (Prim.append_bv undefined undefined undefined)
-  , Prims.bpBvSlice = pure3 (\m n x -> Prim.slice_bv () m n (Prim.width x - m - n) x)
+  , Prims.bpBvJoin  = pure2 Prim.append_bv
+  , Prims.bpBvSlice = pure3 (\m n x -> Prim.slice_bv m n (Prim.width x - m - n) x)
     -- Conditionals
   , Prims.bpMuxBool  = pure3 ite
   , Prims.bpMuxWord  = pure3 ite
@@ -177,30 +177,30 @@ prims =
   , Prims.bpXor    = pure2 (/=)
   , Prims.bpBoolEq = pure2 (==)
     -- Bitvector logical
-  , Prims.bpBvNot  = pure1 (Prim.bvNot undefined)
-  , Prims.bpBvAnd  = pure2 (Prim.bvAnd undefined)
-  , Prims.bpBvOr   = pure2 (Prim.bvOr  undefined)
-  , Prims.bpBvXor  = pure2 (Prim.bvXor undefined)
+  , Prims.bpBvNot  = pure1 Prim.bvNot
+  , Prims.bpBvAnd  = pure2 Prim.bvAnd
+  , Prims.bpBvOr   = pure2 Prim.bvOr 
+  , Prims.bpBvXor  = pure2 Prim.bvXor
     -- Bitvector arithmetic
-  , Prims.bpBvNeg  = pure1 (Prim.bvNeg undefined)
-  , Prims.bpBvAdd  = pure2 (Prim.bvAdd undefined)
-  , Prims.bpBvSub  = pure2 (Prim.bvSub undefined)
-  , Prims.bpBvMul  = pure2 (Prim.bvMul undefined)
-  , Prims.bpBvUDiv = divOp (Prim.bvUDiv undefined)
-  , Prims.bpBvURem = divOp (Prim.bvURem undefined)
-  , Prims.bpBvSDiv = divOp (Prim.bvSDiv undefined)
-  , Prims.bpBvSRem = divOp (Prim.bvSRem undefined)
+  , Prims.bpBvNeg  = pure1 Prim.bvNeg
+  , Prims.bpBvAdd  = pure2 Prim.bvAdd
+  , Prims.bpBvSub  = pure2 Prim.bvSub
+  , Prims.bpBvMul  = pure2 Prim.bvMul
+  , Prims.bpBvUDiv = divOp Prim.bvUDiv
+  , Prims.bpBvURem = divOp Prim.bvURem
+  , Prims.bpBvSDiv = divOp Prim.bvSDiv
+  , Prims.bpBvSRem = divOp Prim.bvSRem
   , Prims.bpBvLg2  = pure1 Prim.bvLg2
     -- Bitvector comparisons
-  , Prims.bpBvEq   = pure2 (Prim.bvEq  undefined)
-  , Prims.bpBvsle  = pure2 (Prim.bvsle undefined)
-  , Prims.bpBvslt  = pure2 (Prim.bvslt undefined)
-  , Prims.bpBvule  = pure2 (Prim.bvule undefined)
-  , Prims.bpBvult  = pure2 (Prim.bvult undefined)
-  , Prims.bpBvsge  = pure2 (Prim.bvsge undefined)
-  , Prims.bpBvsgt  = pure2 (Prim.bvsgt undefined)
-  , Prims.bpBvuge  = pure2 (Prim.bvuge undefined)
-  , Prims.bpBvugt  = pure2 (Prim.bvugt undefined)
+  , Prims.bpBvEq   = pure2 Prim.bvEq 
+  , Prims.bpBvsle  = pure2 Prim.bvsle
+  , Prims.bpBvslt  = pure2 Prim.bvslt
+  , Prims.bpBvule  = pure2 Prim.bvule
+  , Prims.bpBvult  = pure2 Prim.bvult
+  , Prims.bpBvsge  = pure2 Prim.bvsge
+  , Prims.bpBvsgt  = pure2 Prim.bvsgt
+  , Prims.bpBvuge  = pure2 Prim.bvuge
+  , Prims.bpBvugt  = pure2 Prim.bvugt
     -- Bitvector shift/rotate
   , Prims.bpBvRolInt = pure2 bvRotateL
   , Prims.bpBvRorInt = pure2 bvRotateR
@@ -211,9 +211,9 @@ prims =
   , Prims.bpBvShl    = pure3 (\b x y -> bvShiftL b x (unsigned y))
   , Prims.bpBvShr    = pure3 (\b x y -> bvShiftR b x (unsigned y))
     -- Bitvector misc
-  , Prims.bpBvPopcount = pure1 (Prim.bvPopcount undefined)
-  , Prims.bpBvCountLeadingZeros = pure1 (Prim.bvCountLeadingZeros undefined)
-  , Prims.bpBvCountTrailingZeros = pure1 (Prim.bvCountTrailingZeros undefined)
+  , Prims.bpBvPopcount = pure1 Prim.bvPopcount
+  , Prims.bpBvCountLeadingZeros = pure1 Prim.bvCountLeadingZeros
+  , Prims.bpBvCountTrailingZeros = pure1 Prim.bvCountTrailingZeros
   , Prims.bpBvForall = unsupportedConcretePrimitive "bvForall"
 
     -- Integer operations
@@ -245,9 +245,9 @@ constMap =
   flip Map.union (Prims.constMap prims) $
   Map.fromList
   -- Shifts
-  [ ("Prelude.bvShl" , bvShiftOp (Prim.bvShl undefined))
-  , ("Prelude.bvShr" , bvShiftOp (Prim.bvShr undefined))
-  , ("Prelude.bvSShr", bvShiftOp (Prim.bvSShr undefined))
+  [ ("Prelude.bvShl" , bvShiftOp Prim.bvShl)
+  , ("Prelude.bvShr" , bvShiftOp Prim.bvShr)
+  , ("Prelude.bvSShr", bvShiftOp Prim.bvSShr)
   -- Integers
   , ("Prelude.intToNat", Prims.intToNatOp)
   , ("Prelude.natToInt", Prims.natToIntOp)
@@ -291,7 +291,7 @@ intToBvOp =
   Prims.intFun "intToBv x" $ \x -> return $
     VWord $
      if n >= 0 then bv (fromIntegral n) x
-               else bvNeg n $ bv (fromIntegral n) $ negate x
+               else bvNeg $ bv (fromIntegral n) $ negate x
 
 ------------------------------------------------------------
 -- BitVector operations

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -130,8 +130,8 @@ prims =
   , Prims.bpBvAt    = pure2 Prim.bvAt
   , Prims.bpBvLit   = pure2 Prim.bv
   , Prims.bpBvSize  = Prim.width
-  , Prims.bpBvJoin  = pure2 Prim.append_bv
-  , Prims.bpBvSlice = pure3 (\m n x -> Prim.slice_bv m n (Prim.width x - m - n) x)
+  , Prims.bpBvJoin  = pure2 (Prim.append_bv undefined undefined undefined)
+  , Prims.bpBvSlice = pure3 (\m n x -> Prim.slice_bv () m n (Prim.width x - m - n) x)
     -- Conditionals
   , Prims.bpMuxBool  = pure3 ite
   , Prims.bpMuxWord  = pure3 ite
@@ -146,30 +146,30 @@ prims =
   , Prims.bpXor    = pure2 (/=)
   , Prims.bpBoolEq = pure2 (==)
     -- Bitvector logical
-  , Prims.bpBvNot  = pure1 Prim.bvNot
-  , Prims.bpBvAnd  = pure2 Prim.bvAnd
-  , Prims.bpBvOr   = pure2 Prim.bvOr 
-  , Prims.bpBvXor  = pure2 Prim.bvXor
+  , Prims.bpBvNot  = pure1 (Prim.bvNot undefined)
+  , Prims.bpBvAnd  = pure2 (Prim.bvAnd undefined)
+  , Prims.bpBvOr   = pure2 (Prim.bvOr  undefined)
+  , Prims.bpBvXor  = pure2 (Prim.bvXor undefined)
     -- Bitvector arithmetic
-  , Prims.bpBvNeg  = pure1 Prim.bvNeg
-  , Prims.bpBvAdd  = pure2 Prim.bvAdd
-  , Prims.bpBvSub  = pure2 Prim.bvSub
-  , Prims.bpBvMul  = pure2 Prim.bvMul
-  , Prims.bpBvUDiv = divOp Prim.bvUDiv
-  , Prims.bpBvURem = divOp Prim.bvURem
-  , Prims.bpBvSDiv = divOp Prim.bvSDiv
-  , Prims.bpBvSRem = divOp Prim.bvSRem
+  , Prims.bpBvNeg  = pure1 (Prim.bvNeg undefined)
+  , Prims.bpBvAdd  = pure2 (Prim.bvAdd undefined)
+  , Prims.bpBvSub  = pure2 (Prim.bvSub undefined)
+  , Prims.bpBvMul  = pure2 (Prim.bvMul undefined)
+  , Prims.bpBvUDiv = divOp (Prim.bvUDiv undefined)
+  , Prims.bpBvURem = divOp (Prim.bvURem undefined)
+  , Prims.bpBvSDiv = divOp (Prim.bvSDiv undefined)
+  , Prims.bpBvSRem = divOp (Prim.bvSRem undefined)
   , Prims.bpBvLg2  = pure1 Prim.bvLg2
     -- Bitvector comparisons
-  , Prims.bpBvEq   = pure2 Prim.bvEq 
-  , Prims.bpBvsle  = pure2 Prim.bvsle
-  , Prims.bpBvslt  = pure2 Prim.bvslt
-  , Prims.bpBvule  = pure2 Prim.bvule
-  , Prims.bpBvult  = pure2 Prim.bvult
-  , Prims.bpBvsge  = pure2 Prim.bvsge
-  , Prims.bpBvsgt  = pure2 Prim.bvsgt
-  , Prims.bpBvuge  = pure2 Prim.bvuge
-  , Prims.bpBvugt  = pure2 Prim.bvugt
+  , Prims.bpBvEq   = pure2 (Prim.bvEq  undefined)
+  , Prims.bpBvsle  = pure2 (Prim.bvsle undefined)
+  , Prims.bpBvslt  = pure2 (Prim.bvslt undefined)
+  , Prims.bpBvule  = pure2 (Prim.bvule undefined)
+  , Prims.bpBvult  = pure2 (Prim.bvult undefined)
+  , Prims.bpBvsge  = pure2 (Prim.bvsge undefined)
+  , Prims.bpBvsgt  = pure2 (Prim.bvsgt undefined)
+  , Prims.bpBvuge  = pure2 (Prim.bvuge undefined)
+  , Prims.bpBvugt  = pure2 (Prim.bvugt undefined)
     -- Bitvector shift/rotate
   , Prims.bpBvRolInt = pure2 Prim.bvRotateL
   , Prims.bpBvRorInt = pure2 Prim.bvRotateR
@@ -180,9 +180,9 @@ prims =
   , Prims.bpBvShl    = pure3 (\b x y -> Prim.bvShiftL b x (unsigned y))
   , Prims.bpBvShr    = pure3 (\b x y -> Prim.bvShiftR b x (unsigned y))
     -- Bitvector misc
-  , Prims.bpBvPopcount = pure1 Prim.bvPopcount
-  , Prims.bpBvCountLeadingZeros = pure1 Prim.bvCountLeadingZeros
-  , Prims.bpBvCountTrailingZeros = pure1 Prim.bvCountTrailingZeros
+  , Prims.bpBvPopcount = pure1 (Prim.bvPopcount undefined)
+  , Prims.bpBvCountLeadingZeros = pure1 (Prim.bvCountLeadingZeros undefined)
+  , Prims.bpBvCountTrailingZeros = pure1 (Prim.bvCountTrailingZeros undefined)
   , Prims.bpBvForall = unsupportedConcretePrimitive "bvForall"
 
     -- Integer operations
@@ -214,9 +214,9 @@ constMap =
   flip Map.union (Prims.constMap prims) $
   Map.fromList
   -- Shifts
-  [ ("Prelude.bvShl" , bvShiftOp Prim.bvShl)
-  , ("Prelude.bvShr" , bvShiftOp Prim.bvShr)
-  , ("Prelude.bvSShr", bvShiftOp Prim.bvSShr)
+  [ ("Prelude.bvShl" , bvShiftOp (Prim.bvShl undefined))
+  , ("Prelude.bvShr" , bvShiftOp (Prim.bvShr undefined))
+  , ("Prelude.bvSShr", bvShiftOp (Prim.bvSShr undefined))
   -- Integers
   , ("Prelude.intToNat", Prims.intToNatOp)
   , ("Prelude.natToInt", Prims.natToIntOp)
@@ -260,7 +260,7 @@ intToBvOp =
   Prims.intFun "intToBv x" $ \x -> return $
     VWord $
      if n >= 0 then bv (fromIntegral n) x
-               else bvNeg $ bv (fromIntegral n) $ negate x
+               else bvNeg n $ bv (fromIntegral n) $ negate x
 
 ------------------------------------------------------------
 

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -86,16 +86,6 @@ toBool x = error $ unwords ["Verifier.SAW.Simulator.Concrete.toBool", show x]
 vWord :: BitVector -> CValue
 vWord x = VWord x
 
--- | Conversion from list of bits to integer (big-endian)
-bvToInteger :: Vector Bool -> Integer
-bvToInteger = V.foldl' (\x b -> if b then 2*x+1 else 2*x) 0
-
-unpackBitVector :: BitVector -> Vector Bool
-unpackBitVector x = V.generate (Prim.width x) (Prim.bvAt x)
-
-packBitVector :: Vector Bool -> BitVector
-packBitVector v = BV (V.length v) (bvToInteger v)
-
 toWord :: CValue -> BitVector
 toWord (VWord x) = x
 toWord (VVector vv) = packBitVector (fmap (toBool . runIdentity . force) vv)

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -136,7 +136,7 @@ prims =
   , Prims.bpMuxBool  = pure3 ite
   , Prims.bpMuxWord  = pure3 ite
   , Prims.bpMuxInt   = pure3 ite
-  , Prims.bpMuxExtra = pure3 ite
+  , Prims.bpMuxExtra = \_tp -> pure3 ite
     -- Booleans
   , Prims.bpTrue   = True
   , Prims.bpFalse  = False

--- a/saw-core/src/Verifier/SAW/Simulator/MonadLazy.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/MonadLazy.hs
@@ -8,7 +8,7 @@ Portability : non-portable (language extensions)
 -}
 module Verifier.SAW.Simulator.MonadLazy where
 
-import Control.Monad.Identity
+import Control.Monad (liftM)
 import Control.Monad.IO.Class
 import Data.IORef
 

--- a/saw-core/src/Verifier/SAW/Simulator/MonadLazy.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/MonadLazy.hs
@@ -14,7 +14,7 @@ import Data.IORef
 
 newtype Lazy m a = Lazy (m a)
 
-class Monad m => MonadLazy m where
+class MonadIO m => MonadLazy m where
   delay :: m a -> m (Lazy m a)
 
 force :: Lazy m a -> m a
@@ -22,9 +22,6 @@ force (Lazy m) = m
 
 ready :: Monad m => a -> Lazy m a
 ready x = Lazy (return x)
-
-instance MonadLazy Identity where
-  delay m = return (Lazy m)
 
 instance MonadLazy IO where
   delay = delayIO

--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -658,9 +658,9 @@ atWithDefaultOp bp =
         iv <- toBits (bpUnpack bp) i
         case x of
           VVector xv ->
-            selectV (lazyMuxValue bp (VVecType n tp)) (fromIntegral n - 1) (force . vecIdx d xv) iv -- FIXME dangerous fromIntegral
+            selectV (lazyMuxValue bp tp) (fromIntegral n - 1) (force . vecIdx d xv) iv -- FIXME dangerous fromIntegral
           VWord xw ->
-            selectV (lazyMuxValue bp (VVecType n tp)) (fromIntegral n - 1) (liftM VBool . bpBvAt bp xw) iv -- FIXME dangerous fromIntegral
+            selectV (lazyMuxValue bp tp) (fromIntegral n - 1) (liftM VBool . bpBvAt bp xw) iv -- FIXME dangerous fromIntegral
           _ -> panic "atOp: expected vector"
 
       VIntToNat _i ->

--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -315,7 +315,7 @@ toWord pack (VVector vv) = pack =<< V.mapM (liftM toBool . force) vv
 toWord _ x = panic $ unwords ["Verifier.SAW.Simulator.toWord", show x]
 
 toWordPred :: (VMonad l, Show (Extra l)) => Value l -> VWord l -> MBool l
-toWordPred (VFun f) = fmap toBool . f . ready . VWord
+toWordPred (VFun _ f) = fmap toBool . f . ready . VWord
 toWordPred x = panic $ unwords ["Verifier.SAW.Simulator.toWordPred", show x]
 
 toBits :: (VMonad l, Show (Extra l)) => Unpack l -> Value l ->
@@ -434,7 +434,7 @@ coerceOp =
   constFun $
   constFun $
   constFun $
-  VFun force
+  VFun "x" force
 
 ------------------------------------------------------------
 -- Nat primitives
@@ -574,8 +574,8 @@ ltNatOp bp =
 natCaseOp :: (VMonad l, Show (Extra l)) => Value l
 natCaseOp =
   constFun $
-  VFun $ \z -> return $
-  VFun $ \s -> return $
+  VFun "z"  $ \z -> return $
+  VFun "s" $ \s -> return $
   natFun' "natCase" $ \n ->
     if n == 0
     then force z
@@ -644,7 +644,7 @@ atWithDefaultOp :: (VMonadLazy l, Show (Extra l)) => BasePrims l -> Value l
 atWithDefaultOp bp =
   natFun $ \n -> return $
   constFun $
-  VFun $ \d -> return $
+  VFun "d" $ \d -> return $
   strictFun $ \x -> return $
   strictFun $ \idx ->
     case idx of
@@ -674,7 +674,7 @@ updOp bp =
   constFun $
   vectorFun (bpUnpack bp) $ \xv -> return $
   strictFun $ \idx -> return $
-  VFun $ \y ->
+  VFun "y" $ \y ->
     case idx of
       VNat i
         | toInteger i < toInteger (V.length xv)
@@ -867,7 +867,7 @@ shiftOp :: forall l.
 shiftOp bp vecOp wordIntOp wordOp =
   natFun $ \n -> return $
   constFun $
-  VFun $ \z -> return $
+  VFun "z" $ \z -> return $
   strictFun $ \xs -> return $
   strictFun $ \y ->
     case y of
@@ -1134,7 +1134,7 @@ foldrOp unpack =
   constFun $
   constFun $
   strictFun $ \f -> return $
-  VFun $ \z -> return $
+  VFun "z" $ \z -> return $
   strictFun $ \xs -> do
     let g x m = do fx <- apply f x
                    y <- delay m
@@ -1241,8 +1241,8 @@ iteOp :: (VMonadLazy l, Show (Extra l)) => BasePrims l -> Value l
 iteOp bp =
   constFun $
   strictFun $ \b -> return $
-  VFun $ \x -> return $
-  VFun $ \y -> lazyMuxValue bp (toBool b) (force x) (force y)
+  VFun "x" $ \x -> return $
+  VFun "y" $ \y -> lazyMuxValue bp (toBool b) (force x) (force y)
 
 lazyMuxValue ::
   (VMonadLazy l, Show (Extra l)) =>
@@ -1262,7 +1262,7 @@ muxValue :: forall l.
 muxValue bp b = value
   where
     value :: Value l -> Value l -> MValue l
-    value (VFun f)          (VFun g)          = return $ VFun $ \a -> do
+    value (VFun nm f)       (VFun _ g)        = return $ VFun nm $ \a -> do
                                                   x <- f a
                                                   y <- g a
                                                   value x y

--- a/saw-core/src/Verifier/SAW/Simulator/RME.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/RME.hs
@@ -127,7 +127,8 @@ bvShiftOp op =
   pureFun $ \y ->
     case y of
       VNat n   -> vWord (op x (toInteger n))
-      VToNat v -> vWord (genShift muxRMEV op x (toWord v))
+      VBVToNat _sz v -> vWord (genShift muxRMEV op x (toWord v))
+      VIntToNat _i   -> error "RME.shiftOp: intToNat TODO"
       _        -> error $ unwords ["Verifier.SAW.Simulator.RME.shiftOp", show y]
 
 ------------------------------------------------------------
@@ -345,7 +346,8 @@ streamGetOp =
   pureFun $ \xs ->
   strictFun $ \case
     VNat n -> pure $ IntTrie.apply (toStream xs) (toInteger n)
-    VToNat bv ->
+    VIntToNat _i -> error "RME.streamGetOp : symbolic integer TODO"
+    VBVToNat _sz bv ->
       do let trie = toStream xs
              loop k [] = IntTrie.apply trie k
              loop k (b:bs)

--- a/saw-core/src/Verifier/SAW/Simulator/RME.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/RME.hs
@@ -64,7 +64,7 @@ evalSharedTerm m addlPrims t = do
     Sim.evalSharedTerm cfg t
   where
     extcns ec = return $ Prim.userError $ "Unimplemented: external constant " ++ show (ecName ec)
-    neutral nt = return $ Prim.userError $ "Could not evaluate neutral term\n:" ++ show nt
+    neutral _env nt = return $ Prim.userError $ "Could not evaluate neutral term\n:" ++ show nt
 
 ------------------------------------------------------------
 -- Values
@@ -403,7 +403,7 @@ bitBlastBasic :: ModuleMap
               -> Term
               -> IO RValue
 bitBlastBasic m addlPrims ecMap t = do
-  let neutral nt = return $ Prim.userError $ "Could not evaluate neutral term\n:" ++ show nt
+  let neutral _env nt = return $ Prim.userError $ "Could not evaluate neutral term\n:" ++ show nt
 
   cfg <- Sim.evalGlobal m (Map.union constMap addlPrims)
          (\ec -> case Map.lookup (ecVarIndex ec) ecMap of

--- a/saw-core/src/Verifier/SAW/Simulator/RME.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/RME.hs
@@ -63,10 +63,11 @@ evalSharedTerm :: ModuleMap -> Map Ident RValue -> Term -> RValue
 evalSharedTerm m addlPrims t =
   runIdentity $ do
     cfg <- Sim.evalGlobal m (Map.union constMap addlPrims)
-           extcns (const Nothing)
+           extcns (const Nothing) neutral
     Sim.evalSharedTerm cfg t
   where
     extcns ec = return $ Prim.userError $ "Unimplemented: external constant " ++ show (ecName ec)
+    neutral nt = return $ Prim.userError $ "Could not evaluate neutral term\n:" ++ show nt
 
 ------------------------------------------------------------
 -- Values
@@ -390,11 +391,14 @@ bitBlastBasic :: ModuleMap
               -> Term
               -> RValue
 bitBlastBasic m addlPrims ecMap t = runIdentity $ do
+  let neutral nt = return $ Prim.userError $ "Could not evaluate neutral term\n:" ++ show nt
+
   cfg <- Sim.evalGlobal m (Map.union constMap addlPrims)
          (\ec -> case Map.lookup (ecVarIndex ec) ecMap of
                    Just v -> pure v
                    Nothing -> error ("RME: unknown ExtCns: " ++ show (ecName ec)))
          (const Nothing)
+         neutral
   Sim.evalSharedTerm cfg t
 
 

--- a/saw-core/src/Verifier/SAW/Simulator/RME.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/RME.hs
@@ -158,7 +158,7 @@ prims =
   , Prims.bpMuxBool  = pure3 RME.mux
   , Prims.bpMuxWord  = pure3 muxRMEV
   , Prims.bpMuxInt   = pure3 muxInt
-  , Prims.bpMuxExtra = pure3 muxExtra
+  , Prims.bpMuxExtra = \tp -> pure3 (muxExtra tp)
     -- Booleans
   , Prims.bpTrue   = RME.true
   , Prims.bpFalse  = RME.false
@@ -282,11 +282,13 @@ muxInt b x y =
     Just c -> if c then x else y
     Nothing -> if x == y then x else error $ "muxRValue: VInt " ++ show (x, y)
 
-muxExtra :: RME -> RExtra -> RExtra -> RExtra
-muxExtra b (AStream xs) (AStream ys) = AStream (muxRValue b <$> xs <*> ys)
+muxExtra :: TValue ReedMuller -> RME -> RExtra -> RExtra -> RExtra
+muxExtra (VDataType "Prelude.Stream" [TValue tp]) b (AStream xs) (AStream ys) =
+  AStream (muxRValue tp b <$> xs <*> ys)
+muxExtra tp _ _ _ = panic "RME.muxExtra" ["type mismatch", show tp]
 
-muxRValue :: RME -> RValue -> RValue -> RValue
-muxRValue b x y = runIdentity $ Prims.muxValue prims b x y
+muxRValue :: TValue ReedMuller -> RME -> RValue -> RValue -> RValue
+muxRValue tp b x y = runIdentity $ Prims.muxValue prims tp b x y
 
 -- | Signed shift right simply copies the high order bit
 --   into the shifted places.  We special case the zero
@@ -343,7 +345,7 @@ mkStreamOp =
 -- streamGet :: (a :: sort 0) -> Stream a -> Nat -> a;
 streamGetOp :: RValue
 streamGetOp =
-  constFun $
+  strictFun $ \(toTValue -> tp) -> return $
   pureFun $ \xs ->
   strictFun $ \case
     VNat n -> pure $ IntTrie.apply (toStream xs) (toInteger n)
@@ -357,7 +359,7 @@ streamGetOp =
                | Just False <- RME.isBool b
                = loop k0 bs
                | otherwise
-               = muxRValue b (loop k1 bs) (loop k0 bs)
+               = muxRValue tp b (loop k1 bs) (loop k0 bs)
               where
                k0 = k `shiftL` 1
                k1 = k0 + 1

--- a/saw-core/src/Verifier/SAW/Simulator/TermModel.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/TermModel.hs
@@ -1,0 +1,501 @@
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{- |
+Module      : Verifier.SAW.Simulator.TermModel
+Copyright   : Galois, Inc. 2012-2021
+License     : BSD3
+Maintainer  : huffman@galois.com
+Stability   : experimental
+Portability : non-portable (language extensions)
+-}
+
+module Verifier.SAW.Simulator.TermModel
+       ( -- evalTermModel,
+         TmValue, TermModel, Value(..), TValue(..)
+       , VExtra(..)
+       , readBackValue, readBackTValue
+       , normalizeSharedTerm
+       ) where
+
+import Control.Monad.Fix
+import Data.IORef
+--import Data.Vector (Vector)
+--import qualified Data.Vector as V
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Numeric.Natural
+
+import Verifier.SAW.Prim (BitVector(..))
+--import qualified Verifier.SAW.Prim as Prim
+import qualified Verifier.SAW.Simulator as Sim
+import Verifier.SAW.Simulator.Value
+--import qualified Verifier.SAW.Simulator.Prims as Prims
+import Verifier.SAW.TypedAST (ModuleMap, DataType(..))
+import Verifier.SAW.SharedTerm
+import Verifier.SAW.Utils (panic)
+
+------------------------------------------------------------
+
+
+normalizeSharedTerm ::
+  SharedContext ->
+  ModuleMap ->
+  Map Ident TmValue ->
+  Map VarIndex TmValue ->
+  Term ->
+  IO Term
+normalizeSharedTerm sc m addlPrims ecVals t =
+  do cfg <- mfix (\cfg -> Sim.evalGlobal m (Map.union constMap addlPrims) (extcns cfg) (const Nothing))
+     v <- Sim.evalSharedTerm cfg t
+     tv <- evalType cfg =<< scTypeOf sc t
+     readBackValue sc cfg tv v
+  where
+    constMap = error "TermModel TODO: define the constMap!"
+
+    extcns cfg ec =
+      case Map.lookup (ecVarIndex ec) ecVals of
+        Just v  -> return v
+        Nothing ->
+          do ec' <- traverse (readBackTValue sc cfg) ec
+             tm <- scExtCns sc ec'
+             reflectTerm sc cfg (ecType ec) tm
+
+------------------------------------------------------------
+-- Values
+
+data TermModel
+
+type TmValue = Value TermModel
+
+type instance EvalM  TermModel = IO
+type instance VBool  TermModel = Either Term Bool
+type instance VWord  TermModel = Either Term BitVector
+type instance VInt   TermModel = Either Term Integer
+type instance VArray TermModel = Term
+type instance Extra  TermModel = VExtra
+
+data VExtra
+  = VStream Term (Natural -> IO TmValue) (IORef (Map Natural TmValue))
+  | VExtraTerm (TValue TermModel) Term
+
+instance Show VExtra where
+  show (VStream tm _ _) = show tm
+  show (VExtraTerm _ tm) = show tm
+
+readBackTValue :: SharedContext -> Sim.SimulatorConfig TermModel -> TValue TermModel -> IO Term
+readBackTValue sc cfg = loop
+  where
+  loop tv =
+    case tv of
+      VUnitType -> scUnitType sc
+      VBoolType -> scBoolType sc
+      VIntType -> scIntegerType sc
+      VSort s  -> scSort sc s
+      VIntModType m ->
+        do m' <- scNat sc m
+           scIntModType sc m'
+      VArrayType t1 t2 ->
+        do t1' <- loop t1
+           t2' <- loop t2
+           scArrayType sc t1' t2'
+      VVecType n t ->
+        do n' <- scNat sc n
+           t' <- loop t
+           scVecType sc n' t'
+      VPairType t1 t2 ->
+        do t1' <- loop t1
+           t2' <- loop t2
+           scPairType sc t1' t2'
+      VRecordType fs ->
+        do fs' <- traverse (traverse loop) fs
+           scRecordType sc fs'
+      VDataType nm vs ->
+        do dt <- scRequireDataType sc nm
+           dtTy <- evalType cfg (dtType dt)
+           vs' <- readBackDataType dtTy vs
+           scDataTypeApp sc nm vs'
+      VPiType{} ->
+        do (ecs, tm) <- readBackPis tv
+           scGeneralizeExts sc ecs tm
+
+  readBackDataType (VPiType t f) (v:vs) =
+    do v' <- readBackValue sc cfg t v
+       t' <- f (ready v)
+       vs' <- readBackDataType t' vs
+       return (v':vs')
+  readBackDataType (VSort _s) [] = return []
+  readBackDataType _ _ = panic "readBackTValue" ["Arity mismatch in data type in readback"]
+
+  readBackPis (VPiType t f) =
+    do t' <- loop t
+       ec <- scFreshEC sc "x" t'
+       ecTm <- scExtCns sc ec
+       ecVal <- delay (reflectTerm sc cfg t ecTm)
+       body <- f ecVal
+       (ecs,body') <- readBackPis body
+       return (ec:ecs, body')
+
+  readBackPis t =
+    do tm <- loop t
+       return ([], tm)
+
+evalType :: Sim.SimulatorConfig TermModel -> Term -> IO (TValue TermModel)
+evalType cfg tm =
+  Sim.evalSharedTerm cfg tm >>= \case
+    TValue tv -> pure tv
+    _ -> panic "evalType" ["Expected type value"]
+
+reflectTerm :: SharedContext -> Sim.SimulatorConfig TermModel -> TValue TermModel -> Term -> IO (Value TermModel)
+reflectTerm sc cfg = loop
+  where
+  loop tv tm = case tv of
+    VUnitType -> pure VUnit
+    VBoolType -> return (VBool (Left tm))
+    VIntType  -> return (VInt (Left tm))
+    VIntModType m -> return (VIntMod m (Left tm))
+    VVecType _n VBoolType -> return (VWord (Left tm))
+    VArrayType _ _ -> return (VArray tm)
+    VSort _s -> TValue <$> evalType cfg tm
+
+    VPiType t tf ->
+      return (VFun (\x ->
+        do v <- force x
+           tbody <- tf x
+           xtm <- readBackValue sc cfg t v
+           body <- scApply sc tm xtm
+           reflectTerm sc cfg tbody body
+        ))
+
+    VRecordType{} -> return (VExtra (VExtraTerm tv tm))
+    VPairType{} -> return (VExtra (VExtraTerm tv tm))
+    -- NB: not a word
+    VVecType{} -> return (VExtra (VExtraTerm tv tm))
+    VDataType{} -> return (VExtra (VExtraTerm tv tm))
+
+
+readBackValue :: SharedContext -> Sim.SimulatorConfig TermModel -> TValue TermModel -> Value TermModel -> IO Term
+readBackValue sc cfg = loop
+  where
+    loop _ VUnit = scUnitValue sc
+
+    loop _ (VNat n) = scNat sc n
+
+    loop _ (VBool (Left tm)) = return tm
+    loop _ (VBool (Right b)) = scBool sc b
+    
+    loop _ (VInt (Left tm)) = return tm
+    loop _ (VInt (Right i)) = scIntegerConst sc i
+
+    loop _ (VIntMod _ (Left tm)) = return tm
+    loop _ (VIntMod m (Right i)) =
+      do m' <- scNat sc m
+         i' <- scIntegerConst sc i
+         scToIntMod sc m' i'
+
+    loop _ (VWord (Left tm)) = return tm
+    loop _ (VWord (Right bv)) = scBvConst sc (fromIntegral (width bv)) (unsigned bv)
+
+    loop _ (VArray tm) = return tm
+    loop _ (VString s) = scString sc s
+
+    loop _ (TValue tv) = readBackTValue sc cfg tv
+
+    loop _ (VExtra (VExtraTerm _ tm)) = return tm
+    loop _ (VExtra (VStream tm _ _))  = return tm
+
+    loop tv@VPiType{} v@VFun{} =
+      do (ecs, tm) <- readBackFuns tv v
+         scAbstractExts sc ecs tm
+
+    loop (VPairType t1 t2) (VPair v1 v2) =
+      do tm1 <- loop t1 =<< force v1
+         tm2 <- loop t2 =<< force v2
+         scPairValueReduced sc tm1 tm2
+
+    loop (VDataType _nm _ps) (VCtorApp _cnm _vs) =
+      fail "readBackValue: ctor app TODO, this is kind of tricky"
+
+    loop (VRecordType fs) (VRecordValue vs) =
+      do let fm = Map.fromList fs
+         let build (k,v) =
+                  case Map.lookup k fm of
+                    Nothing -> panic "readBackValue" ["field mismatch in record value"
+                                                     , show (map fst fs), show (map snd fs) ]
+                    Just t ->
+                       do tm <- loop t =<< force v
+                          return (k,tm)
+         vs' <- Map.fromList <$> traverse build vs
+         scRecord sc vs'
+
+    loop tv _v = panic "readBackValue" ["type mismatch", show tv]
+
+    readBackFuns (VPiType tv tf) (VFun f) =
+      do t' <- readBackTValue sc cfg tv
+         ec <- scFreshEC sc "x" t'
+         ecTm <- scExtCns sc ec
+         ecVal <- delay (reflectTerm sc cfg tv ecTm)
+         tbody <- tf ecVal
+         body  <- f ecVal
+         (ecs,tm) <- readBackFuns tbody body
+         return (ec:ecs, tm)
+
+    readBackFuns tv v =
+      do tm <- loop tv v
+         return ([], tm)
+
+
+{-
+instance Show TExtra where
+  show (TStream{}) = "<stream>"
+
+wordFun :: (BitVector -> CValue) -> CValue
+wordFun f = pureFun (\x -> f (toWord x))
+
+-- | op : (n : Nat) -> Vec n Bool -> Nat -> Vec n Bool
+bvShiftOp :: (BitVector -> Int -> BitVector) -> CValue
+bvShiftOp natOp =
+  constFun $
+  wordFun $ \x ->
+  pureFun $ \y ->
+    case y of
+      VNat n | toInteger n < toInteger (maxBound :: Int) -> vWord (natOp x (fromIntegral n))
+      _      -> error $ unwords ["Verifier.SAW.Simulator.Concrete.shiftOp", show y]
+
+------------------------------------------------------------
+
+pure1 :: Applicative f => (a -> b) -> a -> f b
+pure1 f x = pure (f x)
+
+pure2 :: Applicative f => (a -> b -> c) -> a -> b -> f c
+pure2 f x y = pure (f x y)
+
+pure3 :: Applicative f => (a -> b -> c -> d) -> a -> b -> c -> f d
+pure3 f x y z = pure (f x y z)
+
+divOp :: (a -> b -> Maybe c) -> a -> b -> Identity c
+divOp f x y = maybe Prim.divideByZero pure (f x y)
+
+ite :: Bool -> a -> a -> a
+ite b x y = if b then x else y
+
+prims :: Prims.BasePrims Concrete
+prims =
+  Prims.BasePrims
+  { Prims.bpAsBool  = Just
+  , Prims.bpUnpack  = pure1 unpackBitVector
+  , Prims.bpPack    = pure1 packBitVector
+  , Prims.bpBvAt    = pure2 Prim.bvAt
+  , Prims.bpBvLit   = pure2 Prim.bv
+  , Prims.bpBvSize  = Prim.width
+  , Prims.bpBvJoin  = pure2 (Prim.append_bv undefined undefined undefined)
+  , Prims.bpBvSlice = pure3 (\m n x -> Prim.slice_bv () m n (Prim.width x - m - n) x)
+    -- Conditionals
+  , Prims.bpMuxBool  = pure3 ite
+  , Prims.bpMuxWord  = pure3 ite
+  , Prims.bpMuxInt   = pure3 ite
+  , Prims.bpMuxExtra = pure3 ite
+    -- Booleans
+  , Prims.bpTrue   = True
+  , Prims.bpFalse  = False
+  , Prims.bpNot    = pure1 not
+  , Prims.bpAnd    = pure2 (&&)
+  , Prims.bpOr     = pure2 (||)
+  , Prims.bpXor    = pure2 (/=)
+  , Prims.bpBoolEq = pure2 (==)
+    -- Bitvector logical
+  , Prims.bpBvNot  = pure1 (Prim.bvNot undefined)
+  , Prims.bpBvAnd  = pure2 (Prim.bvAnd undefined)
+  , Prims.bpBvOr   = pure2 (Prim.bvOr  undefined)
+  , Prims.bpBvXor  = pure2 (Prim.bvXor undefined)
+    -- Bitvector arithmetic
+  , Prims.bpBvNeg  = pure1 (Prim.bvNeg undefined)
+  , Prims.bpBvAdd  = pure2 (Prim.bvAdd undefined)
+  , Prims.bpBvSub  = pure2 (Prim.bvSub undefined)
+  , Prims.bpBvMul  = pure2 (Prim.bvMul undefined)
+  , Prims.bpBvUDiv = divOp (Prim.bvUDiv undefined)
+  , Prims.bpBvURem = divOp (Prim.bvURem undefined)
+  , Prims.bpBvSDiv = divOp (Prim.bvSDiv undefined)
+  , Prims.bpBvSRem = divOp (Prim.bvSRem undefined)
+  , Prims.bpBvLg2  = pure1 Prim.bvLg2
+    -- Bitvector comparisons
+  , Prims.bpBvEq   = pure2 (Prim.bvEq  undefined)
+  , Prims.bpBvsle  = pure2 (Prim.bvsle undefined)
+  , Prims.bpBvslt  = pure2 (Prim.bvslt undefined)
+  , Prims.bpBvule  = pure2 (Prim.bvule undefined)
+  , Prims.bpBvult  = pure2 (Prim.bvult undefined)
+  , Prims.bpBvsge  = pure2 (Prim.bvsge undefined)
+  , Prims.bpBvsgt  = pure2 (Prim.bvsgt undefined)
+  , Prims.bpBvuge  = pure2 (Prim.bvuge undefined)
+  , Prims.bpBvugt  = pure2 (Prim.bvugt undefined)
+    -- Bitvector shift/rotate
+  , Prims.bpBvRolInt = pure2 bvRotateL
+  , Prims.bpBvRorInt = pure2 bvRotateR
+  , Prims.bpBvShlInt = pure3 bvShiftL
+  , Prims.bpBvShrInt = pure3 bvShiftR
+  , Prims.bpBvRol    = pure2 (\x y -> bvRotateL x (unsigned y))
+  , Prims.bpBvRor    = pure2 (\x y -> bvRotateR x (unsigned y))
+  , Prims.bpBvShl    = pure3 (\b x y -> bvShiftL b x (unsigned y))
+  , Prims.bpBvShr    = pure3 (\b x y -> bvShiftR b x (unsigned y))
+    -- Bitvector misc
+  , Prims.bpBvPopcount = pure1 (Prim.bvPopcount undefined)
+  , Prims.bpBvCountLeadingZeros = pure1 (Prim.bvCountLeadingZeros undefined)
+  , Prims.bpBvCountTrailingZeros = pure1 (Prim.bvCountTrailingZeros undefined)
+  , Prims.bpBvForall = unsupportedConcretePrimitive "bvForall"
+
+    -- Integer operations
+  , Prims.bpIntAdd = pure2 (+)
+  , Prims.bpIntSub = pure2 (-)
+  , Prims.bpIntMul = pure2 (*)
+  , Prims.bpIntDiv = pure2 div
+  , Prims.bpIntMod = pure2 mod
+  , Prims.bpIntNeg = pure1 negate
+  , Prims.bpIntAbs = pure1 abs
+  , Prims.bpIntEq  = pure2 (==)
+  , Prims.bpIntLe  = pure2 (<=)
+  , Prims.bpIntLt  = pure2 (<)
+  , Prims.bpIntMin = pure2 min
+  , Prims.bpIntMax = pure2 max
+
+    -- Array operations
+  , Prims.bpArrayConstant = unsupportedConcretePrimitive "bpArrayConstant"
+  , Prims.bpArrayLookup = unsupportedConcretePrimitive "bpArrayLookup"
+  , Prims.bpArrayUpdate = unsupportedConcretePrimitive "bpArrayUpdate"
+  , Prims.bpArrayEq = unsupportedConcretePrimitive "bpArrayEq"
+  }
+
+unsupportedConcretePrimitive :: String -> a
+unsupportedConcretePrimitive = Prim.unsupportedPrimitive "concrete"
+
+constMap :: Map Ident CValue
+constMap =
+  flip Map.union (Prims.constMap prims) $
+  Map.fromList
+  -- Shifts
+  [ ("Prelude.bvShl" , bvShiftOp (Prim.bvShl undefined))
+  , ("Prelude.bvShr" , bvShiftOp (Prim.bvShr undefined))
+  , ("Prelude.bvSShr", bvShiftOp (Prim.bvSShr undefined))
+  -- Integers
+  , ("Prelude.intToNat", Prims.intToNatOp)
+  , ("Prelude.natToInt", Prims.natToIntOp)
+  , ("Prelude.intToBv" , intToBvOp)
+  , ("Prelude.bvToInt" , bvToIntOp)
+  , ("Prelude.sbvToInt", sbvToIntOp)
+  -- Integers mod n
+  , ("Prelude.toIntMod"  , toIntModOp)
+  , ("Prelude.fromIntMod", fromIntModOp)
+  , ("Prelude.intModEq"  , intModEqOp)
+  , ("Prelude.intModAdd" , intModBinOp (+))
+  , ("Prelude.intModSub" , intModBinOp (-))
+  , ("Prelude.intModMul" , intModBinOp (*))
+  , ("Prelude.intModNeg" , intModUnOp negate)
+  -- Streams
+  , ("Prelude.MkStream", mkStreamOp)
+  , ("Prelude.streamGet", streamGetOp)
+  -- Miscellaneous
+  , ("Prelude.bvToNat", bvToNatOp) -- override Prims.constMap
+  , ("Prelude.expByNat", Prims.expByNatOp prims)
+  ]
+
+------------------------------------------------------------
+
+-- primitive bvToNat : (n : Nat) -> Vec n Bool -> Nat;
+bvToNatOp :: CValue
+bvToNatOp = constFun $ wordFun $ VNat . fromInteger . unsigned
+
+-- primitive bvToInt : (n : Nat) -> Vec n Bool -> Integer;
+bvToIntOp :: CValue
+bvToIntOp = constFun $ wordFun $ VInt . unsigned
+
+-- primitive sbvToInt : (n : Nat) -> Vec n Bool -> Integer;
+sbvToIntOp :: CValue
+sbvToIntOp = constFun $ wordFun $ VInt . signed
+
+-- primitive intToBv : (n : Nat) -> Integer -> Vec n Bool;
+intToBvOp :: CValue
+intToBvOp =
+  Prims.natFun' "intToBv n" $ \n -> return $
+  Prims.intFun "intToBv x" $ \x -> return $
+    VWord $
+     if n >= 0 then bv (fromIntegral n) x
+               else bvNeg n $ bv (fromIntegral n) $ negate x
+
+------------------------------------------------------------
+-- BitVector operations
+
+bvRotateL :: BitVector -> Integer -> BitVector
+bvRotateL (BV w x) i = Prim.bv w ((x `shiftL` j) .|. (x `shiftR` (w - j)))
+  where j = fromInteger (i `mod` toInteger w)
+
+bvRotateR :: BitVector -> Integer -> BitVector
+bvRotateR w i = bvRotateL w (- i)
+
+bvShiftL :: Bool -> BitVector -> Integer -> BitVector
+bvShiftL c (BV w x) i = Prim.bv w ((x `shiftL` j) .|. c')
+  where c' = if c then (1 `shiftL` j) - 1 else 0
+        j = fromInteger (i `min` toInteger w)
+
+bvShiftR :: Bool -> BitVector -> Integer -> BitVector
+bvShiftR c (BV w x) i = Prim.bv w (c' .|. (x `shiftR` j))
+  where c' = if c then (full `shiftL` (w - j)) .&. full else 0
+        full = (1 `shiftL` w) - 1
+        j = fromInteger (i `min` toInteger w)
+
+------------------------------------------------------------
+
+toIntModOp :: CValue
+toIntModOp =
+  Prims.natFun $ \n -> return $
+  Prims.intFun "toIntModOp" $ \x -> return $
+  VIntMod n (x `mod` toInteger n)
+
+fromIntModOp :: CValue
+fromIntModOp =
+  constFun $
+  Prims.intModFun "fromIntModOp" $ \x -> pure $
+  VInt x
+
+intModEqOp :: CValue
+intModEqOp =
+  constFun $
+  Prims.intModFun "intModEqOp" $ \x -> return $
+  Prims.intModFun "intModEqOp" $ \y -> return $
+  VBool (x == y)
+
+intModBinOp :: (Integer -> Integer -> Integer) -> CValue
+intModBinOp f =
+  Prims.natFun $ \n -> return $
+  Prims.intModFun "intModBinOp x" $ \x -> return $
+  Prims.intModFun "intModBinOp y" $ \y -> return $
+  VIntMod n (f x y `mod` toInteger n)
+
+intModUnOp :: (Integer -> Integer) -> CValue
+intModUnOp f =
+  Prims.natFun $ \n -> return $
+  Prims.intModFun "intModUnOp" $ \x -> return $
+  VIntMod n (f x `mod` toInteger n)
+
+------------------------------------------------------------
+
+-- MkStream :: (a :: sort 0) -> (Nat -> a) -> Stream a;
+mkStreamOp :: CValue
+mkStreamOp =
+  constFun $
+  pureFun $ \f ->
+  vStream (fmap (\n -> runIdentity (apply f (ready (VNat n)))) IntTrie.identity)
+
+-- streamGet :: (a :: sort 0) -> Stream a -> Nat -> a;
+streamGetOp :: CValue
+streamGetOp =
+  constFun $
+  pureFun $ \xs ->
+  strictFun $ \case
+    VNat n -> return $ IntTrie.apply (toStream xs) (toInteger n)
+    VToNat w -> return $ IntTrie.apply (toStream xs) (unsigned (toWord w))
+    n -> Prims.panic "Verifier.SAW.Simulator.Concrete.streamGetOp"
+               ["Expected Nat value", show n]
+-}

--- a/saw-core/src/Verifier/SAW/Simulator/TermModel.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/TermModel.hs
@@ -184,6 +184,12 @@ readBackValue sc cfg = loop
     loop _ VUnit = scUnitValue sc
 
     loop _ (VNat n) = scNat sc n
+    loop _ (VBVToNat w n) =
+      do tm <- loop (VVecType (fromIntegral w) VBoolType) n
+         scBvToNat sc (fromIntegral w) tm
+    loop _ (VIntToNat i) =
+      do tm <- loop VIntType i
+         scIntToNat sc tm
 
     loop _ (VBool (Left tm)) = return tm
     loop _ (VBool (Right b)) = scBool sc b

--- a/saw-core/src/Verifier/SAW/Simulator/TermModel.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/TermModel.hs
@@ -22,20 +22,22 @@ module Verifier.SAW.Simulator.TermModel
        , normalizeSharedTerm
        ) where
 
+import Control.Monad
 import Control.Monad.Fix
 import Data.IORef
 --import Data.Vector (Vector)
---import qualified Data.Vector as V
+import qualified Data.Vector as V
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Numeric.Natural
 
 import Verifier.SAW.Prim (BitVector(..))
---import qualified Verifier.SAW.Prim as Prim
+import qualified Verifier.SAW.Prim as Prim
 import qualified Verifier.SAW.Simulator as Sim
 import Verifier.SAW.Simulator.Value
---import qualified Verifier.SAW.Simulator.Prims as Prims
-import Verifier.SAW.TypedAST (ModuleMap, DataType(..))
+import qualified Verifier.SAW.Simulator.Prims as Prims
+import Verifier.SAW.TypedAST
+         (ModuleMap, DataType(..), findCtorInMap, ctorType, ctorNumParams)
 import Verifier.SAW.SharedTerm
 import Verifier.SAW.Utils (panic)
 
@@ -50,12 +52,18 @@ normalizeSharedTerm ::
   Term ->
   IO Term
 normalizeSharedTerm sc m addlPrims ecVals t =
-  do cfg <- mfix (\cfg -> Sim.evalGlobal m (Map.union constMap addlPrims) (extcns cfg) (const Nothing))
+  do cfg <- mfix (\cfg -> Sim.evalGlobal m (Map.union (constMap sc cfg) addlPrims)
+                             (extcns cfg) (const Nothing) (neutral cfg))
      v <- Sim.evalSharedTerm cfg t
      tv <- evalType cfg =<< scTypeOf sc t
      readBackValue sc cfg tv v
+
   where
-    constMap = error "TermModel TODO: define the constMap!"
+    neutral cfg nt =
+      do tm <- neutralToSharedTerm sc nt
+         ty <- scTypeOf sc tm
+         tyv <- evalType cfg ty
+         pure (VExtra (VExtraTerm tyv tm))
 
     extcns cfg ec =
       case Map.lookup (ecVarIndex ec) ecVals of
@@ -74,18 +82,31 @@ type TmValue = Value TermModel
 
 type instance EvalM  TermModel = IO
 type instance VBool  TermModel = Either Term Bool
-type instance VWord  TermModel = Either Term BitVector
+type instance VWord  TermModel = Either (Natural, Term) BitVector
 type instance VInt   TermModel = Either Term Integer
-type instance VArray TermModel = Term
+type instance VArray TermModel = TermModelArray
 type instance Extra  TermModel = VExtra
 
 data VExtra
-  = VStream Term (Natural -> IO TmValue) (IORef (Map Natural TmValue))
-  | VExtraTerm (TValue TermModel) Term
+  = VStream
+       (TValue TermModel) -- element type of the stream
+       Term               -- term representing this stream
+       (Natural -> IO TmValue) -- concrete lookup function
+       (IORef (Map Natural TmValue)) -- cashed values of lookup function
+  | VExtraTerm
+       (TValue TermModel) -- type of the term
+       Term               -- term value
 
 instance Show VExtra where
-  show (VStream tm _ _) = show tm
+  show (VStream _ tm _ _) = show tm
   show (VExtraTerm _ tm) = show tm
+
+data TermModelArray =
+  TMArray
+    (TValue TermModel) Term -- @a@
+    (TValue TermModel) Term -- @b@
+    Term -- term of type @Array a b@
+
 
 readBackTValue :: SharedContext -> Sim.SimulatorConfig TermModel -> TValue TermModel -> IO Term
 readBackTValue sc cfg = loop
@@ -158,8 +179,12 @@ reflectTerm sc cfg = loop
     VBoolType -> return (VBool (Left tm))
     VIntType  -> return (VInt (Left tm))
     VIntModType m -> return (VIntMod m (Left tm))
-    VVecType _n VBoolType -> return (VWord (Left tm))
-    VArrayType _ _ -> return (VArray tm)
+    VVecType n VBoolType -> return (VWord (Left (n,tm)))
+    VArrayType a b ->
+      do a' <- readBackTValue sc cfg a
+         b' <- readBackTValue sc cfg b
+         return (VArray (TMArray a a' b b' tm))
+
     VSort _s -> TValue <$> evalType cfg tm
 
     VPiType t tf ->
@@ -171,10 +196,21 @@ reflectTerm sc cfg = loop
            reflectTerm sc cfg tbody body
         ))
 
+    -- TODO: eta-expanding vectors like this kinda sucks.  It would be
+    -- better if we could treat them abstractly, as we are doing below
+    -- with records, pairs and data types.  However, that would be
+    -- a pretty invasive change in the primitives.
+    VVecType n t ->  -- NB: t /= Bool
+      do a  <- readBackTValue sc cfg t
+         n' <- scNat sc n
+         vs <- V.generateM (fromIntegral n) $ \i -> -- TODO fromIntegral...
+                   do i' <- scNat sc (fromIntegral i)
+                      tm' <- scAt sc n' a tm i'
+                      ready <$> reflectTerm sc cfg t tm'
+         pure (VVector vs)
+
     VRecordType{} -> return (VExtra (VExtraTerm tv tm))
     VPairType{} -> return (VExtra (VExtraTerm tv tm))
-    -- NB: not a word
-    VVecType{} -> return (VExtra (VExtraTerm tv tm))
     VDataType{} -> return (VExtra (VExtraTerm tv tm))
 
 
@@ -184,16 +220,18 @@ readBackValue sc cfg = loop
     loop _ VUnit = scUnitValue sc
 
     loop _ (VNat n) = scNat sc n
+
     loop _ (VBVToNat w n) =
       do tm <- loop (VVecType (fromIntegral w) VBoolType) n
          scBvToNat sc (fromIntegral w) tm
+
     loop _ (VIntToNat i) =
       do tm <- loop VIntType i
          scIntToNat sc tm
 
     loop _ (VBool (Left tm)) = return tm
     loop _ (VBool (Right b)) = scBool sc b
-    
+
     loop _ (VInt (Left tm)) = return tm
     loop _ (VInt (Right i)) = scIntegerConst sc i
 
@@ -203,16 +241,20 @@ readBackValue sc cfg = loop
          i' <- scIntegerConst sc i
          scToIntMod sc m' i'
 
-    loop _ (VWord (Left tm)) = return tm
+    loop _ (VWord (Left (_,tm))) = return tm
     loop _ (VWord (Right bv)) = scBvConst sc (fromIntegral (width bv)) (unsigned bv)
 
-    loop _ (VArray tm) = return tm
+    loop _ (VArray (TMArray _ _ _ _ tm)) = return tm
+
     loop _ (VString s) = scString sc s
 
     loop _ (TValue tv) = readBackTValue sc cfg tv
 
-    loop _ (VExtra (VExtraTerm _ tm)) = return tm
-    loop _ (VExtra (VStream tm _ _))  = return tm
+    loop _ (VExtra (VExtraTerm _tp tm)) = return tm
+    loop _ (VExtra (VStream _tp tm _fn _cache))  = return tm
+
+--    loop _ (VFloat _f) = fail "readBackValue: TODO float"
+--    loop _ (VDouble _f) = fail "readBackValue: TODO float"
 
     loop tv@VPiType{} v@VFun{} =
       do (ecs, tm) <- readBackFuns tv v
@@ -223,8 +265,19 @@ readBackValue sc cfg = loop
          tm2 <- loop t2 =<< force v2
          scPairValueReduced sc tm1 tm2
 
-    loop (VDataType _nm _ps) (VCtorApp _cnm _vs) =
-      fail "readBackValue: ctor app TODO, this is kind of tricky"
+    loop (VVecType _n tp) (VVector vs) =
+      do tp' <- readBackTValue sc cfg tp
+         vs' <- traverse (loop tp <=< force) (V.toList vs)
+         scVectorReduced sc tp' vs'
+
+    loop (VDataType _nm _ps) (VCtorApp cnm vs) =
+      case findCtorInMap (Sim.simModMap cfg) cnm of
+        Nothing -> panic "readBackValue" ["Could not find constructor info", show cnm]
+        Just ctor ->
+          do tyv <- evalType cfg (ctorType ctor)
+             vs' <- readBackCtorArgs ctor tyv (V.toList vs)
+             let (ps,args) = splitAt (ctorNumParams ctor) vs'
+             scCtorAppParams sc cnm ps args
 
     loop (VRecordType fs) (VRecordValue vs) =
       do let fm = Map.fromList fs
@@ -240,6 +293,16 @@ readBackValue sc cfg = loop
 
     loop tv _v = panic "readBackValue" ["type mismatch", show tv]
 
+    readBackCtorArgs cnm (VPiType tv tf) (v:vs) =
+      do v' <- force v
+         t  <- loop tv v'
+         ty <- tf (ready v')
+         ts <- readBackCtorArgs cnm ty vs
+         pure (t:ts)
+    readBackCtorArgs _ (VDataType _ _) [] = pure []
+    readBackCtorArgs cnm _ _ = panic "readBackCtorArgs" ["constructor type mismatch", show cnm]
+
+
     readBackFuns (VPiType tv tf) (VFun f) =
       do t' <- readBackTValue sc cfg tv
          ec <- scFreshEC sc "x" t'
@@ -249,207 +312,566 @@ readBackValue sc cfg = loop
          body  <- f ecVal
          (ecs,tm) <- readBackFuns tbody body
          return (ec:ecs, tm)
-
     readBackFuns tv v =
       do tm <- loop tv v
          return ([], tm)
 
 
-{-
-instance Show TExtra where
-  show (TStream{}) = "<stream>"
 
-wordFun :: (BitVector -> CValue) -> CValue
-wordFun f = pureFun (\x -> f (toWord x))
 
--- | op : (n : Nat) -> Vec n Bool -> Nat -> Vec n Bool
-bvShiftOp :: (BitVector -> Int -> BitVector) -> CValue
-bvShiftOp natOp =
-  constFun $
-  wordFun $ \x ->
-  pureFun $ \y ->
-    case y of
-      VNat n | toInteger n < toInteger (maxBound :: Int) -> vWord (natOp x (fromIntegral n))
-      _      -> error $ unwords ["Verifier.SAW.Simulator.Concrete.shiftOp", show y]
+boolTerm :: SharedContext -> VBool TermModel -> IO Term
+boolTerm _ (Left tm) = pure tm
+boolTerm sc (Right b) = scBool sc b
 
-------------------------------------------------------------
+wordWidth :: VWord TermModel -> Natural
+wordWidth (Left (n,_)) = n
+wordWidth (Right bv)   = fromIntegral (Prim.width bv)
 
-pure1 :: Applicative f => (a -> b) -> a -> f b
-pure1 f x = pure (f x)
+wordTerm :: SharedContext -> VWord TermModel -> IO Term
+wordTerm _  (Left (_,tm)) = pure tm
+wordTerm sc (Right bv) =
+  scBvConst sc (fromIntegral (Prim.width bv)) (Prim.unsigned bv)
 
-pure2 :: Applicative f => (a -> b -> c) -> a -> b -> f c
-pure2 f x y = pure (f x y)
+wordValue :: SharedContext -> BitVector -> IO (Natural, Term)
+wordValue sc bv =
+  do let n = fromIntegral (Prim.width bv)
+     tm <- scBvConst sc n (Prim.unsigned bv)
+     pure (n, tm)
 
-pure3 :: Applicative f => (a -> b -> c -> d) -> a -> b -> c -> f d
-pure3 f x y z = pure (f x y z)
+intTerm :: SharedContext -> VInt TermModel -> IO Term
+intTerm _ (Left tm) = pure tm
+intTerm sc (Right i) = scIntegerConst sc i
 
-divOp :: (a -> b -> Maybe c) -> a -> b -> Identity c
-divOp f x y = maybe Prim.divideByZero pure (f x y)
+extraTerm :: VExtra -> IO Term
+extraTerm (VStream _tp tm _ _) = pure tm
+extraTerm (VExtraTerm _ tm) = pure tm
 
-ite :: Bool -> a -> a -> a
-ite b x y = if b then x else y
+extraType :: VExtra -> IO (TValue TermModel)
+extraType (VExtraTerm tp _tm) = pure tp
+extraType (VStream tp _tm _fn _cache) = pure (VDataType "Prelude.Stream" [TValue tp])
 
-prims :: Prims.BasePrims Concrete
-prims =
+unOp ::
+  SharedContext ->
+  (SharedContext -> t -> IO t') ->
+  (a -> b) ->
+  Either t a -> IO (Either t' b)
+unOp sc termOp _valOp (Left t) = Left <$> termOp sc t
+unOp _sc _termOp valOp (Right x) = pure . Right $! valOp x
+
+binOp ::
+  SharedContext ->
+  (SharedContext -> a -> IO t) ->
+  (SharedContext -> t -> t -> IO t') ->
+  (a -> a -> b) ->
+  Either t a -> Either t a -> IO (Either t' b)
+binOp sc toTerm termOp valOp x y =
+  case (x, y) of
+    (Right xv, Right yv) -> pure . Right $! valOp xv yv
+    (Left xtm, Right yv) ->
+      do ytm <- toTerm sc yv
+         Left <$> termOp sc xtm ytm
+    (Right xv, Left ytm) ->
+      do xtm <- toTerm sc xv
+         Left <$> termOp sc xtm ytm
+    (Left xtm, Left ytm) ->
+      Left <$> termOp sc xtm ytm
+
+
+bvUnOp ::
+  SharedContext ->
+  (SharedContext -> Term -> Term -> IO Term) ->
+  (BitVector -> BitVector) ->
+  VWord TermModel -> IO (VWord TermModel)
+bvUnOp sc termOp valOp = \case
+  Right bv -> pure . Right $! valOp bv
+  Left (n,tm) ->
+    do n' <- scNat sc n
+       tm' <- termOp sc n' tm
+       pure (Left (n,tm'))
+
+
+bvBinOp ::
+  SharedContext ->
+  (SharedContext -> Term -> Term -> Term -> IO Term) ->
+  (BitVector -> BitVector -> BitVector) ->
+  VWord TermModel -> VWord TermModel -> IO (VWord TermModel)
+bvBinOp sc termOp valOp = binOp sc wordValue termOp' valOp
+  where
+    termOp' _ (n,x) (_,y) =
+      do n' <- scNat sc n
+         tm <- termOp sc n' x y
+         pure (n, tm)
+
+
+intDivOp ::
+  SharedContext ->
+  (SharedContext -> Term -> Term -> IO Term) ->
+  (Integer -> Integer -> Integer) ->
+  VInt TermModel -> VInt TermModel -> IO (VInt TermModel)
+
+-- Special case for concrete divide-by-0:
+-- return the term instead of producing an error
+intDivOp sc termOp _intOp x y@(Right 0) =
+  do x' <- intTerm sc x
+     y' <- intTerm sc y
+     Left <$> termOp sc x' y'
+intDivOp sc termOp intOp x y =
+  binOp sc scIntegerConst termOp intOp x y
+
+
+bvDivOp ::
+  SharedContext ->
+  (SharedContext -> Term -> Term -> Term -> IO Term) ->
+  (BitVector -> BitVector -> Maybe BitVector) ->
+  VWord TermModel -> VWord TermModel -> IO (VWord TermModel)
+bvDivOp sc termOp valOp x y = fixup =<< binOp sc wordValue termOp' valOp x y
+  where
+    -- Special case for concrete divide-by-0:
+    -- return the term instead of producing an error
+    fixup (Left l) = pure (Left l)
+    fixup (Right (Just bv)) = pure (Right bv)
+    fixup (Right Nothing) =
+      do let n = wordWidth x
+         n' <- scNat sc n
+         xtm <- wordTerm sc x
+         ytm <- wordTerm sc y
+         tm <- termOp sc n' xtm ytm
+         pure (Left (n,tm))
+
+    termOp' _ (n,xtm) (_,ytm) =
+      do n' <- scNat sc n
+         tm <- termOp sc n' xtm ytm
+         pure (n, tm)
+
+bvCmpOp ::
+  SharedContext ->
+  (SharedContext -> Term -> Term -> Term -> IO Term) ->
+  (BitVector -> BitVector -> Bool) ->
+  VWord TermModel -> VWord TermModel -> IO (VBool TermModel)
+bvCmpOp sc termOp valOp = binOp sc wordValue termOp' valOp
+  where
+    termOp' _ (n,x) (_,y) =
+      do n' <- scNat sc n
+         termOp sc n' x y
+
+prims :: SharedContext -> Sim.SimulatorConfig TermModel -> Prims.BasePrims TermModel
+prims sc cfg =
   Prims.BasePrims
-  { Prims.bpAsBool  = Just
-  , Prims.bpUnpack  = pure1 unpackBitVector
-  , Prims.bpPack    = pure1 packBitVector
-  , Prims.bpBvAt    = pure2 Prim.bvAt
-  , Prims.bpBvLit   = pure2 Prim.bv
-  , Prims.bpBvSize  = Prim.width
-  , Prims.bpBvJoin  = pure2 (Prim.append_bv undefined undefined undefined)
-  , Prims.bpBvSlice = pure3 (\m n x -> Prim.slice_bv () m n (Prim.width x - m - n) x)
-    -- Conditionals
-  , Prims.bpMuxBool  = pure3 ite
-  , Prims.bpMuxWord  = pure3 ite
-  , Prims.bpMuxInt   = pure3 ite
-  , Prims.bpMuxExtra = pure3 ite
+  { Prims.bpAsBool  = \case
+       Left _  -> Nothing
+       Right b -> Just b
+
+  , Prims.bpUnpack  = \case
+       Right bv -> pure (fmap Right (Prim.unpackBitVector bv))
+
+       Left (n,tm) ->
+              do n' <- scNat sc n
+                 a  <- scBoolType sc
+                 V.generateM (fromIntegral n) (\i ->
+                    Left <$> (scAt sc n' a tm =<< scNat sc (fromIntegral i)))
+
+  , Prims.bpPack = \vs ->
+       case traverse id vs of
+         Right bs -> pure (Right (Prim.packBitVector bs))
+         Left _ ->
+           do a <- scBoolType sc
+              ts <- traverse (\case Left tm -> pure tm; Right b -> scBool sc b) (V.toList vs)
+              v <- scVector sc a ts
+              let n = fromIntegral (V.length vs)
+              return (Left (n, v))
+
+  , Prims.bpBvAt = \w i ->
+       case w of
+         Right bv -> pure . Right $! Prim.bvAt bv i
+         Left (n,tm) ->
+           do n' <- scNat sc n
+              a <- scBoolType sc
+              i' <- scNat sc (fromIntegral i)
+              Left <$> scAt sc n' a tm i'
+
+  , Prims.bpBvLit = \w x -> pure (Right (Prim.bv w x))
+
+  , Prims.bpBvSize = \case
+       Right bv   -> Prim.width bv
+       Left (n,_) -> fromIntegral n -- gross, TODO
+
+  , Prims.bpBvJoin =
+       let f _ (xn,xtm) (yn,ytm) =
+               do xn' <- scNat sc xn
+                  yn' <- scNat sc yn
+                  a   <- scBoolType sc
+                  tm  <- scAppend sc xn' yn' a xtm ytm
+                  return (xn+yn, tm)
+        in binOp sc wordValue f Prim.append_bv
+
+  , Prims.bpBvSlice = \m n -> \case
+         Right bv -> pure . Right $! Prim.slice_bv m n (Prim.width bv - m - n) bv
+         Left  (w,tm) ->
+           do m' <- scNat sc (fromIntegral m)
+              n' <- scNat sc (fromIntegral n)
+              o' <- scNat sc (w - fromIntegral m - fromIntegral n)
+              a  <- scBoolType sc
+              tm' <- scSlice sc a m' n' o' tm
+              return (Left (fromIntegral n, tm'))
+
+    -- conditionals
+  , Prims.bpMuxBool = \c x y ->
+       case c of
+         Right b -> if b then pure x else pure y
+         Left tm ->
+           do x' <- boolTerm sc x
+              y' <- boolTerm sc y
+              a  <- scBoolType sc
+              Left <$> scIte sc a tm x' y'
+
+  , Prims.bpMuxWord = \c x y ->
+       case c of
+         Right b -> if b then pure x else pure y
+         Left tm ->
+           do x' <- wordTerm sc x
+              y' <- wordTerm sc y
+              a  <- scBitvector sc (wordWidth x)
+              tm' <- scIte sc a tm x' y'
+              pure (Left (wordWidth x, tm'))
+
+  , Prims.bpMuxInt = \c x y ->
+       case c of
+         Right b -> if b then pure x else pure y
+         Left tm ->
+           do x' <- intTerm sc x
+              y' <- intTerm sc y
+              a  <- scIntegerType sc
+              Left <$> scIte sc a tm x' y'
+
+  , Prims.bpMuxExtra = \c x y ->
+       case c of
+         Right b -> if b then pure x else pure y
+         Left tm ->
+           do tp <- extraType x
+              x' <- extraTerm x
+              y' <- extraTerm y
+              a  <- readBackTValue sc cfg tp
+              VExtraTerm tp <$> scIte sc a tm x' y'
+
     -- Booleans
-  , Prims.bpTrue   = True
-  , Prims.bpFalse  = False
-  , Prims.bpNot    = pure1 not
-  , Prims.bpAnd    = pure2 (&&)
-  , Prims.bpOr     = pure2 (||)
-  , Prims.bpXor    = pure2 (/=)
-  , Prims.bpBoolEq = pure2 (==)
+  , Prims.bpTrue   = Right True
+  , Prims.bpFalse  = Right False
+  , Prims.bpNot    = unOp sc scNot not
+  , Prims.bpAnd    = binOp sc scBool scAnd (&&)
+  , Prims.bpOr     = binOp sc scBool scOr  (||)
+  , Prims.bpXor    = binOp sc scBool scXor (/=)
+  , Prims.bpBoolEq = binOp sc scBool scBoolEq (==)
+
     -- Bitvector logical
-  , Prims.bpBvNot  = pure1 (Prim.bvNot undefined)
-  , Prims.bpBvAnd  = pure2 (Prim.bvAnd undefined)
-  , Prims.bpBvOr   = pure2 (Prim.bvOr  undefined)
-  , Prims.bpBvXor  = pure2 (Prim.bvXor undefined)
+  , Prims.bpBvNot  = bvUnOp  sc scBvNot Prim.bvNot
+  , Prims.bpBvAnd  = bvBinOp sc scBvAnd Prim.bvAnd
+  , Prims.bpBvOr   = bvBinOp sc scBvOr  Prim.bvOr
+  , Prims.bpBvXor  = bvBinOp sc scBvXor Prim.bvXor
+
     -- Bitvector arithmetic
-  , Prims.bpBvNeg  = pure1 (Prim.bvNeg undefined)
-  , Prims.bpBvAdd  = pure2 (Prim.bvAdd undefined)
-  , Prims.bpBvSub  = pure2 (Prim.bvSub undefined)
-  , Prims.bpBvMul  = pure2 (Prim.bvMul undefined)
-  , Prims.bpBvUDiv = divOp (Prim.bvUDiv undefined)
-  , Prims.bpBvURem = divOp (Prim.bvURem undefined)
-  , Prims.bpBvSDiv = divOp (Prim.bvSDiv undefined)
-  , Prims.bpBvSRem = divOp (Prim.bvSRem undefined)
-  , Prims.bpBvLg2  = pure1 Prim.bvLg2
+  , Prims.bpBvNeg  = bvUnOp  sc scBvNeg  Prim.bvNeg
+  , Prims.bpBvAdd  = bvBinOp sc scBvAdd  Prim.bvAdd
+  , Prims.bpBvSub  = bvBinOp sc scBvSub  Prim.bvSub
+  , Prims.bpBvMul  = bvBinOp sc scBvMul  Prim.bvMul
+  , Prims.bpBvUDiv = bvDivOp sc scBvUDiv Prim.bvUDiv
+  , Prims.bpBvURem = bvDivOp sc scBvURem Prim.bvURem
+  , Prims.bpBvSDiv = bvDivOp sc scBvSDiv Prim.bvSDiv
+  , Prims.bpBvSRem = bvDivOp sc scBvSRem Prim.bvSRem
+  , Prims.bpBvLg2  = bvUnOp  sc scBvLg2  Prim.bvLg2
+
     -- Bitvector comparisons
-  , Prims.bpBvEq   = pure2 (Prim.bvEq  undefined)
-  , Prims.bpBvsle  = pure2 (Prim.bvsle undefined)
-  , Prims.bpBvslt  = pure2 (Prim.bvslt undefined)
-  , Prims.bpBvule  = pure2 (Prim.bvule undefined)
-  , Prims.bpBvult  = pure2 (Prim.bvult undefined)
-  , Prims.bpBvsge  = pure2 (Prim.bvsge undefined)
-  , Prims.bpBvsgt  = pure2 (Prim.bvsgt undefined)
-  , Prims.bpBvuge  = pure2 (Prim.bvuge undefined)
-  , Prims.bpBvugt  = pure2 (Prim.bvugt undefined)
+  , Prims.bpBvEq   = bvCmpOp sc scBvEq  Prim.bvEq
+  , Prims.bpBvsle  = bvCmpOp sc scBvSLe Prim.bvsle
+  , Prims.bpBvslt  = bvCmpOp sc scBvSLt Prim.bvslt
+  , Prims.bpBvule  = bvCmpOp sc scBvULe Prim.bvule
+  , Prims.bpBvult  = bvCmpOp sc scBvULt Prim.bvult
+  , Prims.bpBvsge  = bvCmpOp sc scBvSGe Prim.bvsge
+  , Prims.bpBvsgt  = bvCmpOp sc scBvSGt Prim.bvsgt
+  , Prims.bpBvuge  = bvCmpOp sc scBvUGe Prim.bvuge
+  , Prims.bpBvugt  = bvCmpOp sc scBvUGt Prim.bvugt
+
     -- Bitvector shift/rotate
-  , Prims.bpBvRolInt = pure2 bvRotateL
-  , Prims.bpBvRorInt = pure2 bvRotateR
-  , Prims.bpBvShlInt = pure3 bvShiftL
-  , Prims.bpBvShrInt = pure3 bvShiftR
-  , Prims.bpBvRol    = pure2 (\x y -> bvRotateL x (unsigned y))
-  , Prims.bpBvRor    = pure2 (\x y -> bvRotateR x (unsigned y))
-  , Prims.bpBvShl    = pure3 (\b x y -> bvShiftL b x (unsigned y))
-  , Prims.bpBvShr    = pure3 (\b x y -> bvShiftR b x (unsigned y))
+  , Prims.bpBvShlInt = \c x amt ->
+      case (c, x) of
+        (Right c', Right x') -> pure . Right $! Prim.bvShiftL c' x' amt
+        _ -> do let n = wordWidth x
+                n'  <- scNat sc n
+                a   <- scBoolType sc
+                ctm <- boolTerm sc c
+                xtm <- wordTerm sc x
+                amttm <- scNat sc (fromInteger amt) -- TODO, should probably be a Natural?
+                tm <- scGlobalApply sc "Prelude.shiftL" [n',a,ctm,xtm,amttm]
+                pure (Left (n, tm))
+
+  , Prims.bpBvShrInt = \c x amt ->
+      case (c, x) of
+        (Right c', Right x') -> pure . Right $! Prim.bvShiftR c' x' amt
+        _ -> do let n = wordWidth x
+                n'  <- scNat sc n
+                a   <- scBoolType sc
+                ctm <- boolTerm sc c
+                xtm <- wordTerm sc x
+                amttm <- scNat sc (fromInteger amt) -- TODO, should probably be a Natural?
+                tm <- scGlobalApply sc "Prelude.shiftR" [n',a,ctm,xtm,amttm]
+                pure (Left (n, tm))
+
+  , Prims.bpBvShl = \c x amt ->
+      case (c, x, amt) of
+        (Right c', Right x', Right amt') -> pure . Right $! Prim.bvShiftL c' x' (Prim.unsigned amt')
+        _ -> do let n = wordWidth x
+                n'  <- scNat sc n
+                a   <- scBoolType sc
+                ctm <- boolTerm sc c
+                xtm <- wordTerm sc x
+                let an = wordWidth amt
+                amttm <- scBvToNat sc an =<< wordTerm sc amt
+                tm <- scGlobalApply sc "Prelude.shiftL" [n',a,ctm,xtm,amttm]
+                return (Left (n, tm))
+
+  , Prims.bpBvShr = \c x amt ->
+      case (c, x, amt) of
+        (Right c', Right x', Right amt') -> pure . Right $! Prim.bvShiftR c' x' (Prim.unsigned amt')
+        _ -> do let n = wordWidth x
+                n'  <- scNat sc n
+                a   <- scBoolType sc
+                ctm <- boolTerm sc c
+                xtm <- wordTerm sc x
+                let an = wordWidth amt
+                amttm <- scBvToNat sc an =<< wordTerm sc amt
+                tm <- scGlobalApply sc "Prelude.shiftR" [n',a,ctm,xtm,amttm]
+                return (Left (n, tm))
+
+  , Prims.bpBvRolInt = \x amt ->
+      case x of
+        Right x' -> pure . Right $! Prim.bvRotateL x' amt
+        Left (n,xtm) ->
+          do n' <- scNat sc n
+             a  <- scBoolType sc
+             amttm <- scNat sc (fromInteger amt) -- TODO Natural
+             tm <- scGlobalApply sc "Prelude.rotateL" [n',a,xtm,amttm]
+             return (Left (n,tm))
+
+  , Prims.bpBvRorInt = \x amt ->
+      case x of
+        Right x' -> pure . Right $! Prim.bvRotateR x' amt
+        Left (n,xtm) ->
+          do n' <- scNat sc n
+             a  <- scBoolType sc
+             amttm <- scNat sc (fromInteger amt) -- TODO Natural
+             tm <- scGlobalApply sc "Prelude.rotateR" [n',a,xtm,amttm]
+             return (Left (n,tm))
+
+  , Prims.bpBvRol = \x amt ->
+      case (x, amt) of
+        (Right x', Right amt') -> pure . Right $! Prim.bvRotateL x' (Prim.unsigned amt')
+        _ ->
+          do let n = wordWidth x
+             n' <- scNat sc n
+             a  <- scBoolType sc
+             xtm <- wordTerm sc x
+             let an = wordWidth amt
+             amttm <- scBvToNat sc an =<< wordTerm sc amt
+             tm <- scGlobalApply sc "Prelude.rotateL" [n',a,xtm,amttm]
+             return (Left (n,tm))
+
+  , Prims.bpBvRor = \x amt ->
+      case (x, amt) of
+        (Right x', Right amt') -> pure . Right $! Prim.bvRotateR x' (Prim.unsigned amt')
+        _ ->
+          do let n = wordWidth x
+             n' <- scNat sc n
+             a  <- scBoolType sc
+             xtm <- wordTerm sc x
+             let an = wordWidth amt
+             amttm <- scBvToNat sc an =<< wordTerm sc amt
+             tm <- scGlobalApply sc "Prelude.rotateR" [n',a,xtm,amttm]
+             return (Left (n,tm))
+
     -- Bitvector misc
-  , Prims.bpBvPopcount = pure1 (Prim.bvPopcount undefined)
-  , Prims.bpBvCountLeadingZeros = pure1 (Prim.bvCountLeadingZeros undefined)
-  , Prims.bpBvCountTrailingZeros = pure1 (Prim.bvCountTrailingZeros undefined)
-  , Prims.bpBvForall = unsupportedConcretePrimitive "bvForall"
+  , Prims.bpBvPopcount = bvUnOp sc scBvPopcount Prim.bvPopcount
+  , Prims.bpBvCountLeadingZeros = bvUnOp sc scBvCountLeadingZeros Prim.bvCountLeadingZeros
+  , Prims.bpBvCountTrailingZeros = bvUnOp sc scBvCountTrailingZeros Prim.bvCountTrailingZeros
+
+  , Prims.bpBvForall = \n f ->
+      do bvty <- scBitvector sc n
+         ec   <- scFreshEC sc "x" bvty
+         ecTm <- scExtCns sc ec
+         res  <- f (Left (n,ecTm))
+         case res of
+           -- computed a constant boolean without consulting the variable, just return it
+           Right b -> return (Right b)
+           Left  resTm ->
+             do n' <- scNat sc n
+                fn <- scAbstractExts sc [ec] resTm
+                Left <$> scBvForall sc n' fn
 
     -- Integer operations
-  , Prims.bpIntAdd = pure2 (+)
-  , Prims.bpIntSub = pure2 (-)
-  , Prims.bpIntMul = pure2 (*)
-  , Prims.bpIntDiv = pure2 div
-  , Prims.bpIntMod = pure2 mod
-  , Prims.bpIntNeg = pure1 negate
-  , Prims.bpIntAbs = pure1 abs
-  , Prims.bpIntEq  = pure2 (==)
-  , Prims.bpIntLe  = pure2 (<=)
-  , Prims.bpIntLt  = pure2 (<)
-  , Prims.bpIntMin = pure2 min
-  , Prims.bpIntMax = pure2 max
+  , Prims.bpIntAdd = binOp sc scIntegerConst scIntAdd (+)
+  , Prims.bpIntSub = binOp sc scIntegerConst scIntSub (-)
+  , Prims.bpIntMul = binOp sc scIntegerConst scIntMul (*)
+  , Prims.bpIntDiv = intDivOp sc scIntDiv div
+  , Prims.bpIntMod = intDivOp sc scIntMod mod
+  , Prims.bpIntNeg = unOp  sc scIntNeg negate
+  , Prims.bpIntAbs = unOp  sc scIntAbs abs
+  , Prims.bpIntEq  = binOp sc scIntegerConst scIntEq (==)
+  , Prims.bpIntLe  = binOp sc scIntegerConst scIntLe (<=)
+  , Prims.bpIntLt  = binOp sc scIntegerConst scIntLt (<)
+  , Prims.bpIntMin = binOp sc scIntegerConst scIntMin min
+  , Prims.bpIntMax = binOp sc scIntegerConst scIntMax max
 
     -- Array operations
-  , Prims.bpArrayConstant = unsupportedConcretePrimitive "bpArrayConstant"
-  , Prims.bpArrayLookup = unsupportedConcretePrimitive "bpArrayLookup"
-  , Prims.bpArrayUpdate = unsupportedConcretePrimitive "bpArrayUpdate"
-  , Prims.bpArrayEq = unsupportedConcretePrimitive "bpArrayEq"
+  , Prims.bpArrayConstant = \a b v ->
+      do v' <- readBackValue sc cfg b v
+         a'   <- readBackTValue sc cfg a
+         b'   <- readBackTValue sc cfg b
+         tm   <- scArrayConstant sc a' b' v'
+         pure (TMArray a a' b b' tm)
+
+  , Prims.bpArrayLookup = \(TMArray a a' b b' arr) idx ->
+      do idx' <- readBackValue sc cfg a idx
+         val  <- scArrayLookup sc a' b' arr idx'
+         reflectTerm sc cfg b val
+
+  , Prims.bpArrayUpdate = \(TMArray a a' b b' arr) idx val ->
+      do idx' <- readBackValue sc cfg a idx
+         val' <- readBackValue sc cfg b val
+         arr' <- scArrayUpdate sc a' b' arr idx' val'
+         pure (TMArray a a' b b' arr')
+
+  , Prims.bpArrayEq = \(TMArray _ a' _ b' arr1) (TMArray _ _ _ _ arr2) ->
+      if arr1 == arr2 then
+        pure (Right True)
+      else
+        Left <$> scArrayEq sc a' b' arr1 arr2
   }
 
-unsupportedConcretePrimitive :: String -> a
-unsupportedConcretePrimitive = Prim.unsupportedPrimitive "concrete"
 
-constMap :: Map Ident CValue
-constMap =
-  flip Map.union (Prims.constMap prims) $
-  Map.fromList
-  -- Shifts
-  [ ("Prelude.bvShl" , bvShiftOp (Prim.bvShl undefined))
-  , ("Prelude.bvShr" , bvShiftOp (Prim.bvShr undefined))
-  , ("Prelude.bvSShr", bvShiftOp (Prim.bvSShr undefined))
-  -- Integers
-  , ("Prelude.intToNat", Prims.intToNatOp)
-  , ("Prelude.natToInt", Prims.natToIntOp)
-  , ("Prelude.intToBv" , intToBvOp)
-  , ("Prelude.bvToInt" , bvToIntOp)
-  , ("Prelude.sbvToInt", sbvToIntOp)
-  -- Integers mod n
-  , ("Prelude.toIntMod"  , toIntModOp)
-  , ("Prelude.fromIntMod", fromIntModOp)
-  , ("Prelude.intModEq"  , intModEqOp)
-  , ("Prelude.intModAdd" , intModBinOp (+))
-  , ("Prelude.intModSub" , intModBinOp (-))
-  , ("Prelude.intModMul" , intModBinOp (*))
-  , ("Prelude.intModNeg" , intModUnOp negate)
-  -- Streams
-  , ("Prelude.MkStream", mkStreamOp)
-  , ("Prelude.streamGet", streamGetOp)
-  -- Miscellaneous
-  , ("Prelude.bvToNat", bvToNatOp) -- override Prims.constMap
-  , ("Prelude.expByNat", Prims.expByNatOp prims)
-  ]
+constMap :: SharedContext -> Sim.SimulatorConfig TermModel -> Map Ident TmValue
+constMap sc cfg = Map.union (Map.fromList localPrims) (Prims.constMap pms)
+  where
+  pms = prims sc cfg
 
-------------------------------------------------------------
+  localPrims =
+    -- Shifts
+    [ ("Prelude.bvShl" , bvShiftOp sc cfg id   scBvShl  Prim.bvShl)
+    , ("Prelude.bvShr" , bvShiftOp sc cfg id   scBvShr  Prim.bvShr)
+    , ("Prelude.bvSShr", bvShiftOp sc cfg succ scBvSShr Prim.bvSShr)
 
--- primitive bvToNat : (n : Nat) -> Vec n Bool -> Nat;
-bvToNatOp :: CValue
-bvToNatOp = constFun $ wordFun $ VNat . fromInteger . unsigned
+    -- Integers
+    , ("Prelude.intToNat", intToNatOp sc)
+    , ("Prelude.natToInt", natToIntOp sc)
+    , ("Prelude.intToBv" , intToBvOp sc)
+    , ("Prelude.bvToInt" , bvToIntOp sc cfg)
+    , ("Prelude.sbvToInt", sbvToIntOp sc cfg)
 
--- primitive bvToInt : (n : Nat) -> Vec n Bool -> Integer;
-bvToIntOp :: CValue
-bvToIntOp = constFun $ wordFun $ VInt . unsigned
+{- TODO!
+    -- Integers mod n
+    , ("Prelude.toIntMod"  , toIntModOp)
+    , ("Prelude.fromIntMod", fromIntModOp)
+    , ("Prelude.intModEq"  , intModEqOp)
+    , ("Prelude.intModAdd" , intModBinOp (+))
+    , ("Prelude.intModSub" , intModBinOp (-))
+    , ("Prelude.intModMul" , intModBinOp (*))
+    , ("Prelude.intModNeg" , intModUnOp negate)
 
--- primitive sbvToInt : (n : Nat) -> Vec n Bool -> Integer;
-sbvToIntOp :: CValue
-sbvToIntOp = constFun $ wordFun $ VInt . signed
+    -- Streams
+    , ("Prelude.MkStream", mkStreamOp)
+    , ("Prelude.streamGet", streamGetOp)
+-}
 
--- primitive intToBv : (n : Nat) -> Integer -> Vec n Bool;
-intToBvOp :: CValue
-intToBvOp =
-  Prims.natFun' "intToBv n" $ \n -> return $
-  Prims.intFun "intToBv x" $ \x -> return $
-    VWord $
-     if n >= 0 then bv (fromIntegral n) x
-               else bvNeg n $ bv (fromIntegral n) $ negate x
+    -- Miscellaneous
+    , ("Prelude.expByNat", Prims.expByNatOp pms)
+    ]
 
-------------------------------------------------------------
--- BitVector operations
 
-bvRotateL :: BitVector -> Integer -> BitVector
-bvRotateL (BV w x) i = Prim.bv w ((x `shiftL` j) .|. (x `shiftR` (w - j)))
-  where j = fromInteger (i `mod` toInteger w)
+-- intToNat : Integer -> Nat;
+intToNatOp :: SharedContext -> TmValue
+intToNatOp _sc =
+  strictFun $ \case
+    VInt (Right i) -> pure . VNat $! fromInteger (max 0 i)
+    x -> pure (VIntToNat x)
 
-bvRotateR :: BitVector -> Integer -> BitVector
-bvRotateR w i = bvRotateL w (- i)
+-- natToInt : Nat -> Integer;
+natToIntOp :: SharedContext -> TmValue
+natToIntOp sc =
+  strictFun $ \case
+    VNat n  ->
+      pure . VInt . Right $! toInteger n
 
-bvShiftL :: Bool -> BitVector -> Integer -> BitVector
-bvShiftL c (BV w x) i = Prim.bv w ((x `shiftL` j) .|. c')
-  where c' = if c then (1 `shiftL` j) - 1 else 0
-        j = fromInteger (i `min` toInteger w)
+    VIntToNat (VInt (Right i)) ->
+      pure . VInt . Right $! max 0 i
+    VIntToNat (VInt (Left tm)) ->
+      do z <- scIntegerConst sc 0
+         VInt . Left <$> scIntMax sc z tm
 
-bvShiftR :: Bool -> BitVector -> Integer -> BitVector
-bvShiftR c (BV w x) i = Prim.bv w (c' .|. (x `shiftR` j))
-  where c' = if c then (full `shiftL` (w - j)) .&. full else 0
-        full = (1 `shiftL` w) - 1
-        j = fromInteger (i `min` toInteger w)
+    VBVToNat _ (VWord (Right bv)) ->
+      pure . VInt . Right $! Prim.unsigned bv
+    VBVToNat _ (VWord (Left (n, tm))) ->
+      do n' <- scNat sc n
+         VInt . Left <$> scBvToInt sc n' tm
+
+    _ -> panic "natToIntOp" ["Expected nat value"]
+
+
+-- primitive intToBv : (n:Nat) -> Integer -> Vec n Bool;
+intToBvOp :: SharedContext -> TmValue
+intToBvOp sc =
+  Prims.natFun' "intToBvOp" $ \n -> pure $
+  strictFun $ \case
+    VInt (Right i) -> pure . VWord . Right $! Prim.bv (fromIntegral n) i -- TODO fromIntegral
+    VInt (Left tm) ->
+      do n' <- scNat sc n
+         tm' <- scIntToBv sc n' tm
+         pure (VWord (Left (n,tm')))
+    _ -> panic "intToBvOp" ["expected integer value"]
+
+-- bvToInt : (n:Nat) -> Vec n Bool -> Integer;
+bvToIntOp :: SharedContext -> Sim.SimulatorConfig TermModel -> TmValue
+bvToIntOp sc cfg =
+  Prims.natFun' "bvToIntOp" $ \n -> pure $
+  strictFun $ \case
+    VWord (Right bv) -> pure . VInt . Right $! Prim.unsigned bv
+    x ->
+      do n' <- scNat sc n
+         tm <- readBackValue sc cfg (VVecType n VBoolType) x
+         VInt . Left <$> scBvToInt sc n' tm
+
+-- sbvToInt : (n:Nat) -> Vec n Bool -> Integer;
+sbvToIntOp :: SharedContext -> Sim.SimulatorConfig TermModel -> TmValue
+sbvToIntOp sc cfg =
+  Prims.natFun' "sbvToIntOp" $ \n -> pure $
+  strictFun $ \case
+    VWord (Right bv) -> pure . VInt . Right $! Prim.signed bv
+    x ->
+      do n' <- scNat sc n
+         tm <- readBackValue sc cfg (VVecType n VBoolType) x
+         VInt . Left <$> scSbvToInt sc n' tm
+
+-- | (n : Nat) -> Vec n Bool -> Nat -> Vec n Bool
+bvShiftOp ::
+  SharedContext ->
+  Sim.SimulatorConfig TermModel ->
+  (Natural -> Natural) ->
+  (SharedContext -> Term -> Term -> Term -> IO Term) ->
+  (BitVector -> Int -> BitVector) ->
+  TmValue
+bvShiftOp sc cfg szf tmOp bvOp =
+  Prims.natFun' "bvShiftOp" $ \n0 -> pure $
+  strictFun $ \w -> pure $
+  strictFun $ \amt ->
+    case (w, amt) of
+      (VWord (Right w'), VNat amt') ->
+        let amt'' = fromInteger (min (toInteger (Prim.width w')) (toInteger amt'))
+         in pure . VWord . Right $! bvOp w' amt''
+      _ ->
+        do let n = szf n0
+           n0'  <- scNat sc n0
+           w'   <- readBackValue sc cfg (VVecType n VBoolType) w
+           amt' <- readBackValue sc cfg (VDataType "Prelude.Nat" []) amt
+           tm   <- tmOp sc n0' w' amt'
+           pure (VWord (Left (n, tm)))
+
+{-
 
 ------------------------------------------------------------
 

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -56,7 +56,8 @@ data Value l
   | VVector !(Vector (Thunk l))
   | VBool (VBool l)
   | VWord (VWord l)
-  | VToNat (Value l)
+  | VBVToNat !Int (Value l) -- TODO: don't use @Int@ for this, use @Natural@
+  | VIntToNat (Value l)
   | VNat !Natural
   | VInt (VInt l)
   | VIntMod !Natural (VInt l)
@@ -157,7 +158,8 @@ instance Show (Extra l) => Show (Value l) where
       VVector xv     -> showList (toList xv)
       VBool _        -> showString "<<boolean>>"
       VWord _        -> showString "<<bitvector>>"
-      VToNat x       -> showString "bvToNat " . showParen True (shows x)
+      VBVToNat n x   -> showString "bvToNat " . shows n . showString " " . showParen True (shows x)
+      VIntToNat x    -> showString "intToNat " . showParen True (shows x)
       VNat n         -> shows n
       VInt _         -> showString "<<integer>>"
       VIntMod n _    -> showString ("<<Z " ++ show n ++ ">>")

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -53,7 +53,7 @@ data Value l
   = VFun !LocalName !(Thunk l -> MValue l)
   | VUnit
   | VPair (Thunk l) (Thunk l) -- TODO: should second component be strict?
-  | VCtorApp !Ident !(Vector (Thunk l))
+  | VCtorApp !Ident ![Thunk l] ![Thunk l]
   | VVector !(Vector (Thunk l))
   | VBool (VBool l)
   | VWord (VWord l)
@@ -184,9 +184,7 @@ instance Show (Extra l) => Show (Value l) where
       VFun {}        -> showString "<<fun>>"
       VUnit          -> showString "()"
       VPair{}        -> showString "<<tuple>>"
-      VCtorApp s xv
-        | V.null xv  -> shows s
-        | otherwise  -> shows s . showList (toList xv)
+      VCtorApp s _ps _xv -> shows s
       VVector xv     -> showList (toList xv)
       VBool _        -> showString "<<boolean>>"
       VWord _        -> showString "<<bitvector>>"

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -50,7 +50,7 @@ Values are parameterized by the /name/ of an instantiation.
 The concrete parameters to use are computed from the name using
 a collection of type families (e.g., 'EvalM', 'VBool', etc.). -}
 data Value l
-  = VFun !(Thunk l -> MValue l)
+  = VFun !LocalName !(Thunk l -> MValue l)
   | VUnit
   | VPair (Thunk l) (Thunk l) -- TODO: should second component be strict?
   | VCtorApp !Ident !(Vector (Thunk l))
@@ -77,13 +77,13 @@ data TValue l
   | VIntType
   | VIntModType !Natural
   | VArrayType !(TValue l) !(TValue l)
-  | VPiType !(TValue l) !(Thunk l -> EvalM l (TValue l))
+  | VPiType LocalName !(TValue l) !(Thunk l -> EvalM l (TValue l))
   | VUnitType
   | VPairType !(TValue l) !(TValue l)
   | VDataType !Ident ![Value l]
   | VRecordType ![(FieldName, TValue l)]
   | VSort !Sort
-
+  | VTyTerm !Sort !Term
 
 -- | Neutral terms represent computations that are blocked
 --   because some internal term cannot be evaluated
@@ -154,13 +154,15 @@ type instance Extra (WithM m l) = Extra l
 --------------------------------------------------------------------------------
 
 strictFun :: VMonad l => (Value l -> MValue l) -> Value l
-strictFun f = VFun (\x -> force x >>= f)
+-- TODO, make callers provide a name?
+strictFun f = VFun "x" (\x -> force x >>= f)
 
 pureFun :: VMonad l => (Value l -> Value l) -> Value l
-pureFun f = VFun (\x -> liftM f (force x))
+-- TODO, make callers provide a name?
+pureFun f = VFun "x" (\x -> liftM f (force x))
 
 constFun :: VMonad l => Value l -> Value l
-constFun x = VFun (\_ -> return x)
+constFun x = VFun "_" (\_ -> return x)
 
 toTValue :: HasCallStack => Value l -> TValue l
 toTValue (TValue x) = x
@@ -202,7 +204,7 @@ instance Show (Extra l) => Show (TValue l) where
       VIntType       -> showString "Integer"
       VIntModType n  -> showParen True (showString "IntMod " . shows n)
       VArrayType{}   -> showString "Array"
-      VPiType t _    -> showParen True
+      VPiType _ t _    -> showParen True
                         (shows t . showString " -> ...")
       VUnitType      -> showString "#()"
       VPairType x y  -> showParen True (shows x . showString " * " . shows y)
@@ -215,6 +217,8 @@ instance Show (Extra l) => Show (TValue l) where
       VVecType n a   -> showString "Vec " . shows n
                         . showString " " . showParen True (showsPrec p a)
       VSort s        -> shows s
+
+      VTyTerm _ tm   -> shows tm
 
 data Nil = Nil
 
@@ -257,8 +261,8 @@ valRecordProj v _ =
   ["Not a record value:", show v]
 
 apply :: (HasCallStack, VMonad l, Show (Extra l)) => Value l -> Thunk l -> MValue l
-apply (VFun f) x = f x
-apply (TValue (VPiType _ f)) x = TValue <$> f x
+apply (VFun _ f) x = f x
+apply (TValue (VPiType _ _ f)) x = TValue <$> f x
 apply v _x = panic "Verifier.SAW.Simulator.Value.apply" ["Not a function value:", show v]
 
 applyAll :: (VMonad l, Show (Extra l)) => Value l -> [Thunk l] -> MValue l
@@ -318,6 +322,7 @@ asFirstOrderTypeTValue v =
     VPiType{}   -> Nothing
     VDataType{} -> Nothing
     VSort{}     -> Nothing
+    VTyTerm{}   -> Nothing
 
 -- | A (partial) injective mapping from type values to strings. These
 -- are intended to be useful as suffixes for names of type instances
@@ -335,7 +340,7 @@ suffixTValue tv =
       do a' <- suffixTValue a
          b' <- suffixTValue b
          Just ("_Array" ++ a' ++ b')
-    VPiType _ _ -> Nothing
+    VPiType _ _ _ -> Nothing
     VUnitType -> Just "_Unit"
     VPairType a b ->
       do a' <- suffixTValue a
@@ -344,7 +349,7 @@ suffixTValue tv =
     VDataType {} -> Nothing
     VRecordType {} -> Nothing
     VSort {} -> Nothing
-
+    VTyTerm{} -> Nothing
 
 neutralToTerm :: NeutralTerm -> Term
 neutralToTerm = loop 

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -377,8 +377,8 @@ neutralToTerm = loop
     Unshared (App (loop nt) arg)
   loop (NeutralRecursorArg rec ixs x) =
     Unshared (FTermF (RecursorApp rec ixs (loop x)))
---  loop (NeutralRecursor rec ixs x) =
---    Unshared (FTermF (RecursorApp (loop rec) ixs x))
+  loop (NeutralRecursor rec ixs x) =
+    Unshared (FTermF (RecursorApp (loop rec) ixs x))
 
 neutralToSharedTerm :: SharedContext -> NeutralTerm -> IO Term
 neutralToSharedTerm sc = loop
@@ -394,9 +394,9 @@ neutralToSharedTerm sc = loop
   loop (NeutralApp nt arg) =
     do tm <- loop nt
        scApply sc tm arg
---  loop (NeutralRecursor nt ixs x) =
---    do tm <- loop nt
---       scFlatTermF sc (RecursorApp tm ixs x)
+  loop (NeutralRecursor nt ixs x) =
+    do tm <- loop nt
+       scFlatTermF sc (RecursorApp tm ixs x)
   loop (NeutralRecursorArg rec ixs nt) =
     do tm <- loop nt
        scFlatTermF sc (RecursorApp rec ixs tm)

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -69,7 +69,8 @@ data Value l
      !Ident -- data type ident
      ![Value l]  -- data type parameters
      !(Value l)  -- motive function
-     !(Map Ident (Thunk l)) -- constructor eliminators
+     !(TValue l) -- type of motive
+     !(Map Ident (Thunk l, TValue l)) -- constructor eliminators and their types
   | VExtra (Extra l)
   | TValue (TValue l)
 
@@ -199,7 +200,8 @@ instance Show (Extra l) => Show (Value l) where
       VRecordValue [] -> showString "{}"
       VRecordValue ((fld,_):_) ->
         showString "{" . showString (Text.unpack fld) . showString " = _, ...}"
-      VRecursor d _ _ _ -> showString "<<recursor: " . shows d . showString ">>"
+      VRecursor d _ _ _ _
+                     -> showString "<<recursor: " . shows d . showString ">>"
       VExtra x       -> showsPrec p x
       TValue x       -> showsPrec p x
     where

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -65,7 +65,11 @@ data Value l
   | VArray (VArray l)
   | VString !Text
   | VRecordValue ![(FieldName, Thunk l)]
-  | VRecursor (CompiledRecursor (Value l))
+  | VRecursor
+     !Ident -- data type ident
+     ![Value l]  -- data type parameters
+     !(Value l)  -- motive function
+     !(Map Ident (Thunk l)) -- constructor eliminators
   | VExtra (Extra l)
   | TValue (TValue l)
 
@@ -99,15 +103,12 @@ data NeutralTerm
   | NeutralPairRight NeutralTerm  -- right pair projection
   | NeutralRecordProj NeutralTerm FieldName -- record projection
   | NeutralApp NeutralTerm Term -- function application
-{-
   | NeutralRecursor
       NeutralTerm -- recursor value
       [Term] -- indices for the inductive type
       Term   -- argument being eliminated
--}
   | NeutralRecursorArg -- recursor application
-      (CompiledRecursor Term)
-      --Term   -- recursor value
+      Term   -- recursor value
       [Term] -- indices for the inductive type
       NeutralTerm -- argument being elminated
 
@@ -198,7 +199,7 @@ instance Show (Extra l) => Show (Value l) where
       VRecordValue [] -> showString "{}"
       VRecordValue ((fld,_):_) ->
         showString "{" . showString (Text.unpack fld) . showString " = _, ...}"
-      VRecursor rec  -> showString "<<recursor: " . shows (recursorDataType rec) . showString ">>"
+      VRecursor d _ _ _ -> showString "<<recursor: " . shows d . showString ">>"
       VExtra x       -> showsPrec p x
       TValue x       -> showsPrec p x
     where

--- a/saw-core/src/Verifier/SAW/Term/CtxTerm.hs
+++ b/saw-core/src/Verifier/SAW/Term/CtxTerm.hs
@@ -560,9 +560,9 @@ ctxRecursorAppM (DataIdent d) paramsM pretM cs_fsM ixsM argM =
               (ctxTermsCtxToListUnsafe <$> paramsM) <*>
               (unCtxTermUnsafe <$> pretM) <*>
               (fmap unCtxTermUnsafe <$> cs_fsM)
-     --rec <- mkFlatTermF (Recursor cmp)
+     rec <- mkFlatTermF (Recursor cmp)
 
-     app <- RecursorApp cmp <$>
+     app <- RecursorApp rec <$>
               (ctxTermsCtxToListUnsafe <$> ixsM) <*>
               (unCtxTermUnsafe <$> argM)
 

--- a/saw-core/src/Verifier/SAW/Term/CtxTerm.hs
+++ b/saw-core/src/Verifier/SAW/Term/CtxTerm.hs
@@ -680,7 +680,8 @@ data CtorArg d ixs ctx a where
   -- parameters of @d@ (not given here), and the @ei@ are the type indices of
   -- @d@.
   RecursiveArg ::
-    Bindings CtxTerm ctx zs -> CtxTerms (CtxInvApp ctx zs) ixs ->
+    Bindings CtxTerm ctx zs ->
+    CtxTerms (CtxInvApp ctx zs) ixs ->
     CtorArg d ixs ctx (Typ (Arrows zs d))
 
 -- | A structure that defines the parameters, arguments, and return type indices
@@ -949,9 +950,16 @@ mkCtorElimTypeFun d c argStruct@(CtorArgStruct {..}) =
 -- where @[ps/params,xs/args]@ substitutes the concrete parameters @pi@ for the
 -- parameter variables of the inductive type and the earlier constructor
 -- arguments @xs@ for the remaining free variables.
-ctxReduceRecursor :: MonadTerm m => Ident -> [Term] -> Term ->
-                     [(Ident,Term)] -> Ident -> [Term] ->
-                     CtorArgStruct d params ixs -> m Term
+ctxReduceRecursor ::
+  MonadTerm m =>
+  Ident  {- ^ data type name -} ->
+  [Term] {- ^ data type parameters -} ->
+  Term   {- ^ elimination motive -} ->
+  [(Ident,Term)] {- ^ constructor eliminator functions -} ->
+  Ident  {- ^ constructor name  -} ->
+  [Term] {- ^ constructor actual arguments -}  ->
+  CtorArgStruct d params ixs {- ^ constructor formal argument descriptor -} ->
+  m Term
 ctxReduceRecursor d params p_ret cs_fs c c_args (CtorArgStruct{..}) =
   (case (invertCtxTerms <$> ctxTermsForBindings ctorParams params,
          ctxTermsForBindings ctorArgs c_args,

--- a/saw-core/src/Verifier/SAW/Term/Functor.hs
+++ b/saw-core/src/Verifier/SAW/Term/Functor.hs
@@ -177,7 +177,7 @@ data FlatTermF e
     -- * The recursor value;
     -- * The indices for the inductive type; AND
     -- * The argument that is being eliminated / pattern-matched
-  | RecursorApp (CompiledRecursor e) [e] e
+  | RecursorApp e [e] e
 
     -- | Non-dependent record types, i.e., N-ary tuple types with named
     -- fields. These are considered equal up to reordering of fields. Actual
@@ -273,10 +273,10 @@ zipWithFlatTermF f = go
     go (Recursor rec1) (Recursor rec2) = Recursor <$> zipRec f rec1 rec2
 
     go (RecursorApp rec1 ixs1 x1) (RecursorApp rec2 ixs2 x2) =
-        RecursorApp <$>
-          (zipRec f rec1 rec2) <*>
-          pure (zipWith f ixs1 ixs2) <*> 
-          pure (f x1 x2)
+        Just $ RecursorApp
+          (f rec1 rec2)
+          (zipWith f ixs1 ixs2)
+          (f x1 x2)
 
     go (RecordType elems1) (RecordType elems2)
       | Just vals2 <- alistAllFields (map fst elems1) elems2 =

--- a/saw-core/src/Verifier/SAW/Term/Pretty.hs
+++ b/saw-core/src/Verifier/SAW/Term/Pretty.hs
@@ -49,6 +49,7 @@ import Data.Foldable (Foldable)
 import qualified Data.Foldable as Fold
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as Text.Lazy
+import qualified Data.Map as Map
 import qualified Data.Vector as V
 import Numeric (showIntAtBase)
 import Prettyprinter
@@ -432,23 +433,40 @@ ppFlatTermF prec tf =
     PairLeft t    -> ppProj "1" <$> ppTerm' PrecArg t
     PairRight t   -> ppProj "2" <$> ppTerm' PrecArg t
 
-    CtorApp c params args ->
-      ppAppList prec (annotate CtorAppStyle (ppIdent c)) <$> mapM (ppTerm' PrecArg) (params ++ args)
-    DataTypeApp dt params args ->
-      ppAppList prec (annotate DataTypeStyle (ppIdent dt)) <$> mapM (ppTerm' PrecArg) (params ++ args)
-    RecursorApp (CompiledRecursor d params p_ret cs_fs) ixs arg ->
+    RecursorType d params motive _ ->
       do params_pp <- mapM (ppTerm' PrecArg) params
-         p_ret_pp <- ppTerm' PrecArg p_ret
-         fs_pp <- mapM (ppTerm' PrecNone . snd) cs_fs
-         ixs_pp <- mapM (ppTerm' PrecArg) ixs
-         arg_pp <- ppTerm' PrecArg arg
+         motive_pp <- ppTerm' PrecArg motive
+         return $
+           ppAppList prec (annotate RecursorStyle (ppIdent d <> "#recType"))
+             (params_pp ++ [motive_pp])
+
+    Recursor (CompiledRecursor d params motive cs_fs) ->
+      do params_pp <- mapM (ppTerm' PrecArg) params
+         motive_pp <- ppTerm' PrecArg motive
+         fs_pp <- traverse (ppTerm' PrecNone) cs_fs
          return $
            ppAppList prec (annotate RecursorStyle (ppIdent d <> "#rec"))
-           (params_pp ++ [p_ret_pp] ++
-            [tupled $
-             zipWith (\(c,_) f_pp -> vsep [ppIdent c, "=>", f_pp])
-             cs_fs fs_pp]
-            ++ ixs_pp ++ [arg_pp])
+             (params_pp ++
+              [motive_pp
+              , tupled $
+                  [ vsep [ppIdent c, "=>", f_pp]
+                  | (c,f_pp) <- Map.toList fs_pp
+                  ]
+              ])
+
+    RecursorApp rec ixs arg ->
+      do --rec_pp <- ppTerm' PrecApp rec
+         rec_pp <- ppFlatTermF prec (Recursor rec)
+         ixs_pp <- mapM (ppTerm' PrecArg) ixs
+         arg_pp <- ppTerm' PrecArg arg
+         return $ ppAppList prec rec_pp (ixs_pp ++ [arg_pp])
+
+    CtorApp c params args ->
+      ppAppList prec (annotate CtorAppStyle (ppIdent c)) <$> mapM (ppTerm' PrecArg) (params ++ args)
+
+    DataTypeApp dt params args ->
+      ppAppList prec (annotate DataTypeStyle (ppIdent dt)) <$> mapM (ppTerm' PrecArg) (params ++ args)
+
     RecordType alist ->
       ppRecord True <$> mapM (\(fld,t) -> (fld,) <$> ppTerm' PrecNone t) alist
     RecordValue alist ->

--- a/saw-core/src/Verifier/SAW/Term/Pretty.hs
+++ b/saw-core/src/Verifier/SAW/Term/Pretty.hs
@@ -455,8 +455,7 @@ ppFlatTermF prec tf =
               ])
 
     RecursorApp rec ixs arg ->
-      do --rec_pp <- ppTerm' PrecApp rec
-         rec_pp <- ppFlatTermF prec (Recursor rec)
+      do rec_pp <- ppTerm' PrecApp rec
          ixs_pp <- mapM (ppTerm' PrecArg) ixs
          arg_pp <- ppTerm' PrecArg arg
          return $ ppAppList prec rec_pp (ixs_pp ++ [arg_pp])

--- a/saw-core/src/Verifier/SAW/Term/Pretty.hs
+++ b/saw-core/src/Verifier/SAW/Term/Pretty.hs
@@ -433,17 +433,17 @@ ppFlatTermF prec tf =
     PairLeft t    -> ppProj "1" <$> ppTerm' PrecArg t
     PairRight t   -> ppProj "2" <$> ppTerm' PrecArg t
 
-    RecursorType d params motive _ ->
+    RecursorType d params motive _motiveTy ->
       do params_pp <- mapM (ppTerm' PrecArg) params
          motive_pp <- ppTerm' PrecArg motive
          return $
            ppAppList prec (annotate RecursorStyle (ppIdent d <> "#recType"))
              (params_pp ++ [motive_pp])
 
-    Recursor (CompiledRecursor d params motive cs_fs) ->
+    Recursor (CompiledRecursor d params motive _motiveTy cs_fs _) ->
       do params_pp <- mapM (ppTerm' PrecArg) params
          motive_pp <- ppTerm' PrecArg motive
-         fs_pp <- traverse (ppTerm' PrecNone) cs_fs
+         fs_pp <- traverse (ppTerm' PrecNone . fst) cs_fs
          return $
            ppAppList prec (annotate RecursorStyle (ppIdent d <> "#rec"))
              (params_pp ++

--- a/saw-core/src/Verifier/SAW/Term/Pretty.hs
+++ b/saw-core/src/Verifier/SAW/Term/Pretty.hs
@@ -18,6 +18,7 @@ Portability : non-portable (language extensions)
 
 module Verifier.SAW.Term.Pretty
   ( SawDoc
+  , renderSawDoc
   , SawStyle(..)
   , PPOpts(..)
   , defaultPPOpts

--- a/saw-core/src/Verifier/SAW/Term/Pretty.hs
+++ b/saw-core/src/Verifier/SAW/Term/Pretty.hs
@@ -436,7 +436,7 @@ ppFlatTermF prec tf =
       ppAppList prec (annotate CtorAppStyle (ppIdent c)) <$> mapM (ppTerm' PrecArg) (params ++ args)
     DataTypeApp dt params args ->
       ppAppList prec (annotate DataTypeStyle (ppIdent dt)) <$> mapM (ppTerm' PrecArg) (params ++ args)
-    RecursorApp d params p_ret cs_fs ixs arg ->
+    RecursorApp (CompiledRecursor d params p_ret cs_fs) ixs arg ->
       do params_pp <- mapM (ppTerm' PrecArg) params
          p_ret_pp <- ppTerm' PrecArg p_ret
          fs_pp <- mapM (ppTerm' PrecNone . snd) cs_fs

--- a/saw-core/src/Verifier/SAW/Testing/Random.hs
+++ b/saw-core/src/Verifier/SAW/Testing/Random.hs
@@ -80,7 +80,7 @@ execTest sc mmap vars tm =
              do argMap0 <- traverse (scFirstOrderValue sc) testVec
                 let argMap = Map.fromList [ (ecVarIndex ec, v) | (ec,v) <- Map.toList argMap0 ]
                 scInstantiateExt sc argMap tm
-     case evalSharedTerm mmap Map.empty Map.empty tm' of
+     liftIO (evalSharedTerm mmap Map.empty Map.empty tm') >>= \case
        -- satisfaible, return counterexample
        VBool True  -> return (Just (Map.toList testVec))
        -- not satisfied by this test vector

--- a/saw-core/src/Verifier/SAW/Typechecker.hs
+++ b/saw-core/src/Verifier/SAW/Typechecker.hs
@@ -35,6 +35,7 @@ import Control.Applicative
 #endif
 import Control.Monad.State
 import Data.List (findIndex)
+import qualified Data.Map as Map
 import Data.Text (Text)
 import qualified Data.Vector as V
 
@@ -191,7 +192,9 @@ typeInferCompleteTerm (matchAppliedRecursor -> Just (maybe_mnm, str, args)) =
           (elims,
            (splitAt (length $ dtIndices dt) ->
             (ixs, arg : rem_args)))))) ->
-         do let cs_fs = zip (map ctorName $ dtCtors dt) elims
+         do let cs_fs = Map.fromList (zip (map ctorName $ dtCtors dt) elims)
+            --rec <- typeInferComplete (Recursor (CompiledRecursor dt_ident params p_ret cs_fs))
+            --typed_r <- typeInferComplete (RecursorApp rec ixs arg)
             comp_rec <- inferAndCompileRecursor dt_ident params p_ret cs_fs
             typed_r <- typeInferComplete (RecursorApp comp_rec ixs arg)
             inferApplyAll typed_r rem_args

--- a/saw-core/src/Verifier/SAW/Typechecker.hs
+++ b/saw-core/src/Verifier/SAW/Typechecker.hs
@@ -433,9 +433,7 @@ processDecls (Un.DataDecl (PosPair p nm) param_ctx dt_tp c_decls : rest) =
             let tp = typedVal typed_tp in
             case mkCtorArgStruct dtName p_ctx ix_ctx tp of
               Just arg_struct ->
-                liftTCM scBuildCtor dtName (mkIdentText mnm c)
-                (map (mkIdentText mnm . fst) typed_ctors)
-                arg_struct
+                liftTCM scBuildCtor dtName (mkIdentText mnm c) arg_struct
               Nothing -> err ("Malformed type form constructor: " ++ show c)
 
   -- Step 6: complete the datatype with the given ctors

--- a/saw-core/src/Verifier/SAW/Typechecker.hs
+++ b/saw-core/src/Verifier/SAW/Typechecker.hs
@@ -192,8 +192,8 @@ typeInferCompleteTerm (matchAppliedRecursor -> Just (maybe_mnm, str, args)) =
            (splitAt (length $ dtIndices dt) ->
             (ixs, arg : rem_args)))))) ->
          do let cs_fs = zip (map ctorName $ dtCtors dt) elims
-            typed_r <- typeInferComplete (RecursorApp dt_ident params
-                                          p_ret cs_fs ixs arg)
+            comp_rec <- inferAndCompileRecursor dt_ident params p_ret cs_fs
+            typed_r <- typeInferComplete (RecursorApp comp_rec ixs arg)
             inferApplyAll typed_r rem_args
        _ -> throwTCError $ NotFullyAppliedRec dt_ident
 typeInferCompleteTerm (Un.Recursor _ _) =

--- a/saw-core/src/Verifier/SAW/Typechecker.hs
+++ b/saw-core/src/Verifier/SAW/Typechecker.hs
@@ -193,10 +193,8 @@ typeInferCompleteTerm (matchAppliedRecursor -> Just (maybe_mnm, str, args)) =
            (splitAt (length $ dtIndices dt) ->
             (ixs, arg : rem_args)))))) ->
          do let cs_fs = Map.fromList (zip (map ctorName $ dtCtors dt) elims)
-            --rec <- typeInferComplete (Recursor (CompiledRecursor dt_ident params p_ret cs_fs))
-            --typed_r <- typeInferComplete (RecursorApp rec ixs arg)
-            comp_rec <- inferAndCompileRecursor dt_ident params p_ret cs_fs
-            typed_r <- typeInferComplete (RecursorApp comp_rec ixs arg)
+            rec <- typeInferComplete (Recursor (CompiledRecursor dt_ident params p_ret cs_fs))
+            typed_r <- typeInferComplete (RecursorApp rec ixs arg)
             inferApplyAll typed_r rem_args
        _ -> throwTCError $ NotFullyAppliedRec dt_ident
 typeInferCompleteTerm (Un.Recursor _ _) =

--- a/saw-core/src/Verifier/SAW/TypedAST.hs
+++ b/saw-core/src/Verifier/SAW/TypedAST.hs
@@ -57,6 +57,7 @@ module Verifier.SAW.TypedAST
  , zipWithFlatTermF
  , freesTermF
  , termToPat
+ , CompiledRecursor(..)
 
  , PPOpts(..)
  , defaultPPOpts

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -74,6 +74,7 @@ import Verifier.SAW.Prim (rethrowEvalError)
 import Verifier.SAW.Rewriter
 import Verifier.SAW.Testing.Random (prepareSATQuery, runManyTests)
 import Verifier.SAW.TypedAST
+import qualified Verifier.SAW.Simulator.TermModel as TM
 
 import SAWScript.Position
 
@@ -484,6 +485,14 @@ resolveName sc nm =
  where
  tnm = Text.pack nm
  fallback = fst <$> io (scResolveUnambiguous sc tnm)
+
+
+normalize_term :: TypedTerm -> TopLevel TypedTerm
+normalize_term tt =
+  do sc <- getSharedContext
+     modmap <- io (scGetModuleMap sc)
+     tm' <- io (TM.normalizeSharedTerm sc modmap mempty mempty (ttTerm tt))
+     pure tt{ ttTerm = tm' }
 
 
 unfoldGoal :: [String] -> ProofScript ()

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -37,6 +37,7 @@ import qualified Data.ByteString.Lazy.UTF8 as B
 import qualified Data.IntMap as IntMap
 import Data.List (isPrefixOf, isInfixOf)
 import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Time.Clock
@@ -507,6 +508,34 @@ goal_eval unints =
      unintSet <- resolveNames unints
      prop' <- io (evalProp sc unintSet (goalProp goal))
      return (prop', EvalEvidence unintSet)
+
+extract_uninterp :: [String] -> TypedTerm -> TopLevel (TypedTerm, [(String,[(TypedTerm,TypedTerm)])])
+extract_uninterp unints tt =
+  do sc <- getSharedContext
+     idxs <- mapM (resolveName sc) unints
+     let unintSet = Set.fromList idxs
+     (tm, repls) <- io (Prover.w4_extract_uninterp sc unintSet (ttTerm tt))
+     tt' <- io (mkTypedTerm sc tm)
+
+     -- printOutLnTop Info "====== Replacement values ======"
+     -- forM_ (zip unints idxs) $ \(nm,idx) ->
+     --   do printOutLnTop Info ("== Values for " ++ nm ++ " ==")
+     --      let ls = fromMaybe [] (Map.lookup idx repls)
+     --      forM_ ls $ \(e,vs) ->
+     --        do es  <- show_term e
+     --           vss <- show_term vs
+     --           printOutLnTop Info (unwords ["output:", es, "inputs:", vss])
+     -- printOutLnTop Info "====== End Replacement values ======"
+
+     replList <- io $
+        forM (zip unints idxs) $ \(nm,idx) ->
+           do let ls = fromMaybe [] (Map.lookup idx repls)
+              xs <- forM ls $ \(e,vs) ->
+                      do e'  <- mkTypedTerm sc e
+                         vs' <- mkTypedTerm sc vs
+                         pure (e',vs')
+              pure (nm,xs)
+     pure (tt', replList)
 
 beta_reduce_goal :: ProofScript ()
 beta_reduce_goal =

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -1076,7 +1076,7 @@ cexEvalFn sc args tm = do
 
   tm' <- scInstantiateExt sc argMap tm
   modmap <- scGetModuleMap sc
-  return $ Concrete.evalSharedTerm modmap mempty mempty tm'
+  Concrete.evalSharedTerm modmap mempty mempty tm'
 
 toValueCase :: (SV.FromValue b) =>
                (b -> SV.Value -> SV.Value -> TopLevel SV.Value)

--- a/src/SAWScript/Crucible/JVM/ResolveSetupValue.hs
+++ b/src/SAWScript/Crucible/JVM/ResolveSetupValue.hs
@@ -252,8 +252,8 @@ resolveBitvectorTerm sym w tm =
              -- concretely evaluate if it is a closed term
              [] ->
                do modmap <- scGetModuleMap sc
-                  let v = Concrete.evalSharedTerm modmap mempty mempty tm
-                  pure (Just (Prim.unsigned (Concrete.toWord v)))
+                  bv <- Concrete.toWord =<< Concrete.evalSharedTerm modmap mempty mempty tm
+                  pure (Just (Prim.unsigned bv))
              _ -> return Nothing
      case mx of
        Just x  -> W4.bvLit sym w (BV.mkBV w x)
@@ -267,7 +267,7 @@ resolveBoolTerm sym tm =
              -- concretely evaluate if it is a closed term
              [] ->
                do modmap <- scGetModuleMap sc
-                  let v = Concrete.evalSharedTerm modmap mempty mempty tm
+                  v <- Concrete.evalSharedTerm modmap mempty mempty tm
                   pure (Just (Concrete.toBool v))
              _ -> return Nothing
      case mx of

--- a/src/SAWScript/Crucible/LLVM/ResolveSetupValue.hs
+++ b/src/SAWScript/Crucible/LLVM/ResolveSetupValue.hs
@@ -376,7 +376,7 @@ resolveSAWPred cc tm = do
      mx <- case getAllExts tm' of
              -- concretely evaluate if it is a closed term
              [] -> do modmap <- scGetModuleMap sc
-                      let v = Concrete.evalSharedTerm modmap mempty mempty tm
+                      v <- Concrete.evalSharedTerm modmap mempty mempty tm
                       pure (Just (Concrete.toBool v))
              _ -> return Nothing
      case mx of
@@ -396,8 +396,8 @@ resolveSAWSymBV cc w tm =
      mx <- case getAllExts tm of
              -- concretely evaluate if it is a closed term
              [] -> do modmap <- scGetModuleMap sc
-                      let v = Concrete.evalSharedTerm modmap mempty mempty tm
-                      pure (Just (Prim.unsigned (Concrete.toWord v)))
+                      bv <- Concrete.toWord =<< Concrete.evalSharedTerm modmap mempty mempty tm
+                      pure (Just (Prim.unsigned bv))
              _ -> return Nothing
      case mx of
        Just x  -> W4.bvLit sym w (BV.mkBV w x)

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1198,6 +1198,11 @@ primitives = Map.fromList
     Current
     [ "Apply the given simplifier rule set to the current goal." ]
 
+  , prim "normalize_term"      "Term -> Term"
+    (funVal1 normalize_term)
+    Experimental
+    [ "normalize the given term by evaluation" ]
+
   , prim "goal_eval"           "ProofScript ()"
     (pureVal (goal_eval []))
     Current

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -34,7 +34,7 @@ import Control.Applicative
 import Data.Traversable hiding ( mapM )
 #endif
 import qualified Control.Exception as X
-import Control.Monad (unless, (>=>))
+import Control.Monad ((>=>))
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString as BS
 import Data.Foldable (foldrM)
@@ -606,12 +606,10 @@ set_color b = do
 
 print_value :: Value -> TopLevel ()
 print_value (VString s) = printOutLnTop Info s
-print_value (VTerm t) = do
+print_value (VTerm t) | null (getAllExts (ttTerm t)) = do
   sc <- getSharedContext
   cenv <- fmap rwCryptol getTopLevelRW
   let cfg = meSolverConfig (CEnv.eModuleEnv cenv)
-  unless (null (getAllExts (ttTerm t))) $
-    fail "term contains symbolic variables"
   sawopts <- getOptions
   t' <- io $ defaultTypedTerm sawopts sc cfg t
   opts <- fmap rwPPOpts getTopLevelRW
@@ -895,6 +893,12 @@ primitives = Map.fromList
     [ "Take a list of 'fresh_symbolic' variable and another term containing"
     , "those variables, and return a new lambda abstraction over the list of"
     , "variables."
+    ]
+
+  , prim "extract_uninterp" "[String] -> Term -> TopLevel (Term, [(String,[(Term, Term)])])"
+    (pureVal extract_uninterp)
+    Experimental
+    [ "Docs TODO!!"
     ]
 
   , prim "sbv_uninterpreted"   "String -> Term -> TopLevel Uninterp"

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -901,6 +901,12 @@ primitives = Map.fromList
     [ "Docs TODO!!"
     ]
 
+  , prim "extract_uninterp2" "[String] -> Term -> TopLevel (Term, [(String,[(Term, Term)])])"
+    (pureVal extract_uninterp2)
+    Experimental
+    [ "Docs TODO!!"
+    ]
+
   , prim "sbv_uninterpreted"   "String -> Term -> TopLevel Uninterp"
     (pureVal sbvUninterpreted)
     Deprecated

--- a/src/SAWScript/Prover/What4.hs
+++ b/src/SAWScript/Prover/What4.hs
@@ -197,9 +197,10 @@ w4_extract_uninterp sc unintSet tm =
   do tp <- scTypeOf sc tm
      modmap <- scGetModuleMap sc
 
-     fot <- case Sim.asFirstOrderTypeValue (Sim.evalSharedTerm modmap mempty mempty tp) of
-              Just fot -> pure fot
-              Nothing  -> fail (unwords ["extract_uninterp, expected first-order type", showTerm tp])
+     fot <- do v <- Sim.evalSharedTerm modmap mempty mempty tp
+               case Sim.asFirstOrderTypeValue v of
+                 Just fot -> pure fot
+                 Nothing  -> fail (unwords ["extract_uninterp, expected first-order type", showTerm tp])
 
      sym <- newSAWCoreBackend sc
      st <- sawCoreState sym

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -335,12 +335,12 @@ tupleLookupValue _ _ = error "tupleLookupValue"
 
 evaluate :: SharedContext -> Term -> IO Concrete.CValue
 evaluate sc t =
-  (\modmap -> Concrete.evalSharedTerm modmap mempty mempty t) <$>
-  scGetModuleMap sc
+  do modmap <- scGetModuleMap sc
+     Concrete.evalSharedTerm modmap mempty mempty t
 
 evaluateTypedTerm :: SharedContext -> TypedTerm -> IO C.Value
 evaluateTypedTerm sc (TypedTerm schema trm) =
-  exportValueWithSchema schema <$> evaluate sc trm
+  exportValueWithSchema schema =<< evaluate sc trm
 
 applyValue :: Value -> Value -> TopLevel Value
 applyValue (VLambda f) x = f x

--- a/src/SAWScript/VerificationCheck.hs
+++ b/src/SAWScript/VerificationCheck.hs
@@ -57,9 +57,9 @@ vcCounterexample sc opts (EqualityCheck nm impNode specNode) evalFn =
      let lschema = (C.Forall [] [] lct)
          sschema = (C.Forall [] [] sct)
      unless (lschema == sschema) $ fail "Mismatched schemas in counterexample"
-     let lv = exportValueWithSchema lschema ln
-         sv = exportValueWithSchema sschema sn
-         opts' = SV.cryptolPPOpts opts
+     lv <- exportValueWithSchema lschema ln
+     sv <- exportValueWithSchema sschema sn
+     let opts' = SV.cryptolPPOpts opts
      -- Grr. Different pretty-printers.
      lv_doc <- CV.runEval mempty (CV.ppValue CV.Concrete opts' lv)
      sv_doc <- CV.runEval mempty (CV.ppValue CV.Concrete opts' sv)


### PR DESCRIPTION
This PR is currently in a very rough state.  It is a series of refactorings designed to enable a "term model" evaluator.  The goal of this evaluator is to provide an evaluation-based simplifier that works directly on saw-core terms and that can gracefully handle all of the constructs appearing in saw-core (including dependent functions).

The technical approach is to use a normalization-by-evaluation technique, which uses the term evaluator to do as much computation as possible, but also allow terms to be treated as opaque, so that they block further evaluation.  To make this work properly requires that the simulator keep track of some more information (specifically, the types of values in the evaluation environment).  This, in turn, has required some relatively extensive refactoring of how datatype recursors are implemented so that type information can be computed and made available in the correct places without computing it fresh on each recursor evaluation (which proves to be much too expensive).

This draft PR currently exists mostly to exercise the CI tests and ensure that these refactoring steps have not broken or significantly slowed down our large-scale proofs.