### PR TITLE
Bump Python dependency versions to match Cryptol

### DIFF
--- a/saw-remote-api/python/poetry.lock
+++ b/saw-remote-api/python/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "argo-client"
-version = "0.0.4"
+version = "0.0.5"
 description = "A JSON RPC client library."
 category = "main"
 optional = false
@@ -36,7 +36,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "cryptol"
-version = "2.11.0"
+version = "2.11.2"
 description = "Cryptol client for the Cryptol 2.11 RPC server"
 category = "main"
 optional = false
@@ -44,7 +44,7 @@ python-versions = "^3.8"
 develop = true
 
 [package.dependencies]
-argo-client = "0.0.4"
+argo-client = "0.0.5"
 BitVector = "^3.4.9"
 requests = "^2.25.1"
 

--- a/saw-remote-api/python/pyproject.toml
+++ b/saw-remote-api/python/pyproject.toml
@@ -15,7 +15,7 @@ python = "^3.8"
 requests = "^2.25.1"
 BitVector = "^3.4.9"
 cryptol = { path = "../../deps/cryptol/cryptol-remote-api/python/", develop = true }
-argo-client = "0.0.4"
+argo-client = "0.0.5"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.812"


### PR DESCRIPTION
This change was originally made by @atomb in this PR that hasn't landed yet: https://github.com/GaloisInc/saw-script/pull/1386/commits/50fcc2760803bdb5645f22bfea8223b5db022d9f

If we want to merge _just_ that change soonish, this PR may be useful. If not we can close it.