### PR TITLE
`saw-remote-api`: Remove uses of `undefined`

### DIFF
--- a/saw-remote-api/src/SAWServer/SetOption.hs
+++ b/saw-remote-api/src/SAWServer/SetOption.hs
@@ -33,9 +33,9 @@ setOption opt =
          updateRW rw { rwLaxArith = enabled }
        EnableLaxPointerOrdering enabled ->
          updateRW rw { rwLaxPointerOrdering = enabled }
-       EnableSMTArrayMemoryModel enabled -> undefined
+       EnableSMTArrayMemoryModel enabled ->
          updateRW rw { rwSMTArrayMemoryModel = enabled }
-       EnableWhat4HashConsing enabled -> undefined
+       EnableWhat4HashConsing enabled ->
          updateRW rw { rwWhat4HashConsing = enabled }
      ok
 


### PR DESCRIPTION
These are most likely placeholder values that were accidentally left in the code. Let's remove them.

Fixes #1390.