### PR TITLE
Comment out the xor_swap_rust proof

### DIFF
--- a/heapster-saw/examples/xor_swap_rust_proofs.v
+++ b/heapster-saw/examples/xor_swap_rust_proofs.v
@@ -11,11 +11,6 @@ From CryptolToCoq Require Import CompMExtra.
 Require Import Examples.xor_swap_rust_gen.
 Import xor_swap_rust.
 
-Definition xor_swap_spec x1 x2 :
-  CompM (bitvector 64 * (bitvector 64 * unit)) :=
-  returnM (x2, (x1, tt)).
-Arguments xor_swap_spec /.
-
 (* FIXME: move lemma to SAWCorePrelude...? *)
 Lemma bvXor_twice_r n x y :
   SAWCorePrelude.bvXor n (SAWCorePrelude.bvXor n x y) y = x.
@@ -30,9 +25,17 @@ Proof.
   admit.
 Admitted.
 
+(* FIXME: write a spec for xor_swap_rust that works! *)
+(*
+Definition xor_swap_spec x1 x2 :
+  CompM (bitvector 64 * (bitvector 64 * unit)) :=
+  returnM (x2, (x1, tt)).
+Arguments xor_swap_spec /.
+
 Lemma xor_swap_correct : refinesFun xor_swap_rust xor_swap_spec.
 Proof.
   prove_refinement.
   rewrite bvXor_twice_r. rewrite bvXor_twice_l.
   reflexivity.
 Qed.
+*)


### PR DESCRIPTION
When the xor_swap_rust example switched to using the Rust type to type-check it, it started using lifetimes, which make the extracted spec more complicated and invalidated the proof. This PR just comments out that proof for now, as it no longer works. Fixing this proof "for real" will require figuring out a bit more about how to do refinement proofs for lifetimes.