### PR TITLE
Tweak the `solveUnsafeAssert` tactic

### DIFF
--- a/saw-core-coq/coq/handwritten/CryptolToCoq/CryptolPrimitivesForSAWCoreExtra.v
+++ b/saw-core-coq/coq/handwritten/CryptolToCoq/CryptolPrimitivesForSAWCoreExtra.v
@@ -67,6 +67,7 @@ Ltac unfoldLets :=
   end.
 
 Ltac solveUnsafeAssert :=
+  try reflexivity;
   try (unfoldLets;
        repeat (repeat solveUnsafeAssertStep; simpl; try reflexivity; try lia);
        trivial).


### PR DESCRIPTION
to optimize for the case where the values being coerced are actually convertible.
