### PR TITLE
Opaque constants

### DIFF
--- a/saw-core-coq/src/Language/Coq/AST.hs
+++ b/saw-core-coq/src/Language/Coq/AST.hs
@@ -70,6 +70,8 @@ data Decl
   = Axiom Ident Type
   | Comment String
   | Definition Ident [Binder] (Maybe Type) Term
+  | Parameter Ident Type
+  | Variable Ident Type
   | InductiveDecl Inductive
   | Snippet String
   deriving (Show)

--- a/saw-core-coq/src/Language/Coq/Pretty.hs
+++ b/saw-core-coq/src/Language/Coq/Pretty.hs
@@ -146,6 +146,12 @@ ppDecl decl = case decl of
   Axiom nm ty ->
     (nest 2 $
      hsep ([text "Axiom", text nm, text ":", ppTerm PrecNone ty, period])) <> hardline
+  Parameter nm ty ->
+    (nest 2 $
+     hsep ([text "Parameter", text nm, text ":", ppTerm PrecNone ty, period])) <> hardline
+  Variable nm ty ->
+    (nest 2 $
+     hsep ([text "Variable", text nm, text ":", ppTerm PrecNone ty, period])) <> hardline
   Comment s ->
     text "(*" <+> text s <+> text "*)" <> hardline
   Definition nm bs mty body ->

--- a/saw-core-coq/src/Verifier/SAW/Translation/Coq/CryptolModule.hs
+++ b/saw-core-coq/src/Verifier/SAW/Translation/Coq/CryptolModule.hs
@@ -16,6 +16,8 @@ import           Verifier.SAW.Translation.Coq.Monad
 import qualified Verifier.SAW.Translation.Coq.Term  as TermTranslation
 import           Verifier.SAW.TypedTerm
 
+
+
 translateTypedTermMap ::
   TermTranslation.TermTranslationMonad m => Map.Map Name TypedTerm -> m [Coq.Decl]
 translateTypedTermMap tm = forM (Map.assocs tm) translateAndRegisterEntry

--- a/saw-core/src/Verifier/SAW/Recognizer.hs
+++ b/saw-core/src/Verifier/SAW/Recognizer.hs
@@ -313,8 +313,8 @@ asLocalVar :: Recognizer Term DeBruijnIndex
 asLocalVar (unwrapTermF -> LocalVar i) = return i
 asLocalVar _ = Nothing
 
-asConstant :: Recognizer Term (ExtCns Term, Term)
-asConstant (unwrapTermF -> Constant ec t) = return (ec, t)
+asConstant :: Recognizer Term (ExtCns Term, Maybe Term)
+asConstant (unwrapTermF -> Constant ec mt) = return (ec, mt)
 asConstant _ = Nothing
 
 asExtCns :: Recognizer Term (ExtCns Term)

--- a/saw-core/src/Verifier/SAW/Rewriter.hs
+++ b/saw-core/src/Verifier/SAW/Rewriter.hs
@@ -360,7 +360,7 @@ ruleOfProp (R.asApplyAll -> (R.isGlobalDef intEqIdent -> Just (), [x, y])) ann =
   Just $ mkRewriteRule [] x y ann
 ruleOfProp (R.asApplyAll -> (R.isGlobalDef intModEqIdent -> Just (), [_, x, y])) ann =
   Just $ mkRewriteRule [] x y ann
-ruleOfProp (unwrapTermF -> Constant _ body) ann = ruleOfProp body ann
+ruleOfProp (unwrapTermF -> Constant _ (Just body)) ann = ruleOfProp body ann
 ruleOfProp (R.asEq -> Just (_, x, y)) ann =
   Just $ mkRewriteRule [] x y ann
 ruleOfProp (R.asEqTrue -> Just body) ann = ruleOfProp body ann

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -117,6 +117,8 @@ data NeutralTerm
       Term   -- recursor value
       [Term] -- indices for the inductive type
       NeutralTerm -- argument being elminated
+  | NeutralConstant -- A constant value with no definition
+      (ExtCns Term)
 
 type Thunk l = Lazy (EvalM l) (Value l)
 
@@ -379,6 +381,8 @@ neutralToTerm = loop
     Unshared (FTermF (RecursorApp r ixs (loop x)))
   loop (NeutralRecursor r ixs x) =
     Unshared (FTermF (RecursorApp (loop r) ixs x))
+  loop (NeutralConstant ec) =
+    Unshared (Constant ec Nothing)
 
 neutralToSharedTerm :: SharedContext -> NeutralTerm -> IO Term
 neutralToSharedTerm sc = loop
@@ -400,6 +404,8 @@ neutralToSharedTerm sc = loop
   loop (NeutralRecursorArg r ixs nt) =
     do tm <- loop nt
        scFlatTermF sc (RecursorApp r ixs tm)
+  loop (NeutralConstant ec) =
+    do scTermF sc (Constant ec Nothing)
 
 ppNeutral :: PPOpts -> NeutralTerm -> SawDoc
 ppNeutral opts = ppTerm opts . neutralToTerm

--- a/saw-core/src/Verifier/SAW/Term/Functor.hs
+++ b/saw-core/src/Verifier/SAW/Term/Functor.hs
@@ -333,7 +333,7 @@ data TermF e
       -- ^ The type of a (possibly) dependent function
     | LocalVar !DeBruijnIndex
       -- ^ Local variables are referenced by deBruijn index.
-    | Constant !(ExtCns e) !e
+    | Constant !(ExtCns e) !(Maybe e)
       -- ^ An abstract constant packaged with its type and definition.
       -- The body and type should be closed terms.
   deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -1481,7 +1481,7 @@ cryptol_load fileReader path = do
   rw <- getTopLevelRW
   let ce = rwCryptol rw
   let ?fileReader = fileReader
-  (m, ce') <- io $ CEnv.loadCryptolModule sc ce path
+  (m, ce') <- io $ CEnv.loadCryptolModule sc CEnv.defaultPrimitiveOptions ce path
   putTopLevelRW $ rw { rwCryptol = ce' }
   return m
 

--- a/src/SAWScript/Prover/Exporter.hs
+++ b/src/SAWScript/Prover/Exporter.hs
@@ -66,7 +66,7 @@ import Prettyprinter (vcat)
 
 import Lang.JVM.ProcessUtils (readProcessExitIfFailure)
 
-import Verifier.SAW.CryptolEnv (initCryptolEnv, loadCryptolModule)
+import Verifier.SAW.CryptolEnv (initCryptolEnv, loadCryptolModule, ImportPrimitiveOptions(..))
 import Verifier.SAW.Cryptol.Prelude (cryptolModule, scLoadPreludeModule, scLoadCryptolModule)
 import Verifier.SAW.ExternalFormat(scWriteExternal)
 import Verifier.SAW.FiniteValue
@@ -471,7 +471,8 @@ writeCoqCryptolModule inputFile outputFile notations skips = io $ do
   let ?fileReader = BS.readFile
   env <- initCryptolEnv sc
   cryptolPrimitivesForSAWCoreModule <- scFindModule sc nameOfCryptolPrimitivesForSAWCoreModule
-  (cm, _) <- loadCryptolModule sc env inputFile
+  let primOpts = ImportPrimitiveOptions{ allowUnknownPrimitives = True }
+  (cm, _) <- loadCryptolModule sc primOpts env inputFile
   let cryptolPreludeDecls = map Coq.moduleDeclName (moduleDecls cryptolPrimitivesForSAWCoreModule)
   let configuration =
         withImportCryptolPrimitivesForSAWCoreExtra $

--- a/src/SAWScript/X86.hs
+++ b/src/SAWScript/X86.hs
@@ -127,7 +127,7 @@ import Verifier.SAW.Recognizer(asBool)
 import Verifier.SAW.Simulator.What4.ReturnTrip (sawRegisterSymFunInterp, toSC, saw_ctx)
 
 -- Cryptol Verifier
-import Verifier.SAW.CryptolEnv(CryptolEnv,initCryptolEnv,loadCryptolModule)
+import Verifier.SAW.CryptolEnv(CryptolEnv,initCryptolEnv,loadCryptolModule,defaultPrimitiveOptions)
 import Verifier.SAW.Cryptol.Prelude(scLoadPreludeModule,scLoadCryptolModule)
 
 -- SAWScript
@@ -365,7 +365,7 @@ loadCry sym mb =
      env <- initCryptolEnv sc
      case mb of
        Nothing   -> return env
-       Just file -> snd <$> loadCryptolModule sc env file
+       Just file -> snd <$> loadCryptolModule sc defaultPrimitiveOptions env file
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a notion of "opaque constant" to saw-core.  These are `Constant` nodes that have no definition.  They are similar in many ways to `ExtCns`, but are explicitly not subject to substitution.

In particular, opaque constants are allowed to appear in the definition of other constants, whereas `ExtCns` are not (CF discussion on #1430).

In `cryptol-saw-core`, if a `primitive` declaration appears in a Cryptol module that is not one of the well-known primitives from the built-in modules we support, it is translated into an opaque constant.  In `saw-core-coq`, opaque constants are translated into Coq `Parameter` declarations.  The end result is that we can posit and reason about abstract Cryptol functions in Coq.

Note, this is based on #1423, only the final two commits properly belong to this PR.