### PR TITLE
Fix flipped operands in `intTests` actual/expected checking

### DIFF
--- a/intTests/IntegrationTest.hs
+++ b/intTests/IntegrationTest.hs
@@ -167,7 +167,7 @@ genTests envvars disabled = map mkTest
       if r == ExitSuccess
         then return ()
         else putStrLn o >> hPutStrLn stderr e
-      r @=? ExitSuccess
+      ExitSuccess @=? r
 
 
 -- | Several of the tests use definitions from the cryptol-specs


### PR DESCRIPTION
The [`(@=?)`](https://hackage.haskell.org/package/tasty-hunit-0.10.0.3/docs/Test-Tasty-HUnit.html#v:-64--61--63-) operator wants the expected value on its left and the actual on its right. This makes that happen.