### PR TITLE
CI: Signing improvements

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -104,10 +104,12 @@ bundle_files() {
 }
 
 sign() {
+  set +x
   gpg --batch --import <(echo "$SIGNING_KEY")
   fingerprint="$(gpg --list-keys | grep galois -a1 | head -n1 | awk '{$1=$1};1')"
   echo "$fingerprint:6" | gpg --import-ownertrust
   gpg --yes --no-tty --batch --pinentry-mode loopback --default-key "$fingerprint" --detach-sign -o "$1".sig --passphrase-file <(echo "$SIGNING_PASSPHRASE") "$1"
+  set -x
 }
 
 zip_dist() {

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -104,9 +104,11 @@ bundle_files() {
 }
 
 sign() {
+  # This is surrounded with `set +x; ...; set -x` to disable printing out
+  # statements that could leak GPG-related secrets.
   set +x
   gpg --batch --import <(echo "$SIGNING_KEY")
-  fingerprint="$(gpg --list-keys | grep galois -a1 | head -n1 | awk '{$1=$1};1')"
+  fingerprint="$(gpg --list-keys | grep Galois -a1 | head -n1 | awk '{$1=$1};1')"
   echo "$fingerprint:6" | gpg --import-ownertrust
   gpg --yes --no-tty --batch --pinentry-mode loopback --default-key "$fingerprint" --detach-sign -o "$1".sig --passphrase-file <(echo "$SIGNING_PASSPHRASE") "$1"
   set -x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,14 +156,14 @@ jobs:
       - shell: bash
         run: .github/ci.sh zip_dist_with_solvers $NAME-with-solvers
 
-      - if: matrix.ghc == '8.10.7' && needs.config.outputs.release == 'true'
+      - if: matrix.ghc == '8.10.7'
         shell: bash
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
         run: .github/ci.sh sign $NAME.tar.gz
 
-      - if: matrix.ghc == '8.10.7' && needs.config.outputs.release == 'true'
+      - if: matrix.ghc == '8.10.7'
         shell: bash
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}


### PR DESCRIPTION
* Always sign binary artifacts, not just for releases. Fixes #1669.
* Use modern GPG keys. Fixes #1668.