### PR TITLE
Mr Solver Widening

### DIFF
--- a/heapster-saw/examples/Makefile
+++ b/heapster-saw/examples/Makefile
@@ -1,4 +1,4 @@
-all: Makefile.coq
+all: Makefile.coq mr-solver-tests
 
 Makefile.coq: _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq
@@ -32,3 +32,12 @@ rust_data.bc: rust_data.rs
 
 rust_lifetimes.bc: rust_lifetimes.rs
 	rustc --crate-type=lib --emit=llvm-bc rust_lifetimes.rs
+
+# Lists all the Mr Solver tests, without their ".saw" suffix
+MR_SOLVER_TESTS = arrays_mr_solver
+
+.PHONY: mr-solver-tests $(MR_SOLVER_TESTS)
+mr-solver-tests: $(MR_SOLVER_TESTS)
+
+$(MR_SOLVER_TESTS):
+	$(SAW) $@.saw

--- a/heapster-saw/examples/arrays_mr_solver.saw
+++ b/heapster-saw/examples/arrays_mr_solver.saw
@@ -1,3 +1,19 @@
 include "arrays.saw";
+
+let eq_bool b1 b2 =
+  if b1 then
+    if b2 then true else false
+  else
+    if b2 then false else true;
+
+let fail = do { print "Test failed"; exit 1; };
+let run_test name test expected =
+  do { if expected then print (str_concat "Test: " name) else
+         print (str_concat (str_concat "Test: " name) " (expecting failure)");
+       actual <- test;
+       if eq_bool actual expected then print "Success\n" else
+         do { print "Test failed\n"; exit 1; }; };
+
+// Test that contains0 |= contains0
 contains0 <- parse_core_mod "arrays" "contains0";
-mr_solver_debug 1 contains0 contains0;
+run_test "contains0 |= contains0" (mr_solver contains0 contains0) true;

--- a/src/SAWScript/Prover/MRSolver/Monad.hs
+++ b/src/SAWScript/Prover/MRSolver/Monad.hs
@@ -185,6 +185,12 @@ data CoIndHyp = CoIndHyp {
   coIndHypRHS :: [Term]
 } deriving Show
 
+-- | Extract the @i@th argument on either the left- or right-hand side of a
+-- coinductive hypothesis
+coIndHypArg :: CoIndHyp -> Either Int Int -> Term
+coIndHypArg (CoIndHyp _ _ _ args1 _) (Left i) = args1 !! i
+coIndHypArg (CoIndHyp _ _ _ _ args2) (Right i) = args2 !! i
+
 -- | A map from pairs of function names to co-inductive hypotheses over those
 -- names
 type CoIndHyps = Map (FunName, FunName) CoIndHyp
@@ -434,7 +440,7 @@ mrTypeOf :: Term -> MRM Term
 mrTypeOf t =
   -- NOTE: scTypeOf' wants the type context in the most recently bound var
   -- first, i.e., in the mrUVarCtxRev order
-  mrUVarCtxRev >>= \ctx -> liftSC2 scTypeOf' (map snd $ reverse ctx) t
+  mrUVarCtxRev >>= \ctx -> liftSC2 scTypeOf' (map snd ctx) t
 
 -- | Check if two 'Term's are convertible in the 'MRM' monad
 mrConvertible :: Term -> Term -> MRM Bool

--- a/src/SAWScript/Prover/MRSolver/Solver.hs
+++ b/src/SAWScript/Prover/MRSolver/Solver.hs
@@ -342,6 +342,88 @@ handling the recursive ones
 
 
 ----------------------------------------------------------------------
+-- * Handling Coinductive Hypotheses
+----------------------------------------------------------------------
+
+-- | Run a compuation under the additional co-inductive assumption that
+-- @forall x1, ..., xn. F y1 ... ym |= G z1 ... zl@, where @F@ and @G@ are
+-- the given 'FunName's, @y1, ..., ym@ and @z1, ..., zl@ are the given
+-- argument lists, and @x1, ..., xn@ is the current context of uvars. If
+-- while running the given computation a 'CoIndHypMismatchWidened' error is
+-- reached with the given names, the state is restored and the computation is
+-- re-run with the widened hypothesis.
+withCoIndHyp :: FunName -> [Term] -> FunName -> [Term] -> MRM a -> MRM a
+withCoIndHyp f1 args1 f2 args2 m =
+  do ctx <- mrUVarCtx
+     withCoIndHyp' (CoIndHyp ctx f1 f2 args1 args2) m
+
+-- | The main loop of 'withCoIndHyp'
+withCoIndHyp' :: CoIndHyp -> MRM a -> MRM a
+withCoIndHyp' hyp m =
+  withCoIndHypRaw hyp m `catchError` \case
+  MRExnWiden nm1' nm2' new_vars
+    | coIndHypLHSFun hyp == nm1' && coIndHypRHSFun hyp == nm2' ->
+        -- NOTE: the state automatically gets reset here because we defined MRM
+        -- with ExceptT at a lower level than StateT
+        do mrDebugPPPrefixSep 1 "Widening recursive assumption for" nm1' "|=" nm2'
+           hyp' <- generalizeCoIndHyp hyp new_vars
+           withCoIndHyp' hyp' m
+  e -> throwError e
+
+
+-- | Test that a coinductive hypothesis for the given function names matches the
+-- given arguments, otherwise throw an exception saying that widening is needed
+matchCoIndHyp :: CoIndHyp -> [Term] -> [Term] -> MRM ()
+matchCoIndHyp hyp args1 args2 =
+  do (args1', args2') <- instantiateCoIndHyp hyp
+     eqs1 <- zipWithM mrProveEq args1' args1
+     eqs2 <- zipWithM mrProveEq args2' args2
+     if and (eqs1 ++ eqs2) then return () else
+       throwError $ MRExnWiden (coIndHypLHSFun hyp) (coIndHypRHSFun hyp)
+       (map Left (findIndices not eqs1) ++ map Right (findIndices not eqs1))
+
+-- | Generalize some of the arguments of a coinductive hypothesis
+generalizeCoIndHyp :: CoIndHyp -> [Either Int Int] -> MRM CoIndHyp
+generalizeCoIndHyp hyp [] = return hyp
+generalizeCoIndHyp hyp all_specs@(arg_spec:arg_specs) =
+  withOnlyUVars (coIndHypCtx hyp) $ do
+  mrDebugPPPrefixSep 2 "generalizeCoIndHyp" hyp "with arg specs" (show all_specs)
+  -- Get the arg and type associated with arg_spec
+  let arg = coIndHypArg hyp arg_spec
+  arg_tp <- mrTypeOf arg
+  ctx <- mrUVarCtx
+  debugPretty 2 ("Current context: " <> ppCtx ctx)
+  -- Sort out the other args that equal arg
+  eq_uneq_specs <- forM arg_specs $ \spec' ->
+    do let arg' = coIndHypArg hyp spec'
+       tp' <- mrTypeOf arg'
+       mrDebugPPPrefixSep 2 "generalizeCoIndHyp: the type of" arg' "is" tp'
+       debugPrint 2 ("arg' = " ++ show arg')
+       tps_eq <- mrConvertible arg_tp tp'
+       args_eq <- if tps_eq then mrProveEq arg arg' else return False
+       return $ if args_eq then Left spec' else Right spec'
+  let (eq_specs, uneq_specs) = partitionEithers eq_uneq_specs
+  -- Add a new variable of type arg_tp, set all eq_specs plus our original
+  -- arg_spec to it, and recurse
+  hyp' <- generalizeCoIndHypArgs hyp arg_tp (arg_spec:eq_specs)
+  generalizeCoIndHyp hyp' uneq_specs
+
+-- | Add a new variable of the given type to the context of a coinductive
+-- hypothesis and set the specified arguments to that new variable
+generalizeCoIndHypArgs :: CoIndHyp -> Term -> [Either Int Int] -> MRM CoIndHyp
+generalizeCoIndHypArgs (CoIndHyp ctx f1 f2 args1 args2) tp specs =
+  do let set_arg i args =
+           take i args ++ (Unshared $ LocalVar 0) : drop (i+1) args
+     let (specs1, specs2) = partitionEithers specs
+     -- NOTE: need to lift the arguments because we are adding a variable
+     args1' <- liftTermLike 0 1 args1
+     args2' <- liftTermLike 0 1 args2
+     let args1'' = foldr set_arg args1' specs1
+         args2'' = foldr set_arg args2' specs2
+     return $ CoIndHyp (ctx ++ [("z",tp)]) f1 f2 args1'' args2''
+
+
+----------------------------------------------------------------------
 -- * Mr Solver Himself (He Identifies as Male)
 ----------------------------------------------------------------------
 
@@ -598,85 +680,6 @@ mrRefinesFun f1 f2
        m2' <- applyNormCompFun f2' x
        mrRefines m1' m2'
 mrRefinesFun _ _ = error "mrRefinesFun: unreachable!"
-
-
--- | Run a compuation under the additional co-inductive assumption that
--- @forall x1, ..., xn. F y1 ... ym |= G z1 ... zl@, where @F@ and @G@ are
--- the given 'FunName's, @y1, ..., ym@ and @z1, ..., zl@ are the given
--- argument lists, and @x1, ..., xn@ is the current context of uvars. If
--- while running the given computation a 'CoIndHypMismatchWidened' error is
--- reached with the given names, the state is restored and the computation is
--- re-run with the widened hypothesis.
-withCoIndHyp :: FunName -> [Term] -> FunName -> [Term] -> MRM a -> MRM a
-withCoIndHyp f1 args1 f2 args2 m =
-  do ctx <- mrUVarCtx
-     withCoIndHyp' (CoIndHyp ctx f1 f2 args1 args2) m
-
--- | The main loop of 'withCoIndHyp'
-withCoIndHyp' :: CoIndHyp -> MRM a -> MRM a
-withCoIndHyp' hyp m =
-  withCoIndHypRaw hyp m `catchError` \case
-  MRExnWiden nm1' nm2' new_vars
-    | coIndHypLHSFun hyp == nm1' && coIndHypRHSFun hyp == nm2' ->
-        -- NOTE: the state automatically gets reset here because we defined MRM
-        -- with ExceptT at a lower level than StateT
-        do mrDebugPPPrefixSep 1 "Widening recursive assumption for" nm1' "|=" nm2'
-           hyp' <- generalizeCoIndHyp hyp new_vars
-           withCoIndHyp' hyp' m
-  e -> throwError e
-
-
--- | Test that a coinductive hypothesis for the given function names matches the
--- given arguments, otherwise throw an exception saying that widening is needed
-matchCoIndHyp :: CoIndHyp -> [Term] -> [Term] -> MRM ()
-matchCoIndHyp hyp args1 args2 =
-  do (args1', args2') <- instantiateCoIndHyp hyp
-     eqs1 <- zipWithM mrProveEq args1' args1
-     eqs2 <- zipWithM mrProveEq args2' args2
-     if and (eqs1 ++ eqs2) then return () else
-       throwError $ MRExnWiden (coIndHypLHSFun hyp) (coIndHypRHSFun hyp)
-       (map Left (findIndices not eqs1) ++ map Right (findIndices not eqs1))
-
-coIndHypArg :: CoIndHyp -> Either Int Int -> Term
-coIndHypArg (CoIndHyp _ _ _ args1 _) (Left i) = args1 !! i
-coIndHypArg (CoIndHyp _ _ _ _ args2) (Right i) = args2 !! i
-
-
--- | Generalize some of the arguments of a coinductive hypothesis
-generalizeCoIndHyp :: CoIndHyp -> [Either Int Int] -> MRM CoIndHyp
-generalizeCoIndHyp hyp [] = return hyp
-generalizeCoIndHyp hyp all_specs@(arg_spec:arg_specs) =
-  withOnlyUVars (coIndHypCtx hyp) $ do
-  mrDebugPPPrefixSep 2 "generalizeCoIndHyp" hyp "with arg specs" (show all_specs)
-  -- Get the arg and type associated with arg_spec
-  let arg = coIndHypArg hyp arg_spec
-  arg_tp <- mrTypeOf arg
-  -- Sort out the other args that equal arg
-  eq_uneq_specs <- forM arg_specs $ \spec' ->
-    do let arg' = coIndHypArg hyp spec'
-       tp' <- mrTypeOf arg'
-       tps_eq <- mrConvertible arg_tp tp'
-       args_eq <- if tps_eq then mrProveEq arg arg' else return False
-       return $ if args_eq then Left spec' else Right spec'
-  let (eq_specs, uneq_specs) = partitionEithers eq_uneq_specs
-  -- Add a new variable of type arg_tp, set all eq_specs plus our original
-  -- arg_spec to it, and recurse
-  hyp' <- generalizeCoIndHypArgs hyp arg_tp (arg_spec:eq_specs)
-  generalizeCoIndHyp hyp' uneq_specs
-
--- | Add a new variable of the given type to the context of a coinductive
--- hypothesis and set the specified arguments to that new variable
-generalizeCoIndHypArgs :: CoIndHyp -> Term -> [Either Int Int] -> MRM CoIndHyp
-generalizeCoIndHypArgs (CoIndHyp ctx f1 f2 args1 args2) tp specs =
-  do let set_arg i args =
-           take i args ++ (Unshared $ LocalVar 0) : drop (i+1) args
-     let (specs1, specs2) = partitionEithers specs
-     -- NOTE: need to lift the arguments because we are adding a variable
-     args1' <- liftTermLike 0 1 args1
-     args2' <- liftTermLike 0 1 args2
-     let args1'' = foldr set_arg args1' specs1
-         args2'' = foldr set_arg args2' specs2
-     return $ CoIndHyp (ctx ++ [("z",tp)]) f1 f2 args1'' args2''
 
 
 ----------------------------------------------------------------------

--- a/src/SAWScript/Prover/MRSolver/Solver.hs
+++ b/src/SAWScript/Prover/MRSolver/Solver.hs
@@ -122,7 +122,6 @@ import qualified Data.Map as Map
 import Verifier.SAW.Term.Functor
 import Verifier.SAW.SharedTerm
 import Verifier.SAW.Recognizer
-import Verifier.SAW.Term.Pretty
 
 import SAWScript.Prover.MRSolver.Term
 import SAWScript.Prover.MRSolver.Monad
@@ -613,8 +612,6 @@ withCoIndHyp f1 args1 f2 args2 m =
   do ctx <- mrUVarCtx
      withCoIndHyp' (CoIndHyp ctx f1 f2 args1 args2) m
 
--- | Test if a 'MRFailure' contains a widening
-
 -- | The main loop of 'withCoIndHyp'
 withCoIndHyp' :: CoIndHyp -> MRM a -> MRM a
 withCoIndHyp' hyp m =
@@ -627,6 +624,7 @@ withCoIndHyp' hyp m =
            hyp' <- generalizeCoIndHyp hyp new_vars
            withCoIndHyp' hyp' m
   e -> throwError e
+
 
 -- | Test that a coinductive hypothesis for the given function names matches the
 -- given arguments, otherwise throw an exception saying that widening is needed


### PR DESCRIPTION
This PR finishes adding support for widening to MR Solver, which is a process that iteratively generalizes the coinductive hypotheses used in proving one recursive function refines another