### PR TITLE
Dangling vars

### DIFF
--- a/intTests/test_dangling_hoist/README
+++ b/intTests/test_dangling_hoist/README
@@ -1,0 +1,6 @@
+This test is related to https://github.com/GaloisInc/saw-script/issues/1316
+Previously, the hoist_ifs_in_goal and goal_eval tactics would not properly
+take care of the dependencies arising from Pi binders and this would
+result in dangling variables. This test exercises those tactics
+with dependent binders to check that this does not occur.
+

--- a/intTests/test_dangling_hoist/test.saw
+++ b/intTests/test_dangling_hoist/test.saw
@@ -1,0 +1,22 @@
+enable_experimental;
+
+prove_extcore do {
+    print_goal;
+    check_goal;
+    hoist_ifs_in_goal;
+    print_goal;
+    check_goal;
+    admit "sure";
+  }
+  (parse_core "(x : Integer) -> (y:Integer) -> (z:Integer) -> (b:Bool) -> EqTrue (intEq z (ite Integer b x y)) -> EqTrue (ite Bool b (intEq z x) (intEq z y))");
+
+
+prove_extcore do {
+    print_goal;
+    check_goal;
+    goal_eval;
+    print_goal;
+    check_goal;
+    admit "sure";
+  }
+  (parse_core "(x : Integer) -> (y:Integer) -> (z:Integer) -> (b:Bool) -> EqTrue (intEq z (ite Integer b x y)) -> EqTrue (ite Bool b (intEq z x) (intEq z y))");

--- a/intTests/test_dangling_hoist/test.sh
+++ b/intTests/test_dangling_hoist/test.sh
@@ -1,0 +1,1 @@
+$SAW test.saw

--- a/src/SAWScript/Proof.hs
+++ b/src/SAWScript/Proof.hs
@@ -422,7 +422,7 @@ simplifySequent sc ss (HypFocusedSequent (FB hs1 h hs2) gs) =
 
 hoistIfsInProp :: SharedContext -> Prop -> IO Prop
 hoistIfsInProp sc p = do
-  (ecs, body) <- unbindProp sc p
+  (ecs, body) <- unbindAndFreshenProp sc p
   body' <-
     case asEqTrue body of
       Just t -> pure t
@@ -435,8 +435,8 @@ hoistIfsInProp sc p = do
 -- | Turn any leading Pi binders in the given prop into
 --   fresh ExtCns values, being careful to ensure that
 --   dependent types are properly substituted.
-unbindProp :: SharedContext -> Prop -> IO ([ExtCns Term], Term)
-unbindProp sc (Prop p0) = loop [] [] p0
+unbindAndFreshenProp :: SharedContext -> Prop -> IO ([ExtCns Term], Term)
+unbindAndFreshenProp sc (Prop p0) = loop [] [] p0
   where
     loop ecs vs p =
       case asPi p of
@@ -456,7 +456,7 @@ unbindProp sc (Prop p0) = loop [] [] p0
 --   perform a variety of simplifications and rewrites.
 evalProp :: SharedContext -> Set VarIndex -> Prop -> IO Prop
 evalProp sc unints p =
-  do (ecs, body) <- unbindProp sc p
+  do (ecs, body) <- unbindAndFreshenProp sc p
      body' <-
        case asEqTrue body of
          Just t -> pure t


### PR DESCRIPTION
A fix for #1316 

The resulting tactics might not quite behave as expected (they will not perform transformations on any propositions on the left of a SAWCore arrow), but they at least do not produce nonsense terms anymore.