### PR TITLE
[MRSolver] Refactor MRM monad, add infrastructure for widening co-inductive hypotheses

### DIFF
--- a/src/SAWScript/Prover/MRSolver/Monad.hs
+++ b/src/SAWScript/Prover/MRSolver/Monad.hs
@@ -127,10 +127,10 @@ instance PrettyInCtx MRFailure where
   prettyInCtx (CoIndHypMismatchWidened nm1 nm2 _) =
     ppWithPrefixSep "[Internal] Trying to widen co-inductive hypothesis on:" nm1 "," nm2
   prettyInCtx (CoIndHypMismatchFailure (tm1, tm2) (tm1', tm2')) =
-    vsepM [return "Could not match co-inductive hypotheis:",
-           ppWithPrefixSep "" tm1' "|=" tm2',
-           return "with goal:",
-           ppWithPrefixSep "" tm1 "|=" tm2]
+    do pp <- ppWithPrefixSep "" tm1 "|=" tm2
+       pp' <- ppWithPrefixSep "" tm1' "|=" tm2'
+       return $ "Could not match co-inductive hypothesis:" <> pp' <> line <>
+                                              "with goal:" <> pp
   prettyInCtx (MRFailureLocalVar x err) =
     local (x:) $ prettyInCtx err
   prettyInCtx (MRFailureCtx ctx err) =

--- a/src/SAWScript/Prover/MRSolver/SMT.hs
+++ b/src/SAWScript/Prover/MRSolver/SMT.hs
@@ -162,7 +162,7 @@ normSMTProp t =
 -- FIXME: use the timeout!
 mrProvableRaw :: Term -> MRM Bool
 mrProvableRaw prop_term =
-  do sc <- mrSC <$> get
+  do sc <- mrSC <$> ask
      prop <- liftSC1 termToProp prop_term
      unints <- Set.map ecVarIndex <$> getAllExtSet <$> liftSC1 propToTerm prop
      debugPrint 2 ("Calling SMT solver with proposition: " ++

--- a/src/SAWScript/Prover/MRSolver/SMT.hs
+++ b/src/SAWScript/Prover/MRSolver/SMT.hs
@@ -262,16 +262,21 @@ mrProveEqSimple eqf t1 t2 =
      t2' <- mrSubstEVars t2
      TermInCtx [] <$> eqf t1' t2'
 
-
--- | Prove that two terms are equal, instantiating evars if necessary, or
--- throwing an error if this is not possible
-mrProveEq :: Term -> Term -> MRM ()
+-- | Prove that two terms are equal, instantiating evars if necessary,
+-- returning true on success
+mrProveEq :: Term -> Term -> MRM Bool
 mrProveEq t1 t2 =
   do mrDebugPPPrefixSep 1 "mrProveEq" t1 "==" t2
      tp <- mrTypeOf t1
      varmap <- mrVars <$> get
      cond_in_ctx <- mrProveEqH varmap tp t1 t2
-     success <- withTermInCtx cond_in_ctx mrProvable
+     withTermInCtx cond_in_ctx mrProvable
+
+-- | Prove that two terms are equal, instantiating evars if necessary, or
+-- throwing an error if this is not possible
+mrAssertProveEq :: Term -> Term -> MRM ()
+mrAssertProveEq t1 t2 =
+  do success <- mrProveEq t1 t2
      if success then return () else
        throwError (TermsNotEq t1 t2)
 

--- a/src/SAWScript/Prover/MRSolver/SMT.hs
+++ b/src/SAWScript/Prover/MRSolver/SMT.hs
@@ -180,7 +180,7 @@ mrProvableRaw prop_term =
 -- assumptions
 mrProvable :: Term -> MRM Bool
 mrProvable bool_tm =
-  do assumps <- mrAssumptions <$> get
+  do assumps <- mrAssumptions <$> ask
      prop <- liftSC2 scImplies assumps bool_tm >>= liftSC1 scEqTrue
      prop_inst <- flip instantiateUVarsM prop $ \nm tp ->
        liftSC1 scWhnf tp >>= \case

--- a/src/SAWScript/Prover/MRSolver/SMT.hs
+++ b/src/SAWScript/Prover/MRSolver/SMT.hs
@@ -17,7 +17,6 @@ namely 'mrProvable' and 'mrProveEq'.
 module SAWScript.Prover.MRSolver.SMT where
 
 import qualified Data.Vector as V
-import Control.Monad.Reader
 import Control.Monad.Except
 
 import Data.Map (Map)

--- a/src/SAWScript/Prover/MRSolver/SMT.hs
+++ b/src/SAWScript/Prover/MRSolver/SMT.hs
@@ -18,7 +18,6 @@ module SAWScript.Prover.MRSolver.SMT where
 
 import qualified Data.Vector as V
 import Control.Monad.Reader
-import Control.Monad.State
 import Control.Monad.Except
 
 import Data.Map (Map)
@@ -162,7 +161,7 @@ normSMTProp t =
 -- FIXME: use the timeout!
 mrProvableRaw :: Term -> MRM Bool
 mrProvableRaw prop_term =
-  do sc <- mrSC <$> ask
+  do sc <- mrSC
      prop <- liftSC1 termToProp prop_term
      unints <- Set.map ecVarIndex <$> getAllExtSet <$> liftSC1 propToTerm prop
      debugPrint 2 ("Calling SMT solver with proposition: " ++
@@ -180,7 +179,7 @@ mrProvableRaw prop_term =
 -- assumptions
 mrProvable :: Term -> MRM Bool
 mrProvable bool_tm =
-  do assumps <- mrAssumptions <$> ask
+  do assumps <- mrAssumptions
      prop <- liftSC2 scImplies assumps bool_tm >>= liftSC1 scEqTrue
      prop_inst <- flip instantiateUVarsM prop $ \nm tp ->
        liftSC1 scWhnf tp >>= \case
@@ -268,7 +267,7 @@ mrProveEq :: Term -> Term -> MRM Bool
 mrProveEq t1 t2 =
   do mrDebugPPPrefixSep 1 "mrProveEq" t1 "==" t2
      tp <- mrTypeOf t1
-     varmap <- mrVars <$> get
+     varmap <- mrVars
      cond_in_ctx <- mrProveEqH varmap tp t1 t2
      withTermInCtx cond_in_ctx mrProvable
 
@@ -348,7 +347,7 @@ mrProveEqH _ (asBVVecType -> Just (n, len, tp)) t1 t2 =
                                                         t1'', ix'', pf'']
      t2_prj <- liftSC2 scGlobalApply "Prelude.atBVVec" [n'', len'', tp'',
                                                         t2'', ix'', pf'']
-     var_map <- mrVars <$> get
+     var_map <- mrVars
      extTermInCtx [("eq_ix",ix_tp),("eq_pf",pf_tp)] <$>
        mrProveEqH var_map tp'' t1_prj t2_prj
 

--- a/src/SAWScript/Prover/MRSolver/Solver.hs
+++ b/src/SAWScript/Prover/MRSolver/Solver.hs
@@ -614,10 +614,10 @@ askMRSolver ::
 askMRSolver sc dlvl timeout t1 t2 =
   do tp1 <- scTypeOf sc t1 >>= scWhnf sc
      tp2 <- scTypeOf sc t2 >>= scWhnf sc
-     let init_info = MRInfo sc timeout dlvl Map.empty
      case asPiList tp1 of
        (uvar_ctx, asCompM -> Just _) ->
-         fmap (either Just (const Nothing)) $ runMRM init_info $
+         fmap (either Just (const Nothing)) $
+         runMRM sc timeout dlvl Map.empty $
          withUVars uvar_ctx $ \vars ->
          do tps_are_eq <- mrConvertible tp1 tp2
             if tps_are_eq then return () else

--- a/src/SAWScript/Prover/MRSolver/Solver.hs
+++ b/src/SAWScript/Prover/MRSolver/Solver.hs
@@ -602,10 +602,10 @@ askMRSolver ::
 askMRSolver sc dlvl timeout t1 t2 =
   do tp1 <- scTypeOf sc t1 >>= scWhnf sc
      tp2 <- scTypeOf sc t2 >>= scWhnf sc
-     init_st <- mkMRState sc Map.empty timeout dlvl
+     let init_info = MRInfo sc timeout dlvl Map.empty
      case asPiList tp1 of
        (uvar_ctx, asCompM -> Just _) ->
-         fmap (either Just (const Nothing)) $ runMRM init_st $
+         fmap (either Just (const Nothing)) $ runMRM init_info $
          withUVars uvar_ctx $ \vars ->
          do tps_are_eq <- mrConvertible tp1 tp2
             if tps_are_eq then return () else


### PR DESCRIPTION
This PR does some refactoring of the `MRM` monad with the main goal of adding the infrastructure for widening co-inductive hypotheses. The actual implementation of the widening algorithm will be in a future PR.