### PR TITLE
X86 preconditions

### DIFF
--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -80,6 +80,7 @@ module SAWScript.Crucible.LLVM.Builtins
     , findDecl
     , findDefMaybeStatic
     , setupLLVMCrucibleContext
+    , setupPrestateConditions
     , checkSpecReturnType
     , verifyPrestate
     , verifyPoststate


### PR DESCRIPTION
Add specification preconditions to the assumption state prior
to beginning symbolic execution instead of just before asserting
postconditions.

This allows the assumptions to be in scope for safety conditions
that arise durning execution.