### PR TITLE
Added support for SAW core bitvector notations

### DIFF
--- a/saw-core/saw-core.cabal
+++ b/saw-core/saw-core.cabal
@@ -26,7 +26,6 @@ library
   build-depends:
     base == 4.*,
     array,
-    bv-sized,
     bytestring,
     containers,
     data-inttrie,

--- a/saw-core/saw-core.cabal
+++ b/saw-core/saw-core.cabal
@@ -26,6 +26,7 @@ library
   build-depends:
     base == 4.*,
     array,
+    bv-sized,
     bytestring,
     containers,
     data-inttrie,

--- a/saw-core/src/Verifier/SAW/Grammar.y
+++ b/saw-core/src/Verifier/SAW/Grammar.y
@@ -80,6 +80,7 @@ import Verifier.SAW.Lexer
   'injectCode' { PosPair _ (TKey "injectCode") }
 
   nat      { PosPair _ (TNat _) }
+  bvlit    { PosPair _ (TBitvector _) }
   '_'      { PosPair _ (TIdent "_") }
   ident    { PosPair _ (TIdent _) }
   identrec { PosPair _ (TRecursor _) }
@@ -177,6 +178,7 @@ AppTerm : AtomTerm                 { $1 }
 AtomTerm :: { Term }
 AtomTerm
   : nat                          { NatLit (pos $1) (tokNat (val $1)) }
+  | bvlit                        { BVLit (pos $1) (tokBits (val $1)) }
   | string                       { StringLit (pos $1) (Text.pack (tokString (val $1))) }
   | Ident                        { Name $1 }
   | IdentRec                     { Recursor Nothing $1 }

--- a/saw-core/src/Verifier/SAW/Term/Pretty.hs
+++ b/saw-core/src/Verifier/SAW/Term/Pretty.hs
@@ -490,7 +490,9 @@ ppBitsToHex (b8:b4:b2:b1:bits') =
   ppBitsToHex bits'
   where toInt True = 1
         toInt False = 0
-ppBitsToHex _ = ""
+ppBitsToHex [] = ""
+ppBitsToHex bits =
+  panic "ppBitsToHex" ["length of bit list is not a multiple of 4", show bits]
 
 -- | Pretty-print a name, using the best unambiguous alias from the
 -- naming environment.

--- a/saw-core/src/Verifier/SAW/Term/Pretty.hs
+++ b/saw-core/src/Verifier/SAW/Term/Pretty.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE PatternGuards #-}
 
 {- |
 Module      : Verifier.SAW.Term.Pretty
@@ -40,6 +41,7 @@ module Verifier.SAW.Term.Pretty
   , ppName
   ) where
 
+import Data.Char (intToDigit)
 import Data.Maybe (isJust)
 import Control.Monad.Reader
 import Control.Monad.State.Strict as State
@@ -62,6 +64,7 @@ import qualified Data.IntMap.Strict as IntMap
 import Verifier.SAW.Name
 import Verifier.SAW.Term.Functor
 import Verifier.SAW.Utils (panic)
+import Verifier.SAW.Recognizer
 
 --------------------------------------------------------------------------------
 -- * Doc annotations
@@ -469,10 +472,25 @@ ppFlatTermF prec tf =
     RecordProj e fld -> ppProj fld <$> ppTerm' PrecArg e
     Sort s h -> return ((if h then pretty ("i"::String) else mempty) <> viaShow s)
     NatLit i -> ppNat <$> (ppOpts <$> ask) <*> return (toInteger i)
+    ArrayValue (asBoolType -> Just _) args
+      | Just bits <- mapM asBool $ V.toList args ->
+        if length bits `mod` 4 == 0 then
+          return $ pretty ("0x" ++ ppBitsToHex bits)
+        else
+          return $ pretty ("0b" ++ map (\b -> if b then '1' else '0') bits)
     ArrayValue _ args   ->
       ppArrayValue <$> mapM (ppTerm' PrecTerm) (V.toList args)
     StringLit s -> return $ viaShow s
     ExtCns cns -> annotate ExtCnsStyle <$> ppBestName (ecName cns)
+
+-- | Pretty-print a big endian list of bit values as a hexadecimal number
+ppBitsToHex :: [Bool] -> String
+ppBitsToHex (b8:b4:b2:b1:bits') =
+  intToDigit (8 * toInt b8 + 4 * toInt b4 + 2 * toInt b2 + toInt b1) :
+  ppBitsToHex bits'
+  where toInt True = 1
+        toInt False = 0
+ppBitsToHex _ = ""
 
 -- | Pretty-print a name, using the best unambiguous alias from the
 -- naming environment.

--- a/saw-core/src/Verifier/SAW/Typechecker.hs
+++ b/saw-core/src/Verifier/SAW/Typechecker.hs
@@ -278,6 +278,11 @@ typeInferCompleteTerm (Un.VecLit _ ts) =
      type_of_tp <- typeInfer tp
      typeInferComplete (ArrayValue (TypedTerm tp type_of_tp) $
                         V.fromList typed_ts)
+typeInferCompleteTerm (Un.BVLit _ []) = throwTCError EmptyVectorLit
+typeInferCompleteTerm (Un.BVLit _ bits) =
+  do tp <- liftTCM scBoolType
+     bit_tms <- mapM (liftTCM scBool) bits
+     typeInferComplete $ ArrayValue tp $ V.fromList bit_tms
 
 typeInferCompleteTerm (Un.BadTerm _) =
   -- Should be unreachable, since BadTerms represent parse errors, that should

--- a/saw-core/src/Verifier/SAW/UntypedAST.hs
+++ b/saw-core/src/Verifier/SAW/UntypedAST.hs
@@ -84,6 +84,8 @@ data Term
   | StringLit Pos Text
     -- | Vector literal.
   | VecLit Pos [Term]
+    -- | Bitvector literal.
+  | BVLit Pos [Bool]
   | BadTerm Pos
  deriving (Show, TH.Lift)
 
@@ -128,6 +130,7 @@ instance Positioned Term where
       NatLit p _           -> p
       StringLit p _        -> p
       VecLit p _           -> p
+      BVLit p _            -> p
       BadTerm p            -> p
 
 instance Positioned TermVar where


### PR DESCRIPTION
This change adds support for SAW core bitvector literals, written either in hexadecimal as `0xXXXX` where each `X` is a hex digit or in binary as `0bBBBBBBBB` where each `B` is either a 0 or a 1.