### PR TITLE
Proof development primitives

### DIFF
--- a/cryptol-saw-core/src/Verifier/SAW/CryptolEnv.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/CryptolEnv.hs
@@ -16,6 +16,7 @@ module Verifier.SAW.CryptolEnv
   , loadCryptolModule
   , bindCryptolModule
   , lookupCryptolModule
+  , combineCryptolEnv
   , importModule
   , bindTypedTerm
   , bindType
@@ -344,6 +345,15 @@ genTermEnv sc modEnv cryEnv0 = do
   traverse (\(t, j) -> incVars sc 0 j t) (C.envE cryEnv)
 
 --------------------------------------------------------------------------------
+
+
+combineCryptolEnv :: CryptolEnv -> CryptolEnv -> IO CryptolEnv
+combineCryptolEnv chkEnv newEnv =
+  do let newMEnv = eModuleEnv newEnv
+     let chkMEnv = eModuleEnv chkEnv
+     let menv' = chkMEnv{ ME.meNameSeeds = ME.meNameSeeds newMEnv }
+     return chkEnv{ eModuleEnv = menv' }
+
 
 checkNotParameterized :: T.Module -> IO ()
 checkNotParameterized m =

--- a/intTests/test_external_abc/test.saw
+++ b/intTests/test_external_abc/test.saw
@@ -44,8 +44,8 @@ let order_res = {{ ([[0x02,0x03],[0x04,0x05]], 0x81050fff) }};
 
 // Check that Verilog counterexamples are in the right order
 sr1 <- sat w4_abc_verilog order_term;
-caseSatResult sr1 undefined (\t -> prove_print yices {{ t == order_res }});
+caseSatResult sr1 (fail "ABC verilog sat fail") (\t -> prove_print yices {{ t == order_res }});
 
 // Check that AIGER counterexamples are in the right order
 sr2 <- sat w4_abc_aiger order_term;
-caseSatResult sr2 undefined (\t -> prove_print yices {{ t == order_res }});
+caseSatResult sr2 (fail "ABC aiger sat fail") (\t -> prove_print yices {{ t == order_res }});

--- a/saw-remote-api/src/SAWServer.hs
+++ b/saw-remote-api/src/SAWServer.hs
@@ -199,8 +199,7 @@ initialState readFileFn =
      cwd <- getCurrentDirectory
      db <- newTheoremDB
      let ro = TopLevelRO
-                { roSharedContext = sc
-                , roJavaCodebase = jcb
+                { roJavaCodebase = jcb
                 , roOptions = opts
                 , roHandleAlloc = halloc
                 , roPosition = PosInternal "SAWServer"
@@ -211,7 +210,6 @@ initialState readFileFn =
 #endif
                 , roInitWorkDir = cwd
                 , roBasicSS = ss
-                , roTheoremDB = db
                 , roStackTrace = []
                 , roSubshell = fail "SAW server does not support subshells."
                 , roLocalEnv = []
@@ -225,6 +223,8 @@ initialState readFileFn =
                 , rwMonadify = defaultMonEnv
                 , rwMRSolverEnv = emptyMREnv
                 , rwPPOpts = defaultPPOpts
+                , rwTheoremDB = db
+                , rwSharedContext = sc
                 , rwJVMTrans = jvmTrans
                 , rwPrimsAvail = mempty
                 , rwSMTArrayMemoryModel = False

--- a/saw-remote-api/src/SAWServer.hs
+++ b/saw-remote-api/src/SAWServer.hs
@@ -212,6 +212,9 @@ initialState readFileFn =
                 , roInitWorkDir = cwd
                 , roBasicSS = ss
                 , roTheoremDB = db
+                , roStackTrace = []
+                , roSubshell = fail "SAW server does not support subshells."
+                , roLocalEnv = []
                 }
          rw = TopLevelRW
                 { rwValues = mempty

--- a/saw-remote-api/src/SAWServer.hs
+++ b/saw-remote-api/src/SAWServer.hs
@@ -212,6 +212,7 @@ initialState readFileFn =
                 , roBasicSS = ss
                 , roStackTrace = []
                 , roSubshell = fail "SAW server does not support subshells."
+                , roProofSubshell = fail "SAW server does not support subshells."
                 , roLocalEnv = []
                 }
          rw = TopLevelRW

--- a/saw-remote-api/src/SAWServer/Eval.hs
+++ b/saw-remote-api/src/SAWServer/Eval.hs
@@ -75,7 +75,8 @@ instance Doc.DescribedMethod (EvalParams Bool cryptolExpr) (EvalResult Bool) whe
       Doc.Paragraph [Doc.Text "The boolean value of the expresssion."])
     ]
 
-eval :: (TypedTerm -> SV.TopLevel a) -> EvalParams a Expression -> Argo.Command SAWState (EvalResult a)
+eval :: (SV.FromValue a, SV.IsValue a) =>
+  (TypedTerm -> SV.TopLevel a) -> EvalParams a Expression -> Argo.Command SAWState (EvalResult a)
 eval f params = do
   state <- Argo.getState
   fileReader <- Argo.getFileReader

--- a/saw-script.cabal
+++ b/saw-script.cabal
@@ -213,6 +213,7 @@ executable saw
     , exceptions
     , filepath
     , haskeline
+    , mtl
     , QuickCheck
     , transformers
     , saw-script

--- a/saw/Main.hs
+++ b/saw/Main.hs
@@ -43,12 +43,13 @@ main = do
         [] -> checkZ3 opts'' *> REPL.run opts''
         _ | runInteractively opts'' -> checkZ3 opts'' *> REPL.run opts''
         [file] -> checkZ3 opts'' *>
-          processFile (AIGProxy AIG.compactProxy) opts'' file subsh `catch`
+          processFile (AIGProxy AIG.compactProxy) opts'' file subsh proofSubsh`catch`
           (\(ErrorCall msg) -> err opts'' msg)
         (_:_) -> err opts'' "Multiple files not yet supported."
     (_, _, errs) -> do hPutStrLn stderr (concat errs ++ usageInfo header options)
                        exitProofUnknown
   where subsh = Just (REPL.subshell (REPL.replBody Nothing (return ())))
+        proofSubsh = Just (REPL.proof_subshell (REPL.replBody Nothing (return ())))
         header = "Usage: saw [OPTION...] [-I | file]"
         checkZ3 opts = do
           p <- findExecutable "z3"

--- a/saw/SAWScript/REPL/Command.hs
+++ b/saw/SAWScript/REPL/Command.hs
@@ -163,7 +163,7 @@ typeOfCmd str =
        Left err -> fail (show err)
        Right expr -> return expr
      let decl = SS.Decl (getPos expr) (SS.PWild Nothing) Nothing expr
-     rw <- getEnvironment
+     rw <- getValueEnvironment
      ~(SS.Decl _pos _ (Just schema) _expr') <-
        either failTypecheck return $ checkDecl (rwTypes rw) (rwTypedef rw) decl
      io $ putStrLn $ SS.pShow schema
@@ -174,7 +174,7 @@ quitCmd  = stop
 
 envCmd :: REPL ()
 envCmd = do
-  env <- getEnvironment
+  env <- getValueEnvironment
   let showLName = SS.getVal
   io $ sequence_ [ putStrLn (showLName x ++ " : " ++ SS.pShow v) | (x, v) <- Map.assocs (rwTypes env) ]
 

--- a/saw/SAWScript/REPL/Command.hs
+++ b/saw/SAWScript/REPL/Command.hs
@@ -30,6 +30,8 @@ module SAWScript.REPL.Command (
 
 --import Verifier.SAW.SharedTerm (SharedContext)
 
+import Data.IORef
+
 import SAWScript.REPL.Monad
 import SAWScript.REPL.Trie
 import SAWScript.Position (getPos)
@@ -228,8 +230,10 @@ sawScriptCmd str = do
     Left err -> io $ print err
     Right stmt ->
       do ro <- getTopLevelRO
-         rwRef <- getEnvironmentRef
-         io $ runTopLevel (interpretStmt True stmt) ro rwRef
+         ref <- getEnvironmentRef
+         rw <- io $ readIORef ref
+         (_, rw') <- io $ runTopLevel (interpretStmt True stmt) ro rw
+         io $ writeIORef ref rw'
 
 replFileName :: String
 replFileName = "<stdin>"

--- a/saw/SAWScript/REPL/Command.hs
+++ b/saw/SAWScript/REPL/Command.hs
@@ -221,7 +221,11 @@ sawScriptCmd str = do
   let tokens = SAWScript.Lexer.lexSAW replFileName str
   case SAWScript.Parser.parseStmtSemi tokens of
     Left err -> io $ print err
-    Right stmt -> void $ liftTopLevel (interpretStmt True stmt)
+    Right stmt ->
+      do mr <- getProofStateRef
+         case mr of
+           Nothing -> void $ liftTopLevel (interpretStmt True stmt)
+           Just r  -> void $ liftProofScript (interpretStmt True stmt) r
 
 replFileName :: String
 replFileName = "<stdin>"

--- a/saw/SAWScript/REPL/Command.hs
+++ b/saw/SAWScript/REPL/Command.hs
@@ -39,7 +39,9 @@ import SAWScript.Position (getPos)
 import Cryptol.Parser (ParseError())
 import Cryptol.Utils.PP hiding ((</>))
 
+import Control.Exception (displayException)
 import Control.Monad (guard)
+
 import Data.Char (isSpace,isPunctuation,isSymbol)
 import Data.Function (on)
 import Data.List (intercalate)
@@ -146,7 +148,7 @@ runCommand c = case c of
                      `SAWScript.REPL.Monad.catchOther` handlerPrint
     where
     handlerPP re = io (putStrLn "" >> print (pp re))
-    handlerPrint e = io (putStrLn "" >> print e)
+    handlerPrint e = io (putStrLn "" >> putStrLn (displayException e))
     handlerFail s = io (putStrLn "" >> putStrLn s)
 
   Unknown cmd -> io (putStrLn ("Unknown command: " ++ cmd))

--- a/saw/SAWScript/REPL/Monad.hs
+++ b/saw/SAWScript/REPL/Monad.hs
@@ -44,6 +44,7 @@ module SAWScript.REPL.Monad (
     -- ** SAWScript stuff
   , getSharedContext
   , getTopLevelRO
+  , getValueEnvironment
   , getEnvironment, modifyEnvironment, putEnvironment
   , getEnvironmentRef
   , getSAWScriptNames
@@ -87,7 +88,7 @@ import SAWScript.AST (Located(getVal))
 import SAWScript.Interpreter (buildTopLevelEnv)
 import SAWScript.Options (Options)
 import SAWScript.TopLevel (TopLevelRO(..), TopLevelRW(..), TopLevel(..))
-import SAWScript.Value (AIGProxy(..))
+import SAWScript.Value (AIGProxy(..), mergeLocalEnv)
 import Verifier.SAW (SharedContext)
 
 deriving instance Typeable AIG.Proxy
@@ -384,6 +385,12 @@ getEnvironmentRef = environment <$> getRefs
 
 getEnvironment :: REPL TopLevelRW
 getEnvironment = readRef environment
+
+getValueEnvironment :: REPL TopLevelRW
+getValueEnvironment =
+  do ro <- getTopLevelRO
+     rw <- getEnvironment
+     io (mergeLocalEnv (roSharedContext ro) (roLocalEnv ro) rw)
 
 putEnvironment :: TopLevelRW -> REPL ()
 putEnvironment = modifyEnvironment . const

--- a/saw/SAWScript/REPL/Monad.hs
+++ b/saw/SAWScript/REPL/Monad.hs
@@ -382,7 +382,7 @@ setCryptolEnv :: CryptolEnv -> REPL ()
 setCryptolEnv x = modifyCryptolEnv (const x)
 
 getSharedContext :: REPL SharedContext
-getSharedContext = fmap roSharedContext getTopLevelRO
+getSharedContext = rwSharedContext <$> getEnvironment
 
 getTopLevelRO :: REPL TopLevelRO
 getTopLevelRO = REPL (return . eTopLevelRO)
@@ -397,7 +397,7 @@ getValueEnvironment :: REPL TopLevelRW
 getValueEnvironment =
   do ro <- getTopLevelRO
      rw <- getEnvironment
-     io (mergeLocalEnv (roSharedContext ro) (roLocalEnv ro) rw)
+     io (mergeLocalEnv (rwSharedContext rw) (roLocalEnv ro) rw)
 
 putEnvironment :: TopLevelRW -> REPL ()
 putEnvironment = modifyEnvironment . const

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -1343,10 +1343,9 @@ caseSatResultPrim sr vUnsat vSat = do
       tt <- io $ typedTermOfFirstOrderValue sc fov
       SV.applyValue vSat (SV.toValue tt)
 
-
 envCmd :: TopLevel ()
 envCmd = do
-  m <- rwTypes <$> getTopLevelRW
+  m <- rwTypes <$> SV.getMergedEnv
   opts <- getOptions
   let showLName = getVal
   io $ sequence_ [ printOutLn opts Info (showLName x ++ " : " ++ pShow v) | (x, v) <- Map.assocs m ]

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -208,11 +208,13 @@ readSBV path unintlst =
 -- support for latches in the 'AIGNetwork' SAWScript type.
 dsecPrint :: TypedTerm -> TypedTerm -> TopLevel ()
 dsecPrint t1 t2 = do
-  withSystemTempFile ".aig" $ \path1 _handle1 -> do
-  withSystemTempFile ".aig" $ \path2 _handle2 -> do
-  Prover.writeSAIGInferLatches path1 t1
-  Prover.writeSAIGInferLatches path2 t2
-  io $ callCommand (abcDsec path1 path2)
+  write_t1 <- Prover.writeSAIGInferLatches t1
+  write_t2 <- Prover.writeSAIGInferLatches t2
+  io $ withSystemTempFile ".aig" $ \path1 _handle1 ->
+       withSystemTempFile ".aig" $ \path2 _handle2 ->
+        do write_t1 path1
+           write_t2 path2
+           callCommand (abcDsec path1 path2)
   where
     -- The '-w' here may be overkill ...
     abcDsec path1 path2 = printf "abc -c 'read %s; dsec -v -w %s;'" path1 path2
@@ -792,7 +794,9 @@ writeAIGPrim :: FilePath -> Term -> TopLevel ()
 writeAIGPrim = Prover.writeAIG
 
 writeSAIGPrim :: FilePath -> TypedTerm -> TopLevel ()
-writeSAIGPrim = Prover.writeSAIGInferLatches
+writeSAIGPrim file tt =
+  do write_tt <- Prover.writeSAIGInferLatches tt
+     io $ write_tt file
 
 writeSAIGComputedPrim :: FilePath -> Term -> Int -> TopLevel ()
 writeSAIGComputedPrim = Prover.writeSAIG
@@ -1375,12 +1379,14 @@ timePrim a = do
   printOutLnTop Info $ printf "Time: %s\n" (show diff)
   return r
 
+failPrim :: String -> TopLevel SV.Value
+failPrim msg = fail msg
+
 failsPrim :: TopLevel SV.Value -> TopLevel ()
 failsPrim m = do
   topRO <- getTopLevelRO
   topRW <- getTopLevelRW
-  ref <- liftIO $ newIORef topRW
-  x <- liftIO $ Ex.try (runTopLevel m topRO ref)
+  x <- liftIO $ Ex.try (runTopLevel m topRO topRW)
   case x of
     Left (ex :: Ex.SomeException) ->
       do liftIO $ putStrLn "== Anticipated failure message =="

--- a/src/SAWScript/Exceptions.hs
+++ b/src/SAWScript/Exceptions.hs
@@ -64,9 +64,10 @@ topLevelExceptionFromException x =
 
 instance Exception TopLevelException
 
-data TraceException = TraceException String
+data TraceException = TraceException [String] SomeException
 
 instance Show TraceException where
-  show (TraceException msg) = "Stack trace:\n" ++ msg
+  show (TraceException msg ex) =
+    unlines (["Stack trace:"] ++ msg ++ [displayException ex])
 
 instance Exception TraceException

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -44,7 +44,7 @@ import qualified Data.Set as Set
 import Data.Set ( Set )
 import qualified Data.Text as Text
 import System.Directory (getCurrentDirectory, setCurrentDirectory, canonicalizePath)
-import System.FilePath (takeDirectory, hasDrive, (</>))
+import System.FilePath (takeDirectory)
 import System.Process (readProcess)
 
 import qualified SAWScript.AST as SS
@@ -104,8 +104,6 @@ import qualified Prettyprinter.Render.Text as PP (putDoc)
 import SAWScript.AutoMatch
 
 import qualified Lang.Crucible.FunctionHandle as Crucible
-
-import SAWScript.VerificationSummary
 
 -- Environment -----------------------------------------------------------------
 

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -896,6 +896,20 @@ primitives = Map.fromList
     , "subshell and resume execution."
     ]
 
+  , prim "proof_checkpoint"      "ProofScript (() -> ProofScript ())"
+    (pureVal proof_checkpoint)
+    Experimental
+    [ "Capture the current state of the proof and return a"
+    , "ProofScript monadic action that, if invoked, will reset the"
+    , "state of the proof back to to what it was at the"
+    , "moment checkpoint was invoked."
+    , ""
+    , "NOTE that this facility is highly experimental and may not"
+    , "be entirely reliable.  It is intended only for proof development"
+    , "where it can speed up the process of experimenting with"
+    , "mid-proof changes. Finalized proofs should not use this facility."
+    ]
+
   , prim "define"              "String -> Term -> TopLevel Term"
     (pureVal definePrim)
     Current

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -839,7 +839,7 @@ primitives = Map.fromList
     [ "Call-with-current-continuation."
     , ""
     , "This is a highly experimental control operator that can be used"
-    , "to capure the surrounding top-level computation as a continuation."
+    , "to capture the surrounding top-level computation as a continuation."
     , "The consequences of delaying and reentering the current continuation"
     , "may be somewhat unpredictable, so use this operator with great caution."
     ]
@@ -847,7 +847,7 @@ primitives = Map.fromList
   , prim "checkpoint"          "TopLevel (() -> TopLevel ())"
     (pureVal checkpoint)
     Experimental
-    [ "Capure the current state of the SAW interpreter, and return"
+    [ "Capture the current state of the SAW interpreter, and return"
     , "A TopLevel monadic action that, if invoked, will reset the"
     , "state of the interpreter back to to what it was at the"
     , "moment checkpoint was invoked."
@@ -861,12 +861,40 @@ primitives = Map.fromList
   , prim "subshell"            "() -> TopLevel ()"
     (\_ _ -> toplevelSubshell)
     Experimental
-    []
+    [ "Open an interactive subshell instance in the context where"
+    , "'subshell' was called. This works either from within execution"
+    , "of a outer shell instance, or from interpreting a file in batch"
+    , "mode. Enter the end-of-file character in your terminal (Ctrl^D, usually)"
+    , "to exit the subshell and resume execution."
+    , ""
+    , "This command is especially useful in conjunction with the 'checkpoint'"
+    , "and 'callcc' commands, which allow state reset capabilities and the capturing"
+    , "of the calling context."
+    , ""
+    , "Note that, due to the way the SAW script interpreter works, changes made"
+    , "to a script file in which the 'subshell' command directly appears will"
+    , "NOT affect subsequent execution following a 'checkpoint' or 'callcc' use."
+    , "However, changes made in a file that executed via 'include' WILL affect"
+    , "restarted executions, as the 'include' command will read and parse the"
+    , "file from scratch."
+    ]
 
   , prim "proof_subshell"      "() -> ProofScript ()"
     (\ _ _ -> proofScriptSubshell)
     Experimental
-    []
+    [ "Open an interactive subshell instance in the context of the current proof."
+    , "This allows the user to interactively execute 'ProofScript' tactic commands"
+    , "directly on the command line an examine their effects using, e.g., 'print_goal'."
+    , "In proof mode, the command prompt will change to 'proof (n)', where the 'n'"
+    , "indicates the number of subgoals remaining to proof for the current overall goal."
+    , "In this mode, tactic commands applied will only affect the current subgoal."
+    , "When a particular subgoal is completed, the next subgoal will automatically become"
+    , "the active subgoal. An overall goal is completed when all subgoals are proved"
+    , "and the current number of subgoals is 0."
+    , ""
+    , "Enter the end-of-file character in your terminal (Ctrl^D, usually) to exit the proof"
+    , "subshell and resume execution."
+    ]
 
   , prim "define"              "String -> Term -> TopLevel Term"
     (pureVal definePrim)

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -38,7 +38,6 @@ import Control.Monad (unless, (>=>), when)
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString as BS
 import Data.Foldable (foldrM)
-import Data.IORef
 import qualified Data.Map as Map
 import Data.Map ( Map )
 import qualified Data.Set as Set
@@ -283,8 +282,7 @@ interpretStmts env stmts =
 
 stmtInterpreter :: StmtInterpreter
 stmtInterpreter ro rw stmts =
-  do ref <- newIORef rw
-     runTopLevel (interpretStmts emptyLocal stmts) ro ref
+  fst <$> runTopLevel (interpretStmts emptyLocal stmts) ro rw
 
 processStmtBind :: Bool -> SS.Pattern -> Maybe SS.Type -> SS.Expr -> TopLevel ()
 processStmtBind printBinds pat _mc expr = do -- mx mt
@@ -458,6 +456,7 @@ buildTopLevelEnv proxy opts =
                    , roInitWorkDir = currDir
                    , roBasicSS = ss
                    , roTheoremDB = thmDB
+                   , roStackTrace = []
                    }
        let bic = BuiltinContext {
                    biSharedContext = sc
@@ -508,8 +507,7 @@ processFile proxy opts file = do
   oldpath <- getCurrentDirectory
   file' <- canonicalizePath file
   setCurrentDirectory (takeDirectory file')
-  ref <- newIORef rw
-  _ <- runTopLevel (interpretFile file' True) ro ref
+  _ <- runTopLevel (interpretFile file' True) ro rw
             `X.catch` (handleException opts)
   setCurrentDirectory oldpath
   return ()
@@ -822,6 +820,31 @@ primitives = Map.fromList
     (pureVal ((++) :: String -> String -> String))
     Current
     [ "Concatenate two strings to yield a third." ]
+
+  , prim "callcc" "{a} ((a -> TopLevel ()) -> TopLevel a) -> TopLevel a"
+    (\_ _ -> toplevelCallCC)
+    Experimental
+    [ "Call-with-current-continuation."
+    , ""
+    , "This is a highly experimental control operator that can be used"
+    , "to capure the surrounding top-level computation as a continuation."
+    , "The consequences of delaying and reentering the current continuation"
+    , "may be somewhat unpredictable, so use this operator with great caution."
+    ]
+
+  , prim "checkpoint"          "TopLevel (() -> TopLevel ())"
+    (pureVal checkpoint)
+    Experimental
+    [ "Capure the current state of the SAW interpreter, and return"
+    , "A TopLevel monadic action that, if invoked, will reset the"
+    , "state of the interpreter back to to what it was at the"
+    , "moment checkpoint was invoked."
+    , ""
+    , "NOTE that this facility is highly experimental and may not"
+    , "be entirely reliable.  It is intended only for proof development"
+    , "where it can speed up the process of experimenting with"
+    , "mid-proof changes. Finalized proofs should not use this facility."
+    ]
 
   , prim "define"              "String -> Term -> TopLevel Term"
     (pureVal definePrim)
@@ -2319,6 +2342,11 @@ primitives = Map.fromList
     [ "Exit SAWScript, returning the supplied exit code to the parent"
     , "process."
     ]
+
+  , prim "fail" "{a} String -> TopLevel a"
+    (\_ _ -> toValue failPrim)
+    Current
+    [ "Throw an exception in the top level monad." ]
 
   , prim "fails"               "{a} TopLevel a -> TopLevel ()"
     (\_ _ -> toValue failsPrim)

--- a/src/SAWScript/TopLevel.hs
+++ b/src/SAWScript/TopLevel.hs
@@ -19,6 +19,8 @@ module SAWScript.TopLevel
   , getTopLevelRW
   , localOptions
   , putTopLevelRW
+  , makeCheckpoint
+  , restoreCheckpoint
   ) where
 
 import SAWScript.Value

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -461,15 +461,13 @@ getMergedEnv =
 -- | TopLevel Read-Only Environment.
 data TopLevelRO =
   TopLevelRO
-  { roSharedContext :: SharedContext
-  , roJavaCodebase  :: JSS.Codebase
+  { roJavaCodebase  :: JSS.Codebase
   , roOptions       :: Options
   , roHandleAlloc   :: Crucible.HandleAllocator
   , roPosition      :: SS.Pos
   , roProxy         :: AIGProxy
   , roInitWorkDir   :: FilePath
   , roBasicSS       :: SAWSimpset
-  , roTheoremDB     :: TheoremDB
   , roStackTrace    :: [String]
     -- ^ SAWScript-internal backtrace for use
     --   when displaying exceptions and such
@@ -493,6 +491,9 @@ data TopLevelRW =
   , rwMRSolverEnv :: MRSolver.MREnv
   , rwProofs  :: [Value] {- ^ Values, generated anywhere, that represent proofs. -}
   , rwPPOpts  :: PPOpts
+  , rwSharedContext :: SharedContext
+  , rwTheoremDB :: TheoremDB
+
   -- , rwCrucibleLLVMCtx :: Crucible.LLVMContext
   , rwJVMTrans :: CJ.JVMContext
   -- ^ crucible-jvm: Handles and info for classes that have already been translated
@@ -597,6 +598,7 @@ restoreCheckpoint chk =
      rw' <- io (combineRW chk rw)
      putTopLevelRW rw'
 
+
 -- | Capture the current state of the TopLevel monad
 --   and return an action that, if invoked, resets
 --   the state back to that point.
@@ -629,10 +631,13 @@ getStackTrace :: TopLevel [String]
 getStackTrace = TopLevel_ (reverse <$> asks roStackTrace)
 
 getSharedContext :: TopLevel SharedContext
-getSharedContext = TopLevel_ (asks roSharedContext)
+getSharedContext = TopLevel_ (rwSharedContext <$> get)
 
 getJavaCodebase :: TopLevel JSS.Codebase
 getJavaCodebase = TopLevel_ (asks roJavaCodebase)
+
+getTheoremDB :: TopLevel TheoremDB
+getTheoremDB = TopLevel_ (rwTheoremDB <$> get)
 
 getOptions :: TopLevel Options
 getOptions = TopLevel_ (asks roOptions)
@@ -808,7 +813,7 @@ runProofScript (ProofScript m) gl ploc rsn =
        Left (stats,cex) -> return (SAWScript.Proof.InvalidProof stats cex pstate)
        Right _ ->
          do sc <- getSharedContext
-            db <- roTheoremDB <$> getTopLevelRO
+            db <- rwTheoremDB <$> getTopLevelRW
             io (finishProof sc db pstate)
 
 scriptTopLevel :: TopLevel a -> ProofScript a

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -392,6 +392,11 @@ toplevelCallCC = VLambda body
            m (VLambda (\v -> return (VTopLevel (k ((VTopLevel (return v)))))))
    body _ = error "toplevelCallCC : expected lambda"
 
+toplevelSubshell :: Value
+toplevelSubshell = VLambda $ \_ ->
+  do m <- roSubshell <$> ask
+     return (VTopLevel (toValue <$> m))
+
 applyValue :: Value -> Value -> TopLevel Value
 applyValue (VLambda f) x = f x
 applyValue _ _ = throwTopLevel "applyValue"
@@ -439,6 +444,10 @@ data TopLevelRO =
     --   when displaying exceptions and such
     --   NB, stored with most recent calls on
     --   top of the stack.
+  , roSubshell      :: TopLevel ()
+    -- ^ An action for entering a subshell.  This
+    --   may raise an error if the current execution
+    --   mode doesn't support subshells (e.g., the remote API)
   }
 
 data TopLevelRW =

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -624,6 +624,15 @@ checkpoint = TopLevel_ $
        do printOutLnTop Info "Restoring state from checkpoint"
           restoreCheckpoint chk
 
+-- | Capture the current proof state and return an
+--   action that, if invoked, resets the state back to that point.
+proof_checkpoint :: ProofScript (() -> ProofScript ())
+proof_checkpoint =
+  do ps <- get
+     return $ \_ ->
+       do scriptTopLevel (printOutLnTop Info "Restoring proof state from checkpoint")
+          put ps
+
 throwTopLevel :: String -> TopLevel a
 throwTopLevel msg = do
   pos <- getPosition


### PR DESCRIPTION
This PR reorganizes the execution internals of SAWScript and implements some additional experimental primitives that will hopefully yield quality-of-life improvements for proof development.

The two main new capabilities are a `callcc` primitive, and a `subshell` primitive. The `subshell` primitive, when executed, will drop the user directly into a REPL session with the same context as the point where `subshell` was called. This should allow the user to experiment, view internal state, etc. interactively. `callcc`, as typical, reifies the rest of the computation as a function that can be called.  This is especially useful in combination with `subshell`, as the user can experiment with state updates and see what effect that has on the remainder of the proof without having to rerun the proof from the beginning.

There is additionally a new `checkpoint` primitive that captures (some) of the mutable state of the system and allows it to be restored at a later time. This facility is _highly_ experimental, and it is relatively easy to work yourself into broken states using it. Probably, we need a more comprehensive plan to deal with the general idea of checkpoint/resume in the entire SAW ecosystem to make this work more reliably.