### PR TITLE
CI: Work around GHC installation issues on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,14 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
 
+      - name: Post-GHC installation fixups on Windows
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          # A workaround for https://github.com/Mistuke/CabalChoco/issues/5
+          cabal user-config update -a "extra-include-dirs: \"\""
+          cabal user-config update -a "extra-lib-dirs: \"\""
+
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:


### PR DESCRIPTION
This should avoid nasty linker errors as observed in https://gitlab.haskell.org/ghc/ghc/-/issues/21111 until the upstream tools can be fixed.