### PR TITLE
Bump `s2n` commit in Dockerfile

### DIFF
--- a/s2nTests/docker/s2n.dockerfile
+++ b/s2nTests/docker/s2n.dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update -y -q && \
     llvm-3.9 \
     make \
     sudo \
+    wget \
     && \
     rm -rf /var/lib/apt/lists/*
 
@@ -19,7 +20,7 @@ RUN mkdir -p /saw-script && \
     git clone https://github.com/GaloisInc/s2n.git && \
     mkdir -p s2n/test-deps/saw/bin && \
     cd s2n && \
-    git checkout 6586f1ad3b35efcd2287ab98a4be124449dcb780
+    git checkout 7f1017ee9b09ab6910f1d2bf56135663ca0b12c5
 
 
 


### PR DESCRIPTION
This bumps the `s2n` commit to GaloisInc/s2n@7f1017ee9b09ab6910f1d2bf56135663ca0b12c5, which points to the `llvm_points_to_bitfield` changes that were merged into the upstream `s2n-tls` repo in aws/s2n-tls#3155.