### PR TITLE
Tactic tweaks

### DIFF
--- a/doc/manual/manual.md
+++ b/doc/manual/manual.md
@@ -1304,8 +1304,10 @@ development, or as a way to provide some evidence for the validity of a
 specification believed to be true but difficult or infeasible to prove.
 
 * `trivial : ProofScript ()` states that the current goal should
-be trivially true (i.e., the constant `True` or a function that
-immediately returns `True`). It fails if that is not the case.
+be trivially true. This tactic recognizes instances of equality
+that can be demonstrated by conversion alone. In particular
+it is able to prove `EqTrue x` goals where `x` reduces to
+the constant value `True`. It fails if this is not the case.
 
 ## Multiple Goals
 
@@ -1330,6 +1332,11 @@ variable in the current proof goal, returning the variable as a `Term`.
 
 * `goal_when : String -> ProofScript () -> ProofScript ()` will run the
 given proof script only when the goal name contains the given string.
+
+* `goal_exact : Term -> ProofScript ()` will attempt to use the given
+term as an exact proof for the current goal. This tactic will succeed
+whever the type of the given term exactly matches the current goal,
+and will fail otherwise.
 
 * `split_goal : ProofScript ()` will split a goal of the form
 `Prelude.and prop1 prop2` into two separate goals `prop1` and `prop2`.

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -629,6 +629,11 @@ goal_apply thm =
   do sc <- SV.scriptTopLevel getSharedContext
      execTactic (tacticApply sc thm)
 
+goal_exact :: TypedTerm -> ProofScript ()
+goal_exact tm =
+  do sc <- SV.scriptTopLevel getSharedContext
+     execTactic (tacticExact sc (ttTerm tm))
+
 goal_assume :: ProofScript Theorem
 goal_assume =
   do sc <- SV.scriptTopLevel getSharedContext

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1393,7 +1393,7 @@ primitives = Map.fromList
     , "rule, this will result in zero or more new subgoals."
     ]
 
-  , prim "goal_exact" "Term -> ProofScript ()"
+  , prim "goal_exact"          "Term -> ProofScript ()"
     (pureVal goal_exact)
     Experimental
     [ "Prove the current goal by giving an explicit proof term."
@@ -1666,7 +1666,11 @@ primitives = Map.fromList
   , prim "trivial"             "ProofScript ()"
     (pureVal trivial)
     Current
-    [ "Succeed only if the proof goal is a literal 'True'." ]
+    [ "Succeeds if the goal is trivial. This tactic recognizes goals"
+    , "that are instances of reflexivity, possibly with quantified variables."
+    , "In particular, it will prove goals of the form 'EqTrue x' when 'x' reduces"
+    , "to the constant value 'True'."
+    ]
 
   , prim "w4"                  "ProofScript ()"
     (pureVal w4_z3)

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1392,6 +1392,14 @@ primitives = Map.fromList
     [ "Apply an introduction rule to the current goal. Depending on the"
     , "rule, this will result in zero or more new subgoals."
     ]
+
+  , prim "goal_exact" "Term -> ProofScript ()"
+    (pureVal goal_exact)
+    Experimental
+    [ "Prove the current goal by giving an explicit proof term."
+    , "This will succeed if the type of the given term matches the current goal."
+    ]
+
   , prim "goal_assume"         "ProofScript Theorem"
     (pureVal goal_assume)
     Experimental

--- a/src/SAWScript/Proof.hs
+++ b/src/SAWScript/Proof.hs
@@ -145,7 +145,15 @@ termToProp sc tm =
       ty <- scTypeOf sc tm
       case evalSharedTerm mmap mempty mempty ty of
         TValue (VSort s) | s == propSort -> return (Prop tm)
-        _ -> fail $ unlines [ "termToProp: Term is not a proposition", showTerm tm, showTerm ty ]
+        _ ->
+          case asLambda tm of
+            Just _ ->
+              fail $ unlines [ "termToProp: Term is not a proposition."
+                             , "Note: the given term is a lambda; try using Pi terms instead."
+                             , showTerm tm, showTerm ty
+                             ]
+            Nothing ->
+              fail $ unlines [ "termToProp: Term is not a proposition", showTerm tm, showTerm ty ]
 
 
 -- | Turn a boolean-valued saw-core term into a proposition by asserting


### PR DESCRIPTION
Minor tactic improvements.  `trivial` can now prove more things (reflexive equalities up to conversion), and there is a new experimental `goal_exact` tactic that allows the user to directly provide a proof term, similar to the `core_thm` top-level command.

We also tweak the error message from `termToProp` to give a hint when the user has used lambdas instead of Pis to state a proposition.