### PR TITLE
Change saw-core tuple representation.

### DIFF
--- a/cryptol-saw-core/saw/Cryptol.sawcore
+++ b/cryptol-saw-core/saw/Cryptol.sawcore
@@ -21,11 +21,11 @@ bvExp n x y = foldr Bool (Vec n Bool) n
   (bvNat n 1)
   (reverse n Bool y);
 
-updFst : (a b : sort 0) -> (a -> a) -> (a * b) -> (a * b);
-updFst a b f x = (f x.(1), x.(2));
+updFst : (a b : sort 0) -> (a -> a) -> #(a, b) -> #(a, b);
+updFst a b f x = (f x.(0), x.(1));
 
-updSnd : (a b : sort 0) -> (b -> b) -> (a * b) -> (a * b);
-updSnd a b f x = (x.(1), f x.(2));
+updSnd : (a b : sort 0) -> (b -> b) -> #(a, b) -> #(a, b);
+updSnd a b f x = (x.(0), f x.(1));
 
 --------------------------------------------------------------------------------
 -- Extended natural numbers
@@ -282,23 +282,25 @@ fun_cong a b c d eq_ab eq_cd =
     (eq_cong (sort 0) a b eq_ab (sort 0) (\ (x:sort 0) -> (x -> c)))
     (eq_cong (sort 0) c d eq_cd (sort 0) (\ (x:sort 0) -> (b -> x)));
 
-pair_cong : (a : sort 0) -> (a' : sort 0) -> (b : sort 0) -> (b' : sort 0) ->
-  Eq (sort 0) a a' -> Eq (sort 0) b b' -> Eq (sort 0) (a * b) (a' * b');
+pair_cong :
+  (a : sort 0) -> (a' : sort 0) ->
+  (b : sort 0) -> (b' : sort 0) ->
+  Eq (sort 0) a a' -> Eq (sort 0) b b' -> Eq (sort 0) #(a, b) #(a', b');
 pair_cong a a' b b' eq_a eq_b =
   trans
-    (sort 0) (a * b) (a' * b) (a' * b')
-    (eq_cong (sort 0) a a' eq_a (sort 0) (\ (x:sort 0) -> (x * b)))
-    (eq_cong (sort 0) b b' eq_b (sort 0) (\ (x:sort 0) -> (a' * x)));
+    (sort 0) #(a, b) #(a', b) #(a', b')
+    (eq_cong (sort 0) a a' eq_a (sort 0) (\ (x:sort 0) -> #(x, b)))
+    (eq_cong (sort 0) b b' eq_b (sort 0) (\ (x:sort 0) -> #(a', x)));
 
 pair_cong1 : (a : sort 0) -> (a' : sort 0) -> (b : sort 0) ->
-  Eq (sort 0) a a' -> Eq (sort 0) (a * b) (a' * b);
+  Eq (sort 0) a a' -> Eq (sort 0) #(a, b) #(a', b);
 pair_cong1 a a' b eq_a =
-  (eq_cong (sort 0) a a' eq_a (sort 0) (\ (x:sort 0) -> (x * b)));
+  (eq_cong (sort 0) a a' eq_a (sort 0) (\ (x:sort 0) -> #(x, b)));
 
 pair_cong2 : (a : sort 0) -> (b : sort 0) -> (b' : sort 0) ->
-  Eq (sort 0) b b' -> Eq (sort 0) (a * b) (a * b');
+  Eq (sort 0) b b' -> Eq (sort 0) #(a, b) #(a, b');
 pair_cong2 a b b' eq_b =
-  (eq_cong (sort 0) b b' eq_b (sort 0) (\ (x:sort 0) -> (a * x)));
+  (eq_cong (sort 0) b b' eq_b (sort 0) (\ (x:sort 0) -> #(a, x)));
 
 axiom unsafeAssert_same_Num :
   (n : Num) -> Eq (Eq Num n n) (unsafeAssert Num n n) (Refl Num n);
@@ -316,105 +318,105 @@ eListSel a n =
 -- List comprehensions
 
 from : (a b : isort 0) -> (m n : Num) -> seq m a -> (a -> seq n b) ->
-        seq (tcMul m n) (a * b);
+        seq (tcMul m n) #(a, b);
 from a b m n =
   Num#rec
-    (\ (m:Num) -> seq m a -> (a -> seq n b) -> seq (tcMul m n) (a * b))
+    (\ (m:Num) -> seq m a -> (a -> seq n b) -> seq (tcMul m n) #(a, b))
     (\ (m:Nat) ->
        Num#rec
          (\ (n:Num) -> Vec m a -> (a -> seq n b) ->
-                        seq (tcMul (TCNum m) n) (a * b))
+                        seq (tcMul (TCNum m) n) #(a, b))
          -- Case 1: (TCNum m, TCNum n)
          (\ (n:Nat) ->
             \ (xs : Vec m a) ->
             \ (k : a -> Vec n b) ->
-              join m n (a * b)
-                   (map a (Vec n (a * b))
+              join m n #(a, b)
+                   (map a (Vec n #(a, b))
                         (\ (x : a) ->
-                           map b (a * b) (\ (y : b) -> (x, y)) n (k x))
+                           map b #(a, b) (\ (y : b) -> (x, y)) n (k x))
                         m xs))
          -- Case 2: n = (TCNum m, TCInf)
          (natCase
             (\ (m':Nat) -> (Vec m' a -> (a -> Stream b) ->
-               seq (if0Nat Num m' (TCNum 0) TCInf) (a * b)))
+               seq (if0Nat Num m' (TCNum 0) TCInf) #(a, b)))
             (\ (xs : Vec 0 a) ->
-             \ (k : a -> Stream b) -> EmptyVec (a * b))
+             \ (k : a -> Stream b) -> EmptyVec #(a, b))
             (\ (m' : Nat) ->
              \ (xs : Vec (Succ m') a) ->
              \ (k : a -> Stream b) ->
-               (\ (x : a) -> streamMap b (a * b) (\ (y:b) -> (x, y)) (k x))
+               (\ (x : a) -> streamMap b #(a, b) (\ (y:b) -> (x, y)) (k x))
                (at (Succ m') a xs 0))
             m)
          n)
     (Num#rec
-       (\ (n:Num) -> Stream a -> (a -> seq n b) -> seq (tcMul TCInf n) (a * b))
+       (\ (n:Num) -> Stream a -> (a -> seq n b) -> seq (tcMul TCInf n) #(a, b))
        -- Case 3: (TCInf, TCNum n)
        (\ (n:Nat) ->
           natCase
             (\ (n':Nat) -> (Stream a -> (a -> Vec n' b) ->
-                seq (if0Nat Num n' (TCNum 0) TCInf) (a * b)))
+                seq (if0Nat Num n' (TCNum 0) TCInf) #(a, b)))
             (\ (xs : Stream a) ->
-             \ (k : a -> Vec 0 b) -> EmptyVec (a * b))
+             \ (k : a -> Vec 0 b) -> EmptyVec #(a, b))
             (\ (n' : Nat) ->
              \ (xs : Stream a) ->
              \ (k : a -> Vec (Succ n') b) ->
                streamJoin
-                 (a * b) n'
+                 #(a, b) n'
                  (streamMap
-                    a (Vec (Succ n') (a * b))
+                    a (Vec (Succ n') #(a, b))
                     (\ (x:a) ->
-                       map b (a * b) (\ (y:b) -> (x, y)) (Succ n') (k x))
+                       map b #(a, b) (\ (y:b) -> (x, y)) (Succ n') (k x))
                     xs))
             n)
        -- Case 4: (TCInf, TCInf)
        (\ (xs : Stream a) ->
         \ (k : a -> Stream b) ->
-          (\ (x : a) -> streamMap b (a * b) (\ (y : b) -> (x, y)) (k x))
+          (\ (x : a) -> streamMap b #(a, b) (\ (y : b) -> (x, y)) (k x))
           (streamGet a xs 0))
        n)
     m;
 
 
-mlet : (a b : isort 0) -> (n : Num) -> a -> (a -> seq n b) -> seq n (a * b);
+mlet : (a b : isort 0) -> (n : Num) -> a -> (a -> seq n b) -> seq n #(a, b);
 mlet a b n =
   Num#rec
-    (\ (n:Num) -> a -> (a -> seq n b) -> seq n (a * b))
+    (\ (n:Num) -> a -> (a -> seq n b) -> seq n #(a, b))
     (\ (n:Nat) -> \ (x:a) -> \ (f:a -> Vec n b) ->
-       map b (a * b) (\ (y : b) -> (x, y)) n (f x))
+       map b #(a, b) (\ (y : b) -> (x, y)) n (f x))
     (\ (x:a) -> \ (f:a -> Stream b) ->
-       streamMap b (a * b) (\ (y : b) -> (x, y)) (f x))
+       streamMap b #(a, b) (\ (y : b) -> (x, y)) (f x))
     n;
 
 seqZip : (a b : isort 0) -> (m n : Num) -> seq m a -> seq n b ->
-          seq (tcMin m n) (a * b);
+          seq (tcMin m n) #(a, b);
 seqZip a b m n =
   Num#rec
-    (\ (m:Num) -> seq m a -> seq n b -> seq (tcMin m n) (a * b))
+    (\ (m:Num) -> seq m a -> seq n b -> seq (tcMin m n) #(a, b))
     (\ (m : Nat) ->
        Num#rec
-         (\ (n:Num) -> Vec m a -> seq n b -> seq (tcMin (TCNum m) n) (a * b))
+         (\ (n:Num) -> Vec m a -> seq n b -> seq (tcMin (TCNum m) n) #(a, b))
          (\ (n:Nat) -> zip a b m n)
          (\ (xs:Vec m a) -> \ (ys:Stream b) ->
-            gen m (a * b) (\ (i : Nat) -> (at m a xs i, streamGet b ys i)))
+            gen m #(a, b) (\ (i : Nat) -> (at m a xs i, streamGet b ys i)))
          n)
     (Num#rec
-       (\ (n:Num) -> Stream a -> seq n b -> seq (tcMin TCInf n) (a * b))
+       (\ (n:Num) -> Stream a -> seq n b -> seq (tcMin TCInf n) #(a, b))
        (\ (n:Nat) ->
         \ (xs:Stream a) -> \ (ys:Vec n b) ->
-          gen n (a * b) (\ (i : Nat) -> (streamGet a xs i, at n b ys i)))
-       (streamMap2 a b (a * b) (\ (x:a) -> \ (y:b) -> (x, y)))
+          gen n #(a, b) (\ (i : Nat) -> (streamGet a xs i, at n b ys i)))
+       (streamMap2 a b #(a, b) (\ (x:a) -> \ (y:b) -> (x, y)))
        n)
     m;
 
-zipSame : (a b : isort 0) -> (n : Nat) -> Vec n a -> Vec n b -> Vec n (a * b);
-zipSame a b n x y = gen n (a*b) (\ (i : Nat) -> (at n a x i, at n b y i));
+zipSame : (a b : isort 0) -> (n : Nat) -> Vec n a -> Vec n b -> Vec n #(a, b);
+zipSame a b n x y = gen n #(a, b) (\ (i : Nat) -> (at n a x i, at n b y i));
 
-seqZipSame : (a b : isort 0) -> (n : Num) -> seq n a -> seq n b -> seq n (a * b);
+seqZipSame : (a b : isort 0) -> (n : Num) -> seq n a -> seq n b -> seq n #(a, b);
 seqZipSame a b n =
   Num#rec
-    (\ (n : Num) -> seq n a -> seq n b -> seq n (a * b))
+    (\ (n : Num) -> seq n a -> seq n b -> seq n #(a, b))
     (\ (n : Nat) -> zipSame a b n)
-    (streamMap2 a b (a*b) (\ (x:a) -> \ (y:b) -> (x,y)))
+    (streamMap2 a b #(a, b) (\ (x:a) -> \ (y:b) -> (x,y)))
     n;
 
 --------------------------------------------------------------------------------
@@ -435,13 +437,27 @@ unitUnary _ = ();
 unitBinary : #() -> #() -> #();
 unitBinary _ _ = ();
 
-pairUnary : (a b : sort 0) -> (a -> a) -> (b -> b) -> (a * b) -> (a * b);
-pairUnary a b f g xy = (f (fst a b xy), g (snd a b xy));
+pairUnary :
+  (t : sort 0) ->
+  (ts : TypeList) ->
+  (t -> t) ->
+  (Tuple ts -> Tuple ts) ->
+  Tuple (TypeCons t ts) -> Tuple (TypeCons t ts);
+pairUnary t ts f g x =
+  consTuple t ts
+  (f (headTuple t ts x))
+  (g (tailTuple t ts x));
 
-pairBinary : (a b : sort 0) -> (a -> a -> a) -> (b -> b -> b)
-           -> (a * b) -> (a * b) -> (a * b);
-pairBinary a b f g x12 y12 = (f (fst a b x12) (fst a b y12),
-                              g (snd a b x12) (snd a b y12));
+pairBinary :
+  (t : sort 0) ->
+  (ts : TypeList) ->
+  (t -> t -> t) ->
+  (Tuple ts -> Tuple ts -> Tuple ts) ->
+  Tuple (TypeCons t ts) -> Tuple (TypeCons t ts) -> Tuple (TypeCons t ts);
+pairBinary t ts f g x y =
+  consTuple t ts
+  (f (headTuple t ts x) (headTuple t ts y))
+  (g (tailTuple t ts x) (tailTuple t ts y));
 
 funBinary : (a b : sort 0) -> (b -> b -> b) -> (a -> b) -> (a -> b) -> (a -> b);
 funBinary a b op f g x = op (f x) (g x);
@@ -497,16 +513,24 @@ unitLe _ _ = True;
 unitLt : #() -> #() -> Bool;
 unitLt _ _ = False;
 
-pairCmp : (a b : sort 0) -> (a -> a -> Bool -> Bool) -> (b -> b -> Bool -> Bool)
-        -> a * b -> a * b -> Bool -> Bool;
-pairCmp a b f g x12 y12 k =
-  f (fst a b x12) (fst a b y12) (g (snd a b x12) (snd a b y12) k);
+pairCmp :
+  (t : sort 0) ->
+  (ts : TypeList) ->
+  (t -> t -> Bool -> Bool) ->
+  (Tuple ts -> Tuple ts -> Bool -> Bool) ->
+  Tuple (TypeCons t ts) -> Tuple (TypeCons t ts) -> Bool -> Bool;
+pairCmp t ts f g x12 y12 k =
+  f (headTuple t ts x12) (headTuple t ts y12)
+    (g (tailTuple t ts x12) (tailTuple t ts y12) k);
 
 pairLt :
-  (a b : sort 0) -> (a -> a -> Bool -> Bool) -> (b -> b -> Bool) ->
-  a * b -> a * b -> Bool;
-pairLt a b f g x y =
-  f (fst a b x) (fst a b y) (g (snd a b x) (snd a b y));
+  (t : sort 0) ->
+  (ts : TypeList) ->
+  (t -> t -> Bool -> Bool) ->
+  (Tuple ts -> Tuple ts -> Bool) ->
+  Tuple (TypeCons t ts) -> Tuple (TypeCons t ts) -> Bool;
+pairLt t ts f g x y =
+  f (headTuple t ts x) (headTuple t ts y) (g (tailTuple t ts x) (tailTuple t ts y));
 
 --------------------------------------------------------------------------------
 -- Dictionaries and overloading
@@ -555,7 +579,7 @@ PEqSeqBool n =
 PEqUnit : PEq #();
 PEqUnit = { eq = \ (x y : #()) -> True };
 
-PEqPair : (a b : sort 0) -> PEq a -> PEq b -> PEq (a * b);
+PEqPair : (t : sort 0) -> (ts : TypeList) -> PEq t -> PEq (Tuple ts) -> PEq (Tuple (TypeCons t ts));
 PEqPair a b pa pb = { eq = pairEq a b pa.eq pb.eq };
 
 
@@ -607,7 +631,10 @@ PCmpSeqBool n =
 PCmpUnit : PCmp #();
 PCmpUnit = { cmpEq = PEqUnit, cmp = unitCmp, le = unitLe, lt = unitLt };
 
-PCmpPair : (a b : sort 0) -> PCmp a -> PCmp b -> PCmp (a * b);
+PCmpPair :
+  (t : sort 0) ->
+  (ts : TypeList) ->
+  PCmp t -> PCmp (Tuple ts) -> PCmp (Tuple (TypeCons t ts));
 PCmpPair a b pa pb =
   { cmpEq  = PEqPair a b pa.cmpEq pb.cmpEq
   , cmp = pairCmp a b pa.cmp pb.cmp
@@ -654,7 +681,12 @@ PSignedCmpSeqBool n =
 PSignedCmpUnit : PSignedCmp #();
 PSignedCmpUnit = { signedCmpEq = PEqUnit, scmp = unitCmp, sle = unitLe, slt = unitLt };
 
-PSignedCmpPair : (a b : sort 0) -> PSignedCmp a -> PSignedCmp b -> PSignedCmp (a * b);
+PSignedCmpPair :
+  (t : sort 0) ->
+  (ts : TypeList) ->
+  PSignedCmp t ->
+  PSignedCmp (Tuple ts) ->
+  PSignedCmp (Tuple (TypeCons t ts));
 PSignedCmpPair a b pa pb =
   { signedCmpEq = PEqPair a b pa.signedCmpEq pb.signedCmpEq
   , scmp = pairCmp a b pa.scmp pb.scmp
@@ -773,9 +805,12 @@ PLogicUnit =
   , not  = unitUnary
   };
 
-PLogicPair : (a b : sort 0) -> PLogic a -> PLogic b -> PLogic (a * b);
+PLogicPair :
+  (t : sort 0) ->
+  (ts : TypeList) ->
+  PLogic t -> PLogic (Tuple ts) -> PLogic (Tuple (TypeCons t ts));
 PLogicPair a b pa pb =
-  { logicZero = (pa.logicZero, pb.logicZero)
+  { logicZero = consTuple a b pa.logicZero pb.logicZero
   , and  = pairBinary a b pa.and pb.and
   , or   = pairBinary a b pa.or  pb.or
   , xor  = pairBinary a b pa.xor pb.xor
@@ -892,14 +927,17 @@ PRingUnit =
   , int = \ (i : Integer) -> ()
   };
 
-PRingPair : (a b : sort 0) -> PRing a -> PRing b -> PRing (a * b);
+PRingPair :
+  (t : sort 0) ->
+  (ts : TypeList) ->
+  PRing t -> PRing (Tuple ts) -> PRing (Tuple (TypeCons t ts));
 PRingPair a b pa pb =
-  { ringZero = (pa.ringZero, pb.ringZero)
+  { ringZero = consTuple a b pa.ringZero pb.ringZero
   , add = pairBinary a b pa.add pb.add
   , sub = pairBinary a b pa.sub pb.sub
   , mul = pairBinary a b pa.mul pb.mul
   , neg = pairUnary a b pa.neg pb.neg
-  , int = \ (i : Integer) -> (pa.int i, pb.int i)
+  , int = \ (i : Integer) -> consTuple a b (pa.int i) (pb.int i)
   };
 
 -- Integral class
@@ -1887,35 +1925,35 @@ processSHA2_512 n x =
 
 ec_double :
   (p : Num) ->
-  IntModNum p * IntModNum p * IntModNum p ->
-  IntModNum p * IntModNum p * IntModNum p;
+  #(IntModNum p, IntModNum p, IntModNum p) ->
+  #(IntModNum p, IntModNum p, IntModNum p);
 ec_double p x =
-  error (IntModNum p * IntModNum p * IntModNum p) "Unimplemented: ec_double";
+  error #(IntModNum p, IntModNum p, IntModNum p) "Unimplemented: ec_double";
 
 ec_add_nonzero :
   (p : Num) ->
-  IntModNum p * IntModNum p * IntModNum p ->
-  IntModNum p * IntModNum p * IntModNum p ->
-  IntModNum p * IntModNum p * IntModNum p;
+  #(IntModNum p, IntModNum p, IntModNum p) ->
+  #(IntModNum p, IntModNum p, IntModNum p) ->
+  #(IntModNum p, IntModNum p, IntModNum p);
 ec_add_nonzero p x y =
-  error (IntModNum p * IntModNum p * IntModNum p) "Unimplemented: ec_add_nonzero";
+  error #(IntModNum p, IntModNum p, IntModNum p) "Unimplemented: ec_add_nonzero";
 
 ec_mult :
   (p : Num) ->
   IntModNum p ->
-  IntModNum p * IntModNum p * IntModNum p ->
-  IntModNum p * IntModNum p * IntModNum p;
+  #(IntModNum p, IntModNum p, IntModNum p) ->
+  #(IntModNum p, IntModNum p, IntModNum p);
 ec_mult p x y =
-  error (IntModNum p * IntModNum p * IntModNum p) "Unimplemented: ec_mult";
+  error #(IntModNum p, IntModNum p, IntModNum p) "Unimplemented: ec_mult";
 
 ec_twin_mult :
   (p : Num) ->
   IntModNum p ->
-  IntModNum p * IntModNum p * IntModNum p ->
-  IntModNum p * IntModNum p * IntModNum p ->
-  IntModNum p * IntModNum p * IntModNum p;
+  #(IntModNum p, IntModNum p, IntModNum p) ->
+  #(IntModNum p, IntModNum p, IntModNum p) ->
+  #(IntModNum p, IntModNum p, IntModNum p);
 ec_twin_mult p x y z =
-  error (IntModNum p * IntModNum p * IntModNum p) "Unimplemented: ec_twin_mult";
+  error #(IntModNum p, IntModNum p, IntModNum p) "Unimplemented: ec_twin_mult";
 
 --------------------------------------------------------------------------------
 -- Rewrite rules

--- a/cryptol-saw-core/saw/CryptolM.sawcore
+++ b/cryptol-saw-core/saw/CryptolM.sawcore
@@ -122,23 +122,23 @@ eListSelM a =
 -- FIXME
 primitive
 fromM : (a b : sort 0) -> (m n : Num) -> mseq m a -> (a -> CompM (mseq n b)) ->
-        CompM (seq (tcMul m n) (a * b));
+        CompM (seq (tcMul m n) #(a, b));
 
 -- FIXME
 primitive
 mletM : (a b : sort 0) -> (n : Num) -> a -> (a -> CompM (mseq n b)) ->
-        CompM (mseq n (a * b));
+        CompM (mseq n #(a, b));
 
 -- FIXME
 primitive
 seqZipM : (a b : sort 0) -> (m n : Num) -> mseq m a -> mseq n b ->
-          CompM (mseq (tcMin m n) (a * b));
+          CompM (mseq (tcMin m n) #(a, b));
 {-
 seqZipM a b m n ms1 ms2 =
   seqMap
-    (CompM a * CompM b) (CompM (a * b)) (tcMin m n)
-    (\ (p : CompM a * CompM b) ->
-       bindM2 a b (a*b) p.(1) p.(2) (\ (x:a) (y:b) -> returnM (a*b) (x,y)))
+    #(CompM a, CompM b) (CompM #(a, b)) (tcMin m n)
+    (\ (p : #(CompM a, CompM b)) ->
+       bindM2 a b #(a, b) p.(0) p.(1) (\ (x:a) (y:b) -> returnM #(a, b) (x, y)))
     (seqZip (CompM a) (CompM b) m n ms1 ms2);
 -}
 

--- a/cryptol-saw-core/src/Verifier/SAW/TypedTerm.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/TypedTerm.hs
@@ -109,8 +109,8 @@ destTupleTypedTerm sc (TypedTerm tp t) =
     Nothing -> fail "asTupleTypedTerm: not a tuple type"
     Just ctys ->
       do let len = length ctys
-         let idxs = take len [1 ..]
-         ts <- traverse (\i -> scTupleSelector sc t i len) idxs
+         let idxs = take len [0..]
+         ts <- traverse (scTupleSelector sc t) idxs
          pure $ zipWith TypedTerm (map (TypedTermSchema . C.tMono) ctys) ts
 
 -- First order types and values ------------------------------------------------

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -129,11 +129,8 @@ flattenBValue (VWord lv) = return lv
 flattenBValue (VExtra (BStream _ _)) = error "Verifier.SAW.Simulator.BitBlast.flattenBValue: BStream"
 flattenBValue (VVector vv) =
   AIG.concat <$> traverse (flattenBValue <=< force) (V.toList vv)
-flattenBValue VUnit = return $ AIG.concat []
-flattenBValue (VPair x y) = do
-  vx <- flattenBValue =<< force x
-  vy <- flattenBValue =<< force y
-  return $ AIG.concat [vx, vy]
+flattenBValue (VTuple xs) =
+  AIG.concat <$> mapM (flattenBValue <=< force) (V.toList xs)
 flattenBValue (VRecordValue elems) = do
   AIG.concat <$> mapM (flattenBValue <=< force . snd) elems
 flattenBValue _ = error $ unwords ["Verifier.SAW.Simulator.BitBlast.flattenBValue: unsupported value"]

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -262,10 +262,8 @@ flattenSValue nm v = do
     Just w -> return ([w], "")
     Nothing ->
       case v of
-        VUnit                     -> return ([], "")
-        VPair x y                 -> do (xs, sx) <- flattenSValue nm =<< force x
-                                        (ys, sy) <- flattenSValue nm =<< force y
-                                        return (xs ++ ys, sx ++ sy)
+        VTuple (V.toList -> ts)   -> do (xss, ss) <- unzip <$> traverse (force >=> flattenSValue nm) ts
+                                        pure (concat xss, concat ss)
         VRecordValue elems        -> do (xss, sxs) <-
                                           unzip <$>
                                           mapM (flattenSValue nm <=< force . snd) elems
@@ -642,13 +640,10 @@ parseUninterpreted cws nm ty =
                   | i <- [0 .. n-1] ]
             return (VVector (V.fromList (map ready xs)))
 
-    VUnitType
-      -> return VUnit
-
-    (VPairType ty1 ty2)
-      -> do x1 <- parseUninterpreted cws (nm ++ ".L") ty1
-            x2 <- parseUninterpreted cws (nm ++ ".R") ty2
-            return (VPair (ready x1) (ready x2))
+    VTupleType tys
+      -> do let mkElem i ty' = parseUninterpreted cws (nm ++ "." ++ show i) ty'
+            xs <- V.imapM mkElem tys
+            pure (VTuple (fmap ready xs))
 
     (VRecordType elem_tps)
       -> (VRecordValue <$>
@@ -898,16 +893,11 @@ sbvSetOutput checkSz (FOTVec n t) (VVector xv) i = do
      Just ws -> do svCgOutputArr ("out_"++show i) ws
                    return $! i+1
      Nothing -> foldM (\i' x -> sbvSetOutput checkSz t x i') i xs
-sbvSetOutput _checkSz (FOTTuple []) VUnit i =
-   return i
-sbvSetOutput checkSz (FOTTuple [t]) v i = sbvSetOutput checkSz t v i
-sbvSetOutput checkSz (FOTTuple (t:ts)) (VPair l r) i = do
-   l' <- liftIO $ force l
-   r' <- liftIO $ force r
-   sbvSetOutput checkSz t l' i >>= sbvSetOutput checkSz (FOTTuple ts) r'
-
-sbvSetOutput _checkSz (FOTRec fs) VUnit i | Map.null fs = do
-   return i
+sbvSetOutput checkSz (FOTTuple ts) (VTuple xs) i =
+  do unless (length ts == V.length xs) $
+       fail "sbvCodeGen: vector length mismatch when setting output values"
+     vs <- liftIO $ traverse force xs
+     foldM (\i' (t, v) -> sbvSetOutput checkSz t v i') i (zip ts (V.toList vs))
 
 sbvSetOutput _checkSz (FOTRec fs) (VRecordValue []) i | Map.null fs = return i
 

--- a/saw-core/prelude/Prelude.sawcore
+++ b/saw-core/prelude/Prelude.sawcore
@@ -22,57 +22,43 @@ sawLet : (a b : sort 0) -> a -> (a -> b) -> b;
 sawLet _ _ x f = f x;
 
 
--- FIXME: below are some defined data-types that could be used in place of
--- the SAW primitive types
-
 --------------------------------------------------------------------------------
--- The Unit type
+-- Tuple types
 
-data UnitType : sort 0 where {
-    Unit : UnitType;
+-- TypeNil, TypeCons and Tuple are used to represent the #(a, b, c)
+-- syntax for tuple types, so it is important that they be defined
+-- before any uses of tuple types in this file.
+
+data TypeList : sort 1 where {
+    TypeNil : TypeList;
+    TypeCons : sort 0 -> TypeList -> TypeList;
   }
 
--- The recursor for the Unit type at sort 0
--- UnitType__rec : (p : UnitType -> sort 0) -> p Unit -> (u : UnitType) -> p u;
--- UnitType__rec p f1 u = UnitType#rec p f1 u;
-UnitType__rec (p : UnitType -> sort 0) (f1 : p Unit) (u : UnitType) : p u
-  = UnitType#rec p f1 u;
+TypeList__rec
+  (p : TypeList -> sort 1)
+  (f1 : p TypeNil)
+  (f2 : (t : sort 0) -> (ts : TypeList) -> p ts -> p (TypeCons t ts))
+  (ts : TypeList)
+  : p ts
+  = TypeList#rec p f1 f2 ts;
+
+primitive Tuple : TypeList -> sort 0;
+
+primitive headTuple : (t : sort 0) -> (ts : TypeList) -> Tuple (TypeCons t ts) -> t;
+primitive tailTuple : (t : sort 0) -> (ts : TypeList) -> Tuple (TypeCons t ts) -> Tuple ts;
+primitive consTuple : (t : sort 0) -> (ts : TypeList) -> t -> Tuple ts -> Tuple (TypeCons t ts);
 
 --------------------------------------------------------------------------------
 -- Pair types
 
-data PairType (a b : sort 0) : sort 0 where {
-  PairValue : a -> b -> PairType a b;
-}
+fst : (a b : sort 0) -> #(a, b) -> a;
+fst a b tup = tup.(0);
 
-pair_example : (a b : sort 0) -> a -> b -> PairType a b;
-pair_example a b x y = PairValue a b x y;
+snd : (a b : sort 0) -> #(a, b) -> b;
+snd a b tup = tup.(1);
 
--- The recursor for primitive pair types at sort 1
-Pair__rec
-  (a b : sort 0)
-  (p : PairType a b -> sort 0)
-  (f : (x:a) -> (y:b) -> p (PairValue a b x y))
-  (pair : PairType a b)
-  : p pair
-  = PairType#rec a b p f pair;
-
-Pair_fst : (a b : sort 0) -> PairType a b -> a;
-Pair_fst a b = Pair__rec a b (\ (p:PairType a b) -> a)
-                             (\ (x:a) -> \ (y: b) -> x);
-
-Pair_snd : (a b : sort 0) -> PairType a b -> b;
-Pair_snd a b = Pair__rec a b (\ (p:PairType a b) -> b)
-                             (\ (x:a) -> \ (y:b) -> y);
-
-fst : (a b : sort 0) -> a * b -> a;
-fst a b tup = tup.(1);
-
-snd : (a b : sort 0) -> a * b -> b;
-snd a b tup = tup.(2);
-
-uncurry (a b c : sort 0) (f : a -> b -> c) : a * b -> c
-  = (\ (x : a * b) -> f x.(1) x.(2));
+uncurry (a b c : sort 0) (f : a -> b -> c) : #(a, b) -> c
+  = (\ (x : #(a, b)) -> f x.(0) x.(1));
 
 --------------------------------------------------------------------------------
 -- String values
@@ -321,11 +307,19 @@ implies__eq a b = Refl Bool (implies a b);
 
 
 
-unitEq : UnitType -> UnitType -> Bool;
+unitEq : Tuple TypeNil -> Tuple TypeNil -> Bool;
 unitEq _ _ = True;
 
-pairEq : (a b : sort 0) -> (a -> a -> Bool) -> (b -> b -> Bool) -> a * b -> a * b -> Bool;
-pairEq a b f g x y = and ( f x.(1) y.(1) ) ( g x.(2) y.(2) );
+pairEq :
+  (t : sort 0) ->
+  (ts : TypeList) ->
+  (t -> t -> Bool) ->
+  (Tuple ts -> Tuple ts -> Bool) ->
+  Tuple (TypeCons t ts) -> Tuple (TypeCons t ts) -> Bool;
+pairEq t ts f g x y =
+  and
+  (f (headTuple t ts x) (headTuple t ts y))
+  (g (tailTuple t ts x) (tailTuple t ts y));
 
 
 --
@@ -878,13 +872,13 @@ expNat b e =
   Nat_cases Nat 1 (\ (e':Nat) -> \ (exp_b_e:Nat) -> mulNat b exp_b_e) e;
 
 -- | Natural division and modulus
-primitive divModNat : Nat -> Nat -> Nat * Nat;
+primitive divModNat : Nat -> Nat -> #(Nat, Nat);
 
 divNat : Nat -> Nat -> Nat;
-divNat x y = (divModNat x y).(1);
+divNat x y = (divModNat x y).(0);
 
 modNat : Nat -> Nat -> Nat;
-modNat x y = (divModNat x y).(2);
+modNat x y = (divModNat x y).(1);
 
 -- There are implicit constructors from integer literals.
 
@@ -972,7 +966,7 @@ single = replicate 1;
 axiom at_single : (a : sort 0) -> (x : a) -> (i : Nat) -> Eq a (at 1 a (single a x) i) x;
 
 -- Zip together two lists (truncating the longer of the two).
-primitive zip : (a b : sort 0) -> (m n : Nat) -> Vec m a -> Vec n b -> Vec (minNat m n) (a * b);
+primitive zip : (a b : sort 0) -> (m n : Nat) -> Vec m a -> Vec n b -> Vec (minNat m n) #(a, b);
 
 primitive foldr : (a b : sort 0) -> (n : Nat) -> (a -> b -> b) -> b -> Vec n a -> b;
 primitive foldl : (a b : sort 0) -> (n : Nat) -> (b -> a -> b) -> b -> Vec n a -> b;
@@ -1149,7 +1143,7 @@ bvCarry n x y = bvult n (bvAdd n x y) x;
 bvSCarry : (n : Nat) -> Vec (Succ n) Bool -> Vec (Succ n) Bool -> Bool;
 bvSCarry n x y = and (boolEq (msb n x) (msb n y)) (xor (msb n x) (msb n (bvAdd (Succ n) x y)));
 
-bvAddWithCarry : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool * Vec n Bool;
+bvAddWithCarry : (n : Nat) -> Vec n Bool -> Vec n Bool -> #(Bool, Vec n Bool);
 bvAddWithCarry n x y = (bvCarry n x y, bvAdd n x y);
 
 axiom bvAddZeroL : (n : Nat) -> (x : Vec n Bool) -> Eq (Vec n Bool) (bvAdd n (bvNat n 0) x) x;
@@ -1497,20 +1491,20 @@ List__rec :
   (l : List a) -> P l;
 List__rec a P f1 f2 l = List#rec a P f1 f2 l;
 
-unfoldList : (a:sort 0) -> List a -> Either #() (a * List a);
+unfoldList : (a:sort 0) -> List a -> Either #() #(a, List a);
 unfoldList a l =
-  List__rec a (\ (_:List a) -> Either #() (a * List a))
-  (Left #() (a * List a) ())
-  (\ (x:a) (l:List a) (_:Either #() (a * List a)) ->
-     Right #() (a * List a) (x, l))
+  List__rec a (\ (_:List a) -> Either #() #(a, List a))
+  (Left #() #(a, List a) ())
+  (\ (x:a) (l:List a) (_:Either #() #(a, List a)) ->
+     Right #() #(a, List a) (x, l))
   l;
 
-foldList : (a:sort 0) -> Either #() (a * List a) -> List a;
+foldList : (a:sort 0) -> Either #() #(a, List a) -> List a;
 foldList a =
-  either #() (a * List a) (List a)
+  either #() #(a, List a) (List a)
          (\ (_ : #()) -> Nil a)
-         (\ (tup : (a * List a)) ->
-            Cons a tup.(1) tup.(2));
+         (\ (tup : #(a, List a)) ->
+            Cons a tup.(0) tup.(1));
 
 -- A list of types, i.e. `List (sort 0)` if `List` was universe polymorphic
 data ListSort : sort 1
@@ -1550,29 +1544,27 @@ data W64List : sort 0 where {
 
 unfoldedW64List : sort 0;
 unfoldedW64List =
-  Either #()
-  (Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()) * W64List * #());
+  Either #() #(Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()), W64List);
 
 unfoldW64List : W64List -> unfoldedW64List;
 unfoldW64List l =
   W64List#rec (\ (_:W64List) -> unfoldedW64List)
-  (Left #() (Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()) * W64List * #()) ())
+  (Left #() #(Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()), W64List) ())
   (\ (bv:Vec 64 Bool) (l':W64List) (_:unfoldedW64List) ->
-     Right #() (Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()) * W64List * #())
+     Right #() #(Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()), W64List)
                (exists (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()) bv (),
-                l', ()))
+                l'))
   l;
 
 foldW64List : unfoldedW64List -> W64List;
 foldW64List =
-  either #() (Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()) * W64List * #())
+  either #() #(Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()), W64List)
          W64List
          (\ (_:#()) -> W64Nil)
-         (\ (bv_l:(Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #())
-                   * W64List * #())) ->
+         (\ (bv_l : #(Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()), W64List)) ->
             W64Cons (Sigma_proj1 (Vec 64 Bool)
-                                 (\ (_:Vec 64 Bool) -> #()) bv_l.(1))
-                    bv_l.(2).(1));
+                                 (\ (_:Vec 64 Bool) -> #()) bv_l.(0))
+                    bv_l.(1));
 
 
 --------------------------------------------------------------------------------
@@ -1962,7 +1954,7 @@ UnfoldedIRT As Ds D = IRTDesc__rec As (\ (_:IRTDesc As) -> IRTSubsts As -> sort 
       Either (recl Ds) (recr Ds))
   (\ (_:IRTDesc As) (recl : IRTSubsts As -> sort 0)
      (_:IRTDesc As) (recr : IRTSubsts As -> sort 0) (Ds:IRTSubsts As) ->
-      recl Ds * recr Ds)
+      #(recl Ds, recr Ds))
   (\ (i:Nat) (_ : listSortGet As i -> IRTDesc As)
      (recf : listSortGet As i -> IRTSubsts As -> sort 0) (Ds:IRTSubsts As) ->
       Sigma (listSortGet As i) (\ (a:listSortGet As i) -> recf a Ds))
@@ -2018,7 +2010,7 @@ foldIRT As Ds D = IRTDesc__rec As (\ (D:IRTDesc As) -> (Ds:IRTSubsts As) -> Unfo
              (\ (xr:UnfoldedIRT As Ds Dr) -> IRT_Right As Ds Dl Dr (recr Ds xr)) x)
   (\ (Dl:IRTDesc As) (recl : (Ds:IRTSubsts As) -> UnfoldedIRT As Ds Dl -> IRT As Ds Dl)
      (Dr:IRTDesc As) (recr : (Ds:IRTSubsts As) -> UnfoldedIRT As Ds Dr -> IRT As Ds Dr)
-     (Ds:IRTSubsts As) (x:UnfoldedIRT As Ds Dl * UnfoldedIRT As Ds Dr) ->
+     (Ds:IRTSubsts As) (x : #(UnfoldedIRT As Ds Dl, UnfoldedIRT As Ds Dr)) ->
       uncurry (UnfoldedIRT As Ds Dl) (UnfoldedIRT As Ds Dr) (IRT As Ds (IRT_prod As Dl Dr))
               (\ (xl:UnfoldedIRT As Ds Dl) (xr:UnfoldedIRT As Ds Dr) ->
                   IRT_pair As Ds Dl Dr (recl Ds xl) (recr Ds xr)) x)
@@ -2093,15 +2085,15 @@ composeM : (a b c: sort 0) -> (a -> CompM b) -> (b -> CompM c) -> a -> CompM c;
 composeM a b c f g x = bindM b c (f x) g;
 
 -- Tuple a type onto the input and output types of a monadic function
-tupleCompMFunBoth : (a b c: sort 0) -> (a -> CompM b) -> (c * a -> CompM (c * b));
+tupleCompMFunBoth : (a b c: sort 0) -> (a -> CompM b) -> #(c, a) -> CompM #(c, b);
 tupleCompMFunBoth a b c f =
-  \ (x:c * a) ->
-    bindM b (c * b) (f x.(2)) (\ (y:b) -> returnM (c*b) (x.(1), y));
+  \ (x : #(c, a)) ->
+    bindM b #(c, b) (f x.(1)) (\ (y:b) -> returnM #(c, b) (x.(0), y));
 
 -- Tuple a valu onto the output of a monadic function
-tupleCompMFunOut : (a b c: sort 0) -> c -> (a -> CompM b) -> (a -> CompM (c * b));
+tupleCompMFunOut : (a b c: sort 0) -> c -> (a -> CompM b) -> (a -> CompM #(c, b));
 tupleCompMFunOut a b c x f =
-  \ (y:a) -> bindM b (c*b) (f y) (\ (z:b) -> returnM (c*b) (x,z));
+  \ (y:a) -> bindM b #(c, b) (f y) (\ (z:b) -> returnM #(c, b) (x, z));
 
 -- Map a monadic function across a vector
 mapM : (a :sort 0) -> (b : isort 0) -> (a -> CompM b) -> (n : Nat) -> Vec n a -> CompM (Vec n b);
@@ -2462,7 +2454,7 @@ multiFixM : (lrts:LetRecTypes) -> lrtPi lrts (lrtTupleType lrts) ->
 multiArgFixM : (lrt:LetRecType) -> (lrtToType lrt -> lrtToType lrt) ->
                lrtToType lrt;
 multiArgFixM lrt F =
-  (multiFixM (LRT_Cons lrt LRT_Nil) (\ (f:lrtToType lrt) -> (F f, ()))).(1);
+  (multiFixM (LRT_Cons lrt LRT_Nil) (\ (f:lrtToType lrt) -> (F f, ()))).(0);
 
 
 -- Test computations

--- a/saw-core/src/Verifier/SAW/Conversion.hs
+++ b/saw-core/src/Verifier/SAW/Conversion.hs
@@ -391,14 +391,13 @@ pureApp mx y = do
   mkTermF (App x y)
 
 mkTuple :: [TermBuilder Term] -> TermBuilder Term
-mkTuple []       = mkTermF (FTermF UnitValue)
-mkTuple (t : ts) = mkTermF . FTermF =<< (PairValue <$> t <*> mkTuple ts)
+mkTuple ts = mkTermF . FTermF . TupleValue . V.fromList =<< sequence ts
 
+-- | Zero-indexed tuple field selection.
 mkTupleSelector :: Int -> Term -> TermBuilder Term
 mkTupleSelector i t
-  | i == 1 = mkTermF (FTermF (PairLeft t))
-  | i > 1  = mkTermF (FTermF (PairRight t)) >>= mkTupleSelector (i - 1)
-  | otherwise = panic "Verifier.SAW.Conversion.mkTupleSelector" ["non-positive index:", show i]
+  | i < 0 = panic "Verifier.SAW.Conversion.mkTupleSelector" ["non-positive index:", show i]
+  | otherwise = mkTermF (FTermF (TupleSelector t i))
 
 mkCtor :: PrimName Term -> [TermBuilder Term] -> [TermBuilder Term] -> TermBuilder Term
 mkCtor i paramsB argsB =

--- a/saw-core/src/Verifier/SAW/Grammar.y
+++ b/saw-core/src/Verifier/SAW/Grammar.y
@@ -157,18 +157,12 @@ Term : LTerm { $1 }
 
 -- Term with uses of pi and lambda, but no type ascriptions
 LTerm :: { Term }
-LTerm : ProdTerm                         { $1 }
+LTerm : AppTerm                          { $1 }
       | PiArg '->' LTerm                 { Pi (pos $2) $1 $3 }
       | '\\' VarCtx '->' LTerm           { Lambda (pos $1) $2 $4 }
 
 PiArg :: { [(TermVar, Term)] }
-PiArg : ProdTerm { mkPiArg $1 }
-
--- Term formed from infix product type operator (right-associative)
-ProdTerm :: { Term }
-ProdTerm
-  : AppTerm                        { $1 }
-  | AppTerm '*' ProdTerm           { PairType (pos $1) $1 $3 }
+PiArg : AppTerm { mkPiArg $1 }
 
 -- Term formed from applications of atomic expressions
 AppTerm :: { Term }
@@ -193,7 +187,7 @@ AtomTerm
   |     '[' sepBy(Term, ',') ']'       { VecLit (pos $1) $2 }
   |     '{' sepBy(FieldValue, ',') '}' { RecordValue (pos $1) $2 }
   | '#' '{' sepBy(FieldType, ',') '}'  { RecordType  (pos $1) $3 }
-  | AtomTerm '.' '(' nat ')'           {% mkTupleProj $1 (tokNat (val $4)) }
+  | AtomTerm '.' '(' nat ')'           { mkTupleSelector $1 (tokNat (val $4)) }
 
 Ident :: { PosPair Text }
 Ident : ident { fmap (Text.pack . tokIdent) $1 }
@@ -335,14 +329,6 @@ mkPiArg :: Term -> [(TermVar, Term)]
 mkPiArg (TypeConstraint (exprAsIdentList -> Just xs) _ t) =
   map (\x -> (x, t)) xs
 mkPiArg lhs = [(UnusedVar (pos lhs), lhs)]
-
--- | Parse a tuple projection of the form @t.(1)@ or @t.(2)@
-mkTupleProj :: Term -> Natural -> Parser Term
-mkTupleProj t 1 = return $ PairLeft t
-mkTupleProj t 2 = return $ PairRight t
-mkTupleProj t _ =
-  do addParseError (pos t) "Projections must be either .(1) or .(2)"
-     return (badTerm (pos t))
 
 -- | Parse a term as a dotted list of strings
 parseModuleName :: Term -> Maybe [Text]

--- a/saw-core/src/Verifier/SAW/OpenTerm.hs
+++ b/saw-core/src/Verifier/SAW/OpenTerm.hs
@@ -28,9 +28,7 @@ module Verifier.SAW.OpenTerm (
   stringLitOpenTerm, stringTypeOpenTerm,
   trueOpenTerm, falseOpenTerm, boolOpenTerm, boolTypeOpenTerm,
   arrayValueOpenTerm, vectorTypeOpenTerm, bvLitOpenTerm, bvTypeOpenTerm,
-  pairOpenTerm, pairTypeOpenTerm, pairLeftOpenTerm, pairRightOpenTerm,
   tupleOpenTerm, tupleTypeOpenTerm, projTupleOpenTerm,
-  tupleOpenTerm', tupleTypeOpenTerm',
   recordOpenTerm, recordTypeOpenTerm, projRecordOpenTerm,
   ctorOpenTerm, dataTypeOpenTerm, globalOpenTerm, extCnsOpenTerm,
   applyOpenTerm, applyOpenTermMulti, applyGlobalOpenTerm,
@@ -139,11 +137,11 @@ natOpenTerm = flatOpenTerm . NatLit
 
 -- | The 'OpenTerm' for the unit value
 unitOpenTerm :: OpenTerm
-unitOpenTerm = flatOpenTerm UnitValue
+unitOpenTerm = tupleOpenTerm []
 
 -- | The 'OpenTerm' for the unit type
 unitTypeOpenTerm :: OpenTerm
-unitTypeOpenTerm = flatOpenTerm UnitType
+unitTypeOpenTerm = tupleTypeOpenTerm []
 
 -- | Build a SAW core string literal.
 stringLitOpenTerm :: Text -> OpenTerm
@@ -190,45 +188,23 @@ bvTypeOpenTerm n =
   applyOpenTermMulti (globalOpenTerm "Prelude.Vec")
   [natOpenTerm (fromIntegral n), boolTypeOpenTerm]
 
--- | Build an 'OpenTerm' for a pair
-pairOpenTerm :: OpenTerm -> OpenTerm -> OpenTerm
-pairOpenTerm t1 t2 = flatOpenTerm $ PairValue t1 t2
-
--- | Build an 'OpenTerm' for a pair type
-pairTypeOpenTerm :: OpenTerm -> OpenTerm -> OpenTerm
-pairTypeOpenTerm t1 t2 = flatOpenTerm $ PairType t1 t2
-
--- | Build an 'OpenTerm' for the left projection of a pair
-pairLeftOpenTerm :: OpenTerm -> OpenTerm
-pairLeftOpenTerm t = flatOpenTerm $ PairLeft t
-
--- | Build an 'OpenTerm' for the right projection of a pair
-pairRightOpenTerm :: OpenTerm -> OpenTerm
-pairRightOpenTerm t = flatOpenTerm $ PairRight t
-
--- | Build a right-nested tuple as an 'OpenTerm'
+-- | Build a tuple as an 'OpenTerm'
 tupleOpenTerm :: [OpenTerm] -> OpenTerm
-tupleOpenTerm = foldr pairOpenTerm unitOpenTerm
+tupleOpenTerm ts = flatOpenTerm $ TupleValue (V.fromList ts)
 
--- | Build a right-nested tuple type as an 'OpenTerm'
+-- | Build a tuple type as an 'OpenTerm'
 tupleTypeOpenTerm :: [OpenTerm] -> OpenTerm
-tupleTypeOpenTerm = foldr pairTypeOpenTerm unitTypeOpenTerm
+tupleTypeOpenTerm ts = applyGlobalOpenTerm "Prelude.Tuple" [typeListOpenTerm ts]
 
--- | Project the @n@th element of a right-nested tuple type
+typeListOpenTerm :: [OpenTerm] -> OpenTerm
+typeListOpenTerm [] =
+  ctorOpenTerm "Prelude.TypeNil" []
+typeListOpenTerm (t : ts) =
+  ctorOpenTerm "Prelude.TypeCons" [t, typeListOpenTerm ts]
+
+-- | Project the @n@th element of a tuple type
 projTupleOpenTerm :: Integer -> OpenTerm -> OpenTerm
-projTupleOpenTerm 0 t = pairLeftOpenTerm t
-projTupleOpenTerm i t = projTupleOpenTerm (i-1) (pairRightOpenTerm t)
-
--- | Build a right-nested tuple as an 'OpenTerm' but without adding a final unit
--- as the right-most element
-tupleOpenTerm' :: [OpenTerm] -> OpenTerm
-tupleOpenTerm' [] = unitOpenTerm
-tupleOpenTerm' ts = foldr1 pairTypeOpenTerm ts
-
--- | Build a right-nested tuple type as an 'OpenTerm'
-tupleTypeOpenTerm' :: [OpenTerm] -> OpenTerm
-tupleTypeOpenTerm' [] = unitTypeOpenTerm
-tupleTypeOpenTerm' ts = foldr1 pairTypeOpenTerm ts
+projTupleOpenTerm i t = flatOpenTerm $ TupleSelector t (fromInteger i) -- FIXME: unchecked fromInteger
 
 -- | Build a record value as an 'OpenTerm'
 recordOpenTerm :: [(FieldName, OpenTerm)] -> OpenTerm

--- a/saw-core/src/Verifier/SAW/Prelude/Constants.hs
+++ b/saw-core/src/Verifier/SAW/Prelude/Constants.hs
@@ -25,6 +25,12 @@ preludeZeroIdent =  mkIdent preludeModuleName "Zero"
 preludeSuccIdent :: Ident
 preludeSuccIdent =  mkIdent preludeModuleName "Succ"
 
+preludeTypeNilIdent :: Ident
+preludeTypeNilIdent = mkIdent preludeModuleName "TypeNil"
+
+preludeTypeConsIdent :: Ident
+preludeTypeConsIdent = mkIdent preludeModuleName "TypeCons"
+
 preludeIntegerIdent :: Ident
 preludeIntegerIdent =  mkIdent preludeModuleName "Integer"
 

--- a/saw-core/src/Verifier/SAW/Rewriter.hs
+++ b/saw-core/src/Verifier/SAW/Rewriter.hs
@@ -71,6 +71,7 @@ import qualified Data.List as List
 import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
+import qualified Data.Vector as V
 import Control.Monad.Trans.Writer.Strict
 import Numeric.Natural
 
@@ -537,9 +538,9 @@ asBetaRedex t =
 
 asPairRedex :: R.Recognizer Term Term
 asPairRedex t =
-    do (u, b) <- R.asPairSelector t
-       (x, y) <- R.asPairValue u
-       return (if b then y else x)
+    do (u, i) <- R.asTupleSelector t
+       ts <- R.asTupleValue u
+       return (ts !! i)
 
 asRecordRedex :: R.Recognizer Term Term
 asRecordRedex t =
@@ -601,7 +602,7 @@ appCollectedArgs t = step0 (unshared t) []
     step1 f args = foldl (++) [] (map (\ x -> step2 f $ unshared x) args)
     -- step2: analyse an arg.  look inside tuples, sequences (TBD), more calls to f
     step2 :: TermF Term -> TermF Term -> [Term]
-    step2 f (FTermF (PairValue x y)) = (step2 f $ unshared x) ++ (step2 f $ unshared y)
+    step2 f (FTermF (TupleValue xs)) = concatMap (step2 f . unshared) (V.toList xs)
     step2 f (s@(App g a)) = possibly_curried_args s f (unshared g) (step2 f $ unshared a)
     step2 _ a = [Unshared a]
     --
@@ -736,12 +737,8 @@ rewriteSharedTermTypeSafe sc ss t0 =
                      FlatTermF Term -> IO (FlatTermF Term)
     rewriteFTermF ftf =
         case ftf of
-          UnitValue        -> return ftf
-          UnitType         -> return ftf
-          PairValue{}      -> traverse rewriteAll ftf
-          PairType{}       -> return ftf -- doesn't matter
-          PairLeft{}       -> traverse rewriteAll ftf
-          PairRight{}      -> traverse rewriteAll ftf
+          TupleValue{}     -> traverse rewriteAll ftf
+          TupleSelector{}  -> traverse rewriteAll ftf
 
           -- NOTE: we don't rewrite arguments of constructors, datatypes, or
           -- recursors because of dependent types, as we could potentially cause

--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -1194,9 +1194,9 @@ muxValue bp tp0 b = value tp0
               y <- g a
               value tp' x y
 
-    value VUnitType VUnit VUnit = return VUnit
-    value (VPairType t1 t2) (VPair x1 x2) (VPair y1 y2) =
-      VPair <$> thunk t1 x1 y1 <*> thunk t2 x2 y2
+    value (VTupleType ts) (VTuple xs) (VTuple ys)
+      | V.length ts == V.length xs && V.length ts == V.length ys
+      = VTuple <$> V.sequence (V.zipWith3 thunk ts xs ys)
 
     value (VRecordType fs) (VRecordValue elems1) (VRecordValue elems2) =
       do let em1 = Map.fromList elems1

--- a/saw-core/src/Verifier/SAW/Simulator/TermModel.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/TermModel.hs
@@ -223,7 +223,6 @@ readBackTValue sc cfg = loop
   where
   loop tv =
     case tv of
-      VUnitType -> scUnitType sc
       VBoolType -> scBoolType sc
       VStringType -> scStringType sc
       VIntType -> scIntegerType sc
@@ -239,10 +238,9 @@ readBackTValue sc cfg = loop
         do n' <- scNat sc n
            t' <- loop t
            scVecType sc n' t'
-      VPairType t1 t2 ->
-        do t1' <- loop t1
-           t2' <- loop t2
-           scPairType sc t1' t2'
+      VTupleType ts ->
+        do ts' <- traverse loop (V.toList ts)
+           scTupleType sc ts'
       VRecordType fs ->
         do fs' <- traverse (traverse loop) fs
            scRecordType sc fs'
@@ -301,7 +299,6 @@ reflectTerm ::
 reflectTerm sc cfg = loop
   where
   loop tv tm = case tv of
-    VUnitType -> pure VUnit
     VBoolType -> return (VBool (Left tm))
     VIntType  -> return (VInt (Left tm))
     VIntModType m -> return (VIntMod m (Left tm))
@@ -337,7 +334,7 @@ reflectTerm sc cfg = loop
 
     VStringType{}   -> return (VExtra (VExtraTerm tv tm))
     VRecordType{}   -> return (VExtra (VExtraTerm tv tm))
-    VPairType{}     -> return (VExtra (VExtraTerm tv tm))
+    VTupleType{}    -> return (VExtra (VExtraTerm tv tm))
     VDataType{}     -> return (VExtra (VExtraTerm tv tm))
     VRecursorType{} -> return (VExtra (VExtraTerm tv tm))
     VTyTerm{}       -> return (VExtra (VExtraTerm tv tm))
@@ -353,8 +350,6 @@ readBackValue ::
   IO Term
 readBackValue sc cfg = loop
   where
-    loop _ VUnit = scUnitValue sc
-
     loop _ (VNat n) = scNat sc n
 
     loop _ (VBVToNat w n) =
@@ -393,10 +388,9 @@ readBackValue sc cfg = loop
       do (ecs, tm) <- readBackFuns tv v
          scAbstractExtsEtaCollapse sc ecs tm
 
-    loop (VPairType t1 t2) (VPair v1 v2) =
-      do tm1 <- loop t1 =<< force v1
-         tm2 <- loop t2 =<< force v2
-         scPairValueReduced sc tm1 tm2
+    loop (VTupleType ts) (VTuple vs) | V.length ts == V.length vs =
+      do tms <- V.sequence $ V.zipWith (\t v -> loop t =<< force v) ts vs
+         scTupleReduced sc (V.toList tms)
 
     loop (VVecType _n tp) (VVector vs) =
       do tp' <- readBackTValue sc cfg tp

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -51,8 +51,7 @@ The concrete parameters to use are computed from the name using
 a collection of type families (e.g., 'EvalM', 'VBool', etc.). -}
 data Value l
   = VFun !LocalName !(Thunk l -> MValue l)
-  | VUnit
-  | VPair (Thunk l) (Thunk l) -- TODO: should second component be strict?
+  | VTuple !(Vector (Thunk l))
   | VCtorApp !(PrimName (TValue l)) ![Thunk l] ![Thunk l]
   | VVector !(Vector (Thunk l))
   | VBool (VBool l)
@@ -83,9 +82,8 @@ data TValue l
   | VArrayType !(TValue l) !(TValue l)
   | VPiType LocalName !(TValue l) !(PiBody l)
   | VStringType
-  | VUnitType
-  | VPairType !(TValue l) !(TValue l)
   | VDataType !(PrimName (TValue l)) ![Value l] ![Value l]
+  | VTupleType !(Vector (TValue l))
   | VRecordType ![(FieldName, TValue l)]
   | VSort !Sort
   | VRecursorType
@@ -105,8 +103,7 @@ data PiBody l
 --   is being hidden, etc.)
 data NeutralTerm
   = NeutralBox Term -- the thing blocking evaluation
-  | NeutralPairLeft NeutralTerm   -- left pair projection
-  | NeutralPairRight NeutralTerm  -- right pair projection
+  | NeutralTupleProj NeutralTerm Int -- tuple projection
   | NeutralRecordProj NeutralTerm FieldName -- record projection
   | NeutralApp NeutralTerm Term -- function application
   | NeutralRecursor
@@ -174,8 +171,7 @@ instance Show (Extra l) => Show (Value l) where
   showsPrec p v =
     case v of
       VFun {}        -> showString "<<fun>>"
-      VUnit          -> showString "()"
-      VPair{}        -> showString "<<tuple>>"
+      VTuple xv      -> showString "<<" . shows (V.length xv) . showString "-tuple>>"
       VCtorApp s _ps _xv -> shows (primName s)
       VVector xv     -> showList (toList xv)
       VBool _        -> showString "<<boolean>>"
@@ -207,8 +203,7 @@ instance Show (Extra l) => Show (TValue l) where
       VArrayType{}   -> showString "Array"
       VPiType _ t _    -> showParen True
                         (shows t . showString " -> ...")
-      VUnitType      -> showString "#()"
-      VPairType x y  -> showParen True (shows x . showString " * " . shows y)
+      VTupleType ts  -> showString "#" . showParen True (showCommas (map shows (V.toList ts)))
       VDataType s ps vs
         | null (ps++vs) -> shows s
         | otherwise  -> shows s . showList (ps++vs)
@@ -221,6 +216,10 @@ instance Show (Extra l) => Show (TValue l) where
       VRecursorType{} -> showString "RecursorType"
 
       VTyTerm _ tm   -> showString "TyTerm (" . (\x -> showTerm tm ++ x) . showString ")"
+    where
+      showCommas [] = id
+      showCommas [x] = x
+      showCommas (x : xs) = x . showString "," . showCommas xs
 
 data Nil = Nil
 
@@ -231,23 +230,10 @@ instance Show Nil where
 -- Basic operations on values
 
 vTuple :: VMonad l => [Thunk l] -> Value l
-vTuple [] = VUnit
-vTuple [_] = error "vTuple: unsupported 1-tuple"
-vTuple [x, y] = VPair x y
-vTuple (x : xs) = VPair x (ready (vTuple xs))
+vTuple xs = VTuple (V.fromList xs)
 
 vTupleType :: VMonad l => [TValue l] -> TValue l
-vTupleType [] = VUnitType
-vTupleType [t] = t
-vTupleType (t : ts) = VPairType t (vTupleType ts)
-
-valPairLeft :: (HasCallStack, VMonad l, Show (Extra l)) => Value l -> MValue l
-valPairLeft (VPair t1 _) = force t1
-valPairLeft v = panic "Verifier.SAW.Simulator.Value.valPairLeft" ["Not a pair value:", show v]
-
-valPairRight :: (HasCallStack, VMonad l, Show (Extra l)) => Value l -> MValue l
-valPairRight (VPair _ t2) = force t2
-valPairRight v = panic "Verifier.SAW.Simulator.Value.valPairRight" ["Not a pair value:", show v]
+vTupleType ts = VTupleType (V.fromList ts)
 
 vRecord :: Map FieldName (Thunk l) -> Value l
 vRecord m = VRecordValue (Map.assocs m)
@@ -289,13 +275,8 @@ asFiniteTypeTValue v =
     VVecType n v1 -> do
       t1 <- asFiniteTypeTValue v1
       return (FTVec n t1)
-    VUnitType -> return (FTTuple [])
-    VPairType v1 v2 -> do
-      t1 <- asFiniteTypeTValue v1
-      t2 <- asFiniteTypeTValue v2
-      case t2 of
-        FTTuple ts -> return (FTTuple (t1 : ts))
-        _ -> return (FTTuple [t1, t2])
+    VTupleType vs ->
+      FTTuple <$> traverse asFiniteTypeTValue (V.toList vs)
     VRecordType elem_tps ->
       FTRec <$> Map.fromList <$>
       mapM (\(fld,tp) -> (fld,) <$> asFiniteTypeTValue tp) elem_tps
@@ -316,13 +297,8 @@ asFirstOrderTypeTValue v =
     VIntModType m -> return (FOTIntMod m)
     VArrayType a b ->
       FOTArray <$> asFirstOrderTypeTValue a <*> asFirstOrderTypeTValue b
-    VUnitType -> return (FOTTuple [])
-    VPairType v1 v2 -> do
-      t1 <- asFirstOrderTypeTValue v1
-      t2 <- asFirstOrderTypeTValue v2
-      case t2 of
-        FOTTuple ts -> return (FOTTuple (t1 : ts))
-        _ -> return (FOTTuple [t1, t2])
+    VTupleType vs ->
+      FOTTuple <$> traverse asFirstOrderTypeTValue (V.toList vs)
     VRecordType elem_tps ->
       FOTRec . Map.fromList <$>
         mapM (traverse asFirstOrderTypeTValue) elem_tps
@@ -351,11 +327,9 @@ suffixTValue tv =
          b' <- suffixTValue b
          Just ("_Array" ++ a' ++ b')
     VPiType _ _ _ -> Nothing
-    VUnitType -> Just "_Unit"
-    VPairType a b ->
-      do a' <- suffixTValue a
-         b' <- suffixTValue b
-         Just ("_Pair" ++ a' ++ b')
+    VTupleType vs ->
+      do vs' <- traverse suffixTValue (V.toList vs)
+         Just ("_Tuple" ++ show (V.length vs) ++ concat vs')
 
     VStringType -> Nothing
     VDataType {} -> Nothing
@@ -369,10 +343,8 @@ neutralToTerm :: NeutralTerm -> Term
 neutralToTerm = loop
   where
   loop (NeutralBox tm) = tm
-  loop (NeutralPairLeft nt) =
-    Unshared (FTermF (PairLeft (loop nt)))
-  loop (NeutralPairRight nt) =
-    Unshared (FTermF (PairRight (loop nt)))
+  loop (NeutralTupleProj nt i) =
+    Unshared (FTermF (TupleSelector (loop nt) i))
   loop (NeutralRecordProj nt f) =
     Unshared (FTermF (RecordProj (loop nt) f))
   loop (NeutralApp nt arg) =
@@ -388,10 +360,9 @@ neutralToSharedTerm :: SharedContext -> NeutralTerm -> IO Term
 neutralToSharedTerm sc = loop
   where
   loop (NeutralBox tm) = pure tm
-  loop (NeutralPairLeft nt) =
-    scFlatTermF sc . PairLeft =<< loop nt
-  loop (NeutralPairRight nt) =
-    scFlatTermF sc . PairRight =<< loop nt
+  loop (NeutralTupleProj nt i) =
+    do tm <- loop nt
+       scFlatTermF sc (TupleSelector tm i)
   loop (NeutralRecordProj nt f) =
     do tm <- loop nt
        scFlatTermF sc (RecordProj tm f)

--- a/saw-core/src/Verifier/SAW/Typechecker.hs
+++ b/saw-core/src/Verifier/SAW/Typechecker.hs
@@ -238,23 +238,19 @@ typeInferCompleteTerm (Un.RecordType _ elems) =
 typeInferCompleteTerm (Un.RecordProj t prj) =
   (RecordProj <$> typeInferComplete t <*> return prj) >>= typeInferComplete
 
--- Unit
-typeInferCompleteTerm (Un.UnitValue _) =
-  typeInferComplete (UnitValue :: FlatTermF TypedTerm)
-typeInferCompleteTerm (Un.UnitType _) =
-  typeInferComplete (UnitType :: FlatTermF TypedTerm)
-
--- Simple pairs
-typeInferCompleteTerm (Un.PairValue _ t1 t2) =
-  (PairValue <$> typeInferComplete t1 <*> typeInferComplete t2)
+-- Tuples
+typeInferCompleteTerm (Un.TupleValue _ ts) =
+  (TupleValue <$> traverse typeInferComplete (V.fromList ts))
   >>= typeInferComplete
-typeInferCompleteTerm (Un.PairType _ t1 t2) =
-  (PairType <$> typeInferComplete t1 <*> typeInferComplete t2)
-  >>= typeInferComplete
-typeInferCompleteTerm (Un.PairLeft t) =
-  (PairLeft <$> typeInferComplete t) >>= typeInferComplete
-typeInferCompleteTerm (Un.PairRight t) =
-  (PairRight <$> typeInferComplete t) >>= typeInferComplete
+typeInferCompleteTerm (Un.TupleType _ ts) =
+  do tts <- traverse typeInferComplete ts
+     v <- liftTCM scTupleType (map typedVal tts)
+     -- Ensure all arguments have type 'sort 0'
+     s0 <- liftTCM scSort (mkSort 0)
+     mapM_ (\tt -> checkSubtype tt s0) tts
+     pure (TypedTerm v s0)
+typeInferCompleteTerm (Un.TupleProj t i) =
+  (TupleSelector <$> typeInferComplete t <*> pure i) >>= typeInferComplete
 
 -- Type ascriptions
 typeInferCompleteTerm (Un.TypeConstraint t _ tp) =


### PR DESCRIPTION
We now have an explicit AST constructor for arbitrary-size tuple values.

Tuple types are formalized as a type constructor that takes a list
of types as an argument:

data TypeList : sort 1 where {
    TypeNil : TypeList;
    TypeCons : sort 0 -> TypeList -> TypeList;
  }

primitive Tuple : TypeList -> sort 0;

Additional primitives allow constructing and deconstructing tuples
in a nested fashion:

primitive headTuple : (t : sort 0) -> (ts : TypeList) -> Tuple (TypeCons t ts) -> t;
primitive tailTuple : (t : sort 0) -> (ts : TypeList) -> Tuple (TypeCons t ts) -> Tuple ts;
primitive consTuple : (t : sort 0) -> (ts : TypeList) -> t -> Tuple ts -> Tuple (TypeCons t ts);

NOTE: This commit makes the cryptol-saw-core test suite pass, but
saw-core-coq fails to compile. Further changes will be necessary.