### PR TITLE
Add bitvector fallbacks to more nat ops in the simulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
         with:
           targets: |
             integration_tests
+            test-sawcore
             cryptol-saw-core-tc-test
             prover_tests
           dest: dist-tests

--- a/saw-core/saw-core.cabal
+++ b/saw-core/saw-core.cabal
@@ -135,6 +135,7 @@ test-suite test-sawcore
     Tests.Parser
     Tests.Rewriter
     Tests.SharedTerm
+    Tests.Simulator
 
 executable extcore-info
   main-is: extcore-info.hs

--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -63,6 +63,7 @@ import Control.Monad.Fix (MonadFix(mfix))
 import Control.Monad.Trans
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Except
+import Data.Bifunctor
 import Data.Bits
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -118,6 +119,17 @@ natFun = PrimFilterFun "expected Nat" r
         r (VCtorApp (primName -> "Prelude.Zero") [] [])  = pure 0
         r (VCtorApp (primName -> "Prelude.Succ") [] [x]) = succ <$> (r =<< lift (force x))
         r _ = mzero
+
+-- | A primitive that requires a natural argument which may or may not be
+-- concrete - like 'natFun' but gives the 'Value' instead of failing if the
+-- argument is not concrete
+maybeNatFun :: VMonad l => (Either (Value l) Natural -> Prim l) -> Prim l
+maybeNatFun = PrimFilterFun "expected Nat" r
+  where r (VNat n) = pure (Right n)
+        r (VCtorApp (primName -> "Prelude.Zero") [] []) = pure (Right 0)
+        r v@(VCtorApp (primName -> "Prelude.Succ") [] [x]) =
+          bimap (const v) succ <$> (r =<< lift (force x))
+        r v = pure (Left v)
 
 -- | A primitive that requires an integer argument
 intFun :: VMonad l => (VInt l -> Prim l) -> Prim l
@@ -313,15 +325,15 @@ constMap bp = Map.fromList
     )
 
   -- Nat
-  , ("Prelude.Succ", succOp)
-  , ("Prelude.addNat", addNatOp)
+  , ("Prelude.Succ", succOp bp)
+  , ("Prelude.addNat", addNatOp bp)
   , ("Prelude.subNat", subNatOp bp)
-  , ("Prelude.mulNat", mulNatOp)
-  , ("Prelude.minNat", minNatOp)
-  , ("Prelude.maxNat", maxNatOp)
-  , ("Prelude.divModNat", divModNatOp)
+  , ("Prelude.mulNat", mulNatOp bp)
+  , ("Prelude.minNat", minNatOp bp)
+  , ("Prelude.maxNat", maxNatOp bp)
+  , ("Prelude.divModNat", divModNatOp bp)
   , ("Prelude.expNat", expNatOp)
-  , ("Prelude.widthNat", widthNatOp)
+  , ("Prelude.widthNat", widthNatOp bp)
   , ("Prelude.natCase", natCaseOp)
   , ("Prelude.equalNat", equalNatOp bp)
   , ("Prelude.ltNat", ltNatOp bp)
@@ -533,79 +545,131 @@ natSize _bp val =
 -- | Convert the given value (which should be of type Nat) to a word
 -- of the given bit-width. The bit-width must be at least as large as
 -- that returned by @natSize@.
-natToWord :: (VMonad l, Show (Extra l)) => BasePrims l -> Int -> Value l -> MWord l
+natToWord :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l ->
+             Natural -> Value l -> MWord l
 natToWord bp w val =
+  unless (w <= fromIntegral (maxBound :: Int))
+         (panic "natToWord" ["width too large", show w]) >>
+  -- TODO, remove the calls to fromIntegral below
   case val of
-    VNat n -> bpBvLit bp w (toInteger n)
+    VNat n -> bpBvLit bp (fromIntegral w) (toInteger n)
     VIntToNat _i -> panic "natToWord of VIntToNat TODO!"
     VBVToNat xsize v ->
       do x <- toWord (bpPack bp) v
-         case compare xsize w of
+         case compare xsize (fromIntegral w) of
            GT -> panic "natToWord: not enough bits"
            EQ -> return x
            LT -> -- zero-extend x to width w
-             do pad <- bpBvLit bp (w - xsize) 0
+             do pad <- bpBvLit bp (fromIntegral w - xsize) 0
                 bpBvJoin bp pad x
     _ -> panic "natToWord: expected Nat"
 
+-- | A primitive which is a unary operation on a natural argument.
+-- The second argument gives this operation for a concrete natural argument.
+-- The third argument gives this operation for a natural argument of the given
+-- size in bits.
+unaryNatOp :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l ->
+              (Natural -> MValue l) ->
+              (Int -> VWord l -> MValue l) -> Prim l
+unaryNatOp bp fn fv = maybeNatFun $ \case
+  Right n -> Prim (fn n)
+  Left v -> Prim $ do x <- natToWord bp (natSize bp v) v
+                      fv (fromIntegral (natSize bp v)) x
+
+-- | A primitive which is a unary operation on a natural argument and which
+-- returns a natural.
+-- The second argument gives this operation for a concrete natural argument.
+-- The third argument gives this operation for a natural argument of the given
+-- size in bits.
+unaryNatToNatOp :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l ->
+                   (Natural -> Natural) ->
+                   (Int -> VWord l -> MWord l) -> Prim l
+unaryNatToNatOp bp fn fv =
+  unaryNatOp bp (\n -> pure (vNat (fn n)))
+                (\w x -> VBVToNat w . VWord <$> fv w x)
+
+-- | A primitive which is a binary operation on natural arguments.
+-- The second argument gives how to combine the the sizes in bits of this
+-- operation's arguments so that no overflow occurs (e.g. 'max' for
+-- comparisons, @(\w1 w2 -> suc (max w1 w2))@ for addition, '(+)' for
+-- multiplication).
+-- The third argument gives this operation for concrete natural arguments.
+-- The fourth argument gives this operation for natural arguments of the size
+-- in bits given by the second argument.
+binNatOp :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l ->
+            (Natural -> Natural -> Natural) ->
+            (Natural -> Natural -> MValue l) ->
+            (Int -> VWord l -> VWord l -> MValue l) -> Prim l
+binNatOp bp fw fn fv = maybeNatFun $ \m -> maybeNatFun $ \n -> go m n
+  where go (Right m) (Right n) = Prim (fn m n)
+        go (Right m) (Left v2) = go (Left (VNat m)) (Left v2)
+        go (Left v1) (Right n) = go (Left v1) (Left (VNat n))
+        go (Left v1) (Left v2) = Prim $
+          do let w = fw (natSize bp v1) (natSize bp v2)
+             x1 <- natToWord bp w v1
+             x2 <- natToWord bp w v2
+             fv (fromIntegral w) x1 x2
+
+-- | A primitive which is a binary operation on natural arguments and which
+-- returns a natural.
+-- The second argument gives how to combine the the sizes in bits of this
+-- operation's arguments so that no overflow occurs (e.g. 'max' for
+-- comparisons, @(\w1 w2 -> suc (max w1 w2))@ for addition, '(+)' for
+-- multiplication).
+-- The third argument gives this operation for concrete natural arguments.
+-- The fourth argument gives this operation for natural arguments of the size
+-- in bits given by the second argument.
+binNatToNatOp :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l ->
+                 (Natural -> Natural -> Natural) ->
+                 (Natural -> Natural -> Natural) ->
+                 (Int -> VWord l -> VWord l -> MWord l) -> Prim l
+binNatToNatOp bp fw fn fv =
+  binNatOp bp fw (\m n -> pure (vNat (fn m n)))
+                 (\w x1 x2 -> VBVToNat w . VWord <$> fv w x1 x2)
+
 -- Succ :: Nat -> Nat;
-succOp :: VMonad l => Prim l
-succOp =
-  natFun $ \n -> PrimValue (vNat (succ n))
+succOp :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l -> Prim l
+succOp bp = unaryNatToNatOp bp succ (\w x -> do o <- bpBvLit bp w 1
+                                                bpBvAdd bp x o)
 
 -- addNat :: Nat -> Nat -> Nat;
-addNatOp :: VMonad l => Prim l
-addNatOp =
-  natFun $ \m ->
-  natFun $ \n ->
-    PrimValue (vNat (m + n))
+addNatOp :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l -> Prim l
+addNatOp bp = binNatToNatOp bp (\w1 w2 -> succ (max w1 w2))
+                               (+) (\_ -> bpBvAdd bp)
 
 -- subNat :: Nat -> Nat -> Nat;
-subNatOp :: (VMonad l, Show (Extra l)) => BasePrims l -> Prim l
-subNatOp bp =
-  strictFun $ \x ->
-  strictFun $ \y -> Prim (g x y)
-  where
-    g (VNat i) (VNat j) = return $ VNat (if i < j then 0 else i - j)
-    g v1 v2 =
-      do let w = toInteger (max (natSize bp v1) (natSize bp v2))
-         unless (w <= toInteger (maxBound :: Int))
-                (panic "subNatOp" ["width too large", show w])
-         x1 <- natToWord bp (fromInteger w) v1
-         x2 <- natToWord bp (fromInteger w) v2
-         lt <- bpBvult bp x1 x2
-         z <- bpBvLit bp (fromInteger w) 0
-         d <- bpBvSub bp x1 x2
-         VBVToNat (fromInteger w) . VWord <$> bpMuxWord bp lt z d -- TODO, boo fromInteger
+subNatOp :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l -> Prim l
+subNatOp bp = binNatToNatOp bp (\w1 w2 -> max w1 w2)
+                               (\i j -> if i < j then 0 else i - j)
+                               (\w x1 x2 -> do lt <- bpBvult bp x1 x2
+                                               z <- bpBvLit bp w 0
+                                               d <- bpBvSub bp x1 x2
+                                               bpMuxWord bp lt z d)
 
 -- mulNat :: Nat -> Nat -> Nat;
-mulNatOp :: VMonad l => Prim l
-mulNatOp =
-  natFun $ \m ->
-  natFun $ \n ->
-    PrimValue (vNat (m * n))
+mulNatOp :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l -> Prim l
+mulNatOp bp = binNatToNatOp bp (+) (*) (\_ -> bpBvMul bp)
 
 -- minNat :: Nat -> Nat -> Nat;
-minNatOp :: VMonad l => Prim l
-minNatOp =
-  natFun $ \m ->
-  natFun $ \n ->
-    PrimValue (vNat (min m n))
+minNatOp :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l -> Prim l
+minNatOp bp = binNatToNatOp bp max min
+                               (\_ x1 x2 -> do lt <- bpBvult bp x1 x2
+                                               bpMuxWord bp lt x1 x2)
 
 -- maxNat :: Nat -> Nat -> Nat;
-maxNatOp :: VMonad l => Prim l
-maxNatOp =
-  natFun $ \m ->
-  natFun $ \n ->
-    PrimValue (vNat (max m n))
+maxNatOp :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l -> Prim l
+maxNatOp bp = binNatToNatOp bp max max
+                               (\_ x1 x2 -> do lt <- bpBvult bp x1 x2
+                                               bpMuxWord bp lt x2 x1)
 
 -- divModNat :: Nat -> Nat -> #(Nat, Nat);
-divModNatOp :: VMonad l => Prim l
-divModNatOp =
-  natFun $ \m ->
-  natFun $ \n -> PrimValue $
-    let (q,r) = divMod m n in
-    vTuple [ready $ vNat q, ready $ vNat r]
+divModNatOp :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l -> Prim l
+divModNatOp bp = binNatOp bp max
+                 (\m n -> let (q,r) = divMod m n in
+                          pure $ vTuple [ready $ vNat q, ready $ vNat r])
+                 (\w x1 x2 -> do q <- VBVToNat w . VWord <$> bpBvUDiv bp x1 x2
+                                 r <- VBVToNat w . VWord <$> bpBvURem bp x1 x2
+                                 pure $ vTuple [ready q, ready r])
 
 -- expNat :: Nat -> Nat -> Nat;
 expNatOp :: VMonad l => Prim l
@@ -615,40 +679,20 @@ expNatOp =
     PrimValue (vNat (m ^ n))
 
 -- widthNat :: Nat -> Nat;
-widthNatOp :: VMonad l => Prim l
-widthNatOp =
-  natFun $ \n ->
-    PrimValue (vNat (widthNat n))
+widthNatOp :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l -> Prim l
+widthNatOp bp = maybeNatFun $ \case
+  Right n -> PrimValue (vNat (widthNat n))
+  Left v -> PrimValue (vNat (natSize bp v))
 
 -- equalNat :: Nat -> Nat -> Bool;
-equalNatOp :: (VMonad l, Show (Extra l)) => BasePrims l -> Prim l
-equalNatOp bp =
-  strictFun $ \x ->
-  strictFun $ \y -> Prim (g x y)
-  where
-    g (VNat i) (VNat j) = VBool <$> bpBool bp (i == j)
-    g v1 v2 =
-      do let w = toInteger (max (natSize bp v1) (natSize bp v2))
-         unless (w <= toInteger (maxBound :: Int))
-                (panic "equalNatOp" ["width too large", show w])
-         x1 <- natToWord bp (fromInteger w) v1
-         x2 <- natToWord bp (fromInteger w) v2
-         VBool <$> bpBvEq bp x1 x2
+equalNatOp :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l -> Prim l
+equalNatOp bp = binNatOp bp max (\i j -> VBool <$> bpBool bp (i == j))
+                                (\_ x1 x2 -> VBool <$> bpBvEq bp x1 x2)
 
 -- ltNat :: Nat -> Nat -> Bool;
-ltNatOp :: (VMonad l, Show (Extra l)) => BasePrims l -> Prim l
-ltNatOp bp =
-  strictFun $ \x ->
-  strictFun $ \y -> Prim (g x y)
-  where
-    g (VNat i) (VNat j) = VBool <$> bpBool bp (i < j)
-    g v1 v2 =
-      do let w = toInteger (max (natSize bp v1) (natSize bp v2))
-         unless (w <= toInteger (maxBound :: Int))
-                (panic "ltNatOp" ["width too large", show w])
-         x1 <- natToWord bp (fromInteger w) v1
-         x2 <- natToWord bp (fromInteger w) v2
-         VBool <$> bpBvult bp x1 x2
+ltNatOp :: (HasCallStack, VMonad l, Show (Extra l)) => BasePrims l -> Prim l
+ltNatOp bp = binNatOp bp max (\i j -> VBool <$> bpBool bp (i < j))
+                             (\_ x1 x2 -> VBool <$> bpBvult bp x1 x2)
 
 -- natCase :: (p :: Nat -> sort 0) -> p Zero -> ((n :: Nat) -> p (Succ n)) -> (n :: Nat) -> p n;
 natCaseOp :: (VMonad l, Show (Extra l)) => Prim l
@@ -1285,12 +1329,10 @@ muxValue bp tp0 b = value tp0
 
     nat :: Value l -> Value l -> MValue l
     nat v1 v2 =
-      do let w = toInteger (max (natSize bp v1) (natSize bp v2))
-         unless (w <= toInteger (maxBound :: Int))
-                (panic "muxValue" ["width too large", show w])
-         x1 <- natToWord bp (fromInteger w) v1
-         x2 <- natToWord bp (fromInteger w) v2
-         VBVToNat (fromInteger w) . VWord <$> bpMuxWord bp b x1 x2
+      do let w = max (natSize bp v1) (natSize bp v2)
+         x1 <- natToWord bp w v1
+         x2 <- natToWord bp w v2
+         VBVToNat (fromIntegral w) . VWord <$> bpMuxWord bp b x1 x2
 
 -- fix :: (a :: sort 0) -> (a -> a) -> a;
 fixOp :: (VMonadLazy l, MonadFix (EvalM l), Show (Extra l)) => Prim l

--- a/saw-core/tests/src/Tests.hs
+++ b/saw-core/tests/src/Tests.hs
@@ -21,6 +21,7 @@ import Tests.CacheTests
 import Tests.Parser
 import Tests.SharedTerm
 import Tests.Rewriter
+import Tests.Simulator
 
 main :: IO ()
 main = defaultMainWithIngredients ingrs tests
@@ -42,4 +43,5 @@ tests =
    , testGroup "Parser" parserTests
    , testGroup "Rewriter" rewriter_tests
    , testGroup "Cache" cacheTests
+   , testGroup "Simulator" simulatorTests
    ]

--- a/saw-core/tests/src/Tests/Rewriter.hs
+++ b/saw-core/tests/src/Tests/Rewriter.hs
@@ -36,10 +36,10 @@ prelude_bveq_sameL_test =
     let eqs = [ "Prelude.bveq_sameL" ]
     ss <- scSimpset sc0 [] eqs []
     let sc = rewritingSharedContext sc0 ss
-    natType <- scMkTerm sc (mkDataType "Prelude.Nat" [] [])
+    natType <- scNatType sc0
     n <- scFreshGlobal sc "n" natType
-    let boolType = mkDataType "Prelude.Bool" [] []
-    bvType <- scMkTerm sc (mkDataType "Prelude.Vec" [] [pure n, boolType])
+    boolType <- scBoolType sc0
+    bvType <- scVecType sc0 n boolType
     x <- scFreshGlobal sc "x" bvType
     z <- scFreshGlobal sc "z" bvType
     let lhs =

--- a/saw-core/tests/src/Tests/Simulator.hs
+++ b/saw-core/tests/src/Tests/Simulator.hs
@@ -168,7 +168,7 @@ normalizeSharedTermTests = [
    \sc -> bindM2 (scLtNat sc) (scBvToNat sc 8 =<< scBvLit sc 8 4) (scNat sc 9),
    \sc -> scBool sc True)
 
-]
+  ]
 
 
 newtype PrettyTerm = PrettyTerm Term deriving (Eq)

--- a/saw-core/tests/src/Tests/Simulator.hs
+++ b/saw-core/tests/src/Tests/Simulator.hs
@@ -1,0 +1,191 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-
+Copyright   : Galois, Inc. 2022
+License     : BSD3
+Maintainer  : myac@galois.com
+Stability   : experimental
+Portability : portable
+-}
+
+module Tests.Simulator
+  ( simulatorTests
+  )
+where
+
+import Control.Monad
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import GHC.Natural
+
+import Verifier.SAW.Prelude
+import Verifier.SAW.SharedTerm
+import Verifier.SAW.Simulator.TermModel
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+bindM2 :: Monad m => (a -> b -> m c) -> m a -> m b -> m c
+bindM2 k m1 m2 = join $ k <$> m1 <*> m2
+
+bindM3 :: Monad m => (a -> b -> c -> m d) -> m a -> m b -> m c -> m d
+bindM3 k m1 m2 m3 = join $ k <$> m1 <*> m2 <*> m3
+
+-- Copied from Prims.hs and TermModel.hs
+bvPad :: SharedContext -> Natural -> Natural -> Term -> IO Term
+bvPad sc w xsize x = do pad <- bpBvLit (fromIntegral $ w - xsize) 0
+                        bpBvJoin pad x
+  where bpBvLit = scBvConst sc
+        bpBvJoin xtm ytm = let (xn, yn) = (w - xsize, xsize) in snd <$>
+          do xn' <- scNat sc xn
+             yn' <- scNat sc yn
+             a   <- scBoolType sc
+             tm  <- scAppend sc xn' yn' a xtm ytm
+             return (xn+yn, tm)
+
+
+simulatorTests :: [TestTree]
+simulatorTests = testNormalizeSharedTerm <$> normalizeSharedTermTests
+
+normalizeSharedTermTests :: [NormalizeSharedTermTest]
+normalizeSharedTermTests = [
+
+  -- Succ 2 ~> 3
+  ("Succ_nat",
+   \sc -> scCtorApp sc "Prelude.Succ" . (:[]) =<< scNat sc 2,
+   \sc -> scNat sc 3),
+  -- Succ (bvToNat 8 2) ~> bvToNat 9 (bvNat 9 3) 
+  ("Succ_bvToNat",
+   \sc -> scCtorApp sc "Prelude.Succ" . (:[]) =<<
+            scBvToNat sc 8 =<< scBvLit sc 8 2,
+   \sc -> scBvToNat sc 9 =<< scBvConst sc 9 3),
+
+  -- 1+2 ~> 3
+  ("add_nats",
+   \sc -> bindM2 (scAddNat sc) (scNat sc 1) (scNat sc 2),
+   \sc -> scNat sc 3),
+  -- (bvToNat 4 1)+(bvToNat 6 2) ~> bvToNat 7 (bvNat 7 3)
+  ("add_bvToNat",
+   \sc -> bindM2 (scAddNat sc) (scBvToNat sc 4 =<< scBvLit sc 4 1)
+                               (scBvToNat sc 6 =<< scBvLit sc 6 2),
+   \sc -> scBvToNat sc 7 =<< scBvConst sc 7 3),
+
+  -- 5-4 ~> 1
+  ("sub_nats",
+   \sc -> bindM2 (scSubNat sc) (scNat sc 5) (scNat sc 4),
+   \sc -> scNat sc 1),
+  -- (bvToNat 8 5)-4 ~> bvToNat 8 (bvNat 8 1)
+  ("sub_bvToNat",
+   \sc -> bindM2 (scSubNat sc) (scBvToNat sc 8 =<< scBvLit sc 8 5)
+                               (scNat sc 4),
+   \sc -> scBvToNat sc 8 =<< scBvConst sc 8 1),
+
+  -- 3*5 ~> 15
+  ("mul_nats",
+   \sc -> bindM2 (scMulNat sc) (scNat sc 3) (scNat sc 5),
+   \sc -> scNat sc 15),
+  -- 3*(bvToNat 8 x) ~> bvToNat 10 (bvMul 10 3 (0b00 # x))
+  ("mul_bvToNat",
+   \sc -> bindM2 (scLambda sc "x") (scBitvector sc 8) $
+          bindM2 (scMulNat sc) (scNat sc 3)
+                               (scBvToNat sc 8 =<< scLocalVar sc 0),
+   \sc -> bindM2 (scLambda sc "x") (scBitvector sc 8) $
+          scBvToNat sc 10 =<< bindM3 (scBvMul sc) (scNat sc 10)
+                                     (scBvConst sc 10 3)
+                                     (bvPad sc 10 8 =<< scLocalVar sc 0)),
+
+  -- max 2 7 ~> 7
+  ("max_nats",
+   \sc -> bindM2 (scMaxNat sc) (scNat sc 2) (scNat sc 7),
+   \sc -> scNat sc 7),
+  -- max 2 (bvToNat 8 7) ~> bvToNat 8 (bvNat 8 7)
+  ("max_bvToNat",
+   \sc -> bindM2 (scMaxNat sc) (scNat sc 2)
+                               (scBvToNat sc 8 =<< scBvLit sc 8 7),
+   \sc -> scBvToNat sc 8 =<< scBvConst sc 8 7),
+
+  -- min 2 7 ~> 2
+  ("min_nats",
+   \sc -> bindM2 (scMinNat sc) (scNat sc 2) (scNat sc 7),
+   \sc -> scNat sc 2),
+  -- min (bvToNat 8 2) 7 ~> bvToNat 8 (bvNat 8 2)
+  ("min_bvToNat",
+   \sc -> bindM2 (scMinNat sc) (scBvToNat sc 8 =<< scBvLit sc 8 2)
+                               (scNat sc 7),
+   \sc -> scBvToNat sc 8 =<< scBvConst sc 8 2),
+
+  -- divMod 22 7 ~> (3, 1)
+  ("divMod_nats",
+   \sc -> bindM2 (scDivModNat sc) (scNat sc 22) (scNat sc 7),
+   \sc -> bindM2 (scPairValue sc) (scNat sc 3) (scNat sc 1)),
+  -- divMod 22 (bvToNat 8 7) ~> (bvToNat 8 (bvNat 8 3), bvToNat 8 (bvNat 8 1))
+  ("divMod_bvToNat",
+   \sc -> bindM2 (scDivModNat sc) (scNat sc 22)
+                                  (scBvToNat sc 8 =<< scBvLit sc 8 7),
+   \sc -> bindM2 (scPairValue sc) (scBvToNat sc 8 =<< scBvConst sc 8 3)
+                                  (scBvToNat sc 8 =<< scBvConst sc 8 1)),
+
+  -- widthNat 5 ~> 3
+  ("widthNat_nat",
+   \sc -> scGlobalApply sc "Prelude.widthNat" . (:[]) =<< scNat sc 5,
+   \sc -> scNat sc 3),
+  -- widthNat (bvToNat 8 5) ~> 8
+  ("widthNat_bvToNat",
+   \sc -> scGlobalApply sc "Prelude.widthNat" . (:[]) =<<
+            scBvToNat sc 8 =<< scBvLit sc 8 5,
+   \sc -> scNat sc 8),
+
+  -- equalNat (3*5) (5*3) ~> True
+  ("equalNat_nats",
+   \sc -> bindM2 (scEqualNat sc)
+                 (bindM2 (scMulNat sc) (scNat sc 3) (scNat sc 5))
+                 (bindM2 (scMulNat sc) (scNat sc 5) (scNat sc 3)),
+   \sc -> scBool sc True),
+  -- equalNat (3*(bvToNat 8 x)) (bvToNat 8 (bvMul 8 x 3)) ~>
+  -- bvEq 10 (bvMul 10 3 (0b00 # x)) (0b00 # bvMul 8 x 3))
+  ("equalNat_bvToNat",
+   \sc -> bindM2 (scLambda sc "x") (scBitvector sc 8) $
+          bindM2 (scEqualNat sc)
+                 (bindM2 (scMulNat sc) (scNat sc 3)
+                                       (scBvToNat sc 8 =<< scLocalVar sc 0))
+                 (scBvToNat sc 8 =<< bindM3 (scBvMul sc) (scNat sc 8)
+                                            (scLocalVar sc 0)
+                                            (scBvConst sc 8 3)),
+   \sc -> bindM2 (scLambda sc "x") (scBitvector sc 8) $
+          bindM3 (scBvEq sc) (scNat sc 10)
+                 (bindM3 (scBvMul sc) (scNat sc 10)
+                                      (scBvConst sc 10 3)
+                                      (bvPad sc 10 8 =<< scLocalVar sc 0))
+                 (bvPad sc 10 8 =<< bindM3 (scBvMul sc) (scNat sc 8)
+                                           (scLocalVar sc 0)
+                                           (scBvConst sc 8 3))),
+    
+  -- ltNat 4 9 ~> True
+  ("ltNat_nats",
+   \sc -> bindM2 (scLtNat sc) (scNat sc 4) (scNat sc 9),
+   \sc -> scBool sc True),
+  -- ltNat (bvToNat 8 4) 9 ~> True
+  ("ltNat_bvToNat",
+   \sc -> bindM2 (scLtNat sc) (scBvToNat sc 8 =<< scBvLit sc 8 4) (scNat sc 9),
+   \sc -> scBool sc True)
+
+]
+
+
+newtype PrettyTerm = PrettyTerm Term deriving (Eq)
+
+instance Show PrettyTerm where
+  show (PrettyTerm t) = show (ppTerm defaultPPOpts t)
+
+type NormalizeSharedTermTest = (String, (SharedContext -> IO Term),
+                                        (SharedContext -> IO Term))
+  
+testNormalizeSharedTerm :: NormalizeSharedTermTest -> TestTree
+testNormalizeSharedTerm (nm, m1, m2) =
+  testCase nm $ do
+    sc <- mkSharedContext
+    scLoadPreludeModule sc
+    t1 <- m1 sc
+    t2 <- m2 sc
+    modmap <- scGetModuleMap sc
+    t1' <- normalizeSharedTerm sc modmap Map.empty Map.empty Set.empty t1
+    assertEqual "Incorrect normalization" (PrettyTerm t2) (PrettyTerm t1')


### PR DESCRIPTION
Currently, the primitives for `subNat`, `equalNat`, and `ltNat` convert their arguments to bitvectors and perform the corresponding bitvector operation if their arguments are not both concrete `Natural`s.

This PR adds similar bitvector fallbacks to all the remaining natural number operations except `expNat` (because there is no corresponding bitvector exp function at the moment) and `natCase`. To do this we generalize the behavior of `subNat`, `equalNat`, and `ltNat` into the functions `binNatOp` and `binNatToNatOp`.

Fixes #1558