### PR TITLE
Heapster: freshen LLVM global names

### DIFF
--- a/heapster-saw/src/Verifier/SAW/Heapster/LLVMGlobalConst.hs
+++ b/heapster-saw/src/Verifier/SAW/Heapster/LLVMGlobalConst.hs
@@ -231,7 +231,9 @@ permEnvAddGlobalConst sc mod_name dlevel endianness w env global =
   case translateLLVMValueTop dlevel endianness w env global of
     Nothing -> return env
     Just (sh, t) ->
-      do let ident = mkSafeIdent mod_name $ show $ L.globalSym global
+      do ident <-
+           scFreshenGlobalIdent sc $
+           mkSafeIdent mod_name $ show $ L.globalSym global
          complete_t <- completeOpenTerm sc t
          tp <- completeOpenTermType sc t
          scInsertDef sc mod_name ident tp complete_t


### PR DESCRIPTION
This PR fixes a bug where LLVM globals with the same names (in different bitcode files) were causing name clashes. Now they are translated to SAW core definitions with fresh names.

To achieve this, this PR also adds a new operator `scFreshenGlobalIdent` to SharedTerm.hs.