### PR TITLE
Temporarily disable saw-remote-api tests on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,8 +294,12 @@ jobs:
           - test: saw-remote-api/scripts/run_rpc_tests.sh
             os: ubuntu-18.04
           # TODO: These tests are disabled pending resolution of issue #1699
-          # - test: saw-remote-api/scripts/run_rpc_tests.sh
-          #   os: macos-12
+          - test: |
+              cd saw-remote-api/
+              poetry update
+              poetry install
+              poetry run mypy saw_client/
+            os: macos-12
           - test: saw-remote-api/scripts/check_docs.sh
             os: ubuntu-18.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
           - name: Install and test
             test: saw-remote-api/scripts/run_rpc_tests.sh
             os: ubuntu-18.04
-          # TODO: These tests are disabled pending resolution of issue #1699
+          # TODO: saw-remote-api unit tests are disabled pending a fix for #1699
           - name: Install on MacOS
             test: |
               cd saw-remote-api/python/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,16 +291,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - test: saw-remote-api/scripts/run_rpc_tests.sh
+          - name: Install and test
+            test: saw-remote-api/scripts/run_rpc_tests.sh
             os: ubuntu-18.04
           # TODO: These tests are disabled pending resolution of issue #1699
-          - test: |
-              cd saw-remote-api/
+          - name: Install on MacOS
+            test: |
+              cd saw-remote-api/python/
               poetry update
               poetry install
               poetry run mypy saw_client/
             os: macos-12
-          - test: saw-remote-api/scripts/check_docs.sh
+          - name: Check docs
+            test: saw-remote-api/scripts/check_docs.sh
             os: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -325,7 +328,7 @@ jobs:
         with:
           poetry-version: 1.1.5
 
-      - name: ${{ matrix.test }}
+      - name: ${{ matrix.name }}
         shell: bash
         run: |
           chmod +x dist/bin/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,8 +293,9 @@ jobs:
         include:
           - test: saw-remote-api/scripts/run_rpc_tests.sh
             os: ubuntu-18.04
-          - test: saw-remote-api/scripts/run_rpc_tests.sh
-            os: macos-12
+          # TODO: These tests are disabled pending resolution of issue #1699
+          # - test: saw-remote-api/scripts/run_rpc_tests.sh
+          #   os: macos-12
           - test: saw-remote-api/scripts/check_docs.sh
             os: ubuntu-18.04
     steps:


### PR DESCRIPTION
See #1699, this is eating a lot of CI resources