### PR TITLE
Add heterogenous equality to Mr. Solver for SHA512 example

### DIFF
--- a/cryptol-saw-core/saw/CryptolM.sawcore
+++ b/cryptol-saw-core/saw/CryptolM.sawcore
@@ -172,6 +172,17 @@ bvVecUpdateM n len a xs i x =
                                            (updBVVec n len a xs i x))
         (bvultWithProof n i len);
 
+fromBVVecUpdateM : (n : Nat) -> (len : Vec n Bool) -> (a : isort 0) ->
+                   BVVec n len a -> Vec n Bool -> a ->
+                   a -> (m : Nat) -> CompM (Vec m a);
+fromBVVecUpdateM n len a xs i x def m =
+  maybe (is_bvult n i len) (CompM (Vec m a))
+        (errorM (Vec m a) "bvVecUpdateM: invalid sequence index")
+        (\ (_:is_bvult n i len) -> returnM (Vec m a)
+                                           (genFromBVVec n len a
+                                             (updBVVec n len a xs i x) def m))
+        (bvultWithProof n i len);
+
 updateM : (n : Nat) -> (a : isort 0) -> Vec n a -> Nat -> a -> CompM (Vec n a);
 updateM n a xs i x =
   maybe (IsLtNat i n) (CompM (Vec n a))

--- a/cryptol-saw-core/saw/CryptolM.sawcore
+++ b/cryptol-saw-core/saw/CryptolM.sawcore
@@ -340,7 +340,7 @@ ecShiftRM : (m : Num) -> (ix a : sort 0) -> PIntegral ix -> PZero a ->
 ecShiftRM =
   Num_rec (\ (m:Num) -> (ix a : sort 0) -> PIntegral ix -> PZero a ->
                         mseq m a -> ix -> mseq m a)
-          (\ (m:Nat) -> ecShiftL (TCNum m))
+          (\ (m:Nat) -> ecShiftR (TCNum m))
           (\ (ix a : sort 0) (pix:PIntegral ix) (pa:PZero a) ->
              ecShiftR TCInf ix (CompM a) pix (PZeroCompM a pa));
 

--- a/heapster-saw/examples/sha512.cry
+++ b/heapster-saw/examples/sha512.cry
@@ -73,14 +73,13 @@ round_00_15_spec i a b c d e f g h T1 =
 
 round_16_80_spec : [w] -> [w] ->
                    [w] -> [w] -> [w] -> [w] -> [w] -> [w] -> [w] -> [w] ->
-                   [16][w] ->
-                   [w] -> [w] -> [w] ->
+                   [16][w] -> [w] ->
                    ([w], [w], [w], [w], [w], [w], [w], [w], [16][w], [w], [w], [w])
-round_16_80_spec i j a b c d e f g h X s0 s1 T1 =
+round_16_80_spec i j a b c d e f g h X T1 =
   (a', b', c', d', e', f', g', h', X', s0', s1', T1'')
   where s0' = sigma_0 (X @ ((j + 1) && 15))
-        s1' = sigma_1 (X @ ((j +  4) && 15))
-        T1' = X @ (j && 15) + s0' + s1' + X @ ((j + 9) && 15)
+        s1' = sigma_1 (X @ ((j + 14) && 15))
+        T1' = (X @ (j && 15)) + s0' + s1' + (X @ ((j + 9) && 15))
         X' = update X (j && 15) T1'
         (a', b', c', d', e', f', g', h', T1'') =
           round_00_15_spec (i + j) a b c d e f g h T1'

--- a/heapster-saw/examples/sha512_mr_solver.saw
+++ b/heapster-saw/examples/sha512_mr_solver.saw
@@ -7,7 +7,10 @@ heapster_define_perm env "int64" " " "llvmptr 64" "exists x:bv 64.eq(llvmword(x)
 heapster_define_perm env "int32" " " "llvmptr 32" "exists x:bv 32.eq(llvmword(x))";
 heapster_define_perm env "int8" " " "llvmptr 8" "exists x:bv 8.eq(llvmword(x))";
 
-heapster_define_perm env "int64_ptr" " " "llvmptr 64" "ptr((W,0) |-> int64<>)";
+// FIXME: We always have rw=W, but without the rw arguments below Heapster
+// doesn't realize the perm is not copyable (it needs to unfold named perms).
+heapster_define_perm env "int64_ptr" "rw:rwmodality" "llvmptr 64" "ptr((rw,0) |-> int64<>)";
+heapster_define_perm env "true_ptr" "rw:rwmodality" "llvmptr 64" "ptr((rw,0) |-> true)";
 
 heapster_assume_fun env "CRYPTO_load_u64_be"
   "(). arg0:ptr((R,0) |-> int64<>) -o \
@@ -16,23 +19,23 @@ heapster_assume_fun env "CRYPTO_load_u64_be"
 
 heapster_typecheck_fun env "round_00_15"
  "(). arg0:int64<>, \
-    \ arg1:int64_ptr<>, arg2:int64_ptr<>, arg3:int64_ptr<>, arg4:int64_ptr<>, \
-    \ arg5:int64_ptr<>, arg6:int64_ptr<>, arg7:int64_ptr<>, arg8:int64_ptr<>, \
-    \ arg9:int64_ptr<> -o \
-    \ arg1:int64_ptr<>, arg2:int64_ptr<>, arg3:int64_ptr<>, arg4:int64_ptr<>, \
-    \ arg5:int64_ptr<>, arg6:int64_ptr<>, arg7:int64_ptr<>, arg8:int64_ptr<>, \
-    \ arg9:int64_ptr<>, ret:true";
+    \ arg1:int64_ptr<W>, arg2:int64_ptr<W>, arg3:int64_ptr<W>, arg4:int64_ptr<W>, \
+    \ arg5:int64_ptr<W>, arg6:int64_ptr<W>, arg7:int64_ptr<W>, arg8:int64_ptr<W>, \
+    \ arg9:int64_ptr<W> -o \
+    \ arg1:int64_ptr<W>, arg2:int64_ptr<W>, arg3:int64_ptr<W>, arg4:int64_ptr<W>, \
+    \ arg5:int64_ptr<W>, arg6:int64_ptr<W>, arg7:int64_ptr<W>, arg8:int64_ptr<W>, \
+    \ arg9:int64_ptr<W>, ret:true";
 
 heapster_typecheck_fun env "round_16_80"
  "(). arg0:int64<>, arg1:int64<>, \
-    \ arg2:int64_ptr<>, arg3:int64_ptr<>, arg4:int64_ptr<>, arg5:int64_ptr<>, \
-    \ arg6:int64_ptr<>, arg7:int64_ptr<>, arg8:int64_ptr<>, arg9:int64_ptr<>, \
+    \ arg2:int64_ptr<W>, arg3:int64_ptr<W>, arg4:int64_ptr<W>, arg5:int64_ptr<W>, \
+    \ arg6:int64_ptr<W>, arg7:int64_ptr<W>, arg8:int64_ptr<W>, arg9:int64_ptr<W>, \
     \ arg10:array(W,0,<16,*8,fieldsh(int64<>)), \
-    \ arg11:ptr((W,0) |-> true), arg12:ptr((W,0) |-> true), arg13:int64_ptr<> -o \
-    \ arg2:int64_ptr<>, arg3:int64_ptr<>, arg4:int64_ptr<>, arg5:int64_ptr<>, \
-    \ arg6:int64_ptr<>, arg7:int64_ptr<>, arg8:int64_ptr<>, arg9:int64_ptr<>, \
+    \ arg11:true_ptr<W>, arg12:true_ptr<W>, arg13:int64_ptr<W> -o \
+    \ arg2:int64_ptr<W>, arg3:int64_ptr<W>, arg4:int64_ptr<W>, arg5:int64_ptr<W>, \
+    \ arg6:int64_ptr<W>, arg7:int64_ptr<W>, arg8:int64_ptr<W>, arg9:int64_ptr<W>, \
     \ arg10:array(W,0,<16,*8,fieldsh(int64<>)), \
-    \ arg11:int64_ptr<>, arg12:int64_ptr<>, arg13:int64_ptr<>, ret:true";
+    \ arg11:int64_ptr<W>, arg12:int64_ptr<W>, arg13:int64_ptr<W>, ret:true";
 
 heapster_typecheck_fun env "return_X"
   "(). arg0:array(W,0,<16,*8,fieldsh(int64<>)) -o \
@@ -40,13 +43,13 @@ heapster_typecheck_fun env "return_X"
 
 heapster_set_translation_checks env false;
 heapster_typecheck_fun env "processBlock"
-  "(). arg0:int64_ptr<>, arg1:int64_ptr<>, arg2:int64_ptr<>, \
-     \ arg3:int64_ptr<>, arg4:int64_ptr<>, arg5:int64_ptr<>, \
-     \ arg6:int64_ptr<>, arg7:int64_ptr<>, \
+  "(). arg0:int64_ptr<W>, arg1:int64_ptr<W>, arg2:int64_ptr<W>, \
+     \ arg3:int64_ptr<W>, arg4:int64_ptr<W>, arg5:int64_ptr<W>, \
+     \ arg6:int64_ptr<W>, arg7:int64_ptr<W>, \
      \ arg8:array(R,0,<16,*8,fieldsh(int64<>)) -o \
-     \ arg0:int64_ptr<>, arg1:int64_ptr<>, arg2:int64_ptr<>, \
-     \ arg3:int64_ptr<>, arg4:int64_ptr<>, arg5:int64_ptr<>, \
-     \ arg6:int64_ptr<>, arg7:int64_ptr<>, \
+     \ arg0:int64_ptr<W>, arg1:int64_ptr<W>, arg2:int64_ptr<W>, \
+     \ arg3:int64_ptr<W>, arg4:int64_ptr<W>, arg5:int64_ptr<W>, \
+     \ arg6:int64_ptr<W>, arg7:int64_ptr<W>, \
      \ arg8:array(R,0,<16,*8,fieldsh(int64<>)), ret:true";
 
 // FIXME: This translation contains errors

--- a/heapster-saw/examples/sha512_mr_solver.saw
+++ b/heapster-saw/examples/sha512_mr_solver.saw
@@ -106,6 +106,4 @@ monadify_term {{ Maj }};
 monadify_term {{ round_00_15_spec }};
 
 run_test "round_00_15 |= round_00_15_spec" (mr_solver round_00_15 {{ round_00_15_spec }}) true;
-
-// FIXME: Need to add heterogenous equality on output types for this to work
-// run_test "round_16_80 |= round_16_80_spec" (mr_solver_debug 0 round_16_80 {{ round_16_80_spec }}) true;
+run_test "round_16_80 |= round_16_80_spec" (mr_solver round_16_80 {{ round_16_80_spec }}) true;

--- a/saw-core/src/Verifier/SAW/Recognizer.hs
+++ b/saw-core/src/Verifier/SAW/Recognizer.hs
@@ -60,6 +60,7 @@ module Verifier.SAW.Recognizer
     -- * Prelude recognizers.
   , asBool
   , asBoolType
+  , asNatType
   , asIntegerType
   , asIntModType
   , asBitvectorType
@@ -356,6 +357,11 @@ asBool _ = Nothing
 
 asBoolType :: Recognizer Term ()
 asBoolType = isGlobalDef "Prelude.Bool"
+
+asNatType :: Recognizer Term ()
+asNatType (asDataType -> Just (o, []))
+  | primName o == preludeNatIdent = return ()
+asNatType _ = Nothing
 
 asIntegerType :: Recognizer Term ()
 asIntegerType = isGlobalDef "Prelude.Integer"

--- a/src/SAWScript/Prover/MRSolver/Monad.hs
+++ b/src/SAWScript/Prover/MRSolver/Monad.hs
@@ -24,6 +24,8 @@ module SAWScript.Prover.MRSolver.Monad where
 
 import Data.List (find, findIndex, foldl')
 import qualified Data.Text as T
+import Numeric.Natural (Natural)
+import Data.Bits (testBit)
 import System.IO (hPutStrLn, stderr)
 import Control.Monad.Reader
 import Control.Monad.State
@@ -467,6 +469,14 @@ mrBvToNat _ (asArrayValue -> Just (asBoolType -> Just _,
                                    mapM asBool -> Just bits)) =
   liftSC1 scNat $ foldl' (\n bit -> if bit then 2*n+1 else 2*n) 0 bits
 mrBvToNat n len = liftSC2 scBvNat n len
+
+-- | Like 'scBvConst', but returns a bitvector literal
+mrBvConst :: Natural -> Integer -> MRM Term
+mrBvConst n x =
+  do bool_tp <- liftSC0 scBoolType
+     bits <- mapM (liftSC1 scBool . testBit x)
+                  [(fromIntegral n - 1), (fromIntegral n - 2) .. 0]
+     liftSC2 scVector bool_tp bits
 
 -- | Get the current context of uvars as a list of variable names and their
 -- types as SAW core 'Term's, with the least recently bound uvar first, i.e., in

--- a/src/SAWScript/Prover/MRSolver/Monad.hs
+++ b/src/SAWScript/Prover/MRSolver/Monad.hs
@@ -22,7 +22,7 @@ monadic combinators for operating on terms.
 
 module SAWScript.Prover.MRSolver.Monad where
 
-import Data.List (find, findIndex)
+import Data.List (find, findIndex, foldl')
 import qualified Data.Text as T
 import System.IO (hPutStrLn, stderr)
 import Control.Monad.Reader
@@ -245,27 +245,6 @@ instance PrettyInCtx DataTypeAssump where
   prettyInCtx (IsNum   x) = prettyInCtx x >>= ppWithPrefix "TCNum"
   prettyInCtx IsInf = return "TCInf"
 
--- | Recognize a term as a @Left@ or @Right@
-asEither :: Recognizer Term (Either Term Term)
-asEither (asCtor -> Just (c, [_, _, x]))
-  | primName c == "Prelude.Left"  = return $ Left x
-  | primName c == "Prelude.Right" = return $ Right x
-asEither _ = Nothing
-
--- | Recognize a term as a @TCNum n@ or @TCInf@
-asNum :: Recognizer Term (Either Term ())
-asNum (asCtor -> Just (c, [n]))
-  | primName c == "Cryptol.TCNum"  = return $ Left n
-asNum (asCtor -> Just (c, []))
-  | primName c == "Cryptol.TCInf"  = return $ Right ()
-asNum _ = Nothing
-
--- | Recognize a term as being of the form @isFinite n@
-asIsFinite :: Recognizer Term Term
-asIsFinite (asApp -> Just (isGlobalDef "CryptolM.isFinite" -> Just (), n)) =
-  Just n
-asIsFinite _ = Nothing
-
 -- | Create a term representing the type @IsFinite n@
 mrIsFinite :: Term -> MRM Term
 mrIsFinite n = liftSC2 scGlobalApply "CryptolM.isFinite" [n]
@@ -480,6 +459,14 @@ funNameType (GlobalName gd projs) =
 -- | Apply a 'Term' to a list of arguments and beta-reduce in Mr. Monad
 mrApplyAll :: Term -> [Term] -> MRM Term
 mrApplyAll f args = liftSC2 scApplyAllBeta f args
+
+-- | Like 'scBvNat', but if given a bitvector literal it is converted to a
+-- natural number literal
+mrBvToNat :: Term -> Term -> MRM Term
+mrBvToNat _ (asArrayValue -> Just (asBoolType -> Just _,
+                                   mapM asBool -> Just bits)) =
+  liftSC1 scNat $ foldl' (\n bit -> if bit then 2*n+1 else 2*n) 0 bits
+mrBvToNat n len = liftSC2 scBvNat n len
 
 -- | Get the current context of uvars as a list of variable names and their
 -- types as SAW core 'Term's, with the least recently bound uvar first, i.e., in

--- a/src/SAWScript/Prover/MRSolver/SMT.hs
+++ b/src/SAWScript/Prover/MRSolver/SMT.hs
@@ -305,7 +305,7 @@ mrProvable (asBool -> Just b) = return b
 mrProvable bool_tm =
   do assumps <- mrAssumptions
      prop <- liftSC2 scImplies assumps bool_tm >>= liftSC1 scEqTrue
-     prop_inst <- instantiateUVarsM instUVar prop
+     prop_inst <- mrSubstEVars prop >>= instantiateUVarsM instUVar
      mrNormTerm prop_inst >>= mrProvableRaw
   where -- | Given a UVar name and type, generate a 'Term' to be passed to
         -- SMT, with special cases for BVVec and pair types

--- a/src/SAWScript/Prover/MRSolver/SMT.hs
+++ b/src/SAWScript/Prover/MRSolver/SMT.hs
@@ -50,15 +50,6 @@ import SAWScript.Prover.MRSolver.Monad
 -- * Various SMT-specific Functions on Terms
 ----------------------------------------------------------------------
 
--- | Test if a 'Term' is a 'BVVec' type
-asBVVecType :: Recognizer Term (Term, Term, Term)
-asBVVecType (asApplyAll ->
-             (isGlobalDef "Prelude.Vec" -> Just _,
-              [(asApplyAll ->
-                (isGlobalDef "Prelude.bvToNat" -> Just _, [n, len])), a])) =
-  Just (n, len, a)
-asBVVecType _ = Nothing
-
 -- | Apply @genBVVec@ to arguments @n@, @len@, and @a@, along with a function of
 -- type @Vec n Bool -> a@
 genBVVecTerm :: SharedContext -> Term -> Term -> Term -> Term -> IO Term
@@ -343,8 +334,7 @@ mrEq t1 t2 = mrTypeOf t1 >>= \tp -> mrEq' tp t1 t2
 -- are equal, where the first 'Term' gives their type (which we assume is the
 -- same for both). This is like 'scEq' except that it works on open terms.
 mrEq' :: Term -> Term -> Term -> MRM Term
-mrEq' (asDataType -> Just (pn, [])) t1 t2
-  | primName pn == "Prelude.Nat" = liftSC2 scEqualNat t1 t2
+mrEq' (asNatType -> Just _) t1 t2 = liftSC2 scEqualNat t1 t2
 mrEq' (asBoolType -> Just _) t1 t2 = liftSC2 scBoolEq t1 t2
 mrEq' (asIntegerType -> Just _) t1 t2 = liftSC2 scIntEq t1 t2
 mrEq' (asVectorType -> Just (n, asBoolType -> Just ())) t1 t2 =

--- a/src/SAWScript/Prover/MRSolver/Solver.hs
+++ b/src/SAWScript/Prover/MRSolver/Solver.hs
@@ -296,7 +296,7 @@ normComp (CompTerm t) =
                                                   i)]) ->
       do body <- mrGlobalDefBody "CryptolM.bvVecAtM"
          if n < 1 `shiftL` fromIntegral w then do
-           n' <- liftSC2 scBvConst w (toInteger n)
+           n' <- mrBvConst w (toInteger n)
            err_str <- liftSC1 scString "FIXME: normComp (atM) error"
            err_tm <- liftSC2 scGlobalApply "Prelude.error" [a, err_str]
            xs' <- liftSC2 scGlobalApply "Prelude.genBVVecFromVec"
@@ -321,14 +321,14 @@ normComp (CompTerm t) =
                                               asBvToNat ->
                                                 Just (w_tm@(asNat -> Just w),
                                                       i), x]) ->
-      do body <- mrGlobalDefBody "CryptolM.bvVecUpdateM"
+      do body <- mrGlobalDefBody "CryptolM.fromBVVecUpdateM"
          if n < 1 `shiftL` fromIntegral w then do
-           n' <- liftSC2 scBvConst w (toInteger n)
+           n' <- mrBvConst w (toInteger n)
            err_str <- liftSC1 scString "FIXME: normComp (updateM) error"
            err_tm <- liftSC2 scGlobalApply "Prelude.error" [a, err_str]
            xs' <- liftSC2 scGlobalApply "Prelude.genBVVecFromVec"
                                         [n_tm, a, xs, err_tm, w_tm, n'] 
-           mrApplyAll body [w_tm, n', a, xs', i, x] >>= normCompTerm
+           mrApplyAll body [w_tm, n', a, xs', i, x, err_tm, n_tm] >>= normCompTerm
          else throwMRFailure (MalformedComp t)
 
     -- Always unfold: sawLet, multiArgFixM, invariantHint, Num_rec

--- a/src/SAWScript/Prover/MRSolver/Solver.hs
+++ b/src/SAWScript/Prover/MRSolver/Solver.hs
@@ -623,7 +623,7 @@ mrRefines t1 t2 =
 -- | The main implementation of 'mrRefines'
 mrRefines' :: NormComp -> NormComp -> MRM ()
 
-mrRefines' (ReturnM e1) (ReturnM e2) = mrAssertProveEq e1 e2
+mrRefines' (ReturnM e1) (ReturnM e2) = mrAssertProveRel True e1 e2
 mrRefines' (ErrorM _) (ErrorM _) = return ()
 mrRefines' (ReturnM e) (ErrorM _) = throwMRFailure (ReturnNotError e)
 mrRefines' (ErrorM _) (ReturnM e) = throwMRFailure (ReturnNotError e)

--- a/src/SAWScript/Prover/MRSolver/Solver.hs
+++ b/src/SAWScript/Prover/MRSolver/Solver.hs
@@ -125,7 +125,7 @@ module SAWScript.Prover.MRSolver.Solver where
 
 import Data.Maybe
 import Data.Either
-import Data.List (findIndices, intercalate, foldl')
+import Data.List (findIndices, intercalate)
 import Data.Bits (shiftL)
 import Control.Monad.Except
 import qualified Data.Map as Map
@@ -147,19 +147,6 @@ import SAWScript.Prover.MRSolver.SMT
 ----------------------------------------------------------------------
 -- * Normalizing and Matching on Terms
 ----------------------------------------------------------------------
-
--- | Like 'asVectorType', but returns 'Nothing' if 'asBVVecType' returns 'Just'
-asNonBVVecVectorType :: Recognizer Term (Term, Term)
-asNonBVVecVectorType (asBVVecType -> Just _) = Nothing
-asNonBVVecVectorType t = asVectorType t
-
--- | Like 'scBvNat', but if given a bitvector literal it is converted to a
--- natural number literal
-mrBvToNat :: Term -> Term -> MRM Term
-mrBvToNat _ (asArrayValue -> Just (asBoolType -> Just _,
-                                   mapM asBool -> Just bits)) =
-  liftSC1 scNat $ foldl' (\n bit -> if bit then 2*n+1 else 2*n) 0 bits
-mrBvToNat n len = liftSC2 scBvNat n len
 
 -- | Pattern-match on a @LetRecTypes@ list in normal form and return a list of
 -- the types it specifies, each in normal form and with uvars abstracted out

--- a/src/SAWScript/Prover/MRSolver/Term.hs
+++ b/src/SAWScript/Prover/MRSolver/Term.hs
@@ -433,6 +433,14 @@ instance PrettyInCtx MRVar where
 instance PrettyInCtx [Term] where
   prettyInCtx xs = list <$> mapM prettyInCtx xs
 
+instance PrettyInCtx a => PrettyInCtx (Maybe a) where
+  prettyInCtx (Just x) = (<+>) "Just" <$> prettyInCtx x
+  prettyInCtx Nothing = return "Nothing"
+
+instance (PrettyInCtx a, PrettyInCtx b) => PrettyInCtx (a,b) where
+  prettyInCtx (x, y) = (\x' y' -> parens (x' <> "," <> y')) <$> prettyInCtx x
+                                                            <*> prettyInCtx y
+
 instance PrettyInCtx TermProj where
   prettyInCtx TermProjLeft = return (pretty '.' <> "1")
   prettyInCtx TermProjRight = return (pretty '.' <> "2")


### PR DESCRIPTION
This PR gets `round_16_80 |= round_16_80_spec` from the SHA512 example working by primarily adding heterogeneous equality to Mr. Solver. It also makes a few other changes, but instead of listing them here, I broke each change into its own commit. Each commit should be self-explanatory.

I'm not totally sure about the interface choices I made in `SMT.hs` in 45de4641368684a608e913ce79ec47ca7d4617a7 (e.g. `mrProveEq` vs. `mrProveRel`, using a `Bool` to indicate heterogeneous equality), so that's definitely worth taking a look at. It's worth saying that I went for `mrProveRel` instead of something like `mrProveHetEq` because we will likely eventually want to add a parameter to this function which additionally lets the user give a custom relation for function terms (for lifetimes).