### PR TITLE
Allow slashes in `write_aig_external` filenames

### DIFF
--- a/intTests/test_external_abc/test.saw
+++ b/intTests/test_external_abc/test.saw
@@ -16,16 +16,16 @@ let q_unsat = {{ \(x:[8]) -> x != 0 /\ x+x == x }};
 
 write_verilog "write_verilog_unsat.v" q_unsat;
 write_smtlib2_w4 "write_smtlib2_w4_unsat.smt2" q_unsat;
-write_aig_external "write_aig_external_unsat.aig" q_unsat;
-write_cnf_external "write_aig_external_unsat.cnf" q_unsat;
+write_aig_external "./write_aig_external_unsat.aig" q_unsat;
+write_cnf_external "./write_aig_external_unsat.cnf" q_unsat;
 
 // A formula that is satisfiable.
 let q_sat = {{ \(x:[8]) -> x+x == x }};
 
 write_verilog "write_verilog_sat.v" q_sat;
 write_smtlib2_w4 "write_smtlib2_w4_sat.smt2" q_sat;
-write_aig_external "write_aig_external_sat.aig" q_sat;
-write_cnf_external "write_aig_external_sat.cnf" q_sat;
+write_aig_external "./write_aig_external_sat.aig" q_sat;
+write_cnf_external "./write_aig_external_sat.cnf" q_sat;
 
 fails (prove_print sbv_abc q_sat);
 fails (prove_print w4_abc_smtlib2 q_sat);

--- a/src/SAWScript/Prover/Exporter.hs
+++ b/src/SAWScript/Prover/Exporter.hs
@@ -56,6 +56,7 @@ import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.SBV.Dynamic as SBV
 import System.Directory (removeFile)
+import System.FilePath (takeBaseName)
 import System.IO
 import System.IO.Temp(emptySystemTempFile)
 import Data.Text (pack)
@@ -148,8 +149,8 @@ writeAIG f t = do
      io $ AIG.writeAiger f aig
 
 withABCVerilog :: FilePath -> Term -> (FilePath -> String) -> TopLevel ()
-withABCVerilog baseName t buildCmd =
-  do verilogFile <- io $ emptySystemTempFile (baseName ++ ".v")
+withABCVerilog fileName t buildCmd =
+  do verilogFile <- io $ emptySystemTempFile (takeBaseName fileName ++ ".v")
      sc <- getSharedContext
      write_verilog sc verilogFile t
      io $


### PR DESCRIPTION
This command uses a temporary file whose name was originally built on
the full filename of the final output file. Now it's built only on the
basename of that file.

Closes #1438