### PR TITLE
Term utilities

### DIFF
--- a/intTests/test_congruence/README
+++ b/intTests/test_congruence/README
@@ -1,0 +1,5 @@
+This is a simple test of the "congruence_for" primitive.
+
+We define a simple cryptol function, ask the system to
+automatically define a congruence rule for it; prove
+it is true, and then use it in another proof.

--- a/intTests/test_congruence/test.saw
+++ b/intTests/test_congruence/test.saw
@@ -1,0 +1,24 @@
+enable_experimental;
+
+let {{
+  f : [32] -> [100][12] -> Integer
+  f x ys = foldl (\i y -> i + toInteger y) (toInteger x) ys
+
+}};
+
+f_cong_term <- congruence_for {{ f }};
+f_cong_thm  <- prove_extcore (w4_unint_z3 ["f"]) f_cong_term;
+
+thm <- prove_print
+       do {
+         goal_intro "x";
+	 goal_intro "y";
+	 unfolding ["ecEq"];
+	 simplify (cryptol_ss ());
+	 goal_apply f_cong_thm;
+	 z3;
+	 z3;
+       }
+       {{ \x y -> f (x+y) zero == f (y+x) zero }};
+
+print thm;

--- a/intTests/test_congruence/test.sh
+++ b/intTests/test_congruence/test.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+$SAW test.saw

--- a/saw-core-coq/src/Verifier/SAW/Translation/Coq/SpecialTreatment.hs
+++ b/saw-core-coq/src/Verifier/SAW/Translation/Coq/SpecialTreatment.hs
@@ -217,6 +217,7 @@ sawCorePreludeSpecialTreatmentMap configuration =
   ++
   [ ("error",             mapsTo sawDefinitionsModule "error")
   , ("fix",               skip)
+  , ("fix_unfold",        skip)
   , ("unsafeAssert",      replaceDropArgs 3 $ Coq.Ltac "solveUnsafeAssert")
   , ("unsafeAssertBVULt", replaceDropArgs 3 $ Coq.Ltac "solveUnsafeAssertBVULt")
   , ("unsafeAssertBVULe", replaceDropArgs 3 $ Coq.Ltac "solveUnsafeAssertBVULe")

--- a/saw-core/prelude/Prelude.sawcore
+++ b/saw-core/prelude/Prelude.sawcore
@@ -158,6 +158,29 @@ eq_inv_map a b a1 a2 eq_a f1 f2 eq_f =
     (trans b (f1 a2) (f2 a2) (f2 a1) eq_f
            (eq_cong a a2 a1 (sym a a1 a2 eq_a) b f2));
 
+
+-- Basic axiom about the behavior of "fix"
+axiom fix_unfold :
+  (a : sort 1) ->
+  (f : a -> a) ->
+  Eq a (fix a f) (f (fix a f));
+
+inverse_eta_rule :
+  (a : sort 1) ->
+  (b : sort 1) ->
+  (f : a -> b) ->
+  (g : a -> b) ->
+  (Eq (a -> b) f g) ->
+  (x : a) ->
+  Eq b (f x) (g x);
+inverse_eta_rule a b f g H =
+  Eq__rec (a -> b) f
+    ( \ (g' : a -> b) -> \ (H':Eq (a -> b) f g') ->
+        ( x : a ) -> Eq b (f x) (g' x))
+    (\ (x:a) -> Refl b (f x))
+    g H;
+
+
 -- Unchecked assertion that two types are equal.
 axiom unsafeAssert : (a : sort 1) -> (x : a) -> (y : a) -> Eq a x y;
 

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -643,6 +643,14 @@ congruence_for tt =
      congTm <- io $ build_congruence sc (ttTerm tt)
      io $ mkTypedTerm sc congTm
 
+-- | Given an input term, construct another term that
+--   represents a congruence law for that term.
+--   This term will be a Curry-Howard style theorem statement
+--   that can be dispatched to solvers, and should have
+--   type "Prop".
+--
+--   This will only work for terms that represent non-dependent
+--   functions.
 build_congruence :: SharedContext -> Term -> IO Term
 build_congruence sc tm =
   do ty <- scTypeOf sc tm

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1075,6 +1075,13 @@ primitives = Map.fromList
     , "is used only for pretty-printing."
     ]
 
+  , prim "term_apply"          "Term -> [Term] -> Term"
+    (funVal2 term_apply)
+    Current
+    [ "Build a term application node that applies the first term"
+    , "(which much be a term representing a function) to given list of arguments."
+    ]
+
   , prim "lambda"              "Term -> Term -> Term"
     (funVal2 lambda)
     Current
@@ -1089,6 +1096,22 @@ primitives = Map.fromList
     , "those variables, and return a new lambda abstraction over the list of"
     , "variables."
     ]
+
+  , prim "size_to_term"      "Type -> Term"
+    (funVal1 size_to_term)
+    Current
+    [ "Convert a Cryptol size type into a Term representation."
+    ]
+
+  , prim "int_to_term"      "Int -> Term"
+    (funVal1 int_to_term)
+    Current
+    [ "Convert a concrete integer value into an integer term." ]
+
+  , prim "nat_to_term"      "Int -> Term"
+    (funVal1 nat_to_term)
+    Current
+    [ "Convert a non-negative integer value into a natural number term." ]
 
   , prim "term_theories" "[String] -> Term -> [String]"
     (funVal2 term_theories)

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1111,6 +1111,14 @@ primitives = Map.fromList
     Experimental
     [ "Apply Cryptol defaulting rules to the given term." ]
 
+  , prim "congruence_for" "Term -> TopLevel Term"
+    (pureVal congruence_for)
+    Experimental
+    [ "Given a term representing a (nondependent) function, attempt"
+    , "to automatically construct the statement of a congruence lemma"
+    , "for the function."
+    ]
+
   , prim "extract_uninterp" "[String] -> [String] -> Term -> TopLevel (Term, [(String,[(Term, Term)])])"
     (pureVal extract_uninterp)
     Experimental


### PR DESCRIPTION
Some utilities for constructing SAWCore terms.

The `term_apply` primitive gives a way to combine terms by application, which was missing previously. The `congruence_for` is a convenience that tries to automatically build the statement of a congruence lemma for a term.  This statement can then be proved and applied as a lemma.
