### PR TITLE
change call site IDs to have an additional Int index

### DIFF
--- a/heapster-saw/src/Verifier/SAW/Heapster/SAWTranslation.hs
+++ b/heapster-saw/src/Verifier/SAW/Heapster/SAWTranslation.hs
@@ -1803,8 +1803,10 @@ lookupEntryTrans :: TypedEntryID blocks args ->
                     TypedBlockMapTrans ext blocks tops ret ->
                     Some (TypedEntryTrans ext blocks tops ret args)
 lookupEntryTrans entryID blkMap =
-  typedBlockTransEntries (RL.get (entryBlockID entryID) blkMap) !!
-  entryIndex entryID
+  maybe (error "lookupEntryTrans") id $
+  find (\(Some entryTrans) ->
+         entryID == typedEntryID (typedEntryTransEntry entryTrans)) $
+  typedBlockTransEntries (RL.get (entryBlockID entryID) blkMap)
 
 -- | Look up the translation of an entry by entry ID and make sure that it has
 -- the supplied ghost arguments


### PR DESCRIPTION
This change allows the same source entrypoint to call the same destination entrypoint multiple times and have distinct call sites. This is needed if the latter is a join point and the former performs a disjunctive elimination before doing a call. The resulting bug is showing up in some of our mbox examples.
