### PR TITLE
Make `goal_eval_unint` handle functions with arguments of type `Nat`.

### DIFF
--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -1519,6 +1519,10 @@ mkArgTerm sc ty val =
       do x <- termOfTValue sc tval
          pure (ArgTermConst x)
 
+    (_, VNat n) ->
+      do x <- scNat sc n
+         pure (ArgTermConst x)
+
     _ -> fail $ "could not create uninterpreted function argument of type " ++ show ty
 
 termOfTValue :: SharedContext -> TValue (What4 sym) -> IO Term


### PR DESCRIPTION
We can now make functions like `take` and `drop` uninterpreted.

Fixes #1588.