### PR TITLE
Address Heapster Implication Prover Bug (Word Equality)

### DIFF
--- a/heapster-saw/src/Verifier/SAW/Heapster/Implication.hs
+++ b/heapster-saw/src/Verifier/SAW/Heapster/Implication.hs
@@ -4085,8 +4085,8 @@ implLLVMFieldTryProveWordEq x fp =
       _ ->
         implDropM y p >>> implLLVMFieldSetTrue x (llvmFieldSetEqVar fp y) >>>
         return Nothing
-  _ ->
-    implDropM y p >>> implLLVMFieldSetTrue x (llvmFieldSetEqVar fp y) >>>
+  p' ->
+    implDropM y p' >>> implLLVMFieldSetTrue x (llvmFieldSetEqVar fp y) >>>
     return Nothing
 
 -- | Like 'implLLVMFieldTryeProveWordEq' but for two field permissions in the


### PR DESCRIPTION
Previously, the function `implLLVMFieldTryProveWordEq` had a case like this:

```haskell
  _ ->
    implDropM y p >>> implLLVMFieldSetTrue x (llvmFieldSetEqVar fp y) >>>
    return Nothing
```

The pattern-match here is on the permission left on top of the stack by an elimination as performed by `elimOrsExistsNamesM`; in the above version, this is being ignored, and the _previous_ permission `p` is propagated to `implDropM`.

This is incorrect, as `elimOrsExistsNamesM` can, of course, perform an elimination and change the permission at the top of the stack. Fortunately, the correction is trivial:

```haskell
  p' ->
    implDropM y p' >>> implLLVMFieldSetTrue x (llvmFieldSetEqVar fp y) >>>
    return Nothing
```

Thank you to @eddywestbrook for catching this!