### PR TITLE
Mr Solver support for monadic Cryptol specs

### DIFF
--- a/cryptol-saw-core/saw/CryptolM.sawcore
+++ b/cryptol-saw-core/saw/CryptolM.sawcore
@@ -24,12 +24,20 @@ numAssertEqM n m =
 isFinite : Num -> Prop;
 isFinite = Num_rec (\ (_:Num) -> Prop) (\ (_:Nat) -> TrueProp) FalseProp;
 
+-- Check whether a Num is finite
+checkFinite : (n:Num) -> Maybe (isFinite n);
+checkFinite =
+  Num_rec (\ (n:Num) -> Maybe (isFinite n))
+          (\ (n:Nat) -> Just (isFinite (TCNum n)) (Refl Bool True))
+          (Nothing (isFinite TCInf));
+
 -- Assert that a Num is finite, or fail
 assertFiniteM : (n:Num) -> CompM (isFinite n);
-assertFiniteM =
-  Num_rec (\ (n:Num) -> CompM (isFinite n))
-          (\ (_:Nat) -> returnM TrueProp TrueI)
-          (errorM FalseProp "assertFiniteM: Num not finite");
+assertFiniteM n =
+  maybe (isFinite n) (CompM (isFinite n))
+        (errorM (isFinite n) "assertFiniteM: Num not finite")
+        (returnM (isFinite n))
+        (checkFinite n);
 
 -- Recurse over a Num known to be finite
 Num_rec_fin : (p: Num -> sort 1) -> ((n:Nat) -> p (TCNum n)) ->

--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -82,11 +82,13 @@ data Env = Env
   , envC :: Map C.Name C.Schema    -- ^ Cryptol type environment
   , envS :: [Term]                 -- ^ SAW-Core bound variable environment (for type checking)
   , envRefPrims :: Map C.PrimIdent C.Expr
+  , envPrims :: Map C.PrimIdent Term -- ^ Translations for other primitives
   , envPrimTypes :: Map C.PrimIdent Term -- ^ Translations for primitive types
   }
 
 emptyEnv :: Env
-emptyEnv = Env Map.empty Map.empty Map.empty Map.empty [] Map.empty Map.empty
+emptyEnv =
+  Env Map.empty Map.empty Map.empty Map.empty [] Map.empty Map.empty Map.empty
 
 liftTerm :: (Term, Int) -> (Term, Int)
 liftTerm (t, j) = (t, j + 1)
@@ -103,6 +105,7 @@ liftEnv env =
       , envC = envC env
       , envS = envS env
       , envRefPrims = envRefPrims env
+      , envPrims = envPrims env
       , envPrimTypes = envPrimTypes env
       }
 
@@ -267,7 +270,7 @@ importType sc env ty =
             C.TCAbstract (C.UserTC n _)
               | Just prim <- C.asPrim n
               , Just t <- Map.lookup prim (envPrimTypes env) ->
-                return t
+                scApplyAllBeta sc t =<< traverse go tyargs
               | True -> panic ("importType: unknown primitive type: " ++ show n) []
         C.PC pc ->
           case pc of
@@ -673,6 +676,9 @@ importPrimitive sc primOpts env n sch
          e <- importExpr sc env expr
          nmi <- importName n
          scConstant' sc nmi e t
+
+  -- lookup primitive in the extra primitive lookup table
+  | Just nm <- C.asPrim n, Just t <- Map.lookup nm (envPrims env) = return t
 
   -- Optionally, create an opaque constant representing the primitive
   -- if it doesn't match one of the ones we know about.

--- a/cryptol-saw-core/src/Verifier/SAW/CryptolEnv.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/CryptolEnv.hs
@@ -126,6 +126,7 @@ data CryptolEnv = CryptolEnv
   , eExtraTypes :: Map T.Name T.Schema  -- ^ Cryptol types for extra names in scope
   , eExtraTSyns :: Map T.Name T.TySyn   -- ^ Extra Cryptol type synonyms in scope
   , eTermEnv    :: Map T.Name Term      -- ^ SAWCore terms for *all* names in scope
+  , ePrims      :: Map C.PrimIdent Term -- ^ SAWCore terms for primitives
   , ePrimTypes  :: Map C.PrimIdent Term -- ^ SAWCore terms for primitive type names
   }
 
@@ -218,7 +219,8 @@ initCryptolEnv sc = do
     , eExtraTypes = Map.empty
     , eExtraTSyns = Map.empty
     , eTermEnv    = termEnv
-    , ePrimTypes   = Map.empty
+    , ePrims      = Map.empty
+    , ePrimTypes  = Map.empty
     }
 
 -- Parse -----------------------------------------------------------------------
@@ -299,6 +301,7 @@ mkCryEnv env =
      let cryEnv = C.emptyEnv
            { C.envE = fmap (\t -> (t, 0)) terms
            , C.envC = types'
+           , C.envPrims = ePrims env
            , C.envPrimTypes = ePrimTypes env
            }
      return cryEnv

--- a/cryptol-saw-core/src/Verifier/SAW/CryptolEnv.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/CryptolEnv.hs
@@ -126,6 +126,7 @@ data CryptolEnv = CryptolEnv
   , eExtraTypes :: Map T.Name T.Schema  -- ^ Cryptol types for extra names in scope
   , eExtraTSyns :: Map T.Name T.TySyn   -- ^ Extra Cryptol type synonyms in scope
   , eTermEnv    :: Map T.Name Term      -- ^ SAWCore terms for *all* names in scope
+  , ePrimTypes  :: Map C.PrimIdent Term -- ^ SAWCore terms for primitive type names
   }
 
 
@@ -217,6 +218,7 @@ initCryptolEnv sc = do
     , eExtraTypes = Map.empty
     , eExtraTSyns = Map.empty
     , eTermEnv    = termEnv
+    , ePrimTypes   = Map.empty
     }
 
 -- Parse -----------------------------------------------------------------------
@@ -297,6 +299,7 @@ mkCryEnv env =
      let cryEnv = C.emptyEnv
            { C.envE = fmap (\t -> (t, 0)) terms
            , C.envC = types'
+           , C.envPrimTypes = ePrimTypes env
            }
      return cryEnv
 

--- a/heapster-saw/examples/Either.cry
+++ b/heapster-saw/examples/Either.cry
@@ -1,0 +1,10 @@
+
+/* The definition of the Either type as an abstract type in Cryptol */
+
+module Either where
+
+primitive type Either : * -> * -> *
+
+primitive Left : {a, b} a -> Either a b
+primitive Right : {a, b} b -> Either a b
+primitive either : {a, b, c} (a -> c) -> (b -> c) -> Either a b -> c

--- a/heapster-saw/examples/either.saw
+++ b/heapster-saw/examples/either.saw
@@ -1,0 +1,15 @@
+/* Helper SAW script for defining the Either type in Cryptol */
+
+eith_tp <- parse_core "\\ (a b:sort 0) -> Either a b";
+cryptol_add_prim_type "Either" "Either" eith_tp;
+
+left_fun <- parse_core "\\ (a b:sort 0) (x:a) -> Left a b x";
+cryptol_add_prim "Either" "Left" left_fun;
+
+right_fun <- parse_core "\\ (a b:sort 0) (x:b) -> Right a b x";
+cryptol_add_prim "Either" "Right" right_fun;
+
+either_fun <- parse_core "either";
+cryptol_add_prim "Either" "either" either_fun;
+
+import "Either.cry";

--- a/heapster-saw/examples/linked_list.cry
+++ b/heapster-saw/examples/linked_list.cry
@@ -1,0 +1,14 @@
+
+module LinkedList where
+
+import Either
+
+primitive type List : * -> *
+
+primitive foldList : {a} Either () (a, List a) -> List a
+primitive unfoldList : {a} List a -> Either () (a, List a)
+
+is_elem_spec : [64] -> List [64] -> [64]
+is_elem_spec x l =
+  either (\ _ -> 0) (\ (y,l') -> if x == y then 1 else is_elem_spec x l')
+         (unfoldList l)

--- a/heapster-saw/examples/linked_list_mr_solver.saw
+++ b/heapster-saw/examples/linked_list_mr_solver.saw
@@ -1,5 +1,9 @@
 include "linked_list.saw";
 
+/***
+ *** Testing infrastructure
+ ***/
+
 let eq_bool b1 b2 =
   if b1 then
     if b2 then true else false
@@ -15,12 +19,37 @@ let run_test name test expected =
          do { print "Test failed\n"; exit 1; }; };
 
 
+/***
+ *** Setup Cryptol environment
+ ***/
+
+include "either.saw";
+
+list_tp <- parse_core "\\ (a:sort 0) -> List a";
+cryptol_add_prim_type "LinkedList" "List" list_tp;
+
+fold_fun <- parse_core "foldList";
+cryptol_add_prim "LinkedList" "foldList" fold_fun;
+
+unfold_fun <- parse_core "unfoldList";
+cryptol_add_prim "LinkedList" "unfoldList" unfold_fun;
+
+import "linked_list.cry";
+
+
+/***
+ *** The actual tests
+ ***/
+
 heapster_typecheck_fun env "is_head"
   "(). arg0:int64<>, arg1:List<int64<>,always,R> -o \
      \ arg0:true, arg1:true, ret:int64<>";
 
+/*
 is_head <- parse_core_mod "linked_list" "is_head";
 run_test "is_head |= is_head" (mr_solver is_head is_head) true;
+*/
 
 is_elem <- parse_core_mod "linked_list" "is_elem";
-run_test "is_elem |= is_elem" (mr_solver is_elem is_elem) true;
+run_test "is_elem |= is_elem_spec" (mr_solver_debug 2 is_elem {{ is_elem_spec }}) true;
+//run_test "is_elem |= is_elem" (mr_solver_debug 1 is_elem is_elem) true;

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -108,6 +108,8 @@ module Verifier.SAW.SharedTerm
     -- *** Functions and function application
   , scApply
   , scApplyAll
+  , scApplyBeta
+  , scApplyAllBeta
   , scGlobalApply
   , scFun
   , scFunAll
@@ -1282,6 +1284,17 @@ betaNormalize sc t0 =
 -- | Apply a function 'Term' to zero or more argument 'Term's.
 scApplyAll :: SharedContext -> Term -> [Term] -> IO Term
 scApplyAll sc = foldlM (scApply sc)
+
+-- | Apply a function to an argument, beta-reducing if the function is a lambda
+scApplyBeta :: SharedContext -> Term -> Term -> IO Term
+scApplyBeta sc (asLambda -> Just (_, _, body)) arg =
+  instantiateVar sc 0 arg body
+scApplyBeta sc f arg = scApply sc f arg
+
+-- | Apply a function 'Term' to zero or more arguments, beta reducing any time
+-- the function is a lambda
+scApplyAllBeta :: SharedContext -> Term -> [Term] -> IO Term
+scApplyAllBeta sc = foldlM (scApplyBeta sc)
 
 -- | Returns the defined constant with the given 'Ident'. Fails if no
 -- such constant exists in the module.

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -106,7 +106,8 @@ import qualified Cryptol.Backend.Monad as C (runEval)
 import qualified Cryptol.Eval.Type as C (evalType)
 import qualified Cryptol.Eval.Value as C (fromVBit, fromVWord)
 import qualified Cryptol.Eval.Concrete as C (Concrete(..), bvVal)
-import qualified Cryptol.Utils.Ident as C (mkIdent, packModName)
+import qualified Cryptol.Utils.Ident as C (mkIdent, packModName,
+                                           textToModName, PrimIdent(..))
 import qualified Cryptol.Utils.RecordMap as C (recordFromFields)
 
 import qualified SAWScript.SBVParser as SBV
@@ -1525,6 +1526,16 @@ cryptol_add_path path =
      let ce' = ce { CEnv.eModuleEnv = me' }
      let rw' = rw { rwCryptol = ce' }
      putTopLevelRW rw'
+
+cryptol_add_prim_type :: String -> String -> TypedTerm -> TopLevel ()
+cryptol_add_prim_type mnm nm tp =
+  do rw <- getTopLevelRW
+     let env = rwCryptol rw
+     let prim_name =
+           C.PrimIdent (C.textToModName $ Text.pack mnm) (Text.pack nm)
+     let env' = env { CEnv.ePrimTypes =
+                        Map.insert prim_name (ttTerm tp) (CEnv.ePrimTypes env) }
+     putTopLevelRW (rw { rwCryptol = env' })
 
 -- | Call 'Cryptol.importSchema' using a 'CEnv.CryptolEnv'
 importSchemaCEnv :: SharedContext -> CEnv.CryptolEnv -> Cryptol.Schema ->

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -1527,6 +1527,17 @@ cryptol_add_path path =
      let rw' = rw { rwCryptol = ce' }
      putTopLevelRW rw'
 
+cryptol_add_prim :: String -> String -> TypedTerm -> TopLevel ()
+cryptol_add_prim mnm nm trm =
+  do rw <- getTopLevelRW
+     let env = rwCryptol rw
+     let prim_name =
+           C.PrimIdent (C.textToModName $ Text.pack mnm) (Text.pack nm)
+     let env' =
+           env { CEnv.ePrims =
+                   Map.insert prim_name (ttTerm trm) (CEnv.ePrims env) }
+     putTopLevelRW (rw { rwCryptol = env' })
+
 cryptol_add_prim_type :: String -> String -> TypedTerm -> TopLevel ()
 cryptol_add_prim_type mnm nm tp =
   do rw <- getTopLevelRW

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1880,7 +1880,7 @@ primitives = Map.fromList
 
   , prim "cryptol_add_prim_type"    "String -> String -> Term -> TopLevel ()"
     (pureVal cryptol_add_prim_type)
-    Current
+    Experimental
     [ "cryptol_add_prim_type mod nm tp sets the translation of Cryptol"
     , "primitive type nm in module mod to tp"
     ]

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1878,6 +1878,13 @@ primitives = Map.fromList
     , "Cryptol source files."
     ]
 
+  , prim "cryptol_add_prim"    "String -> String -> Term -> TopLevel ()"
+    (pureVal cryptol_add_prim)
+    Experimental
+    [ "cryptol_add_prim mod nm trm sets the translation of Cryptol primitive"
+    , "nm in module mod to trm"
+    ]
+
   , prim "cryptol_add_prim_type"    "String -> String -> Term -> TopLevel ()"
     (pureVal cryptol_add_prim_type)
     Experimental

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1878,6 +1878,13 @@ primitives = Map.fromList
     , "Cryptol source files."
     ]
 
+  , prim "cryptol_add_prim_type"    "String -> String -> Term -> TopLevel ()"
+    (pureVal cryptol_add_prim_type)
+    Current
+    [ "cryptol_add_prim_type mod nm tp sets the translation of Cryptol"
+    , "primitive type nm in module mod to tp"
+    ]
+
   -- Java stuff
 
   , prim "java_bool"           "JavaType"

--- a/src/SAWScript/Prover/MRSolver/Monad.hs
+++ b/src/SAWScript/Prover/MRSolver/Monad.hs
@@ -448,7 +448,7 @@ funNameType (GlobalName gd projs) =
 
 -- | Apply a 'Term' to a list of arguments and beta-reduce in Mr. Monad
 mrApplyAll :: Term -> [Term] -> MRM Term
-mrApplyAll f args = liftSC2 scApplyAll f args >>= liftSC1 betaNormalize
+mrApplyAll f args = liftSC2 scApplyAllBeta f args
 
 -- | Get the current context of uvars as a list of variable names and their
 -- types as SAW core 'Term's, with the least recently bound uvar first, i.e., in

--- a/src/SAWScript/Prover/MRSolver/Monad.hs
+++ b/src/SAWScript/Prover/MRSolver/Monad.hs
@@ -229,12 +229,15 @@ instance PrettyInCtx CoIndHyp where
 
 -- | An assumption that something is equal to one of the constructors of a
 -- datatype, e.g. equal to @Left@ of some 'Term' or @Right@ of some 'Term'
-data DataTypeAssump = IsLeft Term | IsRight Term
-                    deriving (Generic, Show, TermLike)
+data DataTypeAssump
+  = IsLeft Term | IsRight Term | IsNum Term | IsInf
+  deriving (Generic, Show, TermLike)
 
 instance PrettyInCtx DataTypeAssump where
   prettyInCtx (IsLeft  x) = prettyInCtx x >>= ppWithPrefix "Left _ _" 
   prettyInCtx (IsRight x) = prettyInCtx x >>= ppWithPrefix "Right _ _"
+  prettyInCtx (IsNum   x) = prettyInCtx x >>= ppWithPrefix "TCNum"
+  prettyInCtx (IsRight x) = prettyInCtx x >>= ppWithPrefix "TCInf"
 
 -- | Recognize a term as a @Left@ or @Right@
 asEither :: Recognizer Term (Either Term Term)
@@ -242,6 +245,20 @@ asEither (asCtor -> Just (c, [_, _, x]))
   | primName c == "Prelude.Left"  = return $ Left x
   | primName c == "Prelude.Right" = return $ Right x
 asEither _ = Nothing
+
+-- | Recognize a term as a @TCNum n@ or @TCInf@
+asNum :: Recognizer Term (Either Term ())
+asNum (asCtor -> Just (c, [n]))
+  | primName c == "Cryptol.TCNum"  = return $ Left n
+asNum (asCtor -> Just (c, []))
+  | primName c == "Cryptol.TCInf"  = return $ Right ()
+asNum _ = Nothing
+
+-- | Recognize a term as being of the form @isFinite n@
+asIsFinite :: Recognizer Term Term
+asIsFinite (asApp -> Just (isGlobalDef "CryptolM.isFinite" -> Just (), n)) =
+  Just n
+asIsFinite _ = Nothing
 
 -- | A map from 'Term's to 'DataTypeAssump's over that term
 type DataTypeAssumps = HashMap Term DataTypeAssump
@@ -589,6 +606,13 @@ mrVarTerm (MRVar ec) =
   do var_tm <- liftSC1 scExtCns ec
      vars <- getAllUVarTerms
      liftSC2 scApplyAll var_tm vars
+
+-- | Create a dummy proof term of the specified type, which can be open but
+-- should be of @Prop@ sort, by creating an 'ExtCns' axiom. This is sound as
+-- long as we only use the resulting term in computation branches where we know
+-- the proposition holds.
+mrDummyProof :: Term -> MRM Term
+mrDummyProof tp = piUVarsM tp >>= mrFreshVar "pf" >>= mrVarTerm
 
 -- | Get the 'VarInfo' associated with a 'MRVar'
 mrVarInfo :: MRVar -> MRM (Maybe MRVarInfo)

--- a/src/SAWScript/Prover/MRSolver/Monad.hs
+++ b/src/SAWScript/Prover/MRSolver/Monad.hs
@@ -237,7 +237,7 @@ instance PrettyInCtx DataTypeAssump where
   prettyInCtx (IsLeft  x) = prettyInCtx x >>= ppWithPrefix "Left _ _" 
   prettyInCtx (IsRight x) = prettyInCtx x >>= ppWithPrefix "Right _ _"
   prettyInCtx (IsNum   x) = prettyInCtx x >>= ppWithPrefix "TCNum"
-  prettyInCtx (IsRight x) = prettyInCtx x >>= ppWithPrefix "TCInf"
+  prettyInCtx IsInf = return "TCInf"
 
 -- | Recognize a term as a @Left@ or @Right@
 asEither :: Recognizer Term (Either Term Term)

--- a/src/SAWScript/Prover/MRSolver/SMT.hs
+++ b/src/SAWScript/Prover/MRSolver/SMT.hs
@@ -124,7 +124,7 @@ primBVTermFun sc =
          scVectorReduced sc tp tms
     v -> lift (putStrLn ("primBVTermFun: unhandled value: " ++ show v)) >> mzero
 
--- | Implementations of primitives for normalizing SMT terms
+-- | Implementations of primitives for normalizing Mr Solver terms
 smtNormPrims :: SharedContext -> Map Ident TmPrim
 smtNormPrims sc = Map.fromList
   [
@@ -149,14 +149,28 @@ smtNormPrims sc = Map.fromList
                  scGlobalApply sc "Prelude.CompM" [tv_trm]))
   ]
 
--- | Normalize a 'Term' before building an SMT query for it
-normSMTProp :: Term -> MRM Term
-normSMTProp t =
+-- | Normalize a 'Term' using some Mr Solver specific primitives
+mrNormTerm :: Term -> MRM Term
+mrNormTerm t =
   debugPrint 2 "Normalizing term:" >>
   debugPrettyInCtx 2 t >>
   liftSC0 return >>= \sc ->
   liftSC0 scGetModuleMap >>= \modmap ->
   liftSC5 normalizeSharedTerm modmap (smtNormPrims sc) Map.empty Set.empty t
+
+-- | Normalize an open term by wrapping it in lambdas, normalizing, and then
+-- removing those lambdas
+mrNormOpenTerm :: Term -> MRM Term
+mrNormOpenTerm body =
+  do ctx <- mrUVarCtx
+     fun_term <- liftSC2 scLambdaList ctx body
+     normed_fun <- mrNormTerm fun_term
+     return (peel_lambdas (length ctx) normed_fun)
+       where
+         peel_lambdas :: Int -> Term -> Term
+         peel_lambdas 0 t = t
+         peel_lambdas i (asLambda -> Just (_, _, t)) = peel_lambdas (i-1) t
+         peel_lambdas _ _ = error "mrNormOpenTerm: unexpected non-lambda term!"
 
 
 ----------------------------------------------------------------------
@@ -192,7 +206,7 @@ mrProvable bool_tm =
   do assumps <- mrAssumptions
      prop <- liftSC2 scImplies assumps bool_tm >>= liftSC1 scEqTrue
      prop_inst <- instantiateUVarsM instUVar prop
-     normSMTProp prop_inst >>= mrProvableRaw
+     mrNormTerm prop_inst >>= mrProvableRaw
   where -- | Given a UVar name and type, generate a 'Term' to be passed to
         -- SMT, with special cases for BVVec and pair types
         instUVar :: LocalName -> Term -> MRM Term

--- a/src/SAWScript/Prover/MRSolver/Solver.hs
+++ b/src/SAWScript/Prover/MRSolver/Solver.hs
@@ -209,6 +209,8 @@ normComp (CompBind m f) =
 normComp (CompTerm t) =
   withFailureCtx (FailCtxMNF t) $
   case asApplyAll t of
+    (f@(asLambda -> Just _), args) ->
+      mrApplyAll f args >>= normCompTerm
     (isGlobalDef "Prelude.returnM" -> Just (), [_, x]) ->
       return $ ReturnM x
     (isGlobalDef "Prelude.bindM" -> Just (), [_, _, m, f]) ->


### PR DESCRIPTION
This PR makes it possible for Mr Solver to work on specifications extracted from Cryptol. This required the following changes:

* Added the `cryptol_add_prim` and `cryptol_add_prim_type` SAW script commands for specifying the translations of Cryptol primitives and primitive types, respectively
* Changed monadification to add a macro for the `either` elimination function;
* Changed monadification so that functions not in the macro table with semi-pure types get monadified to themselves;
* Changed the implementation of `assertFiniteM` in the `CryptolM` SAW core module to use a `Maybe` type;
* Added support to Mr Solver for maybe eliminators over isFinite proofs;
* Added the `mrNormOpenTerm` function to Mr Solver and changed Mr Solver to use it instead of `scWhnf` to normalize terms with data type assumptions; and
* Put all these pieces together in a new test in `linked_list_mr_solver.saw` that uses Mr Solver to prove that `is_elem` refines a cryptol version of its specification