### PR TITLE
[saw-core-coq] Check bitvector lemmas for < 4 bits

### DIFF
--- a/heapster-saw/examples/arrays_proofs.v
+++ b/heapster-saw/examples/arrays_proofs.v
@@ -43,7 +43,7 @@ Proof.
   (* Proving that the loop invariant holds inductively: *)
   - transitivity a2.
     + assumption.
-    + apply isBvsle_suc_r.
+    + apply isBvsle_suc_r; eauto.
       rewrite e_assuming2, e_assuming0.
       reflexivity.
   - apply isBvslt_to_isBvsle_suc.
@@ -80,7 +80,7 @@ Proof.
     discriminate e_maybe.
   - transitivity a2.
     + assumption.
-    + apply isBvsle_suc_r.
+    + apply isBvsle_suc_r; eauto.
       rewrite e_assuming2, e_assuming0.
       reflexivity.
   - apply isBvslt_to_isBvsle_suc.
@@ -215,12 +215,6 @@ Admitted.
 
 (* We *really* need a better bitvector library, the lemmas we need are getting pretty ad-hoc *)
 
-Axiom bvSub_1_lt : forall w a, isBvslt w (intToBv w 0) a ->
-                               isBvslt w (bvSub w a (intToBv w 1)) a.
-
-Axiom isBvslt_suc_r : forall w a, isBvslt w a (bvsmax w) ->
-                                  isBvslt w a (bvAdd w a (intToBv w 1)).
-
 Axiom isBvsle_bvSub_inj_pos : forall w a b c, isBvsle w (intToBv w 0) a ->
                                               isBvsle w (intToBv w 0) b ->
                                               isBvsle w (intToBv w 0) c ->
@@ -252,14 +246,14 @@ Proof.
       (* apply isBvsle_bvSub_inj_pos. *)
       (* I give up I'm done messing around manually with bitvectors for now *)
       admit.
-    + apply bvSub_1_lt.
-      rewrite e_assuming; reflexivity.
+    + apply isBvslt_pred_l; eauto.
+      rewrite <- e_assuming; reflexivity.
   - (* (e_if4 is a contradiction) *)
     admit.
   - rewrite e_assuming.
     change (intToBv 64 2) with (bvAdd 64 (intToBv 64 1) (intToBv 64 1)).
     rewrite <- bvAdd_assoc.
-    rewrite <- isBvslt_suc_r; [ rewrite <- isBvslt_suc_r; [ reflexivity |] |].
+    rewrite <- isBvslt_suc_r.
     + admit.
     + admit.
 Admitted.

--- a/heapster-saw/examples/iter_linked_list_proofs.v
+++ b/heapster-saw/examples/iter_linked_list_proofs.v
@@ -91,7 +91,7 @@ Qed.
 
 Definition incr_list_invar :=
   @list_rect (bitvector 64) (fun _ => Prop) True
-             (fun x _ rec => isBvult 64 x (intToBv 64 0x7fffffffffffffff) /\ rec).
+             (fun x _ rec => isBvslt 64 x (bvsmax 64) /\ rec).
 
 Arguments incr_list_invar !l.
 
@@ -105,11 +105,11 @@ Proof.
   time "no_errors_incr_list" prove_refinement.
   all: try destruct e_assuming as [?e_assuming ?e_assuming];
        try destruct e_assuming0 as [?e_assuming ?e_assuming];
-       try destruct e_assuming1 as [?e_assuming ?e_assuming]; simpl in *.
+       try destruct e_assuming1 as [?e_assuming ?e_assuming]; cbn - [bvsmax] in *.
   (* All but one of the remaining goals are taken care of by assumptions we have in scope: *)
   all: try rewrite appendList_Nil_r; try split; eauto.
   (* We just have to show this case is impossible by virtue of our loop invariant: *)
-  apply isBvult_to_isBvule_suc in e_assuming0.
-  apply bvule_msb_l in e_assuming0; try assumption.
-  compute_bv_funs in e_assuming0; inversion e_assuming0.
+  apply isBvslt_suc_r in e_assuming0.
+  rewrite <- e_assuming0, e_if in e_if0.
+  apply isBvslt_antirefl in e_if0; contradiction.
 Qed.

--- a/heapster-saw/examples/loops_proofs.v
+++ b/heapster-saw/examples/loops_proofs.v
@@ -81,10 +81,16 @@ Definition no_errors_sign_of_sum' : ltac:(let tp := type of no_errors_sign_of_su
                                            in exact tp') := no_errors_sign_of_sum.
 Hint Rewrite no_errors_sign_of_sum' : refinement_proofs.
 
-Lemma no_errors_compare_sum : refinesFun compare_sum (fun _ _ _ => noErrorsSpec).
+Lemma no_errors_compare_sum :
+  refinesFun compare_sum (fun x _ _ => assumingM (isBvslt 64 (bvsmin 64) x)
+                                                 noErrorsSpec).
 Proof.
   unfold compare_sum, compare_sum__tuple_fun, noErrorsSpec.
   time "no_errors_compare_sum" prove_refinement.
+  - assumption. (* doesn't matter what we put here *)
+  - rewrite bvNeg_bvslt_zero_iff in e_if; eauto.
+    rewrite e_if in e_if0.
+    apply isBvslt_antirefl in e_if0; contradiction.
 Qed.
 
 
@@ -100,28 +106,30 @@ Hint Rewrite sign_of_sum_spec_ref' : refinement_proofs.
 
 
 Definition compare_sum_spec (x y z : bitvector 64) : CompM (bitvector 64) :=
-  orM (     assertM (isBvslt _ x (bvAdd _ y z)) >> returnM (intToBv _ 1))
-      (orM (assertM (isBvslt _ (bvAdd _ y z) x) >> returnM (intToBv _ (-1)))
-           (assertM (x = bvAdd _ y z)           >> returnM (intToBv _ 0))).
+  assumingM (isBvslt 64 (bvsmin 64) x /\ bvSubOverflow 64 (bvAdd 64 y z) x = false)
+    (orM (     assertM (isBvslt _ x (bvAdd _ y z)) >> returnM (intToBv _ 1))
+         (orM (assertM (isBvslt _ (bvAdd _ y z) x) >> returnM (intToBv _ (-1)))
+              (assertM (x = bvAdd _ y z)           >> returnM (intToBv _ 0)))).
 
 Lemma compare_sum_spec_ref : refinesFun compare_sum compare_sum_spec.
 Proof.
   unfold compare_sum, compare_sum__tuple_fun, compare_sum_spec.
   time "compare_sum_spec_ref" prove_refinement.
-  all: rewrite bvSub_zero_n in e_assert.
+  all: try rewrite bvSub_zero_n, bvAdd_comm, <- bvSub_eq_bvAdd_neg in e_assert.
   (* Note that there are two versions of each case because of the if! *)
   (* The `x < y + z` case: *)
   1,4: continue_prove_refinement_left.
-  1,2: rewrite bvslt_bvSub_r, bvSub_eq_bvAdd_neg, bvAdd_comm.
-  1,2: assumption.
+  1,2: apply bvslt_bvSub_r; eauto.
   (* The `x > y + z` case: *)
   1,3: continue_prove_refinement_right;
        continue_prove_refinement_left.
-  1,2: rewrite bvslt_bvSub_l, bvSub_eq_bvAdd_neg, bvAdd_comm.
-  1,2: assumption.
+  1,2: apply bvslt_bvSub_l; eauto.
   (* The `x = y + z` case: *)
   1,2: continue_prove_refinement_right;
        continue_prove_refinement_right.
-  1,2: rewrite bvEq_bvSub_r, bvSub_eq_bvAdd_neg, bvAdd_comm.
-  1,2: symmetry; assumption.
+  1,2: rewrite bvEq_bvSub_r; symmetry; eauto.
+  (* The remaining case follows from our precondition (same as no_errors) *)
+  rewrite bvNeg_bvslt_zero_iff in e_if0; eauto.
+  rewrite e_if0 in e_if1.
+  apply isBvslt_antirefl in e_if1; contradiction.
 Qed.

--- a/heapster-saw/examples/mbox_proofs.v
+++ b/heapster-saw/examples/mbox_proofs.v
@@ -119,7 +119,6 @@ Proof.
     + rewrite H1 in e_maybe; discriminate e_maybe.
   (* Showing the loop invariant holds inductively (the remaining two cases) *)
   - rewrite e_assuming1; apply isBvsle_suc_r.
-    apply isBvslt_to_isBvsle.
     rewrite e_assuming2, e_assuming3.
     reflexivity.
   - apply isBvslt_to_isBvsle_suc.
@@ -180,7 +179,6 @@ Proof.
     + rewrite H1 in e_maybe; discriminate e_maybe.
   (* Showing the loop invariant holds inductively (the remaining two cases) *)
   - rewrite e_assuming1; apply isBvsle_suc_r.
-    apply isBvslt_to_isBvsle.
     rewrite e_assuming2, e_assuming3.
     reflexivity.
   - apply isBvslt_to_isBvsle_suc.

--- a/saw-core-coq/coq/handwritten/CryptolToCoq/SAWCoreBitvectors.v
+++ b/saw-core-coq/coq/handwritten/CryptolToCoq/SAWCoreBitvectors.v
@@ -141,7 +141,7 @@ Ltac holds_for_bits_up_to n axiom :=
     compute;
     match goal with
     | |- forall w, @?P w =>
-      idtac "Warning: Admitting the bitvector proposition below if it holds for" w "<" n;
+      idtac "Warning: Admitting the bitvector proposition below if it holds for" w "<=" n;
       idtac G;
       apply (axiom P); intros;
       (* completely destruct every bitvector argument, then try `easy` *)
@@ -153,7 +153,8 @@ Ltac holds_for_bits_up_to n axiom :=
   end.
 
 (* The tactics to use to "prove" a bitvector lemma by showing it holds up to
-   either 3 or 4 bits. Only use the former if the latter is too slow. *)
+   either 3 or 4 bits. Use the latter when coming up with a lemma for some extra
+   assurance, but use the former when finished for better performance. *)
 Ltac holds_for_bits_up_to_3 := holds_for_bits_up_to 3 holds_up_to_3.
 Ltac holds_for_bits_up_to_4 := holds_for_bits_up_to 4 holds_up_to_4.
 
@@ -163,28 +164,28 @@ Ltac holds_for_bits_up_to_4 := holds_for_bits_up_to 4 holds_up_to_4.
 Definition isBvsle w a b : Prop := bvsle w a b = true.
 Definition isBvsle_def w a b : bvsle w a b = true <-> isBvsle w a b := reflexivity _.
 Definition isBvsle_def_opp w a b : bvslt w a b = false <-> isBvsle w b a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvslt w a b : Prop := bvslt w a b = true.
 Definition isBvslt_def w a b : bvslt w a b = true <-> isBvslt w a b := reflexivity _.
 Definition isBvslt_def_opp w a b : bvsle w a b = false <-> isBvslt w b a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvule w a b : Prop := bvule w a b = true.
 Definition isBvule_def w a b : bvule w a b = true <-> isBvule w a b := reflexivity _.
 Definition isBvule_def_opp w a b : bvult w a b = false <-> isBvule w b a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvult w a b : Prop := bvult w a b = true.
 Definition isBvult_def w a b : bvult w a b = true <-> isBvult w a b := reflexivity _.
 Definition isBvult_def_opp w a b : bvule w a b = false <-> isBvult w b a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Instance Reflexive_isBvsle w : Reflexive (isBvsle w).
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Instance Reflexive_isBvule w : Reflexive (isBvule w).
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Instance Transitive_isBvsle w : Transitive (isBvsle w).
 Proof. holds_for_bits_up_to_3. Qed.
@@ -202,90 +203,90 @@ Proof. holds_for_bits_up_to_3. Qed.
 (** Converting between bitvector inqualities **)
 
 Definition isBvslt_to_isBvsle w a b : isBvslt w a b -> isBvsle w a b.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 Instance Proper_isBvslt_isBvsle w :
   Proper (isBvsle w --> isBvsle w ==> impl) (isBvslt w).
 Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvult_to_isBvule w a b : isBvult w a b -> isBvule w a b.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 Instance Proper_isBvult_isBvule w : Proper (isBvule w --> isBvule w ==> impl) (isBvult w).
 Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvule_to_isBvult_or_eq w a b : isBvule w a b -> isBvult w a b \/ a = b.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvslt_to_isBvsle_suc w a b : isBvslt w a b ->
                                           isBvsle w (bvAdd w a (intToBv w 1)) b.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvult_to_isBvule_suc w a b : isBvult w a b ->
                                           isBvule w (bvAdd w a (intToBv w 1)) b.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvult_to_isBvslt_pos w a b : isBvsle w (intToBv w 0) a ->
                                           isBvsle w (intToBv w 0) b ->
                                           isBvult w a b <-> isBvslt w a b.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvule_to_isBvsle_pos w a b : isBvsle w (intToBv w 0) a ->
                                           isBvsle w (intToBv w 0) b ->
                                           isBvule w a b <-> isBvsle w a b.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvslt_to_bvEq_false w a b : isBvslt w a b -> bvEq w a b = false.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvult_to_bvEq_false w a b : isBvult w a b -> bvEq w a b = false.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 
 (** Other lemmas about bitvector inequalities **)
 
 Definition isBvslt_pred_l w a : isBvslt w (bvsmin w) a ->
                                 isBvslt w (bvSub w a (intToBv w 1)) a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvsle_pred_l w a : isBvslt w (bvsmin w) a ->
                                 isBvsle w (bvSub w a (intToBv w 1)) a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvsle_suc_r w a : isBvslt w a (bvsmax w) ->
                                isBvsle w a (bvAdd w a (intToBv w 1)).
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvslt_suc_r w a : isBvslt w a (bvsmax w) ->
                                isBvslt w a (bvAdd w a (intToBv w 1)).
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvslt_antirefl w a : ~ isBvslt w a a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvule_zero_n w a : isBvule w (intToBv w 0) a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvule_n_zero w a : isBvule w a (intToBv w 0) <-> a = intToBv w 0.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvult_n_zero w a : ~ isBvult w a (intToBv w 0).
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Definition isBvsle_antisymm w a b : isBvsle w a b -> isBvsle w b a -> a = b.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 
 (** Lemmas about bitvector addition **)
 
 Lemma bvAdd_id_l w a : bvAdd w (intToBv w 0) a = a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Lemma bvAdd_id_r w a : bvAdd w a (intToBv w 0) = a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Hint Rewrite bvAdd_id_l bvAdd_id_r : SAWCoreBitvectors_eqs.
 
 Lemma bvAdd_comm w a b : bvAdd w a b = bvAdd w b a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Lemma bvAdd_assoc w a b c : bvAdd w (bvAdd w a b) c = bvAdd w a (bvAdd w b c).
 Proof. holds_for_bits_up_to_3. Qed.
@@ -294,20 +295,20 @@ Proof. holds_for_bits_up_to_3. Qed.
 (** Lemmas about bitvector subtraction, negation, and sign bits **)
 
 Lemma bvSub_n_zero w a : bvSub w a (intToBv w 0) = a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Lemma bvSub_zero_n w a : bvSub w (intToBv w 0) a = bvNeg w a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Hint Rewrite bvSub_zero_n : SAWCoreBitvectors_eqs.
 
 Lemma msb_true_iff_bvslt w a :
   msb w a = true <-> isBvslt (Succ w) a (intToBv (Succ w) 0).
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Lemma msb_false_iff_bvsle w a :
   msb w a = false <-> isBvsle (Succ w) (intToBv (Succ w) 0) a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Lemma bvNeg_bvslt_zero_iff w a : isBvslt w (bvsmin w) a ->
   isBvslt w a (intToBv w 0) <-> isBvslt w (intToBv w 0) (bvNeg w a).
@@ -318,17 +319,17 @@ Proof. holds_for_bits_up_to_3. Qed.
 
 Lemma bvslt_bvSub_l w a b : bvSubOverflow w a b = false ->
                             isBvslt w (bvSub w a b) (intToBv w 0) -> isBvslt w a b.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Lemma bvslt_bvSub_r w a b : bvSubOverflow w b a = false ->
                             isBvslt w (intToBv w 0) (bvSub w b a) -> isBvslt w a b.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Lemma bvEq_bvSub_r w a b : a = b <-> intToBv w 0 = bvSub w b a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Lemma bvEq_bvSub_l w a b : a = b <-> bvSub w a b = intToBv w 0.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Lemma bvSub_eq_bvAdd_neg w a b : bvSub w a b = bvAdd w a (bvNeg w b).
 Proof. holds_for_bits_up_to_3. Qed.
@@ -449,7 +450,7 @@ Proof.
 Qed.
 
 Lemma bvEq_sym w a b : bvEq w a b = bvEq w b a.
-Proof. holds_for_bits_up_to_4. Qed.
+Proof. holds_for_bits_up_to_3. Qed.
 
 Lemma bvEq_eq  w a b : bvEq w a b = true <-> a = b.
 Proof.

--- a/saw-core-coq/coq/handwritten/CryptolToCoq/SAWCoreVectorsAsCoqVectors.v
+++ b/saw-core-coq/coq/handwritten/CryptolToCoq/SAWCoreVectorsAsCoqVectors.v
@@ -359,3 +359,11 @@ Global Opaque bvsle.
 
 Definition bvsge (n : nat) (a : bitvector n) (b : bitvector n) : Bool :=
   bvsle n b a.
+
+Definition bvAddOverflow n (a : bitvector n) (b : bitvector n) : Bool :=
+  let c := bvAdd n a b
+   in ((sign a && sign b && ~~ sign c) || (~~ sign a && ~~ sign b && sign c))%bool.
+
+Definition bvSubOverflow n (a : bitvector n) (b : bitvector n) : Bool :=
+  let c := bvSub n a b
+   in ((sign a && ~~ sign b && ~~ sign c) || (~~ sign a && sign b && sign c))%bool.

--- a/saw-core-coq/coq/handwritten/CryptolToCoq/SAWCoreVectorsAsCoqVectors.v
+++ b/saw-core-coq/coq/handwritten/CryptolToCoq/SAWCoreVectorsAsCoqVectors.v
@@ -199,7 +199,7 @@ Definition joinLSB {n} (v : bitvector n) (lsb : bool) : bitvector n.+1 :=
 
 Definition bvToNatFolder (n : nat) (b : bool) := b + n.*2.
 
-Fixpoint bvToNat (size : Nat) (v : bitvector size) : Nat :=
+Definition bvToNat (size : Nat) (v : bitvector size) : Nat :=
   Vector.fold_left bvToNatFolder 0 v.
 
 (* This is used to write literals of bitvector type, e.g. intToBv 64 3 *)
@@ -319,7 +319,7 @@ Fixpoint shiftR (n : nat) (A : Type) (x : A) (v : Vector.t A n) (i : nat)
   : Vector.t A n
   := match i with
      | O => v
-     | S i' => Vector.shiftout (cons _ x _ (shiftL n A x v i'))
+     | S i' => Vector.shiftout (cons _ x _ (shiftR n A x v i'))
      end.
 
 (* This is annoying to implement, so using BITS conversion *)


### PR DESCRIPTION
Inspired by @robdockins' comment in #1236, this PR adds the axiom: 
```coq
Axiom holds_up_to_4 : forall (P : nat -> Prop),
                      P 0 -> P 1 -> P 2 -> P 3 -> P 4 ->
                      forall n, P n.
```
and uses it instead of `Admitted` to ensure that the bitvector propositions in `SAWCoreBitvectors.v` at least work for inputs with less than four bits. In the process, this PR fixes a few incorrect bitvector propositions (namely, `Preorder_isBvslt`, `Preorder_isBvult`, `isBvsle_suc_r`, and `bvNeg_msb`).

This is quick way to gain some confidence in the existing lemmas, not a long-term solution. To reinforce that, the tactic `holds_for_bits_up_to_4`, which tries to prove a lemma using the above axiom, prints out a warning each time it is used.

This PR also fixes the definition of `shiftR`, as noticed in #1236.

This is a draft because I still need to either fix or remove `bvslt_bvSub_r` and `bvslt_bvSub_l`, and have yet to update the heapster example proofs.