### PR TITLE
Propagate Cryptol error strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # next -- TBA
 
-Nothing yet.
+## Bug fixes
+
+* Invoking the Cryptol `error` function in SAW now preserves the error message
+  instead of throwing it away.
 
 # Version 1.3 -- 2025-03-21
 

--- a/cryptol-saw-core/saw/Cryptol.sawcore
+++ b/cryptol-saw-core/saw/Cryptol.sawcore
@@ -1593,17 +1593,13 @@ ecInfFromThen a pa x y =
 
 -- Run-time error
 ecError : (a : isort 0) -> (len : Num) -> seq len (Vec 8 Bool) -> a;
-ecError a len msg = error a "encountered call to the Cryptol 'error' function"; -- FIXME: don't throw away message
-
-{-
-primitive cryError : (a : sort 0) -> (n : Nat) -> Vec n (Vec 8 Bool) -> a;
-
-ecError : (a : sort 0) -> (len : Num) -> seq len (Vec 8 Bool) -> a;
 ecError a =
   finNumRec
     (\ (len:Num) -> seq len (Vec 8 Bool) -> a)
-    (\ (len:Nat) -> cryError a len);
--}
+    (\ (len:Nat) (msg:Vec len (Vec 8 Bool)) ->
+       error a (appendString "encountered call to the Cryptol 'error' function: "
+                             (bytesToString len msg))
+    );
 
 -- Random values
 ecRandom : (a : isort 0) -> Vec 32 Bool -> a;

--- a/intTests/test2049/test.log.1.good
+++ b/intTests/test2049/test.log.1.good
@@ -13,12 +13,12 @@ Literal equality postcondition
 Expected term: 
 let { x@1 = Prelude.Vec 8 Prelude.Bool
     }
- in fresh:zero::table#806
+ in fresh:zero::table#808
 Actual term:
 let { x@1 = Prelude.Vec 8 Prelude.Bool
     }
- in Cryptol.ecArrayUpdate x@1 x@1 fresh:zero::table#806
-      fresh:zero::k#807
+ in Cryptol.ecArrayUpdate x@1 x@1 fresh:zero::table#808
+      fresh:zero::k#809
       (Prelude.bvNat 8 0)
 
  SolverStats {solverStatsSolvers = fromList ["W4 ->z3"], solverStatsGoalSize = 334}

--- a/intTests/test2049/test.log.2.good
+++ b/intTests/test2049/test.log.2.good
@@ -13,12 +13,12 @@ Literal equality postcondition
 Expected term: 
 let { x@1 = Prelude.Vec 8 Prelude.Bool
     }
- in fresh:zero::table#806
+ in fresh:zero::table#808
 Actual term:
 let { x@1 = Prelude.Vec 8 Prelude.Bool
     }
- in Cryptol.ecArrayUpdate x@1 x@1 fresh:zero::table#806
-      fresh:zero::k#807
+ in Cryptol.ecArrayUpdate x@1 x@1 fresh:zero::table#808
+      fresh:zero::k#809
       (Prelude.bvNat 8 0)
 
  SolverStats {solverStatsSolvers = fromList ["W4 ->z3"], solverStatsGoalSize = 334}

--- a/intTests/test_llvm_errors/err001.log.good
+++ b/intTests/test_llvm_errors/err001.log.good
@@ -8,11 +8,11 @@ Expected term:
 let { x@1 = Prelude.Vec 32 Prelude.Bool
       x@2 = Cryptol.TCNum 32
     }
- in Cryptol.ecMul x@1 (Cryptol.PRingSeqBool x@2) fresh:x#803
+ in Cryptol.ecMul x@1 (Cryptol.PRingSeqBool x@2) fresh:x#805
       (Cryptol.ecNumber (Cryptol.TCNum 3) x@1
          (Cryptol.PLiteralSeqBool x@2))
 Actual term:
-Prelude.bvMul 32 (Prelude.bvNat 32 2) fresh:x#803
+Prelude.bvMul 32 (Prelude.bvNat 32 2) fresh:x#805
 
  SolverStats {solverStatsSolvers = fromList ["SBV->Z3"], solverStatsGoalSize = 389}
  ----------Counterexample----------

--- a/intTests/test_simulation_errors/.gitignore
+++ b/intTests/test_simulation_errors/.gitignore
@@ -1,0 +1,3 @@
+*.rawlog
+*.log
+*.diff

--- a/intTests/test_simulation_errors/err001.log.good
+++ b/intTests/test_simulation_errors/err001.log.good
@@ -1,0 +1,3 @@
+ Loading file "err001.saw"
+ Run-time error: encountered call to the Cryptol 'error' function: Descriptive error message
+FAILED

--- a/intTests/test_simulation_errors/err001.saw
+++ b/intTests/test_simulation_errors/err001.saw
@@ -1,0 +1,1 @@
+prove abc {{ error "Descriptive error message" : Bit }};

--- a/intTests/test_simulation_errors/test.sh
+++ b/intTests/test_simulation_errors/test.sh
@@ -1,0 +1,1 @@
+exec ${TEST_SHELL:-bash} ../support/test-and-diff.sh "$@"

--- a/saw-core/prelude/Prelude.sawcore
+++ b/saw-core/prelude/Prelude.sawcore
@@ -1127,12 +1127,6 @@ Nat_complete_induction p f n0 =
 
 
 --------------------------------------------------------------------------------
--- Operations on string values
-
-primitive equalString : String -> String -> Bool;
-
-
---------------------------------------------------------------------------------
 -- "Vec n a" is an array of n elements, each with type "a".
 primitive Vec : Nat -> sort 0 -> sort 0;
 
@@ -1327,6 +1321,17 @@ splitLittleEndian : (m n : Nat)
                   -> Vec (mulNat m n) a
                   -> Vec m (Vec n a);
 splitLittleEndian m n a v = reverse m (Vec n a) (split m n a v);
+
+--------------------------------------------------------------------------------
+-- Operations on string values
+
+primitive appendString : String -> String -> String;
+
+-- Convert a Cryptol string (a sequence of 8-bit ASCII characters) to a SAWCore
+-- String.
+primitive bytesToString : (n : Nat) -> Vec n (Vec 8 Bool) -> String;
+
+primitive equalString : String -> String -> Bool;
 
 --------------------------------------------------------------------------------
 -- Bitvectors

--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -68,6 +68,7 @@ import Data.Functor
 import Data.Maybe (fromMaybe)
 import Data.Bitraversable
 import Data.Bits
+import Data.Char (chr)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Text (Text)
@@ -373,6 +374,8 @@ constMap bp = Map.fromList
 
   -- Strings
   , ("Prelude.String", PrimValue (TValue VStringType))
+  , ("Prelude.appendString", appendStringOp)
+  , ("Prelude.bytesToString", bytesToStringOp bp)
   , ("Prelude.equalString", equalStringOp bp)
 
   -- Overloaded
@@ -729,6 +732,41 @@ natCaseOp =
 
 --------------------------------------------------------------------------------
 -- Strings
+
+-- appendString : String -> String -> String;
+appendStringOp :: VMonad l => Prim l
+appendStringOp =
+  stringFun $ \x ->
+  stringFun $ \y ->
+    Prim $ pure $ VString $ x <> y
+
+-- bytesToString : (n : Nat) -> Vec n (Vec 8 Bool) -> String;
+bytesToStringOp :: forall l. (VMonad l, Show (Extra l))
+                => BasePrims l -> Prim l
+bytesToStringOp bp =
+  constFun $
+  vectorFun (bpUnpack bp) $ \v -> Prim $ do
+    v' <- V.mapM byteToChar v
+    pure $ VString $ Text.pack $ V.toList v'
+  where
+    byteToChar :: Lazy (EvalM l) (Value l) -> EvalM l Char
+    byteToChar lv = do
+      v <- force lv
+      bits <- toBits (bpUnpack bp) v
+      pure $ chr $ bitsToInt $ V.map asBool bits
+
+    bitsToInt :: Vector Bool -> Int
+    bitsToInt = V.ifoldl' (\bits idx b ->
+                            -- Each character's bits are stored in big-endian
+                            -- order in the vector, so we must subtract the
+                            -- index of a bit from 7 (8 - 1) in order to set
+                            -- the bit at that index.
+                            if b then setBit bits (7 - idx) else bits)
+                          zeroBits
+
+    asBool :: VBool l -> Bool
+    asBool vb = fromMaybe (panic "bytesToStringOp: Nothing VBool")
+                          (bpAsBool bp vb)
 
 equalStringOp :: VMonad l => BasePrims l -> Prim l
 equalStringOp bp =


### PR DESCRIPTION
This patch adds two new SAWCore primitives:

* `appendString : String -> String -> String`, which appends the underlying `Text` values in a `String`, and
* `bytesToString : (n : Nat) -> Vec n (Vec 8 Bool) -> String`, which converts a Cryptol string (a sequence of 8-bit ASCII characters) to a SAWCore `String`.

Moreover, this reimplements `ecError` in terms of `appendString`/`bytesToString` such that invoking the Cryptol `error` function from SAW will preserve the string passed to `error`. Previously, if you invoked the following in SAW:

```
sawscript> prove abc {{ error "Descriptive error message" : Bit }}
```

You would get:

```
Run-time error: encountered call to the Cryptol 'error' function
```

Now, you get:

```
Run-time error: encountered call to the Cryptol 'error' function: Descriptive error message
```

Fixes #1326.