### PR TITLE
Coq translator: efficient array and integer literals

### DIFF
--- a/saw-core-coq/src/Language/Coq/Pretty.hs
+++ b/saw-core-coq/src/Language/Coq/Pretty.hs
@@ -133,7 +133,7 @@ ppTerm p e =
       parensIf (p > PrecLambda)
       (ppTerm PrecApp tm <+> text ":" <+> ppTerm PrecApp tp)
     NatLit i ->
-      if i > 20 then
+      if i > 1000 then
         -- Explicitly convert from Z if an integer is too big
         parensIf (p > PrecLambda) (text "Z.to_nat" <+> integer i <> text "%Z")
       else

--- a/saw-core-coq/src/Language/Coq/Pretty.hs
+++ b/saw-core-coq/src/Language/Coq/Pretty.hs
@@ -133,7 +133,11 @@ ppTerm p e =
       parensIf (p > PrecLambda)
       (ppTerm PrecApp tm <+> text ":" <+> ppTerm PrecApp tp)
     NatLit i ->
-      integer i
+      if i > 20 then
+        -- Explicitly convert from Z if an integer is too big
+        parensIf (p > PrecLambda) (text "Z.to_nat" <+> integer i <> text "%Z")
+      else
+        integer i
     ZLit i ->
       -- we use hex unless our integer is a positive or negitive digit
       if abs i > 9  then let ui = toInteger (fromInteger i :: Word64)


### PR DESCRIPTION
Previously, the SAW-core-to-Coq translator would translate array literals to successive applications of the `Vector.cons` constructor, which is *really* slow for large arrays. This PR changes the translation of array literals to use `Vector.of_list` of Coq list literals, which seems to be much faster for large vectors.

Additionally, this PR changes the translation of natural number literals that are big enough (currently defined as greater than 20) to explicitly convert from the Coq integer notation rather than use the natural number notation. Note that Coq already does this anyway under the hood but prints a warning, so this change really just gets rid of the warning.