### PR TITLE
CI: Use macOS 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 # Overall configuration notes:
 # - Artifact uploads for binaries are from GHC 8.10.7
 # - Builds for Ubuntu happen on 18.04 (would like to include 20.04, in addition)
-# - Builds for macOS builds on 10.15 (to avoid GHC bug on macOS 11; solvable with GHC > 8.10.4)
 # - Docker builds happen nightly, on manual invocation, and on release branch commits
 # Please update this comment as those details change.
 
@@ -24,7 +23,7 @@ env:
   # ./saw-remote-api/Dockerfile
   # ./s2nTests/scripts/blst-entrypoint.sh
   # ./s2nTests/docker/saw.dockerfile
-  SOLVER_PKG_VERSION: "snapshot-20210917"
+  SOLVER_PKG_VERSION: "snapshot-20220721"
 
   OCAML_VERSION: 4.09.x
 
@@ -67,9 +66,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-latest]
+        os: [ubuntu-18.04, macos-12, windows-latest]
         ghc: ["8.8.4", "8.10.7", "9.0.2"]
         exclude:
+          # Exclude 8.8 on macOS 12 due to
+          # https://gitlab.haskell.org/ghc/ghc/-/issues/18446
+          - os: macos-12
+            ghc: "8.8.4"
           - os: windows-latest
             ghc: "8.8.4"
           # Exclude 9.0 on Windows for now until
@@ -203,7 +206,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -237,7 +240,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -290,7 +293,7 @@ jobs:
           - test: saw-remote-api/scripts/run_rpc_tests.sh
             os: ubuntu-18.04
           - test: saw-remote-api/scripts/run_rpc_tests.sh
-            os: macos-10.15
+            os: macos-12
           - test: saw-remote-api/scripts/check_docs.sh
             os: ubuntu-18.04
     steps:
@@ -340,7 +343,7 @@ jobs:
         continue-on-error: [false]
         include:
           - suite: integration_tests
-            os: macos-10.15
+            os: macos-12
             continue-on-error: true  # https://github.com/GaloisInc/saw-script/issues/1135
           - suite: integration_tests
             os: windows-latest
@@ -348,7 +351,7 @@ jobs:
             continue-on-error: true  # https://github.com/GaloisInc/saw-script/issues/1135
         exclude:
           - suite: integration_tests
-            os: macos-10.15
+            os: macos-12
             continue-on-error: false
           - suite: integration_tests
             os: windows-latest


### PR DESCRIPTION
GitHub is deprecating (and eventually removing) its macOS 10.15 runners. See actions/virtual-environments#5583. Let's upgrade to a newer version in the CI. This proves relatively straightforward—the only other change required is to upgrade to a newer version of `what4-solvers`.