### PR TITLE
Induction and first-order assertions

### DIFF
--- a/intTests/test_univ_assert/README
+++ b/intTests/test_univ_assert/README
@@ -1,0 +1,4 @@
+This is a test of the capability to assert first-order statements
+to the solver. Here, we are reasoning abstractly over about
+generic properties of addition and multiplication (essentially,
+some of the ring axioms).

--- a/intTests/test_univ_assert/test.saw
+++ b/intTests/test_univ_assert/test.saw
@@ -1,0 +1,33 @@
+enable_experimental;
+
+let {{
+  type vec_t = [384]
+  mul : vec_t -> vec_t -> vec_t
+  mul x y = undefined // this would be e.g. multiplication modulo p
+  add : vec_t -> vec_t -> vec_t
+  add x y = undefined
+
+  term1 x y z1 z2 z3 = add (mul (add (mul (add (mul x y) z1) x) z2) x) z3
+  term2 x y z1 z2 z3 = add (mul y (mul x (mul x x))) (add (mul z1 (mul x x)) (add (mul z2 x) z3))
+}};
+
+// Assume some of the ring axioms
+lemmas <- for
+  [ {{ \x y -> mul x y == mul y x }}
+  , {{ \x y -> add x y == add y x }}
+  , {{ \x y z -> mul (mul x y) z == mul x (mul y z) }}
+  , {{ \x y z -> add (add x y) z == add x (add y z) }}
+  , {{ \x y z -> mul (add x y) z == add (mul x z) (mul y z) }}
+  ]
+  (prove_print assume_unsat);
+
+// Use those axioms to prove a nonmtrivial equality
+thm <- prove_print
+  (do {
+    unfolding ["term1","term2"];
+    for lemmas goal_insert;
+    w4_unint_z3 ["mul","add"];
+  })
+  {{ \x y z1 z2 z3 -> term1 x y z1 z2 z3 == term2 x y z1 z2 z3 }};
+
+print thm;

--- a/intTests/test_univ_assert/test.sh
+++ b/intTests/test_univ_assert/test.sh
@@ -1,0 +1,1 @@
+$SAW test.saw

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -664,8 +664,7 @@ mkUninterpreted k args nm = svUninterpreted k nm' Nothing args
 
 sbvSATQuery :: SharedContext -> Map Ident SPrim -> SATQuery -> IO ([Labeler], [ExtCns Term], Symbolic SBool)
 sbvSATQuery sc addlPrims query =
-  do true <- liftIO (scBool sc True)
-     t <- liftIO (foldM (scAnd sc) true (satAsserts query))
+  do t <- liftIO (satQueryAsTerm sc query)
      let qvars = Map.toList (satVariables query)
      let unintSet = satUninterp query
      let ecVars (ec, fot) = newVars (Text.unpack (toShortName (ecName ec))) fot

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -96,7 +96,7 @@ import Verifier.SAW.TypedAST (FieldName, ModuleMap, toShortName, ctorPrimName, i
 import qualified What4.Expr.Builder as B
 import           What4.Expr.GroundEval
 import           What4.Interface(SymExpr,Pred,SymInteger, IsExpr,
-                                 IsExprBuilder,IsSymExprBuilder)
+                                 IsExprBuilder,IsSymExprBuilder, BoundVar)
 import qualified What4.Interface as W
 import           What4.BaseTypes
 import qualified What4.SWord as SW
@@ -983,17 +983,101 @@ w4Solve :: forall sym.
   sym ->
   SharedContext ->
   SATQuery ->
-  IO ([(ExtCns Term, (Labeler sym, SValue sym))], SBool sym)
+  IO ([(ExtCns Term, (Labeler sym, SValue sym))], [SBool sym])
 w4Solve sym sc satq =
-  do t <- satQueryAsTerm sc satq
-     let varList  = Map.toList (satVariables satq)
+  do let varList  = Map.toList (satVariables satq)
      vars <- evalStateT (traverse (traverse (newVarFOT sym)) varList) 0
      let varMap   = Map.fromList [ (ecVarIndex ec, v) | (ec, (_,v)) <- vars ]
      ref <- newIORef Map.empty
-     bval <- w4SolveBasic sym sc mempty varMap ref (satUninterp satq) t
+
+     bvals <- mapM (w4SolveAssert sym sc varMap ref (satUninterp satq)) (satAsserts satq)
+     return (vars, bvals)
+
+
+w4SolveAssert :: forall sym.
+  IsSymExprBuilder sym =>
+  sym ->
+  SharedContext ->
+  Map VarIndex (SValue sym) {- ^ bindings for ExtCns values -} ->
+  IORef (SymFnCache sym) {- ^ cache for uninterpreted function symbols -} ->
+  Set VarIndex {- ^ variables to hold uninterpreted -} ->
+  SATAssert ->
+  IO (SBool sym)
+w4SolveAssert sym sc varMap ref uninterp (BoolAssert x) =
+  do bval <- w4SolveBasic sym sc mempty varMap ref uninterp x
      case bval of
-       VBool v -> return (vars, v)
-       _ -> fail $ "w4Solve: non-boolean result type. " ++ show bval
+       VBool v -> return v
+       _ -> fail $ "w4SolveAssert: non-boolean result type. " ++ show bval
+
+w4SolveAssert sym sc varMap ref uninterp (UniversalAssert vars hyps concl) =
+  do g <- case hyps of
+            [] -> return concl
+            _  -> do h <- scAndList sc hyps
+                     scImplies sc h concl
+     (svals,bndvars) <- boundFOTs sym vars
+     let varMap' = foldl (\m ((ec,_fot), sval) -> Map.insert (ecVarIndex ec) sval m)
+                         varMap
+                         (zip vars svals)
+     bval <- w4SolveBasic sym sc mempty varMap' ref uninterp g
+     case bval of
+       VBool v ->
+         do final <- foldM (\p (Some bndvar) -> W.forallPred sym bndvar p) v bndvars
+            return final
+
+       _ -> fail $ "w4SolveAssert: non-boolean result type. " ++ show bval
+
+boundFOTs :: forall sym.
+  IsSymExprBuilder sym =>
+  sym ->
+  [(ExtCns Term, FirstOrderType)] ->
+  IO ([SValue sym], [Some (BoundVar sym)])
+boundFOTs sym vars =
+  do (svals,(bndvars,_)) <- runStateT (mapM (uncurry handleVar) vars) ([], 0)
+     return (svals, bndvars)
+
+ where
+   freshBnd :: ExtCns Term -> W.BaseTypeRepr tp -> StateT ([Some (BoundVar sym)],Integer) IO (SymExpr sym tp)
+   freshBnd ec tpr =
+     do (vs,n) <- get
+        let nm = Text.unpack (toShortName (ecName ec)) ++ "." ++ show n
+        bvar <- lift (W.freshBoundVar sym (W.safeSymbol nm) tpr)
+        put (Some bvar : vs, n+1)
+        return (W.varExpr sym bvar)
+
+   handleVar :: ExtCns Term -> FirstOrderType -> StateT ([Some (BoundVar sym)], Integer) IO (SValue sym)
+   handleVar ec fot =
+     case fot of
+       FOTBit -> VBool <$> freshBnd ec BaseBoolRepr
+       FOTInt -> VInt  <$> freshBnd ec BaseIntegerRepr
+       FOTIntMod m -> VIntMod m <$> freshBnd ec BaseIntegerRepr
+       FOTVec 0 FOTBit -> return (VWord ZBV)
+       FOTVec n FOTBit
+         | Just (Some (PosNat nr)) <- somePosNat n ->
+         VWord . DBV <$> freshBnd ec (BaseBVRepr nr)
+
+       FOTVec n tp -> -- NB, not Bit
+         do vs  <- V.replicateM (fromIntegral n) (handleVar ec tp)
+            vs' <- traverse (return . ready) vs
+            return (VVector vs')
+
+       FOTRec tm ->
+         do vs  <- traverse (handleVar ec) tm
+            vs' <- traverse (return . ready) vs
+            return (vRecord vs')
+
+       FOTTuple ts ->
+         do vs  <- traverse (handleVar ec) ts
+            vs' <- traverse (return . ready) vs
+            return (vTuple vs')
+
+       FOTArray idx res
+         | Just (Some idx_repr) <- fotToBaseType idx
+         , Just (Some res_repr) <- fotToBaseType res
+
+         -> VArray . SArray <$> freshBnd ec (BaseArrayRepr (Ctx.Empty Ctx.:> idx_repr) res_repr)
+
+       _ -> fail ("boundFOTs: cannot handle " ++ show fot)
+
 
 --
 -- Pull out argument types until bottoming out at a non-Pi type

--- a/saw-core/prelude/Prelude.sawcore
+++ b/saw-core/prelude/Prelude.sawcore
@@ -797,6 +797,15 @@ data IsLeNat (n:Nat) : Nat -> Prop where {
 IsLtNat : Nat -> Nat -> Prop;
 IsLtNat m n = IsLeNat (Succ m) n;
 
+-- | Restate the recursor on IsLeNat
+IsLeNat__rec :
+  (n  : Nat) ->
+  (p  : (x : Nat) -> IsLeNat n x -> Prop) ->
+  (Hbase : p n (IsLeNat_base n)) ->
+  (Hstep : (x : Nat) -> (H : IsLeNat n x) -> p x H -> p (Succ x) (IsLeNat_succ n x H)) ->
+  (m : Nat) -> (Hm : IsLeNat n m) -> p m Hm;
+IsLeNat__rec n p Hbase Hstep m Hm = IsLeNat#rec n p Hbase Hstep m Hm;
+
 -- | Test if m < n or n <= m
 -- FIXME: implement this!
 primitive natCompareLe : (m n : Nat) -> Either (IsLtNat m n) (IsLeNat n m);
@@ -935,6 +944,77 @@ if0Nat a n x y = natCase (\ (_:Nat) -> a) x (\ (_:Nat) -> y) n;
 -- the multiplication operation, the base of the exponent
 -- and the number of times to multiply.
 primitive expByNat : (a:sort 0) -> a -> (a -> a -> a) -> a -> Nat -> a;
+
+
+-- | LeNat is transitive
+IsLeNat_transitive :
+  (n m o:Nat) ->
+  IsLeNat n m ->
+  IsLeNat m o ->
+  IsLeNat n o;
+IsLeNat_transitive n m o Hnm Hmo =
+  IsLeNat__rec m
+    (\ (x:Nat) -> \(H:IsLeNat m x) -> IsLeNat n x)
+    Hnm
+    (\ (x:Nat) -> \ (H1:IsLeNat m x) -> \ (H2:IsLeNat n x) -> IsLeNat_succ n x H2)
+  o Hmo;
+
+-- No Nat is strictly less than zero
+IsLtNat_Zero_absurd :
+  (p:Prop) ->
+  (m:Nat) ->
+  IsLtNat m Zero ->
+  p;
+IsLtNat_Zero_absurd p m HSmZ =
+  IsLeNat__rec (Succ m)
+    ( \ (x : Nat) -> \ (H:IsLeNat (Succ m) x) -> if0Nat Prop x p TrueProp)
+    TrueI
+    ( \ (x : Nat) -> \ (H1:IsLeNat (Succ m) x) -> \ (H2 : if0Nat Prop x p TrueProp) -> TrueI)
+    Zero HSmZ;
+
+IsLeNat_SuccSucc :
+  (n m:Nat) ->
+  IsLeNat (Succ n) (Succ m) ->
+  IsLeNat n m;
+IsLeNat_SuccSucc n m HSS =
+  IsLeNat__rec (Succ n)
+    ( \ (x : Nat) -> \ (H:IsLeNat (Succ n) x) -> IsLeNat n (pred x))
+    (IsLeNat_base n)
+    (Nat__rec
+      ( \ (x : Nat) -> IsLeNat (Succ n) x -> IsLeNat n (pred x) -> IsLeNat n x)
+      ( \ (H1 : IsLeNat (Succ n) Zero) -> \ (H2 : IsLeNat n (pred Zero)) -> H2)
+      ( \ (x : Nat) ->
+        \ (Hind : IsLeNat (Succ n) x -> IsLeNat n (pred x) -> IsLeNat n x) ->
+        \ (H1 : IsLeNat (Succ n) (Succ x)) ->
+	\ (H2 : IsLeNat n (pred (Succ x))) ->
+	IsLeNat_succ n x H2)
+    )
+  (Succ m) HSS;
+
+-- | The complete induction principle on natural numbers
+Nat_complete_induction :
+  (p : Nat -> Prop) ->
+  ((n : Nat) -> ((m : Nat) -> IsLtNat m n -> p m) -> p n) ->
+  (n : Nat) -> p n;
+
+Nat_complete_induction p f n0 =
+  Nat__rec ( \ (n:Nat) -> (m:Nat) -> IsLeNat m n -> p m)
+    (\ (n:Nat) ->
+     \ (Hn:IsLeNat n 0) ->
+     f n (\ (m:Nat) -> \ (Hm : IsLeNat (Succ m) n) ->
+            IsLtNat_Zero_absurd (p m) m (IsLeNat_transitive (Succ m) n 0 Hm Hn))
+    )
+   (\ (n:Nat) ->
+     \ (Hind : (m:Nat) -> IsLeNat m n -> p m) ->
+     \ (r:Nat) ->
+     \ (Hr:IsLeNat r (Succ n)) ->
+       f r (\ (m:Nat) -> \ (Hm: IsLeNat (Succ m) r) ->
+             Hind m (IsLeNat_SuccSucc m n (IsLeNat_transitive (Succ m) r (Succ n) Hm Hr)))
+    )
+    n0 n0 (IsLeNat_base n0);
+
+
+
 
 --------------------------------------------------------------------------------
 -- Operations on string values
@@ -1764,7 +1844,6 @@ primitive updSliceWithProof : (a : sort 0) -> (n off len : Nat) ->
                               IsLeNat (addNat off len) n ->
                               Vec n a -> Vec len a -> Vec n a;
 
-
 --------------------------------------------------------------------------------
 -- Vectors indexed by bitvectors
 
@@ -1945,6 +2024,29 @@ appendBVVec n len1 len2 a v1 v2 =
             atBVVec n len2 a v2 (bvSub n i len1)
                     (bvult_sum_bvult_sub n i len1 len2 pf12 not_pf1))
          (Refl Bool (bvult n i len1)));
+
+
+-- | The complete induction principle on bitvectors
+BV_complete_induction :
+  (w: Nat) ->
+  (p: Vec w Bool -> Prop) ->
+  ((x : Vec w Bool) -> ((y: Vec w Bool) -> is_bvult w y x -> p y) -> p x) ->
+  (x : Vec w Bool) -> p x;
+BV_complete_induction w p f x0 =
+  Nat_complete_induction
+    (\ (n:Nat) -> (x:Vec w Bool) -> IsLeNat (bvToNat w x) n -> p x)
+    (\ (n:Nat) ->
+     \ (Hind : (m : Nat) -> (Hm : IsLtNat m n) -> (y : Vec w Bool) ->
+               (Hy : IsLeNat (bvToNat w y) m) -> p y) ->
+     \ (x : Vec w Bool) ->
+     \ (Hx : IsLeNat (bvToNat w x) n) ->
+       f x (\ (y:Vec w Bool) -> \ (Hult : is_bvult w y x) ->
+              Hind (bvToNat w y)
+	        (IsLeNat_transitive (Succ (bvToNat w y)) (bvToNat w x) n (bvultToIsLtNat w y x Hult) Hx)
+	        y (IsLeNat_base (bvToNat w y))
+	   )
+    )
+    (bvToNat w x0) x0 (IsLeNat_base (bvToNat w x0));
 
 
 --------------------------------------------------------------------------------

--- a/saw-core/src/Verifier/SAW/SATQuery.hs
+++ b/saw-core/src/Verifier/SAW/SATQuery.hs
@@ -51,7 +51,10 @@ data SATQuery =
 
 data SATAssert
    = BoolAssert Term -- ^ A boolean term to be asserted
-   | UniversalAssert Term -- ^ A univesally-quantified assertion
+   | UniversalAssert [(ExtCns Term, FirstOrderType)] [Term] Term
+          -- ^ A univesally-quantified assertion, consisting of a
+          --   collection of first-order variables, a sequence
+          --   of boolean hypotheses, and a boolean conclusion
 
 -- | The result of a sat query.  In the event a model is found,
 --   return a mapping from the @ExtCns@ variables to values.
@@ -70,7 +73,7 @@ satQueryAsTerm sc satq =
   case satAsserts satq of
          [] -> scBool sc True
          (BoolAssert x:xs) -> loop x xs
-         (UniversalAssert _ : _) -> univFail
+         (UniversalAssert{} : _) -> univFail
  where
    univFail = fail "satQueryAsTerm : Solver backend cannot handle universally-quantifed assertions"
 
@@ -78,4 +81,4 @@ satQueryAsTerm sc satq =
    loop x (BoolAssert y:xs) = 
      do x' <- scAnd sc x y
         loop x' xs
-   loop _ (UniversalAssert _ : _) = univFail
+   loop _ (UniversalAssert{} : _) = univFail

--- a/saw-core/src/Verifier/SAW/SATQuery.hs
+++ b/saw-core/src/Verifier/SAW/SATQuery.hs
@@ -1,10 +1,10 @@
 module Verifier.SAW.SATQuery
 ( SATQuery(..)
 , SATResult(..)
+, SATAssert(..)
 , satQueryAsTerm
 ) where
 
-import Control.Monad (foldM)
 import Data.Map (Map)
 import Data.Set (Set)
 
@@ -42,13 +42,16 @@ data SATQuery =
       --   the solver. Models will not report values
       --   for uninterpreted values.
 
-  , satAsserts   :: [Term]
+  , satAsserts   :: [SATAssert]
       -- ^ A collection of assertions.  These should
       --   all be terms of type @Bool@.  The overall
       --   query should be understood as the conjunction
       --   of these terms.
   }
--- TODO, allow first-order propositions in addition to Boolean terms.
+
+data SATAssert
+   = BoolAssert Term -- ^ A boolean term to be asserted
+   | UniversalAssert Term -- ^ A univesally-quantified assertion
 
 -- | The result of a sat query.  In the event a model is found,
 --   return a mapping from the @ExtCns@ variables to values.
@@ -59,10 +62,20 @@ data SATResult
 
 -- | Compute the conjunction of all the assertions
 --   in this SAT query as a single term of type Bool.
+--
+--   This method of reducing a sat query to a boolean
+--   cannot be used for univerally-quantified assertions.
 satQueryAsTerm :: SharedContext -> SATQuery -> IO Term
 satQueryAsTerm sc satq =
   case satAsserts satq of
          [] -> scBool sc True
-         (x:xs) -> foldM (scAnd sc) x xs
--- TODO, we may have to rethink this function
---  once we allow first-order statements.
+         (BoolAssert x:xs) -> loop x xs
+         (UniversalAssert _ : _) -> univFail
+ where
+   univFail = fail "satQueryAsTerm : Solver backend cannot handle universally-quantifed assertions"
+
+   loop x [] = return x
+   loop x (BoolAssert y:xs) = 
+     do x' <- scAnd sc x y
+        loop x' xs
+   loop _ (UniversalAssert _ : _) = univFail

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -168,6 +168,8 @@ module Verifier.SAW.SharedTerm
   , scXor
   , scBoolEq
   , scIte
+  , scAndList
+  , scOrList
   -- *** Natural numbers
   , scNat
   , scNatType
@@ -1701,6 +1703,25 @@ scBvForall sc w f = scGlobalApply sc "Prelude.bvForall" [w, f]
 scIte :: SharedContext -> Term -> Term ->
          Term -> Term -> IO Term
 scIte sc t b x y = scGlobalApply sc "Prelude.ite" [t, b, x, y]
+
+-- | Build a conjunction from a list of boolean terms.
+scAndList :: SharedContext -> [Term] -> IO Term
+scAndList sc = conj . filter nontrivial
+  where
+    nontrivial x = asBool x /= Just True
+    conj [] = scBool sc True
+    conj [x] = return x
+    conj (x : xs) = foldM (scAnd sc) x xs
+
+-- | Build a conjunction from a list of boolean terms.
+scOrList :: SharedContext -> [Term] -> IO Term
+scOrList sc = disj . filter nontrivial
+  where
+    nontrivial x = asBool x /= Just False
+    disj [] = scBool sc False
+    disj [x] = return x
+    disj (x : xs) = foldM (scOr sc) x xs
+
 
 -- | Create a term applying @Prelude.append@ to two vectors.
 --

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -759,14 +759,14 @@ goal_has_tags tags =
   do s <- get
      case psGoals s of
        g : _ | Set.isSubsetOf (Set.fromList tags) (goalTags g) -> return True
-       _ -> return False  
+       _ -> return False
 
 goal_has_some_tag :: [String] -> ProofScript Bool
 goal_has_some_tag tags =
   do s <- get
      case psGoals s of
        g : _ | not $ Set.disjoint (Set.fromList tags) (goalTags g) -> return True
-       _ -> return False  
+       _ -> return False
 
 goal_num_ite :: Int -> ProofScript SV.Value -> ProofScript SV.Value -> ProofScript SV.Value
 goal_num_ite n s1 s2 =
@@ -1044,11 +1044,11 @@ provePrim script t = do
 proveHelper ::
   String ->
   ProofScript () ->
-  TypedTerm ->
+  Term ->
   (Term -> TopLevel Prop) ->
   TopLevel Theorem
 proveHelper nm script t f = do
-  prop <- f $ ttTerm t
+  prop <- f t
   pos <- SV.getPosition
   let goal = ProofGoal
              { goalNum = 0
@@ -1066,10 +1066,160 @@ proveHelper nm script t f = do
                           ++ SV.showsProofResult opts res ""
   case res of
     ValidProof _stats thm ->
-      do printOutLnTop Debug $ "Valid: " ++ show (ppTerm (SV.sawPPOpts opts) $ ttTerm t)
+      do printOutLnTop Debug $ "Valid: " ++ show (ppTerm (SV.sawPPOpts opts) $ t)
          SV.returnProof thm
     InvalidProof _stats _cex pst -> failProof pst
     UnfinishedProof pst -> failProof pst
+
+proveByBVInduction ::
+  ProofScript () ->
+  TypedTerm ->
+  TopLevel Theorem
+proveByBVInduction script t =
+  do sc <- getSharedContext
+     opts <- rwPPOpts <$> getTopLevelRW
+     ty <- io $ scTypeCheckError sc (ttTerm t)
+     io (checkInductionScheme sc opts [] ty) >>= \case
+       Nothing -> badTy opts ty
+       Just ([],_) -> badTy opts ty
+       Just (pis,w) ->
+         do wt  <- io $ scNat sc w
+            natty <- io $ scNatType sc
+            toNat  <- io $ scGlobalDef sc "Prelude.bvToNat"
+            thmResult <- io $
+                do vars <- reverse <$> mapM (scLocalVar sc) [ 0 .. length pis - 1]
+                   t1   <- scApplyAllBeta sc (ttTerm t) vars
+                   t2   <- scEqTrue sc =<< scTupleSelector sc t1 2 2 -- rightmost tuple element
+                   t3   <- scPiList sc pis t2
+                   _    <- scTypeCheckError sc t3 -- sanity check
+                   return t3
+
+            thmHyp <- io $
+                do vars  <- reverse <$> mapM (scLocalVar sc) [ 0 .. length pis - 1]
+                   t1    <- scApplyAllBeta sc (ttTerm t) vars
+                   tsz   <- scTupleSelector sc t1 1 2 -- left element
+                   tbody <- scEqTrue sc =<< scTupleSelector sc t1 2 2 -- rightmost tuple element
+                   tsz_shft   <- incVars sc 0 (length pis) tsz
+
+                   bvult <- scGlobalDef sc "Prelude.bvult"
+                   islt  <- scEqTrue sc =<< scApplyAll sc bvult [wt, tsz, tsz_shft]
+
+                   tinner <- scPi sc "_" islt =<< incVars sc 0 1 tbody
+                   thyp   <- scPiList sc [ ("i_" <> nm, z) | (nm,z) <- pis ] tinner
+
+                   touter <- scPi sc "_" thyp =<< incVars sc 0 1 tbody
+                   scPiList sc pis touter
+
+            indMotive <- io $
+                do vars   <- reverse <$> mapM (scLocalVar sc) [ 0 .. length pis-1 ]
+                   indVar <- scLocalVar sc (length pis)
+                   t1     <- scApplyAllBeta sc (ttTerm t) vars
+                   tsz    <- scTupleSelector sc t1 1 2 -- left element
+                   tsz'   <- scApplyAll sc toNat [wt, tsz]
+                   teq    <- scDataTypeApp sc "Prelude.IsLeNat" [tsz', indVar]
+                   tbody  <- scEqTrue sc =<< scTupleSelector sc t1 2 2 -- right element
+                   t2     <- scPi sc "_" teq =<< incVars sc 0 1 tbody
+                   t3     <- scPiList sc pis t2
+                   scLambda sc "inductionVar" natty t3
+
+            indHyp <- io $
+                do var0 <- scLocalVar sc 0
+                   var1 <- scLocalVar sc 1
+                   lt   <- scGlobalApply sc "Prelude.IsLtNat" [var0, var1]
+                   inner <- scPi sc "m" natty =<< scPi sc "_" lt =<< scApplyBeta sc indMotive var1
+                   scPi sc "n" natty =<< scPi sc "_" inner =<< scApplyBeta sc indMotive var1
+
+            indHypProof <- io $   -- scFreshGlobal sc "H" =<< scPi sc "_" thmHyp indHyp
+                do hEC  <- scFreshEC sc "H" thmHyp
+                   hVar <- scExtCns sc hEC
+                   nEC  <- scFreshEC sc "n" natty
+                   nVar <- scExtCns sc nEC
+                   hindEC <- scFreshEC sc "Hind" =<<
+                                do var0 <- scLocalVar sc 0
+                                   var1 <- scLocalVar sc 1
+                                   lt   <- scGlobalApply sc "Prelude.IsLtNat" [var0, nVar]
+                                   scPi sc "m" natty =<< scPi sc "_" lt =<< scApplyBeta sc indMotive var1
+                   hindVar <- scExtCns sc hindEC
+                   varECs <- mapM (uncurry (scFreshEC sc)) pis
+                   vars   <- mapM (scExtCns sc) varECs
+
+                   innerVarECs <- mapM (uncurry (scFreshEC sc)) [ ("i_" <> nm, z) | (nm,z) <- pis ]
+                   innerVars   <- mapM (scExtCns sc) innerVarECs
+
+                   outersz <- do t1   <- scApplyAllBeta sc (ttTerm t) vars
+                                 scTupleSelector sc t1 1 2 -- left element
+                   natoutersz <- scApplyAll sc toNat [wt, outersz]
+
+                   innersz <- do t1   <- scApplyAllBeta sc (ttTerm t) innerVars
+                                 scTupleSelector sc t1 1 2 -- left element
+                   natinnersz <- scApplyAll sc toNat [wt, innersz]
+
+                   succinnersz <- scCtorApp sc "Prelude.Succ" [natinnersz]
+
+                   bvltEC  <- scFreshEC sc "Hult" =<< scEqTrue sc =<< scBvULt sc wt innersz outersz
+                   bvltVar <- scExtCns sc bvltEC
+
+                   leEC    <- scFreshEC sc "Hle" =<<
+                                 scDataTypeApp sc "Prelude.IsLeNat" [natoutersz, nVar]
+                   leVar   <- scExtCns sc leEC
+
+                   refl_inner <- scCtorApp sc "Prelude.IsLeNat_base" [natinnersz]
+
+                   prf     <- do hyx <- scGlobalApply sc "Prelude.bvultToIsLtNat" [wt,innersz,outersz,bvltVar]
+                                 scGlobalApply sc "Prelude.IsLeNat_transitive" [succinnersz, natoutersz, nVar, hyx, leVar]
+                   inner   <- do body <- scApplyAll sc hindVar ([natinnersz,prf]++innerVars++[refl_inner])
+                                 scAbstractExts sc (innerVarECs ++ [bvltEC]) body
+
+                   body <- scApplyAll sc hVar (vars ++ [inner])
+
+                   scAbstractExts sc ([hEC, nEC, hindEC] ++ varECs ++ [leEC]) body
+
+            indApp <- io $
+                do vars   <- reverse <$> mapM (scLocalVar sc) [ 0 .. length pis-1 ]
+                   varH   <- scLocalVar sc (length pis)
+                   t1     <- scApplyAllBeta sc (ttTerm t) vars
+                   tsz    <- scTupleSelector sc t1 1 2 -- left element
+                   tsz'   <- scApplyAll sc toNat [wt, tsz]
+                   trefl  <- scCtorApp sc "Prelude.IsLeNat_base" [tsz']
+                   indHypArg <- scApplyBeta sc indHypProof varH
+                   ind    <- scGlobalApply sc "Prelude.Nat_complete_induction" ([indMotive,indHypArg,tsz'] ++ vars ++ [trefl])
+                   ind'   <- scLambdaList sc pis ind
+                   ind''  <- scLambda sc "Hind" thmHyp ind'
+
+                   _tp    <- scTypeCheckError sc ind'' -- sanity check
+                   return ind''
+
+            indAppTT <- io $ mkTypedTerm sc indApp
+
+            ind_scheme_goal <- io $ scFun sc thmHyp thmResult
+            ind_scheme_theorem <- proveHelper "bv_induction_scheme" (goal_exact indAppTT) ind_scheme_goal (io . termToProp sc)
+            let script' = goal_apply ind_scheme_theorem >> script
+            proveHelper "prove_by_bv_induction" script' thmResult (io . termToProp sc)
+
+ where
+  checkInductionScheme sc opts pis ty =
+    do ty' <- scWhnf sc ty
+       case asPi ty' of
+         Just (nm,tp,body) -> checkInductionScheme sc opts ((nm,tp):pis) body
+         Nothing ->
+           case asTupleType ty' of
+             Just [bv, bool] ->
+               do bool' <- scWhnf sc bool
+                  bv'   <- scWhnf sc bv
+                  case (asVectorType bv', asBoolType bool') of
+                    (Just (w,vbool), Just ()) ->
+                      do w' <- scWhnf sc w
+                         vbool' <- scWhnf sc vbool
+                         case (asNat w', asBoolType vbool') of
+                           (Just n, Just ()) -> return (Just (reverse pis, n))
+                           _ -> return Nothing
+                    _ -> return Nothing
+             _ -> return Nothing
+
+  badTy opts ty =
+    fail $ unlines [ "Incorrect type for proof by induction"
+                   , show (ppTerm (SV.sawPPOpts opts) ty)
+                   ]
 
 provePrintPrim ::
   ProofScript () ->
@@ -1077,7 +1227,7 @@ provePrintPrim ::
   TopLevel Theorem
 provePrintPrim script t = do
   sc <- getSharedContext
-  proveHelper "prove_print" script t $ io . predicateToProp sc Universal
+  proveHelper "prove_print" script (ttTerm t) $ io . predicateToProp sc Universal
 
 provePropPrim ::
   ProofScript () ->
@@ -1085,7 +1235,7 @@ provePropPrim ::
   TopLevel Theorem
 provePropPrim script t = do
   sc <- getSharedContext
-  proveHelper "prove_extcore" script t $ io . termToProp sc
+  proveHelper "prove_extcore" script (ttTerm t) $ io . termToProp sc
 
 satPrim ::
   ProofScript () ->

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -1122,12 +1122,12 @@ proveByBVInduction script t =
                    t3     <- scPiList sc pis t2
                    scLambda sc "inductionVar" natty t3
 
-            indHyp <- io $
-                do var0 <- scLocalVar sc 0
-                   var1 <- scLocalVar sc 1
-                   lt   <- scGlobalApply sc "Prelude.IsLtNat" [var0, var1]
-                   inner <- scPi sc "m" natty =<< scPi sc "_" lt =<< scApplyBeta sc indMotive var1
-                   scPi sc "n" natty =<< scPi sc "_" inner =<< scApplyBeta sc indMotive var1
+            -- indHyp <- io $
+            --     do var0 <- scLocalVar sc 0
+            --        var1 <- scLocalVar sc 1
+            --        lt   <- scGlobalApply sc "Prelude.IsLtNat" [var0, var1]
+            --        inner <- scPi sc "m" natty =<< scPi sc "_" lt =<< scApplyBeta sc indMotive var1
+            --        scPi sc "n" natty =<< scPi sc "_" inner =<< scApplyBeta sc indMotive var1
 
             indHypProof <- io $   -- scFreshGlobal sc "H" =<< scPi sc "_" thmHyp indHyp
                 do hEC  <- scFreshEC sc "H" thmHyp

--- a/src/SAWScript/Crucible/JVM/Builtins.hs
+++ b/src/SAWScript/Crucible/JVM/Builtins.hs
@@ -105,7 +105,6 @@ import qualified Data.Parameterized.Context as Ctx
 import Verifier.SAW.FiniteValue (ppFirstOrderValue)
 import Verifier.SAW.Name (toShortName)
 import Verifier.SAW.SharedTerm
-import Verifier.SAW.Recognizer
 import Verifier.SAW.TypedTerm
 
 import Verifier.SAW.Simulator.What4.ReturnTrip

--- a/src/SAWScript/Crucible/JVM/Builtins.hs
+++ b/src/SAWScript/Crucible/JVM/Builtins.hs
@@ -722,14 +722,6 @@ verifySimulate opts cc pfs mspec args assumes top_loc lemmas globals _checkSat m
            return (Crucible.RegEntry tr v))
       ctx
 
--- | Build a conjunction from a list of boolean terms.
-scAndList :: SharedContext -> [Term] -> IO Term
-scAndList sc = conj . filter nontrivial
-  where
-    nontrivial x = asBool x /= Just True
-    conj [] = scBool sc True
-    conj (x : xs) = foldM (scAnd sc) x xs
-
 --------------------------------------------------------------------------------
 
 verifyPoststate ::

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -1594,15 +1594,6 @@ prepareArgs sym ctx x =
        return (Crucible.RegEntry tr v))
   ctx
 
-
--- | Build a conjunction from a list of boolean terms.
-scAndList :: SharedContext -> [Term] -> IO Term
-scAndList sc = conj . filter nontrivial
-  where
-    nontrivial x = asBool x /= Just True
-    conj [] = scBool sc True
-    conj (x : xs) = foldM (scAnd sc) x xs
-
 --------------------------------------------------------------------------------
 
 verifyPoststate ::

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -1497,6 +1497,13 @@ primitives = Map.fromList
     , "if unsuccessful."
     ]
 
+  , prim "prove_by_bv_induction"  "ProofScript () -> Term -> TopLevel Theorem"
+    (pureVal proveByBVInduction)
+    Experimental
+    [ "TODO, real docs.  Attempt to prove a fact by induction on the less-than"
+    , "order on bitvectors."
+    ]
+
   , prim "prove_extcore"         "ProofScript () -> Term -> TopLevel Theorem"
     (pureVal provePropPrim)
     Current

--- a/src/SAWScript/Proof.hs
+++ b/src/SAWScript/Proof.hs
@@ -1087,7 +1087,7 @@ propToSATQuery sc unintSet prop =
                Nothing -> fail $ "propToSATQuery: expected EqTrue, actual:\n" ++ showTerm tm'
                Just tmBool -> return (UniversalAssert (reverse vars) (reverse xs) tmBool)
 
-    processAssert mmap tp = 
+    processAssert mmap tp =
       case asEqTrue tp of
         Just x -> return (BoolAssert x)
         _ -> processUnivAssert mmap [] [] tp


### PR DESCRIPTION
This PR adds some new capabilities to SAW's proof engine. 

The first is the ability to automatically generate and use induction principles on bitvector values to prove inductive properties, with a new `prove_by_bv_induction` command.  The idea is that the user specifies both the property to prove and also a decreasing bitvector value.  The system automatically constructs an appropriate induction schema by reduction to induction on the natural numbers and applies it to the term.  For example:

```
prove_by_bv_induction tac {{ \(x:[64]) (y:[64]) -> ( x, x+y == y+x) }}; 
```

Indicates that the user is attempting to prove that 64-bit addition is commutative by induction on the (unsigned) value of `x`. Upon invoking this, the given tactic will need to prove a goal of the following form (which as been cleaned up a bit for readability):

```
let { x@1 = Vec 64 Bool
    }
 in (x : x@1)
-> (y : x@1)
-> ((i_x : x@1)
    -> (i_y : x@1)
    -> EqTrue (bvult 64 i_x x)
    -> EqTrue
         (ecEq x@1 (PEqWord 64) (bvAdd 64 i_x i_y) (bvAdd 64 i_y i_x)))
-> EqTrue (ecEq x@1 (PEqWord 64) (bvAdd 64 x y) (bvAdd 64 y x))
```

This provides the user with an induction hypothesis for all `x_i` values less than `x`.

Also in this PR is the ability to assert universally-quantified statements to solvers via the What4 backend. This is helpful for, e.g., actually invoking the induction hypotheses that arise as above, but also for general reasoning up to universal lemmas.