### PR TITLE
Mergify: switch from strict mode to a merge queue

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,8 @@
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=mergify
+
 pull_request_rules:
   - name: Automatic merge on approval, CI, and ready-to-merge label
     conditions:
@@ -6,9 +11,9 @@ pull_request_rules:
       - label=ready-to-merge
     actions:
       update: {}
-      merge:
+      queue:
         method: merge
-        strict: smart+fasttrack
+        name: default
   - name: Delete head branch after merge
     conditions:
       - merged


### PR DESCRIPTION
Previously, we were using Mergify's `smart` mode to serialize the PRs that Mergify merges. This mode has been deprecated, however, and indeed, there is a `smart` mode brownout today to force Mergify users to switch over: https://blog.mergify.com/strict-mode-deprecation/ This PR does just that, based on the migration strategy suggested in that link.