### PR TITLE
upper bound on aeson version

### DIFF
--- a/saw-remote-api/saw-remote-api.cabal
+++ b/saw-remote-api/saw-remote-api.cabal
@@ -35,7 +35,7 @@ common errors
 
 common deps
   build-depends: base >=4.11.1.0 && <4.15,
-                 aeson,
+                 aeson >= 1.4.2 && < 2.0,
                  aig,
                  argo,
                  base64-bytestring,

--- a/saw-script.cabal
+++ b/saw-script.cabal
@@ -91,7 +91,7 @@ library
     , flexdis86
     , elf-edit
     , reflection
-    , aeson
+    , aeson >= 1.4.2 && < 2.0
 
   hs-source-dirs: src
 


### PR DESCRIPTION
Aeson v2.0 changed some of the data representations (see [Changelog](https://hackage.haskell.org/package/aeson-2.0.0.0/changelog)). For now, adding a strict upper bound may help mitigate build breakages affected by this. A more thorough fix could be added as well and/or later. (See https://github.com/GaloisInc/argo/pull/188)