### PR TITLE
Sim refactor

### DIFF
--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -1608,6 +1608,7 @@ asCryptolTypeValue v =
     -- TODO?
     SC.VPiType _nm _v1 (SC.VDependentPi _) -> Nothing
     SC.VRecordType{} -> Nothing
+    SC.VRecursorType{} -> Nothing
     SC.VTyTerm{} -> Nothing
 
 

--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -1579,14 +1579,14 @@ asCryptolTypeValue v =
       Right t2 <- asCryptolTypeValue v2
       return (Right (C.tSeq (C.tNum n) t2))
 
-    SC.VDataType "Prelude.Stream" [SC.TValue v1] ->
+    SC.VDataType (primName -> "Prelude.Stream") [SC.TValue v1] [] ->
         do Right t1 <- asCryptolTypeValue v1
            return (Right (C.tSeq C.tInf t1))
 
-    SC.VDataType "Cryptol.Num" [] ->
+    SC.VDataType (primName -> "Cryptol.Num") [] [] ->
       return (Left C.KNum)
 
-    SC.VDataType _ _ -> Nothing
+    SC.VDataType _ _ _ -> Nothing
 
     SC.VUnitType -> return (Right (C.tTuple []))
     SC.VPairType v1 v2 -> do

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -305,7 +305,7 @@ muxInt _ x y = if x == y then return x else fail $ "muxBVal: VInt " ++ show (x, 
 
 muxBExtra :: AIG.IsAIG l g => g s ->
   TValue (BitBlast (l s)) -> l s -> BExtra (l s) -> BExtra (l s) -> IO (BExtra (l s))
-muxBExtra be (VDataType "Prelude.Stream" [TValue tp]) c x y =
+muxBExtra be (VDataType (primName -> "Prelude.Stream") [TValue tp] []) c x y =
   do let f i = do xi <- lookupBStream (VExtra x) i
                   yi <- lookupBStream (VExtra y) i
                   muxBVal be tp c xi yi

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -449,9 +449,11 @@ bitBlastBasic :: AIG.IsAIG l g
               -> Term
               -> IO (BValue (l s))
 bitBlastBasic be m addlPrims ecMap t = do
+  let neutral _env nt = fail ("bitBlastBasic: could not evaluate neutral term: " ++ show nt)
   cfg <- Sim.evalGlobal m (Map.union (beConstMap be) (addlPrims be))
          (bitBlastExtCns ecMap)
          (const Nothing)
+         neutral
   Sim.evalSharedTerm cfg t
 
 bitBlastExtCns ::

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -45,6 +45,7 @@ import Verifier.SAW.TypedAST
 import qualified Verifier.SAW.Simulator.Concrete as Concrete
 import qualified Verifier.SAW.Prim as Prim
 import qualified Verifier.SAW.Recognizer as R
+import Verifier.SAW.Utils (panic)
 
 import qualified Data.AIG as AIG
 
@@ -296,19 +297,21 @@ lazyMux be muxFn c tm fm
       f <- fm
       muxFn c t f
 
-muxBVal :: AIG.IsAIG l g => g s -> l s -> BValue (l s) -> BValue (l s) -> IO (BValue (l s))
+muxBVal :: AIG.IsAIG l g => g s -> TValue (BitBlast (l s)) -> l s -> BValue (l s) -> BValue (l s) -> IO (BValue (l s))
 muxBVal be = Prims.muxValue (prims be)
 
 muxInt :: a -> Integer -> Integer -> IO Integer
 muxInt _ x y = if x == y then return x else fail $ "muxBVal: VInt " ++ show (x, y)
 
-muxBExtra :: AIG.IsAIG l g => g s -> l s -> BExtra (l s) -> BExtra (l s) -> IO (BExtra (l s))
-muxBExtra be c x y =
+muxBExtra :: AIG.IsAIG l g => g s ->
+  TValue (BitBlast (l s)) -> l s -> BExtra (l s) -> BExtra (l s) -> IO (BExtra (l s))
+muxBExtra be (VDataType "Prelude.Stream" [TValue tp]) c x y =
   do let f i = do xi <- lookupBStream (VExtra x) i
                   yi <- lookupBStream (VExtra y) i
-                  muxBVal be c xi yi
+                  muxBVal be tp c xi yi
      r <- newIORef Map.empty
      return (BStream f r)
+muxBExtra _ tp _ _ _ = panic "AIG: muxBExtra" ["Type mismatch", show tp]
 
 -- | Barrel-shifter algorithm. Takes a list of bits in big-endian order.
 genShift ::
@@ -396,13 +399,13 @@ mkStreamOp =
 -- streamGet :: (a :: sort 0) -> Stream a -> Nat -> a;
 streamGetOp :: AIG.IsAIG l g => g s -> BValue (l s)
 streamGetOp be =
-  constFun $
+  strictFun $ \(toTValue -> tp) -> return $
   strictFun $ \xs -> return $
   strictFun $ \case
     VNat n -> lookupBStream xs n
     VBVToNat _ w ->
        do bs <- toWord w
-          AIG.muxInteger (lazyMux be (muxBVal be)) ((2 ^ AIG.length bs) - 1) bs (lookupBStream xs)
+          AIG.muxInteger (lazyMux be (muxBVal be tp)) ((2 ^ AIG.length bs) - 1) bs (lookupBStream xs)
     v -> fail (unlines ["Verifier.SAW.Simulator.BitBlast.streamGetOp", "Expected Nat value", show v])
 
 

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -151,7 +151,7 @@ bvShiftOp bvOp natOp =
   strictFun $ \y ->
     case y of
       VNat n   -> return (vWord (natOp x n))
-      VToNat v -> fmap vWord (bvOp x =<< toWord v)
+      VBVToNat _ v -> fmap vWord (bvOp x =<< toWord v)
       _        -> error $ unwords ["Verifier.SAW.Simulator.BitBlast.shiftOp", show y]
 
 lvSShr :: LitVector l -> Natural -> LitVector l
@@ -400,7 +400,7 @@ streamGetOp be =
   strictFun $ \xs -> return $
   strictFun $ \case
     VNat n -> lookupBStream xs n
-    VToNat w ->
+    VBVToNat _ w ->
        do bs <- toWord w
           AIG.muxInteger (lazyMux be (muxBVal be)) ((2 ^ AIG.length bs) - 1) bs (lookupBStream xs)
     v -> fail (unlines ["Verifier.SAW.Simulator.BitBlast.streamGetOp", "Expected Nat value", show v])

--- a/saw-core-coq/src/Verifier/SAW/Translation/Coq/Term.hs
+++ b/saw-core-coq/src/Verifier/SAW/Translation/Coq/Term.hs
@@ -253,10 +253,10 @@ flatTermFToExpr tf = -- traceFTermF "flatTermFToExpr" tf $
 
          pure (Coq.App rect_var (ps ++ [m] ++ elimlist))
 
-    RecursorApp rec indices termEliminated ->
-      do rec' <- translateTerm rec
+    RecursorApp r indices termEliminated ->
+      do r' <- translateTerm r
          let args = indices ++ [termEliminated]
-         Coq.App rec' <$> mapM translateTerm args
+         Coq.App r' <$> mapM translateTerm args
 
     Sort s -> pure (Coq.Sort (translateSort s))
     NatLit i -> pure (Coq.NatLit (toInteger i))

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -67,7 +67,7 @@ import qualified Verifier.SAW.Simulator.Prims as Prims
 import Verifier.SAW.SATQuery
 import Verifier.SAW.SharedTerm
 import Verifier.SAW.Simulator.Value
-import Verifier.SAW.TypedAST (FieldName, identName, toShortName)
+import Verifier.SAW.TypedAST (FieldName, toShortName, identBaseName)
 import Verifier.SAW.FiniteValue
             (FirstOrderType(..), FirstOrderValue(..)
             , fovVec, firstOrderTypeOf, asFirstOrderType
@@ -272,7 +272,7 @@ flattenSValue nm v = do
         VIntMod n si              -> return ([svRem si (svInteger KUnbounded (toInteger n))], "")
         VWord sw                  -> return (if intSizeOf sw > 0 then [sw] else [], "")
         VCtorApp i ps ts          -> do (xss, ss) <- unzip <$> traverse (force >=> flattenSValue nm) (ps++ts)
-                                        return (concat xss, "_" ++ identName i ++ concat ss)
+                                        return (concat xss, "_" ++ (Text.unpack (identBaseName (primName i))) ++ concat ss)
         VNat n                    -> return ([], "_" ++ show n)
         TValue (suffixTValue -> Just s)
                                   -> return ([], s)
@@ -560,7 +560,7 @@ muxBVal :: TValue SBV -> SBool -> SValue -> SValue -> IO SValue
 muxBVal = Prims.muxValue prims
 
 muxSbvExtra :: TValue SBV -> SBool -> SbvExtra -> SbvExtra -> IO SbvExtra
-muxSbvExtra (VDataType "Prelude.Stream" [TValue tp]) c x y =
+muxSbvExtra (VDataType (primName -> "Prelude.Stream") [TValue tp] []) c x y =
   do let f i = do xi <- lookupSbvExtra x i
                   yi <- lookupSbvExtra y i
                   muxBVal tp c xi yi

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -581,7 +581,8 @@ sbvSolveBasic sc addlPrims unintSet t = do
   let uninterpreted ec
         | Set.member (ecVarIndex ec) unintSet = Just (extcns ec)
         | otherwise                           = Nothing
-  cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted
+  let neutral _env nt = fail ("sbvSolveBasic: could not evaluate neutral term: " ++ show nt)
+  cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted neutral
   Sim.evalSharedTerm cfg t
 
 parseUninterpreted :: [SVal] -> String -> TValue SBV -> IO SValue
@@ -658,8 +659,9 @@ sbvSATQuery sc addlPrims query =
           let uninterpreted ec
                 | Set.member (ecVarIndex ec) unintSet = Just (mkUninterp ec)
                 | otherwise                           = Nothing
+          let neutral _env nt = fail ("sbvSATQuery: could not evaluate neutral term: " ++ show nt)
 
-          cfg  <- liftIO (Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted)
+          cfg  <- liftIO (Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted neutral)
           bval <- liftIO (Sim.evalSharedTerm cfg t)
 
           case bval of

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -350,7 +350,7 @@ bvShiftOp bvOp natOp =
     case y of
       VNat i | j < toInteger (maxBound :: Int) -> return (vWord (natOp x (fromInteger j)))
         where j = toInteger i `min` toInteger (intSizeOf x)
-      VToNat v -> fmap (vWord . bvOp x) (toWord v)
+      VBVToNat _ v -> fmap (vWord . bvOp x) (toWord v)
       _        -> error $ unwords ["Verifier.SAW.Simulator.SBV.bvShiftOp", show y]
 
 -- bvShl : (w : Nat) -> Vec w Bool -> Nat -> Vec w Bool;
@@ -383,7 +383,7 @@ intToNatOp =
       Nothing ->
         let z  = svInteger KUnbounded 0
             i' = svIte (svLessThan i z) z i
-         in pure (VToNat (VInt i'))
+         in pure (VIntToNat (VInt i'))
 
 -- primitive natToInt :: Nat -> Integer;
 natToIntOp :: SValue
@@ -497,7 +497,7 @@ streamGetOp =
   strictFun $ \xs -> return $
   strictFun $ \case
     VNat n -> lookupSStream xs n
-    VToNat w ->
+    VBVToNat _ w ->
       do ilv <- toWord w
          selectV (lazyMux muxBVal) ((2 ^ intSizeOf ilv) - 1) (lookupSStream xs) ilv
     v -> Prims.panic "SBV.streamGetOp" ["Expected Nat value", show v]

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -271,7 +271,7 @@ flattenSValue nm v = do
         VIntMod 0 si              -> return ([si], "")
         VIntMod n si              -> return ([svRem si (svInteger KUnbounded (toInteger n))], "")
         VWord sw                  -> return (if intSizeOf sw > 0 then [sw] else [], "")
-        VCtorApp i (V.toList->ts) -> do (xss, ss) <- unzip <$> traverse (force >=> flattenSValue nm) ts
+        VCtorApp i ps ts          -> do (xss, ss) <- unzip <$> traverse (force >=> flattenSValue nm) (ps++ts)
                                         return (concat xss, "_" ++ identName i ++ concat ss)
         VNat n                    -> return ([], "_" ++ show n)
         TValue (suffixTValue -> Just s)

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -335,7 +335,7 @@ intToNatOp sym =
         do z <- W.intLit sym 0
            pneg <- W.intLt sym i z
            i' <- W.intIte sym pneg z i
-           pure (VToNat (VInt i'))
+           pure (VIntToNat (VInt i'))
 
 -- primitive natToInt :: Nat -> Integer;
 natToIntOp :: forall sym. Sym sym => sym -> SValue sym
@@ -410,7 +410,7 @@ bvShiftOp sym bvOp natOp =
     case y of
       VNat i   -> VWord <$> natOp x j
         where j = toInteger i `min` SW.bvWidth x
-      VToNat v -> VWord <$> (bvOp x =<< toWord sym v)
+      VBVToNat _ v -> VWord <$> (bvOp x =<< toWord sym v)
       _        -> error $ unwords ["Verifier.SAW.Simulator.What4.bvShiftOp", show y]
 
 -- bvShl : (w : Nat) -> Vec w Bool -> Nat -> Vec w Bool;
@@ -522,7 +522,7 @@ streamGetOp sym =
   strictFun $ \xs -> return $
   strictFun $ \case
     VNat n -> lookupSStream xs n
-    VToNat w ->
+    VBVToNat _ w ->
       do ilv <- toWord sym w
          selectV sym (lazyMux @sym (muxBVal sym)) ((2 ^ SW.bvWidth ilv) - 1) (lookupSStream xs) ilv
     v -> Prims.panic "streamGetOp" ["Expected Nat value", show v]

--- a/saw-core/src/Verifier/SAW/Conversion.hs
+++ b/saw-core/src/Verifier/SAW/Conversion.hs
@@ -265,15 +265,15 @@ asCtor :: ArgsMatchable v a => Ident -> v a -> Matcher a
 asCtor o = resolveArgs $ Matcher (Net.Atom (identText o)) match
   where match t = do
           CtorApp c params l <- R.asFTermF t
-          guard (c == o)
+          guard (o == primName c)
           return (params ++ l)
 
 -- | Match a datatype.
-asDataType :: ArgsMatchable v a => Ident -> v a -> Matcher a
-asDataType o = resolveArgs $ Matcher (Net.Atom (identText o)) match
+asDataType :: ArgsMatchable v a => PrimName a -> v a -> Matcher a
+asDataType o = resolveArgs $ Matcher (Net.Atom (identText (primName o))) match
   where match t = do
           DataTypeApp dt params l <- R.asFTermF t
-          guard (dt == o)
+          guard (primVarIndex dt == primVarIndex o)
           return (params ++ l)
 
 -- | Match any sort.
@@ -400,14 +400,17 @@ mkTupleSelector i t
   | i > 1  = mkTermF (FTermF (PairRight t)) >>= mkTupleSelector (i - 1)
   | otherwise = panic "Verifier.SAW.Conversion.mkTupleSelector" ["non-positive index:", show i]
 
-mkCtor :: Ident -> [TermBuilder Term] -> [TermBuilder Term] -> TermBuilder Term
+mkCtor :: PrimName Term -> [TermBuilder Term] -> [TermBuilder Term] -> TermBuilder Term
 mkCtor i paramsB argsB =
   do params <- sequence paramsB
      args <- sequence argsB
      mkTermF $ FTermF $ CtorApp i params args
 
-mkDataType :: Ident -> [TermBuilder Term] -> [TermBuilder Term] ->
-              TermBuilder Term
+mkDataType ::
+  PrimName Term ->
+  [TermBuilder Term] ->
+  [TermBuilder Term] ->
+  TermBuilder Term
 mkDataType i paramsB argsB =
   do params <- sequence paramsB
      args <- sequence argsB

--- a/saw-core/src/Verifier/SAW/ExternalFormat.hs
+++ b/saw-core/src/Verifier/SAW/ExternalFormat.hs
@@ -173,8 +173,8 @@ scWriteExternal t0 =
                        , show (Map.toList cs_fs)
                        , show (map (\ec -> (primVarIndex ec, primType ec)) ctorOrder)
                        ])
-            RecursorApp rec ixs e -> pure $
-              unwords (["RecursorApp", show rec] ++
+            RecursorApp r ixs e -> pure $
+              unwords (["RecursorApp", show r] ++
                        map show ixs ++ [show e])
 
             RecordType elem_tps -> pure $ unwords ["RecordType", show elem_tps]
@@ -328,9 +328,9 @@ scReadExternal sc input =
                         readElimsMap elims <*>
                         readCtorList ctorOrder
                pure (FTermF (Recursor rec))
-        ("RecursorApp" : rec : (splitLast -> Just (ixs, arg))) ->
+        ("RecursorApp" : r : (splitLast -> Just (ixs, arg))) ->
             do app <- RecursorApp <$>
-                        readIdx rec <*>
+                        readIdx r <*>
                         traverse readIdx ixs <*>
                         readIdx arg
                pure (FTermF app)

--- a/saw-core/src/Verifier/SAW/Module.hs
+++ b/saw-core/src/Verifier/SAW/Module.hs
@@ -151,24 +151,25 @@ data Ctor =
     -- where the @ps@ are the parameters and the @ix@s are the indices of
     -- datatype @d@
   , ctorIotaReduction ::
-       Term   {- ^ eliminator term -} ->
+       Term   {- ^ recursor term -} ->
        Map VarIndex Term {- ^ constructor eliminators -} ->
        [Term] {- ^ constructor arguments -} ->
        IO Term
     -- ^ Cached functon for computing the result of one step of iota
     --   reduction of the term
     --
-    -- > RecursorApp d params p_ret elims ixs (c params args)
+    -- > RecursorApp rec ixs (c params args)
     --
-    -- where @params@, @p_ret@, @elims@, and @args@ are distinct free variables,
-    -- in that order, so that the last @arg@ is the most recently-bound
-    -- variable, i.e., has deBruijn index 0.  This means that an iota reduction
-    -- of the above recursor application can be performed by passing the
-    -- concrete parameters, eliminators, and constructor arguments to this function.
-    -- Note that we are assuming that the @elims@ are in the same order as they are
-    -- listed in the corresponding 'DataType' for this constructor.
+    --   The arguments to this function are the recusor value, the
+    --   the map from the recursor that maps constructors to eliminator
+    --   functions, and the arguments to the constructor.
 
   , ctorIotaTemplate :: Term
+    -- ^ Cached term used for computing iota reductions.  It has free variables
+    --   @rec@, @elim@ and @args@, in that order so that the last @arg@ is the
+    --   most recently-bound variable with deBruijn index 0.  The @rec@ variable
+    --   represents the recursor value, @elim@ represents the eliminator function
+    --   for the constructor, and @args@ represent the arguments to this constructor.
   }
 
 -- | Return the number of parameters of a constructor

--- a/saw-core/src/Verifier/SAW/Module.hs
+++ b/saw-core/src/Verifier/SAW/Module.hs
@@ -146,19 +146,25 @@ data Ctor =
     --
     -- where the @ps@ are the parameters and the @ix@s are the indices of
     -- datatype @d@
-  , ctorIotaReduction :: Term
-    -- ^ Cached result of one step of iota reduction of the term
+  , ctorIotaReduction ::
+       Term   {- ^ eliminator term -} ->
+       Map Ident Term {- ^ constructor eliminators -} ->
+       [Term] {- ^ constructor arguments -} ->
+       IO Term
+    -- ^ Cached functon for computing the result of one step of iota
+    --   reduction of the term
     --
     -- > RecursorApp d params p_ret elims ixs (c params args)
     --
     -- where @params@, @p_ret@, @elims@, and @args@ are distinct free variables,
     -- in that order, so that the last @arg@ is the most recently-bound
-    -- variable, i.e., has deBruijn index 0. This means that an iota reduction
-    -- of the above recursor application can be performed by substituting the
-    -- concrete parameters, eliminators, and constructor arguments into the
-    -- 'Term' stored in 'ctorIotaReduction'. Note that we are assuming that the
-    -- @elims@ are in the same order as they are listed in the corresponding
-    -- 'DataType' for this constructor.
+    -- variable, i.e., has deBruijn index 0.  This means that an iota reduction
+    -- of the above recursor application can be performed by passing the
+    -- concrete parameters, eliminators, and constructor arguments to this function.
+    -- Note that we are assuming that the @elims@ are in the same order as they are
+    -- listed in the corresponding 'DataType' for this constructor.
+
+  , ctorIotaTemplate :: Term
   }
 
 -- | Return the number of parameters of a constructor

--- a/saw-core/src/Verifier/SAW/Module.hs
+++ b/saw-core/src/Verifier/SAW/Module.hs
@@ -155,7 +155,7 @@ data Ctor =
        Map VarIndex Term {- ^ constructor eliminators -} ->
        [Term] {- ^ constructor arguments -} ->
        IO Term
-    -- ^ Cached functon for computing the result of one step of iota
+    -- ^ Cached function for computing the result of one step of iota
     --   reduction of the term
     --
     -- > RecursorApp rec ixs (c params args)

--- a/saw-core/src/Verifier/SAW/Name.hs
+++ b/saw-core/src/Verifier/SAW/Name.hs
@@ -40,6 +40,7 @@ module Verifier.SAW.Name
   , VarIndex
   , ExtCns(..)
   , scFreshNameURI
+  , PrimName(..)
     -- * Naming Environments
   , SAWNamingEnv(..)
   , emptySAWNamingEnv
@@ -233,6 +234,29 @@ instance Ord (ExtCns e) where
 
 instance Hashable (ExtCns e) where
   hashWithSalt x ec = hashWithSalt x (ecVarIndex ec)
+
+
+-- Primitive Names ------------------------------------------------------------
+
+-- | Names of SAWCore primitives, data types and data type constructors.
+data PrimName e =
+  PrimName
+  { primVarIndex :: !VarIndex
+  , primName     :: !Ident
+  , primType     :: e
+  }
+  deriving (Show, Functor, Foldable, Traversable)
+
+instance Eq (PrimName e) where
+  x == y = primVarIndex x == primVarIndex y
+
+instance Ord (PrimName e) where
+  compare x y = compare (primVarIndex x) (primVarIndex y)
+
+instance Hashable (PrimName e) where
+  hashWithSalt x pn = hashWithSalt x (primVarIndex pn)
+
+
 
 scFreshNameURI :: Text -> VarIndex -> URI
 scFreshNameURI nm i = fromMaybe (panic "scFreshNameURI" ["Failed to constructed name URI", show nm, show i]) $

--- a/saw-core/src/Verifier/SAW/Prelude/Constants.hs
+++ b/saw-core/src/Verifier/SAW/Prelude/Constants.hs
@@ -19,9 +19,6 @@ preludeModuleName = mkModuleName ["Prelude"]
 preludeNatIdent :: Ident
 preludeNatIdent =  mkIdent preludeModuleName "Nat"
 
-preludeNatType :: FlatTermF e
-preludeNatType =  DataTypeApp preludeNatIdent [] []
-
 preludeZeroIdent :: Ident
 preludeZeroIdent =  mkIdent preludeModuleName "Zero"
 

--- a/saw-core/src/Verifier/SAW/Prim.hs
+++ b/saw-core/src/Verifier/SAW/Prim.hs
@@ -275,6 +275,36 @@ lg2rem n = (k+1, 2*d+r)
   where (q, r) = n `divMod` 2
         (k, d) = lg2rem q
 
+------------------------------------------------------------
+-- BitVector shift/rotate
+
+bvRotateL :: BitVector -> Integer -> BitVector
+bvRotateL (BV w x) i = bv w ((x `shiftL` j) .|. (x `shiftR` (w - j)))
+  where j = fromInteger (i `mod` toInteger w)
+
+bvRotateR :: BitVector -> Integer -> BitVector
+bvRotateR w i = bvRotateL w (- i)
+
+bvShiftL ::
+  Bool {- ^ bit value to shift in -} ->
+  BitVector {- ^ value to shift -} ->
+  Integer {- ^ amount to shift by -} ->
+  BitVector
+bvShiftL c (BV w x) i = bv w ((x `shiftL` j) .|. c')
+  where c' = if c then (1 `shiftL` j) - 1 else 0
+        j = fromInteger (i `min` toInteger w)
+
+bvShiftR ::
+  Bool {- ^ bit value to shift in -} ->
+  BitVector {- ^ value to shift -} ->
+  Integer {- ^ amount to shift by -} ->
+  BitVector
+bvShiftR c (BV w x) i = bv w (c' .|. (x `shiftR` j))
+  where c' = if c then (full `shiftL` (w - j)) .&. full else 0
+        full = (1 `shiftL` w) - 1
+        j = fromInteger (i `min` toInteger w)
+
+
 ----------------------------------------
 -- Errors
 

--- a/saw-core/src/Verifier/SAW/Prim.hs
+++ b/saw-core/src/Verifier/SAW/Prim.hs
@@ -56,6 +56,16 @@ signed (BV w x)
 bvAt :: BitVector -> Int -> Bool
 bvAt (BV w x) i = testBit x (w - 1 - i)
 
+-- | Conversion from list of bits to integer (big-endian)
+bvToInteger :: Vector Bool -> Integer
+bvToInteger = V.foldl' (\x b -> if b then 2*x+1 else 2*x) 0
+
+unpackBitVector :: BitVector -> Vector Bool
+unpackBitVector x = V.generate (width x) (bvAt x)
+
+packBitVector :: Vector Bool -> BitVector
+packBitVector v = BV (V.length v) (bvToInteger v)
+
 ------------------------------------------------------------
 -- Primitive operations
 

--- a/saw-core/src/Verifier/SAW/Recognizer.hs
+++ b/saw-core/src/Verifier/SAW/Recognizer.hs
@@ -42,6 +42,7 @@ module Verifier.SAW.Recognizer
   , asDataType
   , asDataTypeParams
   , asRecursorApp
+  , asRecursorType
   , isDataType
   , asNat
   , asBvNat
@@ -273,11 +274,16 @@ asDataTypeParams t = do DataTypeApp c ps args <- asFTermF t; return (c,ps,args)
 asDataType :: Recognizer Term (Ident, [Term])
 asDataType t = do DataTypeApp c ps args <- asFTermF t; return (c,ps ++ args)
 
-asRecursorApp :: Recognizer Term (Ident,[Term],Term,
-                                               [(Ident,Term)],[Term],Term)
+asRecursorType :: Recognizer Term (Ident, [Term], Term, Term)
+asRecursorType t =
+  do RecursorType d ps motive motive_ty <- asFTermF t
+     return (d,ps,motive,motive_ty)
+
+asRecursorApp :: Recognizer Term (Term, CompiledRecursor Term, [Term], Term)
 asRecursorApp t =
-  do RecursorApp d params p_ret cs_fs ixs arg <- asFTermF t;
-     return (d, params, p_ret, cs_fs, ixs, arg)
+  do RecursorApp rec ixs arg <- asFTermF t
+     Recursor crec <- asFTermF rec
+     return (rec, crec, ixs, arg)
 
 isDataType :: Ident -> Recognizer [Term] a -> Recognizer Term a
 isDataType i p t = do

--- a/saw-core/src/Verifier/SAW/Recognizer.hs
+++ b/saw-core/src/Verifier/SAW/Recognizer.hs
@@ -38,7 +38,6 @@ module Verifier.SAW.Recognizer
   , asRecordSelector
   , asCtorParams
   , asCtor
-  , asCtorOrNat
   , asDataType
   , asDataTypeParams
   , asRecursorApp
@@ -71,7 +70,6 @@ module Verifier.SAW.Recognizer
   , asArrayType
   ) where
 
-import Control.Applicative
 import Control.Lens
 import Control.Monad
 import Data.Map (Map)
@@ -92,10 +90,6 @@ instance Field2 (a :*: b) (a :*: b') b b' where
   _2 k (a :*: b) = (a :*:) <$> indexed k (1 :: Int) b
 
 type Recognizer t a = t -> Maybe a
-
--- | Tries both recognizers.
-orElse :: Recognizer t a -> Recognizer t a -> Recognizer t a
-orElse f g t = f t <|> g t
 
 -- | Recognizes the head and tail of a list, and returns head.
 (<:) :: Recognizer t a -> Recognizer [t] () -> Recognizer [t] a
@@ -129,7 +123,7 @@ asModuleIdentifier (EC _ nmi _) =
 asGlobalDef :: Recognizer Term Ident
 asGlobalDef t =
   case unwrapTermF t of
-    FTermF (Primitive ec) -> asModuleIdentifier ec
+    FTermF (Primitive pn) -> Just (primName pn)
     Constant ec _ -> asModuleIdentifier ec
     _ -> Nothing
 
@@ -245,36 +239,22 @@ asRecordSelector t = do
 
 -- | Test whether a term is an application of a constructor, and, if so, return
 -- the constructor, its parameters, and its arguments
-asCtorParams :: Recognizer Term (Ident, [Term], [Term])
+asCtorParams :: Recognizer Term (PrimName Term, [Term], [Term])
 asCtorParams t = do CtorApp c ps args <- asFTermF t; return (c,ps,args)
 
--- | Just like 'asCtorParams', but treat natural number literals as constructor
--- applications, i.e., @0@ becomes the constructor @Zero@, and any non-zero
--- literal @k@ becomes @Succ (k-1)@
-asCtorOrNat :: Recognizer Term (Ident, [Term], [Term])
-asCtorOrNat = asCtorParams `orElse` (asNatLit >=> helper) where
-  asNatLit (unwrapTermF -> FTermF (NatLit i)) = return i
-  asNatLit _ = Nothing
-  helper 0 = return (preludeZeroIdent, [], [])
-  helper k =
-    if k > 0 then
-      return (preludeSuccIdent, [], [Unshared (FTermF (NatLit $ k-1))])
-    else error "asCtorOrNat: negative natural number literal!"
-
-
 -- | A version of 'asCtorParams' that combines the parameters and normal args
-asCtor :: Recognizer Term (Ident, [Term])
+asCtor :: Recognizer Term (PrimName Term, [Term])
 asCtor t = do CtorApp c ps args <- asFTermF t; return (c,ps ++ args)
 
 -- | A version of 'asDataType' that returns the parameters separately
-asDataTypeParams :: Recognizer Term (Ident, [Term], [Term])
+asDataTypeParams :: Recognizer Term (PrimName Term, [Term], [Term])
 asDataTypeParams t = do DataTypeApp c ps args <- asFTermF t; return (c,ps,args)
 
 -- | A version of 'asDataTypeParams' that combines the params and normal args
-asDataType :: Recognizer Term (Ident, [Term])
+asDataType :: Recognizer Term (PrimName Term, [Term])
 asDataType t = do DataTypeApp c ps args <- asFTermF t; return (c,ps ++ args)
 
-asRecursorType :: Recognizer Term (Ident, [Term], Term, Term)
+asRecursorType :: Recognizer Term (PrimName Term, [Term], Term, Term)
 asRecursorType t =
   do RecursorType d ps motive motive_ty <- asFTermF t
      return (d,ps,motive,motive_ty)
@@ -285,15 +265,17 @@ asRecursorApp t =
      Recursor crec <- asFTermF rec
      return (rec, crec, ixs, arg)
 
-isDataType :: Ident -> Recognizer [Term] a -> Recognizer Term a
+isDataType :: PrimName Term -> Recognizer [Term] a -> Recognizer Term a
 isDataType i p t = do
   (o,l) <- asDataType t
   if i == o then p l else Nothing
 
 asNat :: Recognizer Term Natural
 asNat (unwrapTermF -> FTermF (NatLit i)) = return i
-asNat (asCtor -> Just (c, [])) | c == "Prelude.Zero" = return 0
-asNat (asCtor -> Just (c, [asNat -> Just i])) | c == "Prelude.Succ" = return (i+1)
+asNat (asCtor -> Just (c, []))
+  | primName c == preludeZeroIdent = return 0
+asNat (asCtor -> Just (c, [asNat -> Just i]))
+  | primName c == preludeSuccIdent = return (i+1)
 asNat _ = Nothing
 
 asBvNat :: Recognizer Term (Natural :*: Natural)
@@ -386,7 +368,7 @@ asEq :: Recognizer Term (Term, Term, Term)
 asEq t =
   do (o, l) <- asDataType t
      case l of
-       [a, x, y] | "Prelude.Eq" == o -> return (a, x, y)
+       [a, x, y] | "Prelude.Eq" == primName o -> return (a, x, y)
        _ -> Nothing
 
 asEqTrue :: Recognizer Term Term

--- a/saw-core/src/Verifier/SAW/Recognizer.hs
+++ b/saw-core/src/Verifier/SAW/Recognizer.hs
@@ -261,9 +261,9 @@ asRecursorType t =
 
 asRecursorApp :: Recognizer Term (Term, CompiledRecursor Term, [Term], Term)
 asRecursorApp t =
-  do RecursorApp rec ixs arg <- asFTermF t
-     Recursor crec <- asFTermF rec
-     return (rec, crec, ixs, arg)
+  do RecursorApp rc ixs arg <- asFTermF t
+     Recursor crec <- asFTermF rc
+     return (rc, crec, ixs, arg)
 
 isDataType :: PrimName Term -> Recognizer [Term] a -> Recognizer Term a
 isDataType i p t = do

--- a/saw-core/src/Verifier/SAW/Rewriter.hs
+++ b/saw-core/src/Verifier/SAW/Rewriter.hs
@@ -532,12 +532,19 @@ asRecordRedex t =
 -- constructor application; specifically, this function recognizes
 --
 -- > RecursorApp rec _ (CtorApp c _ args)
+--
+-- Note that this function does not recognize applications of
+-- recursors to concrete Nat values; see @asNatIotaRedex@.
 asIotaRedex :: R.Recognizer Term (Term, CompiledRecursor Term, PrimName Term, [Term])
 asIotaRedex t =
   do (rec, crec, _, arg) <- R.asRecursorApp t
      (c, _, args) <- R.asCtorParams arg
      return (rec, crec, c, args)
 
+-- | An iota redex whose argument is a concrete nautral number; specifically,
+--   this function recognizes
+--
+--   > RecursorApp rec _ n
 asNatIotaRedex :: R.Recognizer Term (Term, CompiledRecursor Term, Natural)
 asNatIotaRedex t =
   do (rec, crec, _, arg) <- R.asRecursorApp t

--- a/saw-core/src/Verifier/SAW/Rewriter.hs
+++ b/saw-core/src/Verifier/SAW/Rewriter.hs
@@ -379,7 +379,7 @@ scExpandRewriteRule sc (RewriteRule ctxt lhs rhs _ ann) =
                   return (mkRewriteRule ctxt l x ann)
          Just <$> traverse mkRule (Map.assocs m)
     (R.asApplyAll ->
-     (R.asRecursorApp -> Just (d, params, p_ret, cs_fs, _ixs, R.asLocalVar -> Just i),
+     (R.asRecursorApp -> Just (rec, crec, _ixs, R.asLocalVar -> Just i),
       more)) ->
       do let ctxt1 = reverse (drop (i+1) (reverse ctxt))
          let ctxt2 = reverse (take i (reverse ctxt))
@@ -406,21 +406,22 @@ scExpandRewriteRule sc (RewriteRule ctxt lhs rhs _ ann) =
                   -- Adjust the indices and substitute the new
                   -- constructor value to make the new params, lhs,
                   -- and rhs in context @ctxt'@.
-                  params' <- traverse adjust params
                   lhs' <- adjust lhs
-                  p_ret' <- adjust p_ret
-                  cs_fs' <- traverse (traverse adjust) cs_fs
+
+                  rec'  <- adjust rec
+                  crec' <- traverse adjust crec
                   args' <- traverse (incVars sc 0 i) args
                   more' <- traverse adjust more
                   let cn = ctorName ctor
-                  rhs1 <- scReduceRecursor sc d params' p_ret' cs_fs' cn args'
+
+                  rhs1 <- scReduceRecursor sc rec' crec' cn args'
                   rhs2 <- scApplyAll sc rhs1 more'
                   rhs3 <- betaReduce rhs2
                   -- re-fold recursive occurrences of the original rhs
                   let ss = addRule (mkRewriteRule ctxt rhs lhs Nothing) emptySimpset
                   (_,rhs') <- rewriteSharedTerm sc (ss :: Simpset ()) rhs3
                   return (mkRewriteRule ctxt' lhs' rhs' ann)
-         dt <- scRequireDataType sc d
+         dt <- scRequireDataType sc (recursorDataType crec)
          rules <- traverse ctorRule (dtCtors dt)
          return (Just rules)
     _ -> return Nothing
@@ -530,12 +531,12 @@ asRecordRedex t =
 -- | An iota redex is a recursor application whose main argument is a
 -- constructor application; specifically, this function recognizes
 --
--- > RecursorApp d params p_ret cs_fs _ (CtorApp c _ args)
-asIotaRedex :: R.Recognizer Term (Ident, [Term], Term, [(Ident, Term)], Ident, [Term])
+-- > RecursorApp rec _ (CtorApp c _ args)
+asIotaRedex :: R.Recognizer Term (Term, CompiledRecursor Term, Ident, [Term])
 asIotaRedex t =
-  do (d, params, p_ret, cs_fs, _, arg) <- R.asRecursorApp t
+  do (rec, crec, _, arg) <- R.asRecursorApp t
      (c, _, args) <- asCtorOrNat arg
-     return (d, params, p_ret, cs_fs, c, args)
+     return (rec, crec, c, args)
 
 
 ----------------------------------------------------------------------
@@ -586,8 +587,8 @@ reduceSharedTerm :: SharedContext -> Term -> Maybe (IO Term)
 reduceSharedTerm sc (asBetaRedex -> Just (_, _, body, arg)) = Just (instantiateVar sc 0 arg body)
 reduceSharedTerm _ (asPairRedex -> Just t) = Just (return t)
 reduceSharedTerm _ (asRecordRedex -> Just t) = Just (return t)
-reduceSharedTerm sc (asIotaRedex -> Just (d, params, p_ret, cs_fs, c, args)) =
-  Just $ scReduceRecursor sc d params p_ret cs_fs c args
+reduceSharedTerm sc (asIotaRedex -> Just (rec, crec, c, args)) =
+  Just $ scReduceRecursor sc rec crec c args
 reduceSharedTerm _ _ = Nothing
 
 -- | Rewriter for shared terms.  The annotations of any used rules are collected
@@ -712,6 +713,9 @@ rewriteSharedTermTypeSafe sc ss t0 =
           -- a term to become ill-typed
           CtorApp{}        -> return ftf
           DataTypeApp{}    -> return ftf -- could treat same as CtorApp
+
+          RecursorType{}   -> return ftf
+          Recursor{}       -> return ftf
           RecursorApp{}    -> return ftf -- could treat same as CtorApp
 
           RecordType{}     -> traverse rewriteAll ftf

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -215,6 +215,7 @@ module Verifier.SAW.SharedTerm
   , scBvShl, scBvShr, scBvSShr
   , scBvUExt, scBvSExt
   , scBvTrunc
+  , scBvLg2
   , scBvPopcount
   , scBvCountLeadingZeros
   , scBvCountTrailingZeros
@@ -224,6 +225,7 @@ module Verifier.SAW.SharedTerm
   , scArrayConstant
   , scArrayLookup
   , scArrayUpdate
+  , scArrayEq
     -- ** Utilities
 --  , scTrue
 --  , scFalse
@@ -2005,6 +2007,12 @@ scBvSRem sc n x y = scGlobalApply sc "Prelude.bvSRem" [n, x, y]
 scBvSDiv :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvSDiv sc n x y = scGlobalApply sc "Prelude.bvSDiv" [n, x, y]
 
+-- | Create a term applying the lg2 bitvector primitive.
+--
+-- > bvLg2 : (n : Nat) -> Vec n Bool -> Vec n Bool;
+scBvLg2 :: SharedContext -> Term -> Term -> IO Term
+scBvLg2 sc n x = scGlobalApply sc "Prelude.bvLg2" [n, x]
+
 -- | Create a term applying the population count bitvector primitive.
 --
 -- > bvPopcount : (n : Nat) -> Vec n Bool -> Vec n Bool;
@@ -2168,14 +2176,14 @@ scUpdBvFun sc n a f i v = scGlobalApply sc "Prelude.updBvFun" [n, a, f, i, v]
 scArrayType :: SharedContext -> Term -> Term -> IO Term
 scArrayType sc a b = scGlobalApply sc "Prelude.Array" [a, b]
 
--- Create a term computing a constant array, given an index type, element type,
+-- | Create a term computing a constant array, given an index type, element type,
 -- and element (all as 'Term's).
 --
 -- > arrayConstant : (a b : sort 0) -> b -> (Array a b);
 scArrayConstant :: SharedContext -> Term -> Term -> Term -> IO Term
 scArrayConstant sc a b e = scGlobalApply sc "Prelude.arrayConstant" [a, b, e]
 
--- Create a term computing the value at a particular index of an array.
+-- | Create a term computing the value at a particular index of an array.
 --
 -- > arrayLookup : (a b : sort 0) -> (Array a b) -> a -> b;
 scArrayLookup :: SharedContext -> Term -> Term -> Term -> Term -> IO Term
@@ -2186,6 +2194,12 @@ scArrayLookup sc a b f i = scGlobalApply sc "Prelude.arrayLookup" [a, b, f, i]
 -- > arrayUpdate : (a b : sort 0) -> (Array a b) -> a -> b -> (Array a b);
 scArrayUpdate :: SharedContext -> Term -> Term -> Term -> Term -> Term -> IO Term
 scArrayUpdate sc a b f i e = scGlobalApply sc "Prelude.arrayUpdate" [a, b, f, i, e]
+
+-- | Create a term computing the equality of two arrays.
+--
+-- > arrayEq : (a b : sort 0) -> (Array a b) -> (Array a b) -> Bool;
+scArrayEq :: SharedContext -> Term -> Term -> Term -> Term -> IO Term
+scArrayEq sc a b x y = scGlobalApply sc "Prelude.arrayEq" [a, b, x, y]
 
 ------------------------------------------------------------
 -- | The default instance of the SharedContext operations.

--- a/saw-core/src/Verifier/SAW/Simulator.hs
+++ b/saw-core/src/Verifier/SAW/Simulator.hs
@@ -308,8 +308,13 @@ evalRecursorApp modmap lam ps p_ret cs_fs (VNat 0) =
 evalRecursorApp modmap lam ps p_ret cs_fs (VNat i) =
   evalRecursorApp modmap lam ps p_ret cs_fs
   (VCtorApp "Prelude.Succ" (V.singleton $ ready $ VNat $ i-1))
-evalRecursorApp _modmap _lam _ps _p_ret _cs_fs (VToNat _bv) =
-  panic $ "evalRecursorApp: VToNat!"
+
+evalRecursorApp _modmap _lam _ps _p_ret _cs_fs (VBVToNat _ _bv) =
+  panic $ "evalRecursorApp: VBVToNat!"
+
+evalRecursorApp _modmap _lam _ps _p_ret _cs_fs (VIntToNat _i) =
+  panic $ "evalRecursorApp: VIntToNat!"
+
 evalRecursorApp _ _ _ _ _ v =
   panic $ "evalRecursorApp: non-constructor value: " ++ show v
 

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -155,7 +155,7 @@ prims =
   , Prims.bpMuxBool  = pure3 ite
   , Prims.bpMuxWord  = pure3 ite
   , Prims.bpMuxInt   = pure3 ite
-  , Prims.bpMuxExtra = pure3 ite
+  , Prims.bpMuxExtra = \_tp -> pure3 ite
     -- Booleans
   , Prims.bpTrue   = True
   , Prims.bpFalse  = False

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -364,6 +364,7 @@ streamGetOp =
   pureFun $ \xs ->
   strictFun $ \case
     VNat n -> return $ IntTrie.apply (toStream xs) (toInteger n)
-    VToNat w -> return $ IntTrie.apply (toStream xs) (unsigned (toWord w))
+    VIntToNat (VInt i) -> return $ IntTrie.apply (toStream xs) i
+    VBVToNat _ w -> return $ IntTrie.apply (toStream xs) (unsigned (toWord w))
     n -> Prims.panic "Verifier.SAW.Simulator.Concrete.streamGetOp"
                ["Expected Nat value", show n]

--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -425,7 +425,9 @@ bvNatOp bp =
 
 -- bvToNat : (n : Nat) -> Vec n Bool -> Nat;
 bvToNatOp :: VMonad l => Value l
-bvToNatOp = constFun $ pureFun VToNat
+bvToNatOp =
+  natFun' "bvToNat" $ \n -> return $
+  pureFun (VBVToNat (fromIntegral n)) -- TODO, bad fromIntegral
 
 -- coerce :: (a b :: sort 0) -> Eq (sort 0) a b -> a -> b;
 coerceOp :: VMonad l => Value l
@@ -441,11 +443,11 @@ coerceOp =
 -- | Return the number of bits necessary to represent the given value,
 -- which should be a value of type Nat.
 natSize :: BasePrims l -> Value l -> Natural
-natSize bp val =
+natSize _bp val =
   case val of
     VNat n -> widthNat n
-    VToNat (VVector v) -> fromIntegral (V.length v)
-    VToNat (VWord w) -> fromIntegral (bpBvSize bp w)
+    VBVToNat n _ -> fromIntegral n -- TODO, remove this fromIntegral
+    VIntToNat _ -> panic "natSize: symbolic integer (TODO)"
     _ -> panic "natSize: expected Nat"
 
 -- | Convert the given value (which should be of type Nat) to a word
@@ -455,9 +457,9 @@ natToWord :: (VMonad l, Show (Extra l)) => BasePrims l -> Int -> Value l -> MWor
 natToWord bp w val =
   case val of
     VNat n -> bpBvLit bp w (toInteger n)
-    VToNat v ->
+    VIntToNat _i -> panic "natToWord of VIntToNat TODO!"
+    VBVToNat xsize v ->
       do x <- toWord (bpPack bp) v
-         let xsize = bpBvSize bp x
          case compare xsize w of
            GT -> panic "natToWord: not enough bits"
            EQ -> return x
@@ -495,7 +497,7 @@ subNatOp bp =
          lt <- bpBvult bp x1 x2
          z <- bpBvLit bp (fromInteger w) 0
          d <- bpBvSub bp x1 x2
-         VToNat . VWord <$> bpMuxWord bp lt z d
+         VBVToNat (fromInteger w) . VWord <$> bpMuxWord bp lt z d -- TODO, boo fromInteger
 
 -- mulNat :: Nat -> Nat -> Nat;
 mulNatOp :: VMonad l => Value l
@@ -649,7 +651,7 @@ atWithDefaultOp bp =
           VVector xv -> force (vecIdx d xv (fromIntegral i)) -- FIXME dangerous fromIntegral
           VWord xw -> VBool <$> bpBvAt bp xw (fromIntegral i) -- FIXME dangerous fromIntegral
           _ -> panic "atOp: expected vector"
-      VToNat i -> do
+      VBVToNat _sz i -> do
         iv <- toBits (bpUnpack bp) i
         case x of
           VVector xv ->
@@ -657,6 +659,9 @@ atWithDefaultOp bp =
           VWord xw ->
             selectV (lazyMuxValue bp) (fromIntegral n - 1) (liftM VBool . bpBvAt bp xw) iv -- FIXME dangerous fromIntegral
           _ -> panic "atOp: expected vector"
+
+      VIntToNat _i -> panic "atWithDefault: symbolic integer TODO"
+
       _ -> panic $ "atOp: expected Nat, got " ++ show idx
 
 -- upd :: (n :: Nat) -> (a :: sort 0) -> Vec n a -> Nat -> a -> Vec n a;
@@ -672,18 +677,20 @@ updOp bp =
         | toInteger i < toInteger (V.length xv)
            -> return (VVector (xv V.// [(fromIntegral i, y)]))
         | otherwise                   -> return (VVector xv)
-      VToNat (VWord w) ->
-        do let wsize = bpBvSize bp w
-               f i = do b <- bpBvEq bp w =<< bpBvLit bp wsize (toInteger i)
+      VBVToNat wsize (VWord w) ->
+        do let f i = do b <- bpBvEq bp w =<< bpBvLit bp wsize (toInteger i)
                         if wsize < 64 && toInteger i >= 2 ^ wsize
                           then return (xv V.! i)
                           else delay (lazyMuxValue bp b (force y) (force (xv V.! i)))
            yv <- V.generateM (V.length xv) f
            return (VVector yv)
-      VToNat (VVector iv) ->
+      VBVToNat _sz (VVector iv) ->
         do let update i = return (VVector (xv V.// [(i, y)]))
            iv' <- V.mapM (liftM toBool . force) iv
            selectV (lazyMuxValue bp) (fromIntegral n - 1) update iv' -- FIXME dangerous fromIntegral
+
+      VIntToNat _ -> panic "updOp: symbolic integer TODO"
+
       _ -> panic $ "updOp: expected Nat, got " ++ show idx
 
 -- primitive EmptyVec :: (a :: sort 0) -> Vec 0 a;
@@ -790,7 +797,7 @@ expByNatOp bp =
   pureFun $ \mul ->
   pureFun $ \x   ->
   strictFun $ \case
-    VToNat w ->
+    VBVToNat _sz w ->
       do let loop acc [] = return acc
              loop acc (b:bs)
                | Just False <- bpAsBool bp b
@@ -807,6 +814,10 @@ expByNatOp bp =
                     loop acc' bs
 
          loop one . V.toList =<< toBits (bpUnpack bp) w
+
+    -- This can't really be implemented, we should throw an unsupported exception
+    -- of some kind instead
+    VIntToNat _ -> panic "expByNat: symbolic integer"
 
     VNat n ->
       do let loop acc [] = return acc
@@ -864,7 +875,7 @@ shiftOp bp vecOp wordIntOp wordOp =
             zb <- toBool <$> force z
             VWord <$> wordIntOp zb xw (toInteger (min i n))
           _ -> panic $ "shiftOp: " ++ show xs
-      VToNat (VVector iv) -> do
+      VBVToNat _sz (VVector iv) -> do
         bs <- V.toList <$> traverse (fmap toBool . force) iv
         case xs of
           VVector xv -> VVector <$> shifter muxVector (\v i -> return (vecOp z v i)) xv bs
@@ -872,7 +883,7 @@ shiftOp bp vecOp wordIntOp wordOp =
             zb <- toBool <$> force z
             VWord <$> shifter (bpMuxWord bp) (wordIntOp zb) xw bs
           _ -> panic $ "shiftOp: " ++ show xs
-      VToNat (VWord iw) ->
+      VBVToNat _sz (VWord iw) ->
         case xs of
           VVector xv -> do
             bs <- V.toList <$> bpUnpack bp iw
@@ -881,6 +892,9 @@ shiftOp bp vecOp wordIntOp wordOp =
             zb <- toBool <$> force z
             VWord <$> wordOp zb xw iw
           _ -> panic $ "shiftOp: " ++ show xs
+
+      VIntToNat _i -> panic "shiftOp: symbolic integer TODO"
+
       _ -> panic $ "shiftOp: " ++ show y
   where
     muxVector :: VBool l -> Vector (Thunk l) -> Vector (Thunk l) -> EvalM l (Vector (Thunk l))
@@ -908,13 +922,13 @@ rotateOp bp vecOp wordIntOp wordOp =
           VVector xv -> return $ VVector (vecOp xv (toInteger i))
           VWord xw -> VWord <$> wordIntOp xw (toInteger i)
           _ -> panic $ "rotateOp: " ++ show xs
-      VToNat (VVector iv) -> do
+      VBVToNat _sz (VVector iv) -> do
         bs <- V.toList <$> traverse (fmap toBool . force) iv
         case xs of
           VVector xv -> VVector <$> shifter muxVector (\v i -> return (vecOp v i)) xv bs
           VWord xw -> VWord <$> shifter (bpMuxWord bp) wordIntOp xw bs
           _ -> panic $ "rotateOp: " ++ show xs
-      VToNat (VWord iw) ->
+      VBVToNat _sz (VWord iw) ->
         case xs of
           VVector xv -> do
             bs <- V.toList <$> bpUnpack bp iw
@@ -922,6 +936,9 @@ rotateOp bp vecOp wordIntOp wordOp =
           VWord xw -> do
             VWord <$> wordOp xw iw
           _ -> panic $ "rotateOp: " ++ show xs
+
+      VIntToNat _i -> panic "rotateOp: symbolic integer TODO"
+
       _ -> panic $ "rotateOp: " ++ show y
   where
     muxVector :: VBool l -> Vector (Thunk l) -> Vector (Thunk l) -> EvalM l (Vector (Thunk l))
@@ -1266,7 +1283,8 @@ muxValue bp b = value
     value x@(VWord _)       y                 = toVector (bpUnpack bp) x >>= \xv -> value (VVector xv) y
     value x                 y@(VWord _)       = toVector (bpUnpack bp) y >>= \yv -> value x (VVector yv)
     value x@(VNat _)        y                 = nat x y
-    value x@(VToNat _)      y                 = nat x y
+    value x@(VBVToNat _ _)  y                 = nat x y
+    value x@(VIntToNat _)   y                 = nat x y
     value (TValue x)        (TValue y)        = TValue <$> tvalue x y
     value x                 y                 =
       panic $ "Verifier.SAW.Simulator.Prims.iteOp: malformed arguments: "
@@ -1293,7 +1311,7 @@ muxValue bp b = value
                 (panic "muxValue" ["width too large", show w])
          x1 <- natToWord bp (fromInteger w) v1
          x2 <- natToWord bp (fromInteger w) v2
-         VToNat . VWord <$> bpMuxWord bp b x1 x2
+         VBVToNat (fromInteger w) . VWord <$> bpMuxWord bp b x1 x2
 
 -- fix :: (a :: sort 0) -> (a -> a) -> a;
 fixOp :: (VMonadLazy l, MonadFix (EvalM l), Show (Extra l)) => Value l

--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ViewPatterns #-}
 
 {- |
 Module      : Verifier.SAW.Simulator.Prims
@@ -26,7 +27,7 @@ import GHC.Stack( HasCallStack )
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
 #endif
-import Control.Monad (foldM, liftM, zipWithM, unless)
+import Control.Monad (liftM, unless, foldM, zipWithM)
 import Control.Monad.Fix (MonadFix(mfix))
 import Data.Bits
 import Data.Map (Map)
@@ -64,7 +65,7 @@ data BasePrims l =
   , bpMuxBool  :: VBool l -> VBool l -> VBool l -> MBool l
   , bpMuxWord  :: VBool l -> VWord l -> VWord l -> MWord l
   , bpMuxInt   :: VBool l -> VInt l -> VInt l -> MInt l
-  , bpMuxExtra :: VBool l -> Extra l -> Extra l -> EvalM l (Extra l)
+  , bpMuxExtra :: TValue l -> VBool l -> Extra l -> Extra l -> EvalM l (Extra l)
     -- Booleans
   , bpTrue   :: VBool l
   , bpFalse  :: VBool l
@@ -641,7 +642,7 @@ eqOp bp =
 atWithDefaultOp :: (VMonadLazy l, Show (Extra l)) => BasePrims l -> Value l
 atWithDefaultOp bp =
   natFun $ \n -> return $
-  constFun $
+  strictFun $ \(toTValue -> tp) -> return $
   VFun "d" $ \d -> return $
   strictFun $ \x -> return $
   strictFun $ \idx ->
@@ -655,9 +656,9 @@ atWithDefaultOp bp =
         iv <- toBits (bpUnpack bp) i
         case x of
           VVector xv ->
-            selectV (lazyMuxValue bp) (fromIntegral n - 1) (force . vecIdx d xv) iv -- FIXME dangerous fromIntegral
+            selectV (lazyMuxValue bp tp) (fromIntegral n - 1) (force . vecIdx d xv) iv -- FIXME dangerous fromIntegral
           VWord xw ->
-            selectV (lazyMuxValue bp) (fromIntegral n - 1) (liftM VBool . bpBvAt bp xw) iv -- FIXME dangerous fromIntegral
+            selectV (lazyMuxValue bp tp) (fromIntegral n - 1) (liftM VBool . bpBvAt bp xw) iv -- FIXME dangerous fromIntegral
           _ -> panic "atOp: expected vector"
 
       VIntToNat _i -> panic "atWithDefault: symbolic integer TODO"
@@ -668,7 +669,7 @@ atWithDefaultOp bp =
 updOp :: (VMonadLazy l, Show (Extra l)) => BasePrims l -> Value l
 updOp bp =
   natFun $ \n -> return $
-  constFun $
+  strictFun $ \(toTValue -> tp) -> return $
   vectorFun (bpUnpack bp) $ \xv -> return $
   strictFun $ \idx -> return $
   VFun "y" $ \y ->
@@ -681,13 +682,13 @@ updOp bp =
         do let f i = do b <- bpBvEq bp w =<< bpBvLit bp wsize (toInteger i)
                         if wsize < 64 && toInteger i >= 2 ^ wsize
                           then return (xv V.! i)
-                          else delay (lazyMuxValue bp b (force y) (force (xv V.! i)))
+                          else delay (lazyMuxValue bp tp b (force y) (force (xv V.! i)))
            yv <- V.generateM (V.length xv) f
            return (VVector yv)
       VBVToNat _sz (VVector iv) ->
         do let update i = return (VVector (xv V.// [(i, y)]))
            iv' <- V.mapM (liftM toBool . force) iv
-           selectV (lazyMuxValue bp) (fromIntegral n - 1) update iv' -- FIXME dangerous fromIntegral
+           selectV (lazyMuxValue bp (VVecType n tp)) (fromIntegral n - 1) update iv' -- FIXME dangerous fromIntegral
 
       VIntToNat _ -> panic "updOp: symbolic integer TODO"
 
@@ -792,7 +793,7 @@ vZipOp unpack =
 -- primitive expByNat : (a:sort 0) -> a -> (a -> a -> a) -> a -> Nat -> a;
 expByNatOp :: (MonadLazy (EvalM l), VMonad l, Show (Extra l)) => BasePrims l -> Value l
 expByNatOp bp =
-  constFun $
+  strictFun $ \(toTValue -> tp) -> return $
   pureFun $ \one ->
   pureFun $ \mul ->
   pureFun $ \x   ->
@@ -810,7 +811,7 @@ expByNatOp bp =
                | otherwise
                = do sq   <- applyAll mul [ ready acc, ready acc ]
                     sq_x <- applyAll mul [ ready sq, ready x ]
-                    acc' <- muxValue bp b sq_x sq
+                    acc' <- muxValue bp tp b sq_x sq
                     loop acc' bs
 
          loop one . V.toList =<< toBits (bpUnpack bp) w
@@ -855,7 +856,7 @@ shifter mux op = go
 
 -- shift{L,R} :: (n :: Nat) -> (a :: sort 0) -> a -> Vec n a -> Nat -> Vec n a;
 shiftOp :: forall l.
-  (VMonadLazy l, Show (Extra l)) =>
+  (HasCallStack, VMonadLazy l, Show (Extra l)) =>
   BasePrims l ->
   (Thunk l -> Vector (Thunk l) -> Integer -> Vector (Thunk l)) ->
   (VBool l -> VWord l -> Integer -> MWord l) ->
@@ -863,7 +864,7 @@ shiftOp :: forall l.
   Value l
 shiftOp bp vecOp wordIntOp wordOp =
   natFun $ \n -> return $
-  constFun $
+  strictFun $ \(toTValue -> tp) -> return $
   VFun "z" $ \z -> return $
   strictFun $ \xs -> return $
   strictFun $ \y ->
@@ -878,7 +879,7 @@ shiftOp bp vecOp wordIntOp wordOp =
       VBVToNat _sz (VVector iv) -> do
         bs <- V.toList <$> traverse (fmap toBool . force) iv
         case xs of
-          VVector xv -> VVector <$> shifter muxVector (\v i -> return (vecOp z v i)) xv bs
+          VVector xv -> VVector <$> shifter (muxVector n tp) (\v i -> return (vecOp z v i)) xv bs
           VWord xw -> do
             zb <- toBool <$> force z
             VWord <$> shifter (bpMuxWord bp) (wordIntOp zb) xw bs
@@ -887,7 +888,7 @@ shiftOp bp vecOp wordIntOp wordOp =
         case xs of
           VVector xv -> do
             bs <- V.toList <$> bpUnpack bp iw
-            VVector <$> shifter muxVector (\v i -> return (vecOp z v i)) xv bs
+            VVector <$> shifter (muxVector n tp) (\v i -> return (vecOp z v i)) xv bs
           VWord xw -> do
             zb <- toBool <$> force z
             VWord <$> wordOp zb xw iw
@@ -897,23 +898,24 @@ shiftOp bp vecOp wordIntOp wordOp =
 
       _ -> panic $ "shiftOp: " ++ show y
   where
-    muxVector :: VBool l -> Vector (Thunk l) -> Vector (Thunk l) -> EvalM l (Vector (Thunk l))
-    muxVector b v1 v2 = toVector (bpUnpack bp) =<< muxVal b (VVector v1) (VVector v2)
+    muxVector :: Natural -> TValue l -> VBool l ->
+      Vector (Thunk l) -> Vector (Thunk l) -> EvalM l (Vector (Thunk l))
+    muxVector n tp b v1 v2 = toVector (bpUnpack bp) =<< muxVal (VVecType n tp) b (VVector v1) (VVector v2)
 
-    muxVal :: VBool l -> Value l -> Value l -> MValue l
+    muxVal :: TValue l -> VBool l -> Value l -> Value l -> MValue l
     muxVal = muxValue bp
 
 -- rotate{L,R} :: (n :: Nat) -> (a :: sort 0) -> Vec n a -> Nat -> Vec n a;
 rotateOp :: forall l.
-  (VMonadLazy l, Show (Extra l)) =>
+  (HasCallStack, VMonadLazy l, Show (Extra l)) =>
   BasePrims l ->
   (Vector (Thunk l) -> Integer -> Vector (Thunk l)) ->
   (VWord l -> Integer -> MWord l) ->
   (VWord l -> VWord l -> MWord l) ->
   Value l
 rotateOp bp vecOp wordIntOp wordOp =
-  constFun $
-  constFun $
+  natFun $ \n -> return $
+  strictFun $ \(toTValue -> tp) -> return $
   strictFun $ \xs -> return $
   strictFun $ \y ->
     case y of
@@ -925,14 +927,14 @@ rotateOp bp vecOp wordIntOp wordOp =
       VBVToNat _sz (VVector iv) -> do
         bs <- V.toList <$> traverse (fmap toBool . force) iv
         case xs of
-          VVector xv -> VVector <$> shifter muxVector (\v i -> return (vecOp v i)) xv bs
+          VVector xv -> VVector <$> shifter (muxVector n tp) (\v i -> return (vecOp v i)) xv bs
           VWord xw -> VWord <$> shifter (bpMuxWord bp) wordIntOp xw bs
           _ -> panic $ "rotateOp: " ++ show xs
       VBVToNat _sz (VWord iw) ->
         case xs of
           VVector xv -> do
             bs <- V.toList <$> bpUnpack bp iw
-            VVector <$> shifter muxVector (\v i -> return (vecOp v i)) xv bs
+            VVector <$> shifter (muxVector n tp) (\v i -> return (vecOp v i)) xv bs
           VWord xw -> do
             VWord <$> wordOp xw iw
           _ -> panic $ "rotateOp: " ++ show xs
@@ -941,10 +943,11 @@ rotateOp bp vecOp wordIntOp wordOp =
 
       _ -> panic $ "rotateOp: " ++ show y
   where
-    muxVector :: VBool l -> Vector (Thunk l) -> Vector (Thunk l) -> EvalM l (Vector (Thunk l))
-    muxVector b v1 v2 = toVector (bpUnpack bp) =<< muxVal b (VVector v1) (VVector v2)
+    muxVector :: HasCallStack => Natural -> TValue l -> VBool l ->
+      Vector (Thunk l) -> Vector (Thunk l) -> EvalM l (Vector (Thunk l))
+    muxVector n tp b v1 v2 = toVector (bpUnpack bp) =<< muxVal (VVecType n tp) b (VVector v1) (VVector v2)
 
-    muxVal :: VBool l -> Value l -> Value l -> MValue l
+    muxVal :: HasCallStack => TValue l -> VBool l -> Value l -> Value l -> MValue l
     muxVal = muxValue bp
 
 vRotateL :: Vector a -> Integer -> Vector a
@@ -1233,62 +1236,86 @@ errorOp =
 ------------------------------------------------------------
 -- Conditionals
 
-iteOp :: (VMonadLazy l, Show (Extra l)) => BasePrims l -> Value l
+iteOp :: (HasCallStack, VMonadLazy l, Show (Extra l)) => BasePrims l -> Value l
 iteOp bp =
-  constFun $
+  strictFun $ \(toTValue -> tp) -> return $
   strictFun $ \b -> return $
   VFun "x" $ \x -> return $
-  VFun "y" $ \y -> lazyMuxValue bp (toBool b) (force x) (force y)
+  VFun "y" $ \y -> lazyMuxValue bp tp (toBool b) (force x) (force y)
 
 lazyMuxValue ::
-  (VMonadLazy l, Show (Extra l)) =>
-  BasePrims l -> VBool l -> MValue l -> MValue l -> MValue l
-lazyMuxValue bp b x y =
+  (HasCallStack, VMonadLazy l, Show (Extra l)) =>
+  BasePrims l ->
+  TValue l ->
+  VBool l -> MValue l -> MValue l -> MValue l
+lazyMuxValue bp tp b x y =
   case bpAsBool bp b of
     Just True  -> x
     Just False -> y
     Nothing ->
       do x' <- x
          y' <- y
-         muxValue bp b x' y'
+         muxValue bp tp b x' y'
 
 muxValue :: forall l.
-  (VMonadLazy l, Show (Extra l)) =>
-  BasePrims l -> VBool l -> Value l -> Value l -> MValue l
-muxValue bp b = value
+  (HasCallStack, VMonadLazy l, Show (Extra l)) =>
+  BasePrims l ->
+  TValue l ->
+  VBool l -> Value l -> Value l -> MValue l
+muxValue bp tp0 b = value tp0
   where
-    value :: Value l -> Value l -> MValue l
-    value (VFun nm f)       (VFun _ g)        = return $ VFun nm $ \a -> do
-                                                  x <- f a
-                                                  y <- g a
-                                                  value x y
-    value VUnit             VUnit             = return VUnit
-    value (VPair x1 x2)     (VPair y1 y2)     = VPair <$> thunk x1 y1 <*> thunk x2 y2
-    value (VRecordValue elems1) (VRecordValue
-                                 (alistAllFields (map fst elems1) ->
-                                  Just elems2)) =
-      VRecordValue <$>
-      zipWithM (\(f,th1) th2 -> (f,) <$> thunk th1 th2) elems1 elems2
-    value (VCtorApp i xv)   (VCtorApp j yv)   | i == j = VCtorApp i <$> thunks xv yv
-    value (VVector xv)      (VVector yv)      = VVector <$> thunks xv yv
-    value (VBool x)         (VBool y)         = VBool <$> bpMuxBool bp b x y
-    value (VWord x)         (VWord y)         = VWord <$> bpMuxWord bp b x y
-    value (VInt x)          (VInt y)          = VInt <$> bpMuxInt bp b x y
-    value (VIntMod n x)     (VIntMod _ y)     = VIntMod n <$> bpMuxInt bp b x y
-    value (VNat m)          (VNat n)          | m == n = return $ VNat m
-    value (VString x)       (VString y)       | x == y = return $ VString x
-    value (VFloat x)        (VFloat y)        | x == y = return $ VFloat x
-    value (VDouble x)       (VDouble y)       | x == y = return $ VDouble y
-    value (VExtra x)        (VExtra y)        = VExtra <$> bpMuxExtra bp b x y
-    value x@(VWord _)       y                 = toVector (bpUnpack bp) x >>= \xv -> value (VVector xv) y
-    value x                 y@(VWord _)       = toVector (bpUnpack bp) y >>= \yv -> value x (VVector yv)
-    value x@(VNat _)        y                 = nat x y
-    value x@(VBVToNat _ _)  y                 = nat x y
-    value x@(VIntToNat _)   y                 = nat x y
-    value (TValue x)        (TValue y)        = TValue <$> tvalue x y
-    value x                 y                 =
+    value :: TValue l -> Value l -> Value l -> MValue l
+    value _ (VNat m)  (VNat n)      | m == n = return $ VNat m
+    value _ (VString x) (VString y) | x == y = return $ VString x
+
+    value (VPiType _ _tp body) (VFun nm f) (VFun _ g) =
+        return $ VFun nm $ \a ->
+           do tp' <- applyPiBody body a
+              x <- f a
+              y <- g a
+              value tp' x y
+
+    value VUnitType VUnit VUnit = return VUnit
+    value (VPairType t1 t2) (VPair x1 x2) (VPair y1 y2) =
+      VPair <$> thunk t1 x1 y1 <*> thunk t2 x2 y2
+
+    value (VRecordType fs) (VRecordValue elems1) (VRecordValue elems2) =
+      do let em1 = Map.fromList elems1
+         let em2 = Map.fromList elems2
+         let build (f,tp) = case (Map.lookup f em1, Map.lookup f em2) of
+                              (Just v1, Just v2) ->
+                                 do v <- thunk tp v1 v2
+                                    pure (f,v)
+                              _ -> panic "muxValue" ["Record field missing!", show f]
+         VRecordValue <$> traverse build fs
+
+-- TODO, fix datatypes!
+--    value (VDataType _nm _ps) (VCtorApp i xv) (VCtorApp j yv)
+--      | i == j = VCtorApp i <$> muxCtorArgs i xv yv
+
+    value (VVecType _ tp) (VVector xv) (VVector yv) =
+      VVector <$> thunks tp xv yv
+
+    value tp (VExtra x) (VExtra y) =
+      VExtra <$> bpMuxExtra bp tp b x y
+
+    value _ (VBool x)         (VBool y)         = VBool <$> bpMuxBool bp b x y
+    value _ (VWord x)         (VWord y)         = VWord <$> bpMuxWord bp b x y
+    value _ (VInt x)          (VInt y)          = VInt <$> bpMuxInt bp b x y
+    value _ (VIntMod n x)     (VIntMod _ y)     = VIntMod n <$> bpMuxInt bp b x y
+
+    value tp x@(VWord _)       y                = toVector (bpUnpack bp) x >>= \xv -> value tp (VVector xv) y
+    value tp x                 y@(VWord _)      = toVector (bpUnpack bp) y >>= \yv -> value tp x (VVector yv)
+
+    value _ x@(VNat _)        y                 = nat x y
+    value _ x@(VBVToNat _ _)  y                 = nat x y
+    value _ x@(VIntToNat _)   y                 = nat x y
+
+    value _ (TValue x)        (TValue y)        = TValue <$> tvalue x y
+
+    value tp x                y                 =
       panic $ "Verifier.SAW.Simulator.Prims.iteOp: malformed arguments: "
-      ++ show x ++ " " ++ show y
+      ++ show x ++ " " ++ show y ++ " " ++ show tp
 
     tvalue :: TValue l -> TValue l -> EvalM l (TValue l)
     tvalue (VSort x)         (VSort y)         | x == y = return $ VSort y
@@ -1296,13 +1323,13 @@ muxValue bp b = value
       panic $ "Verifier.SAW.Simulator.Prims.iteOp: malformed arguments: "
       ++ show x ++ " " ++ show y
 
-    thunks :: Vector (Thunk l) -> Vector (Thunk l) -> EvalM l (Vector (Thunk l))
-    thunks xv yv
-      | V.length xv == V.length yv = V.zipWithM thunk xv yv
+    thunks :: TValue l -> Vector (Thunk l) -> Vector (Thunk l) -> EvalM l (Vector (Thunk l))
+    thunks tp xv yv
+      | V.length xv == V.length yv = V.zipWithM (thunk tp) xv yv
       | otherwise                  = panic "Verifier.SAW.Simulator.Prims.iteOp: malformed arguments"
 
-    thunk :: Thunk l -> Thunk l -> EvalM l (Thunk l)
-    thunk x y = delay $ do x' <- force x; y' <- force y; value x' y'
+    thunk :: TValue l -> Thunk l -> Thunk l -> EvalM l (Thunk l)
+    thunk tp x y = delay $ do x' <- force x; y' <- force y; value tp x' y'
 
     nat :: Value l -> Value l -> MValue l
     nat v1 v2 =

--- a/saw-core/src/Verifier/SAW/Simulator/RME.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/RME.hs
@@ -127,7 +127,8 @@ bvShiftOp op =
   pureFun $ \y ->
     case y of
       VNat n   -> vWord (op x (toInteger n))
-      VToNat v -> vWord (genShift muxRMEV op x (toWord v))
+      VBVToNat _sz v -> vWord (genShift muxRMEV op x (toWord v))
+      VIntToNat _i   -> error "RME.shiftOp: intToNat TODO"
       _        -> error $ unwords ["Verifier.SAW.Simulator.RME.shiftOp", show y]
 
 ------------------------------------------------------------
@@ -345,7 +346,8 @@ streamGetOp =
   pureFun $ \xs ->
   strictFun $ \case
     VNat n -> pure $ IntTrie.apply (toStream xs) (toInteger n)
-    VToNat bv ->
+    VIntToNat _i -> error "RME.streamGetOp : symbolic integer TODO"
+    VBVToNat _sz bv ->
       do let trie = toStream xs
              loop k [] = IntTrie.apply trie k
              loop k (b:bs)

--- a/saw-core/src/Verifier/SAW/Simulator/RME.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/RME.hs
@@ -282,7 +282,7 @@ muxInt b x y =
     Nothing -> if x == y then x else error $ "muxRValue: VInt " ++ show (x, y)
 
 muxExtra :: TValue ReedMuller -> RME -> RExtra -> RExtra -> RExtra
-muxExtra (VDataType "Prelude.Stream" [TValue tp]) b (AStream xs) (AStream ys) =
+muxExtra (VDataType (primName -> "Prelude.Stream") [TValue tp] []) b (AStream xs) (AStream ys) =
   AStream (muxRValue tp b <$> xs <*> ys)
 muxExtra tp _ _ _ = panic "RME.muxExtra" ["type mismatch", show tp]
 

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -57,7 +57,8 @@ data Value l
   | VVector !(Vector (Thunk l))
   | VBool (VBool l)
   | VWord (VWord l)
-  | VToNat (Value l)
+  | VBVToNat !Int (Value l) -- TODO: don't use @Int@ for this, use @Natural@
+  | VIntToNat (Value l)
   | VNat !Natural
   | VInt (VInt l)
   | VIntMod !Natural (VInt l)
@@ -183,7 +184,8 @@ instance Show (Extra l) => Show (Value l) where
       VVector xv     -> showList (toList xv)
       VBool _        -> showString "<<boolean>>"
       VWord _        -> showString "<<bitvector>>"
-      VToNat x       -> showString "bvToNat " . showParen True (shows x)
+      VBVToNat n x   -> showString "bvToNat " . shows n . showString " " . showParen True (shows x)
+      VIntToNat x    -> showString "intToNat " . showParen True (shows x)
       VNat n         -> shows n
       VInt _         -> showString "<<integer>>"
       VIntMod n _    -> showString ("<<Z " ++ show n ++ ">>")

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -385,10 +385,10 @@ neutralToTerm = loop
     Unshared (FTermF (RecordProj (loop nt) f))
   loop (NeutralApp nt arg) =
     Unshared (App (loop nt) arg)
-  loop (NeutralRecursorArg rec ixs x) =
-    Unshared (FTermF (RecursorApp rec ixs (loop x)))
-  loop (NeutralRecursor rec ixs x) =
-    Unshared (FTermF (RecursorApp (loop rec) ixs x))
+  loop (NeutralRecursorArg r ixs x) =
+    Unshared (FTermF (RecursorApp r ixs (loop x)))
+  loop (NeutralRecursor r ixs x) =
+    Unshared (FTermF (RecursorApp (loop r) ixs x))
 
 neutralToSharedTerm :: SharedContext -> NeutralTerm -> IO Term
 neutralToSharedTerm sc = loop
@@ -407,9 +407,9 @@ neutralToSharedTerm sc = loop
   loop (NeutralRecursor nt ixs x) =
     do tm <- loop nt
        scFlatTermF sc (RecursorApp tm ixs x)
-  loop (NeutralRecursorArg rec ixs nt) =
+  loop (NeutralRecursorArg r ixs nt) =
     do tm <- loop nt
-       scFlatTermF sc (RecursorApp rec ixs tm)
+       scFlatTermF sc (RecursorApp r ixs tm)
 
 ppNeutral :: PPOpts -> NeutralTerm -> SawDoc
 ppNeutral opts = ppTerm opts . neutralToTerm

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -53,7 +53,7 @@ data Value l
   = VFun !LocalName !(Thunk l -> MValue l)
   | VUnit
   | VPair (Thunk l) (Thunk l) -- TODO: should second component be strict?
-  | VCtorApp !Ident !(Vector (Thunk l))
+  | VCtorApp !Ident ![Thunk l] ![Thunk l]
   | VVector !(Vector (Thunk l))
   | VBool (VBool l)
   | VWord (VWord l)
@@ -188,9 +188,7 @@ instance Show (Extra l) => Show (Value l) where
       VFun {}        -> showString "<<fun>>"
       VUnit          -> showString "()"
       VPair{}        -> showString "<<tuple>>"
-      VCtorApp s xv
-        | V.null xv  -> shows s
-        | otherwise  -> shows s . showList (toList xv)
+      VCtorApp s _ps _xv -> shows s
       VVector xv     -> showList (toList xv)
       VBool _        -> showString "<<boolean>>"
       VWord _        -> showString "<<bitvector>>"

--- a/saw-core/src/Verifier/SAW/Term/CtxTerm.hs
+++ b/saw-core/src/Verifier/SAW/Term/CtxTerm.hs
@@ -72,8 +72,6 @@ module Verifier.SAW.Term.CtxTerm
   ) where
 
 import Data.Kind(Type)
---import Data.Map (Map)
---import qualified Data.Map as Map
 import Data.Proxy
 import Data.Type.Equality
 import Control.Monad

--- a/saw-core/src/Verifier/SAW/Term/Functor.hs
+++ b/saw-core/src/Verifier/SAW/Term/Functor.hs
@@ -40,6 +40,7 @@ module Verifier.SAW.Term.Functor
   , NameInfo(..)
   , toShortName
   , toAbsoluteName
+  , CompiledRecursor(..)
     -- * Terms and associated operations
   , TermIndex
   , Term(..)
@@ -158,16 +159,25 @@ data FlatTermF e
     -- an inductively-defined type; the parameters (of the inductive type to
     -- which this constructor belongs) and indices are kept separate
   | CtorApp !Ident ![e] ![e]
+
+    -- | The type of a recursor, which is specified by the datatype name,
+    --   the parameters to the data type, the motive function, and the
+    --   type of the motive function.
+  | RecursorType Ident ![e] !e !e
+
+    -- | A recursor, which is specified by giving the datatype name,
+    --   the parameters to the datatype, a motive and elimiation functions
+    --   for each constructor. A recursor can be used with the special
+    --   @RecursorApp@ term, which provides the datatype indices and
+    --   actual argument to the eliminator.
+  | Recursor (CompiledRecursor e)
+
     -- | An eliminator / pattern-matching function for an inductively-defined
     -- type, given by:
-    -- * The (identifier of the) inductive type it eliminates;
-    -- * The parameters of that inductive type;
-    -- * The return type, also called the "intent", given by a function from
-    --   type indices of the inductive type to a type;
-    -- * The elimination function for each constructor of that inductive type;
-    -- * The indices for that inductive type; AND
+    -- * The recursor value;
+    -- * The indices for the inductive type; AND
     -- * The argument that is being eliminated / pattern-matched
-  | RecursorApp !Ident [e] e [(Ident,e)] [e] e
+  | RecursorApp e [e] e
 
     -- | Non-dependent record types, i.e., N-ary tuple types with named
     -- fields. These are considered equal up to reordering of fields. Actual
@@ -198,6 +208,22 @@ data FlatTermF e
 
 instance Hashable e => Hashable (FlatTermF e) -- automatically derived
 
+-- Capture more type information here so we can
+--  use it during evaluation time to remember the
+--  types of the parameters, motive and eliminator functions.
+data CompiledRecursor e =
+  CompiledRecursor
+  { recursorDataType :: Ident
+  , recursorParams   :: [e]
+  , recursorMotive   :: e
+  , recursorMotiveTy :: e
+  , recursorElims    :: Map Ident (e, e) -- eliminator functions and their types
+  , recursorCtorOrder :: [Ident]
+  }
+ deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+
+instance Hashable e => Hashable (CompiledRecursor e) -- automatically derived
+
 -- | Test if the association list used in a 'RecordType' or 'RecordValue' uses
 -- precisely the given field names and no more. If so, return the values
 -- associated with those field names, in the order given in the input, and
@@ -212,6 +238,21 @@ alistAllFields (fld:flds) alist
     deleteField f ((f',_):rest) | f == f' = rest
     deleteField f (x:rest) = x : deleteField f rest
 alistAllFields _ _ = Nothing
+
+zipPair :: (x -> y -> z) -> (x,x) -> (y,y) -> (z,z)
+zipPair f (x1,x2) (y1,y2) = (f x1 y1, f x2 y2)
+
+zipRec :: (x -> y -> z) -> CompiledRecursor x -> CompiledRecursor y -> Maybe (CompiledRecursor z)
+zipRec f (CompiledRecursor d1 ps1 m1 mty1 es1 ord1) (CompiledRecursor d2 ps2 m2 mty2 es2 ord2)
+  | d1 == d2, Map.keysSet es1 == Map.keysSet es2, ord1 == ord2
+  = Just $ CompiledRecursor d1
+              (zipWith f ps1 ps2)
+              (f m1 m2)
+              (f mty1 mty2)
+              (Map.intersectionWith (zipPair f) es1 es2)
+              ord1
+
+  | otherwise = Nothing
 
 -- | Zip a binary function @f@ over a pair of 'FlatTermF's by applying @f@
 -- pointwise to immediate subterms, if the two 'FlatTermF's are the same
@@ -234,13 +275,18 @@ zipWithFlatTermF f = go
       | cx == cy = Just $ CtorApp cx (zipWith f psx psy) (zipWith f lx ly)
     go (DataTypeApp dx psx lx) (DataTypeApp dy psy ly)
       | dx == dy = Just $ DataTypeApp dx (zipWith f psx psy) (zipWith f lx ly)
-    go (RecursorApp d1 ps1 p1 cs_fs1 ixs1 x1) (RecursorApp d2 ps2 p2 cs_fs2 ixs2 x2)
+
+    go (RecursorType d1 ps1 m1 mty1) (RecursorType d2 ps2 m2 mty2)
       | d1 == d2
-      , Just fs2 <- alistAllFields (map fst cs_fs1) cs_fs2
-      = Just $
-        RecursorApp d1 (zipWith f ps1 ps2) (f p1 p2)
-        (zipWith (\(c,f1) f2 -> (c, f f1 f2)) cs_fs1 fs2)
-        (zipWith f ixs1 ixs2) (f x1 x2)
+      = Just $ RecursorType d1 (zipWith f ps1 ps2) (f m1 m2) (f mty1 mty2)
+
+    go (Recursor rec1) (Recursor rec2) = Recursor <$> zipRec f rec1 rec2
+
+    go (RecursorApp rec1 ixs1 x1) (RecursorApp rec2 ixs2 x2) =
+        Just $ RecursorApp
+          (f rec1 rec2)
+          (zipWith f ixs1 ixs2)
+          (f x1 x2)
 
     go (RecordType elems1) (RecordType elems2)
       | Just vals2 <- alistAllFields (map fst elems1) elems2 =

--- a/saw-core/src/Verifier/SAW/Term/Functor.hs
+++ b/saw-core/src/Verifier/SAW/Term/Functor.hs
@@ -168,7 +168,7 @@ data FlatTermF e
   | RecursorType !(PrimName e) ![e] !e !e
 
     -- | A recursor, which is specified by giving the datatype name,
-    --   the parameters to the datatype, a motive and elimiation functions
+    --   the parameters to the datatype, a motive and elimination functions
     --   for each constructor. A recursor can be used with the special
     --   @RecursorApp@ term, which provides the datatype indices and
     --   actual argument to the eliminator.

--- a/saw-core/src/Verifier/SAW/Term/Pretty.hs
+++ b/saw-core/src/Verifier/SAW/Term/Pretty.hs
@@ -18,6 +18,7 @@ Portability : non-portable (language extensions)
 
 module Verifier.SAW.Term.Pretty
   ( SawDoc
+  , renderSawDoc
   , SawStyle(..)
   , PPOpts(..)
   , defaultPPOpts
@@ -37,7 +38,6 @@ module Verifier.SAW.Term.Pretty
   , OccurrenceMap
   , shouldMemoizeTerm
   , ppName
-  , renderSawDoc
   ) where
 
 import Data.Maybe (isJust)

--- a/saw-core/src/Verifier/SAW/Term/Pretty.hs
+++ b/saw-core/src/Verifier/SAW/Term/Pretty.hs
@@ -447,8 +447,8 @@ ppFlatTermF prec tf =
            ppAppList prec (annotate RecursorStyle (nm <> "#rec"))
              (params_pp ++ [motive_pp, tupled f_pps])
 
-    RecursorApp rec ixs arg ->
-      do rec_pp <- ppTerm' PrecApp rec
+    RecursorApp r ixs arg ->
+      do rec_pp <- ppTerm' PrecApp r
          ixs_pp <- mapM (ppTerm' PrecArg) ixs
          arg_pp <- ppTerm' PrecArg arg
          return $ ppAppList prec rec_pp (ixs_pp ++ [arg_pp])

--- a/saw-core/src/Verifier/SAW/Typechecker.hs
+++ b/saw-core/src/Verifier/SAW/Typechecker.hs
@@ -193,8 +193,8 @@ typeInferCompleteTerm (matchAppliedRecursor -> Just (maybe_mnm, str, args)) =
            (splitAt (length $ dtIndices dt) ->
             (ixs, arg : rem_args)))))) ->
          do crec    <- compileRecursor dt params motive elims
-            rec     <- typeInferComplete (Recursor crec)
-            typed_r <- typeInferComplete (RecursorApp rec ixs arg)
+            r       <- typeInferComplete (Recursor crec)
+            typed_r <- typeInferComplete (RecursorApp r ixs arg)
             inferApplyAll typed_r rem_args
 
        _ -> throwTCError $ NotFullyAppliedRec (dtPrimName dt)

--- a/saw-core/src/Verifier/SAW/TypedAST.hs
+++ b/saw-core/src/Verifier/SAW/TypedAST.hs
@@ -57,6 +57,7 @@ module Verifier.SAW.TypedAST
  , zipWithFlatTermF
  , freesTermF
  , termToPat
+ , CompiledRecursor(..)
 
  , PPOpts(..)
  , defaultPPOpts

--- a/saw-core/src/Verifier/SAW/TypedAST.hs
+++ b/saw-core/src/Verifier/SAW/TypedAST.hs
@@ -43,8 +43,10 @@ module Verifier.SAW.TypedAST
  , allModuleAxioms
    -- * Data types and definitions.
  , DataType(..)
+ , dtPrimName
  , Ctor(..)
  , ctorNumParams
+ , ctorPrimName
  , CtorArg(..)
  , Def(..)
  , DefQualifier(..)
@@ -76,6 +78,7 @@ module Verifier.SAW.TypedAST
  , FieldName
  , LocalName
  , ExtCns(..)
+ , PrimName(..)
  , VarIndex
    -- * Utility functions
   , BitSet, emptyBitSet, inBitSet, unionBitSets, intersectBitSets

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -640,11 +640,11 @@ readSchema str =
 
 data Primitive
   = Primitive
-    { primName :: SS.LName
-    , primType :: SS.Schema
-    , primLife :: PrimitiveLifecycle
-    , primDoc  :: [String]
-    , primFn   :: Options -> BuiltinContext -> Value
+    { primitiveName :: SS.LName
+    , primitiveType :: SS.Schema
+    , primitiveLife :: PrimitiveLifecycle
+    , primitiveDoc  :: [String]
+    , primitiveFn   :: Options -> BuiltinContext -> Value
     }
 
 primitives :: Map SS.LName Primitive
@@ -2928,11 +2928,11 @@ primitives = Map.fromList
     prim :: String -> String -> (Options -> BuiltinContext -> Value) -> PrimitiveLifecycle -> [String]
          -> (SS.LName, Primitive)
     prim name ty fn lc doc = (qname, Primitive
-                                     { primName = qname
-                                     , primType = readSchema ty
-                                     , primDoc  = doc
-                                     , primFn   = fn
-                                     , primLife = lc
+                                     { primitiveName = qname
+                                     , primitiveType = readSchema ty
+                                     , primitiveDoc  = doc
+                                     , primitiveFn   = fn
+                                     , primitiveLife = lc
                                      })
       where qname = qualify name
 
@@ -2962,14 +2962,14 @@ filterAvail ::
   Map SS.LName Primitive ->
   Map SS.LName Primitive
 filterAvail primsAvail =
-  Map.filter (\p -> primLife p `Set.member` primsAvail)
+  Map.filter (\p -> primitiveLife p `Set.member` primsAvail)
 
 primTypeEnv :: Set PrimitiveLifecycle -> Map SS.LName SS.Schema
-primTypeEnv primsAvail = fmap primType (filterAvail primsAvail primitives)
+primTypeEnv primsAvail = fmap primitiveType (filterAvail primsAvail primitives)
 
 valueEnv :: Set PrimitiveLifecycle -> Options -> BuiltinContext -> Map SS.LName Value
 valueEnv primsAvail opts bic = fmap f (filterAvail primsAvail primitives)
-  where f p = (primFn p) opts bic
+  where f p = (primitiveFn p) opts bic
 
 -- | Map containing the formatted documentation string for each
 -- saw-script primitive.
@@ -2978,7 +2978,7 @@ primDocEnv primsAvail =
   Map.fromList [ (getVal n, doc n p) | (n, p) <- Map.toList prims ]
     where
       prims = filterAvail primsAvail primitives
-      tag p = case primLife p of
+      tag p = case primitiveLife p of
                 Current -> []
                 Deprecated -> ["DEPRECATED", ""]
                 Experimental -> ["EXPERIMENTAL", ""]
@@ -2987,9 +2987,9 @@ primDocEnv primsAvail =
                 , "-----------"
                 , ""
                 ] ++ tag p ++
-                [ "    " ++ getVal n ++ " : " ++ SS.pShow (primType p)
+                [ "    " ++ getVal n ++ " : " ++ SS.pShow (primitiveType p)
                 , ""
-                ] ++ primDoc p
+                ] ++ primitiveDoc p
 
 qualify :: String -> Located SS.Name
 qualify s = Located s s (SS.PosInternal "coreEnv")

--- a/src/SAWScript/Prover/MRSolver.hs
+++ b/src/SAWScript/Prover/MRSolver.hs
@@ -357,9 +357,9 @@ applyCompFun (CompFunMark f mark) t =
 -- | Take in an @InputOutputTypes@ list (as a SAW core term) and build a fresh
 -- function variable for each pair of input and output types in it
 mkFunVarsForTps :: Term -> MRM [LocalFunName]
-mkFunVarsForTps (asCtor -> Just ("Prelude.TypesNil", [])) =
+mkFunVarsForTps (asCtor -> Just (primName -> "Prelude.TypesNil", [])) =
   return []
-mkFunVarsForTps (asCtor -> Just ("Prelude.TypesCons", [a, b, tps])) =
+mkFunVarsForTps (asCtor -> Just (primName -> "Prelude.TypesCons", [a, b, tps])) =
   do compM <- liftSC1 scGlobalDef "Prelude.CompM"
      comp_b <- liftSC2 scApply compM b
      tp <- liftSC3 scPi "x" a comp_b


### PR DESCRIPTION
This PR implements a variety of refactorings, mostly to the saw-core simulator.  These refactorings are aimed toward implementing a new evaluation mode for saw-core which does evaluation and simplification directly on saw-core terms, without passing first through what4, or some other term representation.  The goal of this is to make the term evaluator a _total_ function 
on well-typed terms, so that terms are reconstructed as necessary when an external variable or opaque constant is encountered.

In order to enable the term evaluator, a number of improvements to the generic evaluator code are necessary.  First, the environment that binds de Bruijn variables to values must also keep track of the types of variables, because the term reconstruction procedure is type-directed.  Achieving this required a relatively extensive detour into reworking some aspects related to the implementation of datatype recursors. The end result is that it is now possible to lambda-abstract over recursor values and later apply them to data type arguments (although no concrete syntax exists for this).  Secondly, the evaluator needs a way to gracefully handle the situation where evaluation gets "stuck" on a term that isn't in canonical form for an eliminator.  These "neutral" terms represent places where evaluation would proceed into external variables, opaque constants, or other forms that don't immediately evaluate.  The simulator would mostly `panic` before in these situations.

Along the way, a number of other, smaller, improvements have been made.  There are some situations involving the new `VIntToNat` constructor that still need to be handled, but they were already non-working cases before.

This PR consists entirely of internal changes that I expect to have minimal user-facing impact.