### PR TITLE
Allow use of Cryptol property names as simplification rules

### DIFF
--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -1214,6 +1214,20 @@ cryptolURI (p:ps) (Just uniq) =
        }
 
 -- | Tests if the given 'NameInfo' represents a name imported
+--   from Cryptol. If so, return the unqualified identifier
+--   associated with that 'NameInfo'.
+isCryptolName :: NameInfo -> Maybe Text
+isCryptolName (ImportedName uri _)
+  | Just sch <- uriScheme uri
+  , unRText sch == "cryptol"
+  , Left True <- uriAuthority uri
+  , Just (False, x :| xs) <- uriPath uri
+  , [] <- uriQuery uri
+  , Nothing <- uriFragment uri
+  = Just (unRText (last (x:xs)))
+isCryptolName _ = Nothing
+
+-- | Tests if the given 'NameInfo' represents a name imported
 --   from the given Cryptol module name.  If so, it returns
 --   the identifier within that module.  Note, this does
 --   not match dynamic identifiers from the \"\<interactive\>\"

--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -1214,20 +1214,6 @@ cryptolURI (p:ps) (Just uniq) =
        }
 
 -- | Tests if the given 'NameInfo' represents a name imported
---   from Cryptol. If so, return the unqualified identifier
---   associated with that 'NameInfo'.
-isCryptolName :: NameInfo -> Maybe Text
-isCryptolName (ImportedName uri _)
-  | Just sch <- uriScheme uri
-  , unRText sch == "cryptol"
-  , Left True <- uriAuthority uri
-  , Just (False, x :| xs) <- uriPath uri
-  , [] <- uriQuery uri
-  , Nothing <- uriFragment uri
-  = Just (unRText (last (x:xs)))
-isCryptolName _ = Nothing
-
--- | Tests if the given 'NameInfo' represents a name imported
 --   from the given Cryptol module name.  If so, it returns
 --   the identifier within that module.  Note, this does
 --   not match dynamic identifiers from the \"\<interactive\>\"

--- a/intTests/test_property_as_rewrite_rule/README.md
+++ b/intTests/test_property_as_rewrite_rule/README.md
@@ -1,4 +1,5 @@
-This tests limited automatic unfolding in `addsimp*`. Rather than unwrap
-`XorInvolutes` into its functional definition at the `prove*` site, we can prove
-the property by name and include its *immediate* definition as the rewrite rule.
-No further unwrapping takes place.
+This tests limited automatic unfolding in `addsimp*`. Rather than manually
+unwrap `XorInvolutes` into its functional definition at the `prove*` site in
+SAW, we can prove the property by name and include its *immediate* definition as
+the rewrite rule. No further unwrapping takes place, since `XorInvolutes`
+unfolds to a well-formed simplification rule.

--- a/intTests/test_property_as_rewrite_rule/README.md
+++ b/intTests/test_property_as_rewrite_rule/README.md
@@ -1,0 +1,4 @@
+This tests limited automatic unfolding in `addsimp*`. Rather than unwrap
+`XorInvolutes` into its functional definition at the `prove*` site, we can prove
+the property by name and include its *immediate* definition as the rewrite rule.
+No further unwrapping takes place.

--- a/intTests/test_property_as_rewrite_rule/test.cry
+++ b/intTests/test_property_as_rewrite_rule/test.cry
@@ -1,0 +1,4 @@
+module Test where
+
+XorInvolutes : [8] -> [8] -> Bit
+property XorInvolutes x y = (x ^ y) ^ y == x

--- a/intTests/test_property_as_rewrite_rule/test.saw
+++ b/intTests/test_property_as_rewrite_rule/test.saw
@@ -1,0 +1,4 @@
+import "test.cry";
+
+p <- prove_print z3 {{ XorInvolutes }};
+let rules = addsimp p empty_ss;

--- a/intTests/test_property_as_rewrite_rule/test.saw
+++ b/intTests/test_property_as_rewrite_rule/test.saw
@@ -1,4 +1,13 @@
 import "test.cry";
 
-p <- prove_print z3 {{ XorInvolutes }};
-let rules = addsimp p empty_ss;
+// Existing capability
+p1 <- prove_print z3 {{ \(x: [8]) (y: [8]) -> (x ^ y) ^ y == x }};
+let r1 = addsimp p1 empty_ss;
+
+// New capability
+p2 <- prove_print z3 {{ XorInvolutes }};
+let r2 = addsimp p2 empty_ss;
+
+// New capability
+p3 <- prove_print z3 {{ \x y -> XorInvolutes x y }};
+let r3 = addsimp p3 empty_ss;

--- a/intTests/test_property_as_rewrite_rule/test.sh
+++ b/intTests/test_property_as_rewrite_rule/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$SAW test.saw

--- a/saw-core/src/Verifier/SAW/Rewriter.hs
+++ b/saw-core/src/Verifier/SAW/Rewriter.hs
@@ -382,13 +382,13 @@ ruleOfProp sc term ann
     pure $ Just $ mkRewriteRule [] x y False ann
   | (R.isGlobalDef intModEqIdent -> Just (), [_, x, y]) <- R.asApplyAll term =
     pure $ Just $ mkRewriteRule [] x y False ann
-  | (R.asConstant -> Just (_, Just body), as) <- R.asApplyAll term =
-    do  app <- scApplyAllBeta sc body as
-        ruleOfProp sc app ann
   | Constant _ (Just body) <- unwrapTermF term = ruleOfProp sc body ann
   | Just (_, x, y) <- R.asEq term =
     pure $ Just $ mkRewriteRule [] x y False ann
   | Just body <- R.asEqTrue term = ruleOfProp sc body ann
+  | (R.asConstant -> Just (_, Just body), as) <- R.asApplyAll term =
+    do  app <- scApplyAllBeta sc body as
+        ruleOfProp sc app ann
   | otherwise = pure Nothing
 
 -- | Generate a rewrite rule from the type of an identifier, using 'ruleOfTerm'

--- a/saw-core/src/Verifier/SAW/Rewriter.hs
+++ b/saw-core/src/Verifier/SAW/Rewriter.hs
@@ -30,7 +30,6 @@ module Verifier.SAW.Rewriter
   , ruleOfTerm
   , ruleOfTerms
   , ruleOfProp
-  , unfoldableTerm
   , scDefRewriteRules
   , scEqsRewriteRules
   , scEqRewriteRule
@@ -395,27 +394,6 @@ scEqRewriteRule sc i = ruleOfTerm <$> scTypeOfGlobal sc i <*> pure Nothing
 -- | Collects rewrite rules from named constants, whose types must be equations.
 scEqsRewriteRules :: SharedContext -> [Ident] -> IO [RewriteRule a]
 scEqsRewriteRules sc = mapM (scEqRewriteRule sc)
-
--- | Finds the first named constant in the term that may be amenable to
--- unfolding
-unfoldableTerm :: Term -> Either NameInfo ()
-unfoldableTerm t
-  | Just _ <- R.asFTermF t =
-    Right ()
-  | Just _ <- R.asLocalVar t =
-    Right ()
-  | Just (EC _ nmi _, Just _body) <- R.asConstant t =
-    -- is matching (Just _body) too strict?
-    Left nmi
-  | Just (_, _, body) <- R.asLambda t =
-    unfoldableTerm body
-  | Just (_, _, body) <- R.asPi t =
-    unfoldableTerm body
-  | Just body <- R.asEqTrue t =
-    unfoldableTerm body
-  | Just (f, x) <- R.asApp t =
-    unfoldableTerm f >> unfoldableTerm x
-  | otherwise = Right ()
 
 -- | Transform the given rewrite rule to a set of one or more
 -- equivalent rewrite rules, if possible.

--- a/saw-core/src/Verifier/SAW/Rewriter.hs
+++ b/saw-core/src/Verifier/SAW/Rewriter.hs
@@ -358,34 +358,37 @@ ruleOfTerms l r = mkRewriteRule [] l r False Nothing
 
 -- | Converts a parameterized equality predicate to a RewriteRule,
 -- returning 'Nothing' if the predicate is not an equation.
-ruleOfProp :: Term -> Maybe a -> Maybe (RewriteRule a)
-ruleOfProp (R.asPi -> Just (_, ty, body)) ann =
-  do rule <- ruleOfProp body ann
-     Just rule { ctxt = ty : ctxt rule }
-ruleOfProp (R.asLambda -> Just (_, ty, body)) ann =
-  do rule <- ruleOfProp body ann
-     Just rule { ctxt = ty : ctxt rule }
-ruleOfProp (R.asApplyAll -> (R.isGlobalDef ecEqIdent -> Just (), [_, _, x, y])) ann =
-  Just $ mkRewriteRule [] x y False ann
-ruleOfProp (R.asApplyAll -> (R.isGlobalDef bvEqIdent -> Just (), [_, x, y])) ann =
-  Just $ mkRewriteRule [] x y False ann
-ruleOfProp (R.asApplyAll -> (R.isGlobalDef equalNatIdent -> Just (), [x, y])) ann =
-  Just $ mkRewriteRule [] x y False ann
-ruleOfProp (R.asApplyAll -> (R.isGlobalDef boolEqIdent -> Just (), [x, y])) ann =
-  Just $ mkRewriteRule [] x y False ann
-ruleOfProp (R.asApplyAll -> (R.isGlobalDef vecEqIdent -> Just (), [_, _, _, x, y])) ann =
-  Just $ mkRewriteRule [] x y False ann
-ruleOfProp (R.asApplyAll -> (R.isGlobalDef arrayEqIdent -> Just (), [_, _, x, y])) ann =
-  Just $ mkRewriteRule [] x y False ann
-ruleOfProp (R.asApplyAll -> (R.isGlobalDef intEqIdent -> Just (), [x, y])) ann =
-  Just $ mkRewriteRule [] x y False ann
-ruleOfProp (R.asApplyAll -> (R.isGlobalDef intModEqIdent -> Just (), [_, x, y])) ann =
-  Just $ mkRewriteRule [] x y False ann
-ruleOfProp (unwrapTermF -> Constant _ (Just body)) ann = ruleOfProp body ann
-ruleOfProp (R.asEq -> Just (_, x, y)) ann =
-  Just $ mkRewriteRule [] x y False ann
-ruleOfProp (R.asEqTrue -> Just body) ann = ruleOfProp body ann
-ruleOfProp _ _ = Nothing
+ruleOfProp :: SharedContext -> Term -> Maybe a -> IO (Maybe (RewriteRule a))
+ruleOfProp sc (R.asPi -> Just (_, ty, body)) ann =
+  do rule <- ruleOfProp sc body ann
+     pure $ (\r -> r { ctxt = ty : ctxt r }) <$> rule
+ruleOfProp sc (R.asLambda -> Just (_, ty, body)) ann =
+  do rule <- ruleOfProp sc body ann
+     pure $ (\r -> r { ctxt = ty : ctxt r }) <$> rule
+ruleOfProp _sc (R.asApplyAll -> (R.isGlobalDef ecEqIdent -> Just (), [_, _, x, y])) ann =
+  pure $ Just $ mkRewriteRule [] x y False ann
+ruleOfProp _sc (R.asApplyAll -> (R.isGlobalDef bvEqIdent -> Just (), [_, x, y])) ann =
+  pure $ Just $ mkRewriteRule [] x y False ann
+ruleOfProp _sc (R.asApplyAll -> (R.isGlobalDef equalNatIdent -> Just (), [x, y])) ann =
+  pure $ Just $ mkRewriteRule [] x y False ann
+ruleOfProp _sc (R.asApplyAll -> (R.isGlobalDef boolEqIdent -> Just (), [x, y])) ann =
+  pure $ Just $ mkRewriteRule [] x y False ann
+ruleOfProp _sc (R.asApplyAll -> (R.isGlobalDef vecEqIdent -> Just (), [_, _, _, x, y])) ann =
+  pure $ Just $ mkRewriteRule [] x y False ann
+ruleOfProp _sc (R.asApplyAll -> (R.isGlobalDef arrayEqIdent -> Just (), [_, _, x, y])) ann =
+  pure $ Just $ mkRewriteRule [] x y False ann
+ruleOfProp _sc (R.asApplyAll -> (R.isGlobalDef intEqIdent -> Just (), [x, y])) ann =
+  pure $ Just $ mkRewriteRule [] x y False ann
+ruleOfProp _sc (R.asApplyAll -> (R.isGlobalDef intModEqIdent -> Just (), [_, x, y])) ann =
+  pure $ Just $ mkRewriteRule [] x y False ann
+ruleOfProp sc (unwrapTermF -> Constant _ (Just body)) ann = ruleOfProp sc body ann
+ruleOfProp _sc (R.asEq -> Just (_, x, y)) ann =
+  pure $ Just $ mkRewriteRule [] x y False ann
+ruleOfProp sc (R.asEqTrue -> Just body) ann = ruleOfProp sc body ann
+ruleOfProp sc (R.asApplyAll -> (R.asConstant -> Just (_, Just body), as)) ann =
+  do  app <- scApplyAllBeta sc body as
+      ruleOfProp sc app ann
+ruleOfProp _ _ _ = pure Nothing
 
 -- | Generate a rewrite rule from the type of an identifier, using 'ruleOfTerm'
 scEqRewriteRule :: SharedContext -> Ident -> IO (RewriteRule a)

--- a/saw-core/src/Verifier/SAW/Rewriter.hs
+++ b/saw-core/src/Verifier/SAW/Rewriter.hs
@@ -30,6 +30,7 @@ module Verifier.SAW.Rewriter
   , ruleOfTerm
   , ruleOfTerms
   , ruleOfProp
+  , unfoldableTerm
   , scDefRewriteRules
   , scEqsRewriteRules
   , scEqRewriteRule
@@ -394,6 +395,27 @@ scEqRewriteRule sc i = ruleOfTerm <$> scTypeOfGlobal sc i <*> pure Nothing
 -- | Collects rewrite rules from named constants, whose types must be equations.
 scEqsRewriteRules :: SharedContext -> [Ident] -> IO [RewriteRule a]
 scEqsRewriteRules sc = mapM (scEqRewriteRule sc)
+
+-- | Finds the first named constant in the term that may be amenable to
+-- unfolding
+unfoldableTerm :: Term -> Either NameInfo ()
+unfoldableTerm t
+  | Just _ <- R.asFTermF t =
+    Right ()
+  | Just _ <- R.asLocalVar t =
+    Right ()
+  | Just (EC _ nmi _, Just _body) <- R.asConstant t =
+    -- is matching (Just _body) too strict?
+    Left nmi
+  | Just (_, _, body) <- R.asLambda t =
+    unfoldableTerm body
+  | Just (_, _, body) <- R.asPi t =
+    unfoldableTerm body
+  | Just body <- R.asEqTrue t =
+    unfoldableTerm body
+  | Just (f, x) <- R.asApp t =
+    unfoldableTerm f >> unfoldableTerm x
+  | otherwise = Right ()
 
 -- | Transform the given rewrite rule to a set of one or more
 -- equivalent rewrite rules, if possible.

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -1523,29 +1523,19 @@ beta_reduce_term (TypedTerm schema t) = do
   t' <- io $ betaNormalize sc t
   return (TypedTerm schema t')
 
-addSimpWith :: (forall a. RewriteRule a -> RewriteRule a) -> Theorem -> SV.SAWSimpset -> TopLevel SV.SAWSimpset
-addSimpWith f thm ss =
-  do  sc <- getSharedContext
-      mkRule sc (thmProp thm)
-  where
-    mkRule sc prop =
-      io (propToRewriteRule sc prop (Just (thmNonce thm))) >>= \case
-        Right Nothing -> fail "addsimp: cannot interpret theorem as equation"
-        Right (Just rule) -> pure (addRule (f rule) ss)
-        Left nmi ->
-          case Cryptol.isCryptolName nmi of
-            Nothing -> fail "addsimp: cannot unfold a non-cryptol term"
-            Just name ->
-              do  idx <- resolveName sc (Text.unpack name)
-                  prop' <- io $ unfoldProp sc (Set.fromList idx) prop
-                  prop'' <- io $ betaReduceProp sc prop'
-                  mkRule sc prop''
-
 addsimp :: Theorem -> SV.SAWSimpset -> TopLevel SV.SAWSimpset
-addsimp = addSimpWith id
+addsimp thm ss =
+  do sc <- getSharedContext
+     io (propToRewriteRule sc (thmProp thm) (Just (thmNonce thm))) >>= \case
+       Nothing -> fail "addsimp: theorem not an equation"
+       Just rule -> pure (addRule rule ss)
 
 addsimp_shallow :: Theorem -> SV.SAWSimpset -> TopLevel SV.SAWSimpset
-addsimp_shallow = addSimpWith shallowRule
+addsimp_shallow thm ss =
+  do sc <- getSharedContext
+     io (propToRewriteRule sc (thmProp thm) (Just (thmNonce thm))) >>= \case
+       Nothing -> fail "addsimp: theorem not an equation"
+       Just rule -> pure (addRule (shallowRule rule) ss)
 
 -- TODO: remove this, it implicitly adds axioms
 addsimp' :: Term -> SV.SAWSimpset -> TopLevel SV.SAWSimpset

--- a/src/SAWScript/Proof.hs
+++ b/src/SAWScript/Proof.hs
@@ -224,16 +224,12 @@ boolToProp sc vars tm =
 propToTerm :: SharedContext -> Prop -> IO Term
 propToTerm _sc (Prop tm) = pure tm
 
--- | Attempt to interpret a proposition as a rewrite rule. If interpretation
--- fails, check if a (sub)term can be unfolded.
-propToRewriteRule :: SharedContext -> Prop -> Maybe a -> IO (Either NameInfo (Maybe (RewriteRule a)))
+-- | Attempt to interpret a proposition as a rewrite rule.
+propToRewriteRule :: SharedContext -> Prop -> Maybe a -> IO (Maybe (RewriteRule a))
 propToRewriteRule _sc (Prop tm) ann =
   case ruleOfProp tm ann of
-    Just r  -> pure (Right (Just r))
-    Nothing ->
-      case unfoldableTerm tm of
-        Left nmi -> pure (Left nmi)
-        Right () -> pure (Right Nothing)
+    Nothing -> pure Nothing
+    Just r  -> pure (Just r)
 
 -- | Attempt to split an if/then/else proposition.
 --   If it succeeds to find a term like "EqTrue (ite Bool b x y)",
@@ -401,7 +397,6 @@ localHypSimpset sqt hs ss0 = Fold.foldlM processHyp ss0 nhyps
     processHyp ss (n,h) =
       case ruleOfProp (unProp h) Nothing of
         Nothing -> fail $ "Hypothesis " ++ show n ++ "cannot be used as a rewrite rule."
-        -- check `unfoldableTerm`?
         Just r  -> return (addRule r ss)
 
     nhyps = [ (n,h)

--- a/src/SAWScript/Proof.hs
+++ b/src/SAWScript/Proof.hs
@@ -224,12 +224,16 @@ boolToProp sc vars tm =
 propToTerm :: SharedContext -> Prop -> IO Term
 propToTerm _sc (Prop tm) = pure tm
 
--- | Attempt to interpret a proposition as a rewrite rule.
-propToRewriteRule :: SharedContext -> Prop -> Maybe a -> IO (Maybe (RewriteRule a))
+-- | Attempt to interpret a proposition as a rewrite rule. If interpretation
+-- fails, check if a (sub)term can be unfolded.
+propToRewriteRule :: SharedContext -> Prop -> Maybe a -> IO (Either NameInfo (Maybe (RewriteRule a)))
 propToRewriteRule _sc (Prop tm) ann =
   case ruleOfProp tm ann of
-    Nothing -> pure Nothing
-    Just r  -> pure (Just r)
+    Just r  -> pure (Right (Just r))
+    Nothing ->
+      case unfoldableTerm tm of
+        Left nmi -> pure (Left nmi)
+        Right () -> pure (Right Nothing)
 
 -- | Attempt to split an if/then/else proposition.
 --   If it succeeds to find a term like "EqTrue (ite Bool b x y)",
@@ -397,6 +401,7 @@ localHypSimpset sqt hs ss0 = Fold.foldlM processHyp ss0 nhyps
     processHyp ss (n,h) =
       case ruleOfProp (unProp h) Nothing of
         Nothing -> fail $ "Hypothesis " ++ show n ++ "cannot be used as a rewrite rule."
+        -- check `unfoldableTerm`?
         Just r  -> return (addRule r ss)
 
     nhyps = [ (n,h)


### PR DESCRIPTION
Allow users to `prove` Cryptol properties by name, without unfolding, and use them as simplification rules in SAW. (The former was already possible, this PR introduces the latter as a new capability.) See the included regression test for an example.