### PR TITLE
cryptol-saw-core: SuiteB and ECC prims

### DIFF
--- a/cryptol-saw-core/saw/Cryptol.sawcore
+++ b/cryptol-saw-core/saw/Cryptol.sawcore
@@ -1658,6 +1658,89 @@ ecArrayUpdate : (a b : sort 0) -> (Array a b) -> a -> b -> (Array a b);
 ecArrayUpdate = arrayUpdate;
 
 --------------------------------------------------------------------------------
+-- Suite-B Primitives
+
+AESEncRound : Vec 4 (Vec 32 Bool) -> Vec 4 (Vec 32 Bool);
+AESEncRound x =
+  error (Vec 4 (Vec 32 Bool)) "Unimplemented: AESEncRound";
+
+AESEncFinalRound : Vec 4 (Vec 32 Bool) -> Vec 4 (Vec 32 Bool);
+AESEncFinalRound x =
+  error (Vec 4 (Vec 32 Bool)) "Unimplemented: AESEncFinalRound";
+
+AESDecRound : Vec 4 (Vec 32 Bool) -> Vec 4 (Vec 32 Bool);
+AESDecRound x =
+  error (Vec 4 (Vec 32 Bool)) "Unimplemented: AESDecRound";
+
+AESDecFinalRound : Vec 4 (Vec 32 Bool) -> Vec 4 (Vec 32 Bool);
+AESDecFinalRound x =
+  error (Vec 4 (Vec 32 Bool)) "Unimplemented: AESDecFinalRound";
+
+AESInvMixColumns : Vec 4 (Vec 32 Bool) -> Vec 4 (Vec 32 Bool);
+AESInvMixColumns x =
+  error (Vec 4 (Vec 32 Bool)) "Unimplemented: AESInvMixColumns";
+
+AESKeyExpand :
+  (k : Num) ->
+  seq k (Vec 32 Bool) ->
+  seq (tcMul (TCNum 4) (tcAdd (TCNum 7) k)) (Vec 32 Bool);
+AESKeyExpand k x =
+  error
+    (seq (tcMul (TCNum 4) (tcAdd (TCNum 7) k)) (Vec 32 Bool))
+    "Unimplemented: AESKeyExpand";
+
+processSHA2_224 : (n : Num) -> seq n (Vec 16 (Vec 32 Bool)) -> Vec 7 (Vec 32 Bool);
+processSHA2_224 n x =
+  error (Vec 7 (Vec 32 Bool)) "Unimplemented: processSHA2_224";
+
+processSHA2_256 : (n : Num) -> seq n (Vec 16 (Vec 32 Bool)) -> Vec 8 (Vec 32 Bool);
+processSHA2_256 n x =
+  error (Vec 8 (Vec 32 Bool)) "Unimplemented: processSHA2_256";
+
+processSHA2_384 : (n : Num) -> seq n (Vec 16 (Vec 64 Bool)) -> Vec 6 (Vec 64 Bool);
+processSHA2_384 n x =
+  error (Vec 6 (Vec 64 Bool)) "Unimplemented: processSHA2_384";
+
+processSHA2_512 : (n : Num) -> seq n (Vec 16 (Vec 64 Bool)) -> Vec 8 (Vec 64 Bool);
+processSHA2_512 n x =
+  error (Vec 8 (Vec 64 Bool)) "Unimplemented: processSHA2_512";
+
+--------------------------------------------------------------------------------
+-- Prime-EC Primitives
+
+ec_double :
+  (p : Num) ->
+  IntModNum p * IntModNum p * IntModNum p ->
+  IntModNum p * IntModNum p * IntModNum p;
+ec_double p x =
+  error (IntModNum p * IntModNum p * IntModNum p) "Unimplemented: ec_double";
+
+ec_add_nonzero :
+  (p : Num) ->
+  IntModNum p * IntModNum p * IntModNum p ->
+  IntModNum p * IntModNum p * IntModNum p ->
+  IntModNum p * IntModNum p * IntModNum p;
+ec_add_nonzero p x y =
+  error (IntModNum p * IntModNum p * IntModNum p) "Unimplemented: ec_add_nonzero";
+
+ec_mult :
+  (p : Num) ->
+  IntModNum p ->
+  IntModNum p * IntModNum p * IntModNum p ->
+  IntModNum p * IntModNum p * IntModNum p;
+ec_mult p x y =
+  error (IntModNum p * IntModNum p * IntModNum p) "Unimplemented: ec_mult";
+
+ec_twin_mult :
+  (p : Num) ->
+  IntModNum p ->
+  IntModNum p * IntModNum p * IntModNum p ->
+  IntModNum p * IntModNum p * IntModNum p ->
+  IntModNum p * IntModNum p * IntModNum p;
+ec_twin_mult p x y z =
+  error (IntModNum p * IntModNum p * IntModNum p) "Unimplemented: ec_twin_mult";
+
+--------------------------------------------------------------------------------
 -- Rewrite rules
 
 axiom replicate_False : (n : Nat) -> Eq (Vec n Bool) (replicate n Bool False) (bvNat n 0);

--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -45,7 +45,8 @@ import qualified Cryptol.TypeCheck.Subst as C (Subst, apSubst, listSubst, single
 import qualified Cryptol.ModuleSystem.Name as C
   (asPrim, nameUnique, nameIdent, nameInfo, NameInfo(..))
 import qualified Cryptol.Utils.Ident as C
-  ( Ident, PrimIdent(..), mkIdent, prelPrim, floatPrim, arrayPrim
+  ( Ident, PrimIdent(..), mkIdent
+  , prelPrim, floatPrim, arrayPrim, suiteBPrim, primeECPrim
   , ModName, modNameToText, identText, interactiveName
   , ModPath(..), modPathSplit
   )
@@ -654,7 +655,7 @@ proveProp sc env prop =
 
 importPrimitive :: SharedContext -> Env -> C.Name -> C.Schema -> IO Term
 importPrimitive sc env n sch
-  | Just nm <- C.asPrim n, Just term <- Map.lookup nm (prelPrims <> arrayPrims <> floatPrims) = term sc
+  | Just nm <- C.asPrim n, Just term <- Map.lookup nm allPrims = term sc
   | Just nm <- C.asPrim n, Just expr <- Map.lookup nm (envRefPrims env) =
       do t <- importSchema sc env sch
          e <- importExpr sc env expr
@@ -662,6 +663,9 @@ importPrimitive sc env n sch
          scConstant' sc nmi e t
   | Just nm <- C.asPrim n = panic "Unknown Cryptol primitive name" [show nm]
   | otherwise = panic "Improper Cryptol primitive name" [show n]
+
+allPrims :: Map C.PrimIdent (SharedContext -> IO Term)
+allPrims = prelPrims <> arrayPrims <> floatPrims <> suiteBPrims <> primeECPrims
 
 prelPrims :: Map C.PrimIdent (SharedContext -> IO Term)
 prelPrims =
@@ -817,6 +821,31 @@ floatPrims =
   , ("fpSqrt",         flip scGlobalDef "Cryptol.fpSqrt")
   ]
 
+suiteBPrims :: Map C.PrimIdent (SharedContext -> IO Term)
+suiteBPrims =
+  Map.fromList $
+  first C.suiteBPrim <$>
+  [ ("AESEncRound",      flip scGlobalDef "Cryptol.AESEncRound")
+  , ("AESEncFinalRound", flip scGlobalDef "Cryptol.AESEncFinalRound")
+  , ("AESDecRound",      flip scGlobalDef "Cryptol.AESDecRound")
+  , ("AESDecFinalRound", flip scGlobalDef "Cryptol.AESDecFinalRound")
+  , ("AESInvMixColumns", flip scGlobalDef "Cryptol.AESInvMixColumns")
+  , ("AESKeyExpand",     flip scGlobalDef "Cryptol.AESKeyExpand")
+  , ("processSHA2_224",  flip scGlobalDef "Cryptol.processSHA2_224")
+  , ("processSHA2_256",  flip scGlobalDef "Cryptol.processSHA2_256")
+  , ("processSHA2_384",  flip scGlobalDef "Cryptol.processSHA2_384")
+  , ("processSHA2_512",  flip scGlobalDef "Cryptol.processSHA2_512")
+  ]
+
+primeECPrims :: Map C.PrimIdent (SharedContext -> IO Term)
+primeECPrims =
+  Map.fromList $
+  first C.primeECPrim <$>
+  [ ("ec_double",      flip scGlobalDef "Cryptol.ec_double")
+  , ("ec_add_nonzero", flip scGlobalDef "Cryptol.ec_add_nonzero")
+  , ("ec_mult",        flip scGlobalDef "Cryptol.ec_mult")
+  , ("ec_twin_mult",   flip scGlobalDef "Cryptol.ec_twin_mult")
+  ]
 
 -- | Convert a Cryptol expression to a SAW-Core term. Calling
 -- 'scTypeOf' on the result of @'importExpr' sc env expr@ must yield a

--- a/cryptol-saw-core/test/CryptolVerifierTC.hs
+++ b/cryptol-saw-core/test/CryptolVerifierTC.hs
@@ -31,11 +31,17 @@ main =
      putStrLn "Translated Float.cry!"
      cenv2 <- CEnv.importModule sc cenv1 (Right N.arrayName) Nothing CEnv.OnlyPublic Nothing
      putStrLn "Translated Array.cry!"
-     cenv3 <- CEnv.parseDecls sc cenv2 (CEnv.InputText superclassContents "superclass.cry" 1 1)
+     cenv3 <- CEnv.importModule sc cenv2 (Right N.suiteBName) Nothing CEnv.OnlyPublic Nothing
+     putStrLn "Translated SuiteB.cry!"
+     cenv4 <- CEnv.importModule sc cenv3 (Right N.primeECName) Nothing CEnv.OnlyPublic Nothing
+     putStrLn "Translated PrimeEC.cry!"
+     cenv5 <- CEnv.importModule sc cenv4 (Right N.preludeReferenceName) Nothing CEnv.OnlyPublic Nothing
+     putStrLn "Translated Reference.cry!"
+     cenv6 <- CEnv.parseDecls sc cenv5 (CEnv.InputText superclassContents "superclass.cry" 1 1)
      putStrLn "Translated superclass.cry!"
-     cenv4 <- CEnv.parseDecls sc cenv3 (CEnv.InputText instanceContents "instance.cry" 1 1)
+     cenv7 <- CEnv.parseDecls sc cenv6 (CEnv.InputText instanceContents "instance.cry" 1 1)
      putStrLn "Translated instance.cry!"
-     mapM_ (checkTranslation sc) $ Map.assocs (CEnv.eTermEnv cenv4)
+     mapM_ (checkTranslation sc) $ Map.assocs (CEnv.eTermEnv cenv7)
      putStrLn "Checked all terms!"
 
 checkTranslation :: SharedContext -> (N.Name, Term) -> IO ()


### PR DESCRIPTION
This adds saw-core stubs for all the cryptol primitives in the built-in cryptol modules `SuiteB.cry` and `PrimeEC.cry`. The stubs just call `error`, but the stubs can be used as uninterpreted functions. Fixes #1098.