### PR TITLE
`s2n-tests`: Simplify artifact handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,12 +204,6 @@ jobs:
           path: dist/bin
           name: ${{ runner.os }}-bins
 
-      - if: "matrix.os == 'ubuntu-18.04'"
-        uses: actions/upload-artifact@v2
-        with:
-          name: "saw-${{ runner.os }}-${{ matrix.ghc }}"
-          path: "dist/bin/saw"
-
   mr-solver-tests:
     needs: [build]
     strategy:
@@ -544,14 +538,12 @@ jobs:
       - name: Download previously-built SAW
         uses: actions/download-artifact@v2
         with:
-          name: "saw-Linux-${{ matrix.ghc }}"
+          name: "${{ runner.os }}-bins"
           path: ./s2nTests/bin
 
       - shell: bash
         working-directory: s2nTests
         run: |
-          curl -o solvers-bin.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/$SOLVER_PKG_VERSION/ubuntu-18.04-bin.zip"
-          (cd bin && unzip ../solvers-bin.zip)
           docker-compose pull
           grep -h '^FROM' docker/*.dockerfile | sort -u | awk '{print $2}' | xargs -n1 -P8 docker pull
 


### PR DESCRIPTION
Previously, we uploaded a duplicate SAW binary specifically for use by the `s2n-tests` job. This is unnecessary, however, as the same binary is contained within a more general artifact that we upload for the SAW test suite. This patch removes the duplicate artifact, thereby simplifying the overall CI setup.

Fixes #1726.