### PR TITLE
Fix `blst-verification` regression test and update pinned commit

### DIFF
--- a/s2nTests/docker/blst.dockerfile
+++ b/s2nTests/docker/blst.dockerfile
@@ -5,7 +5,7 @@ RUN pip3 install wllvm
 
 RUN git clone https://github.com/GaloisInc/blst-verification.git /workdir && \
     cd /workdir && \
-    git checkout e8181fb9f5ebe4d5234b16837b86384849523730 && \
+    git checkout f7c50e400d18066cc4849513418c3f407ba3c608 && \
     git config --file=.gitmodules submodule.blst.url https://github.com/supranational/blst && \
     git config --file=.gitmodules submodule.blst_patched.url https://github.com/supranational/blst && \
     git config --file=.gitmodules submodule.blst_bulk_addition.url https://github.com/supranational/blst && \

--- a/s2nTests/docker/blst.dockerfile
+++ b/s2nTests/docker/blst.dockerfile
@@ -5,8 +5,10 @@ RUN pip3 install wllvm
 
 RUN git clone https://github.com/GaloisInc/blst-verification.git /workdir && \
     cd /workdir && \
-    git checkout 05d29b0e9d826053185e5bdba287045aab0b4669 && \
+    git checkout e8181fb9f5ebe4d5234b16837b86384849523730 && \
     git config --file=.gitmodules submodule.blst.url https://github.com/supranational/blst && \
+    git config --file=.gitmodules submodule.blst_patched.url https://github.com/supranational/blst && \
+    git config --file=.gitmodules submodule.blst_bulk_addition.url https://github.com/supranational/blst && \
     git config --file=.gitmodules submodule.cryptol-specs.url https://github.com/GaloisInc/cryptol-specs && \
     git submodule sync && \
     git submodule update --init

--- a/s2nTests/scripts/blst-entrypoint.sh
+++ b/s2nTests/scripts/blst-entrypoint.sh
@@ -20,5 +20,6 @@ yices-smt2 --version
 ./scripts/build_x86.sh
 ./scripts/build_llvm.sh
 
-./scripts/prove.sh
+saw proof/memory_safety.saw
+
 ./scripts/check.sh | if grep False; then exit 1; fi


### PR DESCRIPTION
See #1620 for context on this.

Note that this still uses `git config` to change SSH submodule clones into HTTPS. I'm not sure if there's a great way around this generally. It's often more convenient to use SSH for submodules while developing (e.g. if one wants to push commits from the submodule), while using SSH from Actions, especially inside Docker, will likely involve a lot of cumbersome key management.

I'm marking this as a draft for now because the new checked-out commit still isn't on `main` of `blst-verification`.