### PR TITLE
Fix crux-mir-comp build and add to CI

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -58,9 +58,9 @@ build() {
   cabal v2-configure -j --enable-tests
   git status --porcelain
   if $IS_WIN; then
-    pkgs=(saw)
+    pkgs=(saw crux-mir-comp)
   else
-    pkgs=(saw saw-remote-api)
+    pkgs=(saw crux-mir-comp saw-remote-api)
   fi
   tee -a cabal.project.local > /dev/null < cabal.project.ci
   if ! retry cabal v2-build "$@" "${pkgs[@]}"; then

--- a/crux-mir-comp/crux-mir-comp.cabal
+++ b/crux-mir-comp/crux-mir-comp.cabal
@@ -81,7 +81,7 @@ executable crux-mir-comp
                 crux-mir,
                 template-haskell
 
-  ghc-options: -Wall
+  ghc-options: -Wall -threaded
   ghc-prof-options: -O2 -fprof-auto-top
   default-language: Haskell2010
 
@@ -90,7 +90,7 @@ test-suite test
   type: exitcode-stdio-1.0
   hs-source-dirs: test
 
-  ghc-options: -Wall
+  ghc-options: -Wall -threaded
   ghc-prof-options: -fprof-auto -O2
 
   main-is: Test.hs

--- a/crux-mir-comp/src/Mir/Compositional.hs
+++ b/crux-mir-comp/src/Mir/Compositional.hs
@@ -31,7 +31,7 @@ import Mir.Compositional.Clobber (clobberGlobalsOverride)
 
 compositionalOverrides ::
     forall sym p t st fs args ret blocks rtp a r .
-    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p) =>
+    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs) =>
     Maybe (SomeOnlineSolver sym) ->
     CollectionState ->
     Text ->

--- a/crux-mir-comp/src/Mir/Compositional/Clobber.hs
+++ b/crux-mir-comp/src/Mir/Compositional/Clobber.hs
@@ -6,7 +6,7 @@
 module Mir.Compositional.Clobber
 where
 
-import Control.Lens ((^.), (^?), (%=), ix)
+import Control.Lens ((^.), (^?), ix)
 import Control.Monad.Except
 import qualified Data.Map as Map
 import qualified Data.Parameterized.Context as Ctx
@@ -23,9 +23,6 @@ import Lang.Crucible.Backend
 import Lang.Crucible.Simulator
 import Lang.Crucible.Types
 
-import qualified Crux.Model as Crux
-import Crux.Types (HasModel(..))
-
 import Mir.Generator (CollectionState, collection, staticMap, StaticVar(..))
 import Mir.Intrinsics hiding (MethodSpec, MethodSpecBuilder)
 import qualified Mir.Mir as M
@@ -39,7 +36,7 @@ import Mir.Compositional.Convert
 
 -- | Replace each primitive value within `rv` with a fresh symbolic variable.
 clobberSymbolic :: forall sym p t st fs tp rtp args ret.
-    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p, HasCallStack) =>
+    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasCallStack) =>
     sym -> ProgramLoc -> String -> TypeShape tp -> RegValue sym tp ->
     OverrideSim (p sym) sym MIR rtp args ret (RegValue sym tp)
 clobberSymbolic sym loc nameStr shp rv = go shp rv
@@ -76,7 +73,7 @@ clobberSymbolic sym loc nameStr shp rv = go shp rv
 -- immutable (`&`) access.  So this function modifies only the portions of `rv`
 -- that lie within an `UnsafeCell` and leaves the rest unchanged.
 clobberImmutSymbolic :: forall sym p t st fs tp rtp args ret.
-    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p, HasCallStack) =>
+    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasCallStack) =>
     sym -> ProgramLoc -> String -> TypeShape tp -> RegValue sym tp ->
     OverrideSim (p sym) sym MIR rtp args ret (RegValue sym tp)
 clobberImmutSymbolic sym loc nameStr shp rv = go shp rv
@@ -118,7 +115,7 @@ clobberImmutSymbolic sym loc nameStr shp rv = go shp rv
 
 -- | Construct a fresh symbolic `RegValue` of type `tp`.
 freshSymbolic :: forall sym p t st fs tp rtp args ret.
-    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p, HasCallStack) =>
+    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasCallStack) =>
     sym -> ProgramLoc -> String -> TypeShape tp ->
     OverrideSim (p sym) sym MIR rtp args ret (RegValue sym tp)
 freshSymbolic sym loc nameStr shp = go shp
@@ -129,7 +126,8 @@ freshSymbolic sym loc nameStr shp = go shp
     go (PrimShape _ btpr) = do
         let nameSymbol = W4.safeSymbol nameStr
         expr <- liftIO $ W4.freshConstant sym nameSymbol btpr
-        stateContext . cruciblePersonality . personalityModel %= Crux.addVar loc nameStr btpr expr
+        let ev = CreateVariableEvent loc nameStr btpr expr
+        liftIO $ addAssumptions sym (singleEvent ev)
         return expr
     go (ArrayShape (M.TyArray _ len) _ shp) =
         MirVector_Vector <$> V.replicateM len (go shp)
@@ -155,7 +153,7 @@ freshSymbolic sym loc nameStr shp = go shp
 -- might write through the old ref before replacing it with a new one.
 
 clobberGlobals :: forall sym p t st fs rtp args ret.
-    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p, HasCallStack) =>
+    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasCallStack) =>
     sym -> ProgramLoc -> String -> CollectionState ->
     OverrideSim (p sym) sym MIR rtp args ret ()
 clobberGlobals sym loc nameStr cs = do
@@ -173,7 +171,7 @@ clobberGlobals sym loc nameStr cs = do
         writeGlobal gv rv'
 
 clobberGlobalsOverride :: forall sym p t st fs rtp args ret.
-    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p, HasCallStack) =>
+    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasCallStack) =>
     CollectionState ->
     OverrideSim (p sym) sym MIR rtp args ret ()
 clobberGlobalsOverride cs = do

--- a/crux-mir-comp/src/Mir/Cryptol.hs
+++ b/crux-mir-comp/src/Mir/Cryptol.hs
@@ -64,7 +64,7 @@ import Mir.Compositional.Convert
 
 cryptolOverrides ::
     forall sym p t st fs args ret blocks rtp a r .
-    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p) =>
+    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs) =>
     Maybe (SomeOnlineSolver sym) ->
     CollectionState ->
     Text ->
@@ -133,7 +133,7 @@ cryptolOverrides _symOnline cs name cfg
 
 cryptolLoad ::
     forall sym p t st fs rtp a r tp .
-    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p) =>
+    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs) =>
     M.Collection ->
     M.FnSig ->
     TypeRepr tp ->
@@ -163,7 +163,7 @@ cryptolLoad col sig (FunctionHandleRepr argsCtx retTpr) modulePathStr nameStr = 
 cryptolLoad _ _ tpr _ _ = fail $ "cryptol::load: bad function type " ++ show tpr
 
 loadString ::
-    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p) =>
+    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs) =>
     RegValue sym (MirSlice (BVType 8)) ->
     String ->
     OverrideSim (p sym) sym MIR rtp a r Text
@@ -174,7 +174,7 @@ loadString str desc = getString str >>= \x -> case x of
 
 cryptolOverride ::
     forall sym p t st fs rtp a r .
-    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p) =>
+    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs) =>
     M.Collection ->
     MirHandle ->
     RegValue sym (MirSlice (BVType 8)) ->
@@ -202,14 +202,14 @@ data LoadedCryptolFunc sym = forall args ret . LoadedCryptolFunc
     { _lcfArgs :: Assignment TypeShape args
     , _lcfRet :: TypeShape ret
     , _lcfRun :: forall p rtp r.
-        HasModel p => OverrideSim (p sym) sym MIR rtp args r (RegValue sym ret)
+        OverrideSim (p sym) sym MIR rtp args r (RegValue sym ret)
     }
 
 -- | Load a Cryptol function, returning an `OverrideSim` action that can be
 -- used to run the function.
 loadCryptolFunc ::
     forall sym p t st fs rtp a r .
-    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p) =>
+    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs) =>
     M.Collection ->
     M.FnSig ->
     Text ->
@@ -259,7 +259,7 @@ loadCryptolFunc col sig modulePath name = do
 
 cryptolRun ::
     forall sym p t st fs rtp r args ret .
-    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p) =>
+    (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs) =>
     SAW.SharedContext ->
     String ->
     Assignment TypeShape args ->


### PR DESCRIPTION
The crux-mir-comp build had bitrotted due to not being included in CI.  This branch fixes the build and adds it to CI.  For now, it attempts to build crux-mir-comp but doesn't run the test suite, since the test suite has extra dependencies (mir-json and translated libraries).