### PR TITLE
Adapt to `NuMatchingAny1` becoming a quantified constraint

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -44,4 +44,4 @@ packages:
 source-repository-package
     type: git
     location: https://github.com/eddywestbrook/hobbits.git
-    tag: e49911ce987c4e0fea8c63608d16638b243b051f
+    tag: b88cbfcad607a5ad05d9134e1f0b2461dd68c3d7

--- a/heapster-saw/src/Verifier/SAW/Heapster/Implication.hs
+++ b/heapster-saw/src/Verifier/SAW/Heapster/Implication.hs
@@ -461,7 +461,7 @@ data SimplImpl ps_in ps_out where
 
   -- | For any unit-typed variable @x@ and unit-type expression @e@, prove
   -- @x:eq(e)@
-  -- 
+  --
   -- > (x:unit,e:unit) . -o x:eq(e)
   SImpl_UnitEq :: ExprVar UnitType -> PermExpr UnitType ->
                   SimplImpl RNil (RNil :> UnitType)
@@ -1596,15 +1596,6 @@ idLocalPermImpl = LocalPermImpl $ PermImpl_Done $ LocalImplRet Refl
 
 -- type IsLLVMPointerTypeList w ps = RAssign ((:~:) (LLVMPointerType w)) ps
 
-instance NuMatchingAny1 EqPerm where
-  nuMatchingAny1Proof = nuMatchingProof
-
-instance NuMatchingAny1 (LocalImplRet ps) where
-  nuMatchingAny1Proof = nuMatchingProof
-
-instance NuMatchingAny1 (OrListDisj ps a) where
-  nuMatchingAny1Proof = nuMatchingProof
-
 -- Many of these types are mutually recursive. Moreover, Template Haskell
 -- declaration splices strictly separate top-level groups, so if we were to
 -- write each $(mkNuMatching [t| ... |]) splice individually, the splices
@@ -2659,7 +2650,7 @@ orListPerm or_list = foldr1 ValPerm_Or $ orListDisjs or_list
 mbOrListPerm :: Mb ctx (OrList ps a disj) -> Mb ctx (ValuePerm a)
 mbOrListPerm = mbMapCl $(mkClosed [| orListPerm |])
 
--- | Build an 'MbPermSets' 
+-- | Build an 'MbPermSets'
 orListMbPermSets :: PermSet (ps :> a) -> ExprVar a -> OrList ps a disjs ->
                     MbPermSets disjs
 orListMbPermSets _ _ MNil = MbPermSets_Nil

--- a/heapster-saw/src/Verifier/SAW/Heapster/Permissions.hs
+++ b/heapster-saw/src/Verifier/SAW/Heapster/Permissions.hs
@@ -53,6 +53,7 @@ import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Control.Applicative hiding (empty)
+import Control.Monad.Extra (concatMapM)
 import Control.Monad.Identity hiding (ap)
 import Control.Monad.State hiding (ap)
 import Control.Monad.Reader hiding (ap)
@@ -897,45 +898,38 @@ data PermEnv = PermEnv {
 -- * Template Haskell–generated instances
 ----------------------------------------------------------------------
 
-instance NuMatchingAny1 PermExpr where
-  nuMatchingAny1Proof = nuMatchingProof
-
-instance NuMatchingAny1 ValuePerm where
-  nuMatchingAny1Proof = nuMatchingProof
-
-instance NuMatchingAny1 VarAndPerm where
-  nuMatchingAny1Proof = nuMatchingProof
-
-instance NuMatchingAny1 ExprAndPerm where
-  nuMatchingAny1Proof = nuMatchingProof
-
-instance NuMatchingAny1 DistPerms where
-  nuMatchingAny1Proof = nuMatchingProof
-
-$(mkNuMatching [t| forall a . BVFactor a |])
-$(mkNuMatching [t| RWModality |])
-$(mkNuMatching [t| forall b args w. NamedShapeBody b args w |])
-$(mkNuMatching [t| forall b args w. NamedShape b args w |])
-$(mkNuMatching [t| forall w . LLVMFieldShape w |])
-$(mkNuMatching [t| forall a . PermExpr a |])
-$(mkNuMatching [t| forall w. BVRange w |])
-$(mkNuMatching [t| forall a. MbRangeForType a |])
-$(mkNuMatching [t| forall a. NuMatching a => SomeTypedMb a |])
-$(mkNuMatching [t| forall w. BVProp w |])
-$(mkNuMatching [t| forall w sz . LLVMFieldPerm w sz |])
-$(mkNuMatching [t| forall w . LLVMArrayBorrow w |])
-$(mkNuMatching [t| forall w . LLVMArrayPerm w |])
-$(mkNuMatching [t| forall w . LLVMBlockPerm w |])
-$(mkNuMatching [t| forall ns. NameSortRepr ns |])
-$(mkNuMatching [t| forall ns args a. NameReachConstr ns args a |])
-$(mkNuMatching [t| forall ns args a. NamedPermName ns args a |])
-$(mkNuMatching [t| forall a. PermOffset a |])
-$(mkNuMatching [t| forall ghosts args gouts ret. FunPerm ghosts args gouts ret |])
-$(mkNuMatching [t| forall a . AtomicPerm a |])
-$(mkNuMatching [t| forall a . ValuePerm a |])
--- $(mkNuMatching [t| forall as. ValuePerms as |])
-$(mkNuMatching [t| forall a . VarAndPerm a |])
-$(mkNuMatching [t| forall a . ExprAndPerm a |])
+-- Many of these types are mutually recursive. Moreover, Template Haskell
+-- declaration splices strictly separate top-level groups, so if we were to
+-- write each $(mkNuMatching [t| ... |]) splice individually, the splices
+-- involving mutually recursive types would not typecheck. As a result, we
+-- must put everything into a single splice so that it forms a single top-level
+-- group.
+$(concatMapM mkNuMatching
+  [ [t| forall a . BVFactor a |]
+  , [t| RWModality |]
+  , [t| forall b args w. NamedShapeBody b args w |]
+  , [t| forall b args w. NamedShape b args w |]
+  , [t| forall w . LLVMFieldShape w |]
+  , [t| forall a . PermExpr a |]
+  , [t| forall w. BVRange w |]
+  , [t| forall a. MbRangeForType a |]
+  , [t| forall a. NuMatching a => SomeTypedMb a |]
+  , [t| forall w. BVProp w |]
+  , [t| forall w sz . LLVMFieldPerm w sz |]
+  , [t| forall w . LLVMArrayBorrow w |]
+  , [t| forall w . LLVMArrayPerm w |]
+  , [t| forall w . LLVMBlockPerm w |]
+  , [t| forall ns. NameSortRepr ns |]
+  , [t| forall ns args a. NameReachConstr ns args a |]
+  , [t| forall ns args a. NamedPermName ns args a |]
+  , [t| forall a. PermOffset a |]
+  , [t| forall ghosts args gouts ret. FunPerm ghosts args gouts ret |]
+  , [t| forall a . AtomicPerm a |]
+  , [t| forall a . ValuePerm a |]
+  -- , [t| forall as. ValuePerms as |]
+  , [t| forall a . VarAndPerm a |]
+  , [t| forall a . ExprAndPerm a |]
+  ])
 
 $(mkNuMatching [t| forall w . LLVMArrayIndex w |])
 $(mkNuMatching [t| forall args ret. SomeFunPerm args ret |])
@@ -2206,7 +2200,7 @@ mbRangeFTDelete
     bvRangeDelete rng1 rng2
 mbRangeFTDelete mb_rng _ = [mb_rng]
 
--- | Delete all ranges in any of a list of ranges from 
+-- | Delete all ranges in any of a list of ranges from
 mbRangeFTsDelete :: [MbRangeForType a] -> [MbRangeForType a] ->
                     [MbRangeForType a]
 mbRangeFTsDelete rngs_l rngs_r =

--- a/heapster-saw/src/Verifier/SAW/Heapster/SAWTranslation.hs
+++ b/heapster-saw/src/Verifier/SAW/Heapster/SAWTranslation.hs
@@ -2102,7 +2102,7 @@ getTopPermM :: ImpTransM ext blocks tops rets (ps :> tp) ctx (PermTrans ctx tp)
 getTopPermM = (\(_ :>: p) -> p) <$> itiPermStack <$> ask
 
 -- | Helper to disambiguate the @ext@ type variable
-getExtReprM :: PermCheckExtC ext =>
+getExtReprM :: PermCheckExtC ext exprExt =>
                ImpTransM ext blocks tops rets ps ctx (ExtRepr ext)
 getExtReprM = return knownRepr
 
@@ -2955,10 +2955,10 @@ translateSimplImpl (ps0 :: Proxy ps0) mb_simpl m = case mbMatch mb_simpl of
        let fromJustOrError (Just x) = x
            fromJustOrError Nothing = error "translateSimplImpl: SImpl_MapLifetime"
            ps_in'_vars =
-             RL.map (translateVar . getCompose) $ mbRAssign $ 
+             RL.map (translateVar . getCompose) $ mbRAssign $
              fmap (fromJustOrError . exprPermsVars) ps_in'
            ps_out_vars =
-             RL.map (translateVar . getCompose) $ mbRAssign $ 
+             RL.map (translateVar . getCompose) $ mbRAssign $
              fmap (fromJustOrError . exprPermsVars) ps_out
        impl_in_tm <-
          translateCurryLocalPermImpl "Error mapping lifetime input perms:" impl_in
@@ -4012,7 +4012,7 @@ translateRWV :: TransInfo info => Mb ctx (RegWithVal a) ->
 translateRWV mb_rwv = transTerm1 <$> translate mb_rwv
 
 -- translate for a TypedExpr yields an ExprTrans
-instance (PermCheckExtC ext, TransInfo info) =>
+instance (PermCheckExtC ext exprExt, TransInfo info) =>
          Translate info ctx (App ext RegWithVal tp) (ExprTrans tp) where
   translate mb_e = case mbMatch mb_e of
     [nuMP| BaseIsEq BaseBoolRepr e1 e2 |] ->
@@ -4243,14 +4243,14 @@ instance (PermCheckExtC ext, TransInfo info) =>
 
 
 -- translate for a TypedExpr yields an ExprTrans
-instance (PermCheckExtC ext, TransInfo info) =>
+instance (PermCheckExtC ext exprExt, TransInfo info) =>
          Translate info ctx (TypedExpr ext tp) (ExprTrans tp) where
   translate mb_x = case mbMatch mb_x of
     [nuMP| TypedExpr _ (Just e) |] -> translate e
     [nuMP| TypedExpr app Nothing |] -> translate app
 
 -- | Get the output permission on the return value of a 'TypedExpr'
-exprOutPerm :: PermCheckExtC ext => Mb ctx (TypedExpr ext tp) ->
+exprOutPerm :: PermCheckExtC ext exprExt => Mb ctx (TypedExpr ext tp) ->
                PermTrans ctx tp
 exprOutPerm mb_x = case mbMatch mb_x of
   [nuMP| TypedExpr _ (Just e) |] -> PTrans_Eq e
@@ -4295,8 +4295,8 @@ translateApply nm f perms =
 -- | Translate a call to (the translation of) an entrypoint, by either calling
 -- the letrec-bound variable for the entrypoint, if it has one, or by just
 -- translating the body of the entrypoint if it does not.
-translateCallEntry :: forall ext tops args ghosts blocks ctx rets.
-                      PermCheckExtC ext => String ->
+translateCallEntry :: forall ext tops args ghosts blocks ctx rets exprExt.
+                      PermCheckExtC ext exprExt => String ->
                       TypedEntryTrans ext blocks tops rets args ghosts ->
                       Mb ctx (RAssign ExprVar (tops :++: args)) ->
                       Mb ctx (RAssign ExprVar ghosts) ->
@@ -4329,7 +4329,7 @@ translateCallEntry nm entry_trans mb_tops_args mb_ghosts =
               (translate $ typedEntryBody entry)
 
 
-instance PermCheckExtC ext =>
+instance PermCheckExtC ext exprExt =>
          Translate (ImpTransInfo ext blocks tops rets ps) ctx
          (CallSiteImplRet blocks tops args ghosts ps) OpenTerm where
   translate (mbMatch ->
@@ -4339,13 +4339,13 @@ instance PermCheckExtC ext =>
          itiBlockMapTrans <$> ask
        translateCallEntry "CallSiteImplRet" entry_trans mb_tavars mb_gvars
 
-instance PermCheckExtC ext =>
+instance PermCheckExtC ext exprExt =>
          ImplTranslateF (CallSiteImplRet blocks tops args ghosts)
          ext blocks tops rets where
   translateF mb_tgt = translate mb_tgt
 
 
-instance PermCheckExtC ext =>
+instance PermCheckExtC ext exprExt =>
          Translate (ImpTransInfo ext blocks tops rets ps) ctx
          (TypedJumpTarget blocks tops ps) OpenTerm where
   translate (mbMatch -> [nuMP| TypedJumpTarget siteID _ _ mb_perms_in |]) =
@@ -4355,7 +4355,7 @@ instance PermCheckExtC ext =>
        translate $ flip fmap mb_perms_in $ \perms_in ->
          varSubst (permVarSubstOfNames $ distPermsVars perms_in) mb_impl
 
-instance PermCheckExtC ext =>
+instance PermCheckExtC ext exprExt =>
          ImplTranslateF (TypedJumpTarget blocks tops) ext blocks tops rets where
   translateF mb_tgt = translate mb_tgt
 
@@ -4366,7 +4366,7 @@ instance PermCheckExtC ext =>
 
 -- | Translate a 'TypedStmt' to a function on translation computations
 translateStmt ::
-  PermCheckExtC ext => ProgramLoc ->
+  PermCheckExtC ext exprExt => ProgramLoc ->
   Mb ctx (TypedStmt ext stmt_rets ps_in ps_out) ->
   ImpTransM ext blocks tops rets ps_out (ctx :++: stmt_rets) OpenTerm ->
   ImpTransM ext blocks tops rets ps_in ctx OpenTerm
@@ -4582,7 +4582,7 @@ translateLLVMStmt mb_stmt m = case mbMatch mb_stmt of
 -- * Translating Sequences of Typed Crucible Statements
 ----------------------------------------------------------------------
 
-instance PermCheckExtC ext =>
+instance PermCheckExtC ext exprExt =>
          Translate (ImpTransInfo ext blocks tops rets ps) ctx
          (TypedRet tops rets ps) OpenTerm where
   translate (mbMatch -> [nuMP| TypedRet Refl mb_rets mb_rets_ns mb_perms |]) =
@@ -4604,11 +4604,11 @@ instance PermCheckExtC ext =>
          applyOpenTermMulti (globalOpenTerm "Prelude.returnM")
          [ret_tp, sigma_trm]
 
-instance PermCheckExtC ext =>
+instance PermCheckExtC ext exprExt =>
          ImplTranslateF (TypedRet tops rets) ext blocks tops rets where
   translateF mb_ret = translate mb_ret
 
-instance PermCheckExtC ext =>
+instance PermCheckExtC ext exprExt =>
          Translate (ImpTransInfo ext blocks tops rets ps) ctx
          (TypedTermStmt blocks tops rets ps) OpenTerm where
   translate mb_x = case mbMatch mb_x of
@@ -4624,7 +4624,7 @@ instance PermCheckExtC ext =>
       mkErrorCompM "Error (unknown message)"
 
 
-instance PermCheckExtC ext =>
+instance PermCheckExtC ext exprExt =>
          Translate (ImpTransInfo ext blocks tops rets ps) ctx
          (TypedStmtSeq ext blocks tops rets ps) OpenTerm where
   translate mb_x = case mbMatch mb_x of
@@ -4633,7 +4633,7 @@ instance PermCheckExtC ext =>
       translateStmt (mbLift loc) stmt (translate $ mbCombine (mbLift pxys) mb_seq)
     [nuMP| TypedTermStmt _ term_stmt |] -> translate term_stmt
 
-instance PermCheckExtC ext =>
+instance PermCheckExtC ext exprExt =>
          ImplTranslateF (TypedStmtSeq
                          ext blocks tops rets) ext blocks tops rets where
   translateF mb_seq = translate mb_seq
@@ -4747,7 +4747,7 @@ lambdaBlockMap = helper where
 --
 -- over the top-level, local, and ghost arguments and (the translations of) the
 -- input permissions of the entrypoint
-translateEntryBody :: PermCheckExtC ext =>
+translateEntryBody :: PermCheckExtC ext exprExt =>
                       TypedBlockMapTrans ext blocks tops rets ->
                       TypedEntry TransPhase ext blocks tops rets args ghosts ->
                       TypeTransM ctx OpenTerm
@@ -4761,7 +4761,7 @@ translateEntryBody mapTrans entry =
 
 -- | Translate all the entrypoints in a 'TypedBlockMap' that correspond to
 -- letrec-bound functions to SAW core functions as in 'translateEntryBody'
-translateBlockMapBodies :: PermCheckExtC ext =>
+translateBlockMapBodies :: PermCheckExtC ext exprExt =>
                            TypedBlockMapTrans ext blocks tops rets ->
                            TypedBlockMap TransPhase ext blocks tops rets ->
                            TypeTransM ctx OpenTerm
@@ -4774,7 +4774,7 @@ translateBlockMapBodies mapTrans =
 
 -- | Translate a typed CFG to a SAW term
 translateCFG ::
-  PermCheckExtC ext =>
+  PermCheckExtC ext exprExt =>
   PermEnv -> ChecksFlag ->
   TypedCFG ext blocks ghosts inits gouts ret ->
   OpenTerm
@@ -4946,7 +4946,7 @@ tcTranslateAddCFGs sc mod_name env checks endianness dlevel cfgs_and_perms =
        applyOpenTerm (globalOpenTerm "Prelude.lrtTupleType") lrts
      tup_fun_tm <- completeNormOpenTerm sc $
        applyOpenTermMulti (globalOpenTerm "Prelude.multiFixM") [lrts, tup_fun]
-     scInsertDef sc mod_name tup_fun_ident tup_fun_tp tup_fun_tm 
+     scInsertDef sc mod_name tup_fun_ident tup_fun_tp tup_fun_tm
      new_entries <-
        zipWithM
        (\cfg_and_perm i ->

--- a/heapster-saw/src/Verifier/SAW/Heapster/TypedCrucible.hs
+++ b/heapster-saw/src/Verifier/SAW/Heapster/TypedCrucible.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -24,6 +25,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Verifier.SAW.Heapster.TypedCrucible where
 
@@ -89,8 +91,16 @@ import GHC.Stack (HasCallStack)
 ----------------------------------------------------------------------
 
 -- | A Crucible extension that satisfies 'NuMatching'
-type NuMatchingExtC ext =
-  (NuMatchingAny1 (ExprExtension ext RegWithVal)
+type NuMatchingExtC ext exprExt =
+  (
+#if __GLASGOW_HASKELL__ >= 902
+    NuMatchingAny1 (ExprExtension ext RegWithVal)
+#else
+    -- See Note [QuantifiedConstraints + TypeFamilies trick] in
+    -- Verifier.SAW.Heapster.CruUtil
+    exprExt ~ ExprExtension ext RegWithVal
+  , NuMatchingAny1 exprExt
+#endif
   -- (NuMatchingAny1 (ExprExtension ext TypedReg)
    -- , NuMatchingAny1 (StmtExtension ext TypedReg))
   )
@@ -108,8 +118,8 @@ instance KnownRepr ExtRepr LLVM where
 
 -- | The constraints for a Crucible syntax extension that supports permission
 -- checking
-type PermCheckExtC ext =
-  (NuMatchingExtC ext, IsSyntaxExtension ext, KnownRepr ExtRepr ext)
+type PermCheckExtC ext exprExt =
+  (NuMatchingExtC ext exprExt, IsSyntaxExtension ext, KnownRepr ExtRepr ext)
 
 -- | Extension-specific state
 data PermCheckExtState ext where
@@ -333,28 +343,13 @@ $(mkNuMatching [t| forall tp. TypedReg tp |])
 $(mkNuMatching [t| forall tp. RegWithVal tp |])
 $(mkNuMatching [t| forall ctx. TypedRegs ctx |])
 
-instance NuMatchingAny1 TypedReg where
-  nuMatchingAny1Proof = nuMatchingProof
-
-instance NuMatchingAny1 RegWithVal where
-  nuMatchingAny1Proof = nuMatchingProof
-
-$(mkNuMatching [t| forall ext tp. NuMatchingExtC ext => TypedExpr ext tp |])
+$(mkNuMatching [t| forall ext tp exprExt. NuMatchingExtC ext exprExt => TypedExpr ext tp |])
 $(mkNuMatching [t| forall ghosts args gouts ret.
                 TypedFnHandle ghosts args gouts ret |])
 $(mkNuMatching [t| forall blocks args. TypedBlockID blocks args |])
 $(mkNuMatching [t| forall blocks args. TypedEntryID blocks args |])
 $(mkNuMatching [t| forall blocks args ghosts. TypedCallSiteID blocks args ghosts |])
 $(mkNuMatching [t| forall blocks tops ps_in. TypedJumpTarget blocks tops ps_in |])
-
-instance NuMatchingAny1 (TypedJumpTarget blocks tops) where
-  nuMatchingAny1Proof = nuMatchingProof
-
-instance NuMatchingAny1 (TypedBlockID blocks) where
-  nuMatchingAny1Proof = nuMatchingProof
-
-instance NuMatchingAny1 (TypedEntryID blocks) where
-  nuMatchingAny1Proof = nuMatchingProof
 
 instance Closable (TypedBlockID blocks args) where
   toClosed (TypedBlockID memb ix) =
@@ -784,21 +779,13 @@ data TypedStmtSeq ext blocks tops rets ps_in where
 $(mkNuMatching [t| forall r ps. NuMatchingAny1 r => AnnotPermImpl r ps |])
 $(mkNuMatching [t| forall tp ps_out ps_in.
                 TypedLLVMStmt tp ps_out ps_in |])
-$(mkNuMatching [t| forall ext stmt_rets ps_in ps_out. NuMatchingExtC ext =>
+$(mkNuMatching [t| forall ext stmt_rets ps_in ps_out exprExt. NuMatchingExtC ext exprExt =>
                 TypedStmt ext stmt_rets ps_in ps_out |])
 $(mkNuMatching [t| forall tops rets ps. TypedRet tops rets ps |])
-
-instance NuMatchingAny1 (TypedRet tops rets) where
-  nuMatchingAny1Proof = nuMatchingProof
-
 $(mkNuMatching [t| forall blocks tops rets ps_in.
                 TypedTermStmt blocks tops rets ps_in |])
-$(mkNuMatching [t| forall ext blocks tops rets ps_in.
-                NuMatchingExtC ext => TypedStmtSeq ext blocks tops rets ps_in |])
-
-instance NuMatchingExtC ext =>
-         NuMatchingAny1 (TypedStmtSeq ext blocks tops rets) where
-  nuMatchingAny1Proof = nuMatchingProof
+$(mkNuMatching [t| forall ext blocks tops rets ps_in exprExt.
+                NuMatchingExtC ext exprExt => TypedStmtSeq ext blocks tops rets ps_in |])
 
 
 instance SubstVar PermVarSubst m =>
@@ -829,7 +816,7 @@ instance (NuMatchingAny1 r, SubstVar PermVarSubst m,
   genSubst s (mbMatch -> [nuMP| AnnotPermImpl err impl |]) =
     AnnotPermImpl (mbLift err) <$> genSubst s impl
 
-instance (PermCheckExtC ext, NuMatchingAny1 f,
+instance (PermCheckExtC ext exprExt, NuMatchingAny1 f,
           SubstVar PermVarSubst m, Substable1 PermVarSubst f m,
           Substable PermVarSubst (f BoolType) m) =>
          Substable PermVarSubst (App ext f a) m where
@@ -943,7 +930,7 @@ instance (PermCheckExtC ext, NuMatchingAny1 f,
              ++ mbLift (fmap (show . ppApp (const (pretty "_"))) mb_expr))
 
 
-instance (PermCheckExtC ext, SubstVar PermVarSubst m) =>
+instance (PermCheckExtC ext exprExt, SubstVar PermVarSubst m) =>
          Substable PermVarSubst (TypedExpr ext tp) m where
   genSubst s (mbMatch -> [nuMP| TypedExpr app maybe_val |]) =
     TypedExpr <$> genSubst s app <*> genSubst s maybe_val
@@ -980,7 +967,7 @@ instance SubstVar PermVarSubst m =>
     [nuMP| TypedLLVMIte w r1 r2 r3 |] ->
       TypedLLVMIte (mbLift w) <$> genSubst s r1 <*> genSubst s r2 <*> genSubst s r3
 
-instance (PermCheckExtC ext, SubstVar PermVarSubst m) =>
+instance (PermCheckExtC ext exprExt, SubstVar PermVarSubst m) =>
          Substable PermVarSubst (TypedStmt ext rets ps_in ps_out) m where
   genSubst s mb_x = case mbMatch mb_x of
     [nuMP| TypedSetReg tp expr |] ->
@@ -1029,7 +1016,7 @@ instance SubstVar PermVarSubst m =>
     [nuMP| TypedErrorStmt str r |] ->
       TypedErrorStmt (mbLift str) <$> genSubst s r
 
-instance (PermCheckExtC ext, SubstVar PermVarSubst m) =>
+instance (PermCheckExtC ext exprExt, SubstVar PermVarSubst m) =>
          Substable PermVarSubst (TypedStmtSeq ext blocks tops rets ps_in) m where
   genSubst s mb_x = case mbMatch mb_x of
     [nuMP| TypedImplStmt impl_seq |] ->
@@ -1041,7 +1028,7 @@ instance (PermCheckExtC ext, SubstVar PermVarSubst m) =>
       TypedTermStmt (mbLift loc) <$> genSubst s term_stmt
 
 
-instance (PermCheckExtC ext, SubstVar PermVarSubst m) =>
+instance (PermCheckExtC ext exprExt, SubstVar PermVarSubst m) =>
          Substable1 PermVarSubst (TypedStmtSeq ext blocks tops rets) m where
   genSubst1 = genSubst
 
@@ -1108,9 +1095,6 @@ data CallSiteImplRet blocks tops args ghosts ps_out =
 
 $(mkNuMatching [t| forall blocks tops args ghosts ps_out.
                 CallSiteImplRet blocks tops args ghosts ps_out |])
-
-instance NuMatchingAny1 (CallSiteImplRet blocks tops args ghosts) where
-  nuMatchingAny1Proof = nuMatchingProof
 
 instance SubstVar PermVarSubst m =>
          Substable PermVarSubst (CallSiteImplRet
@@ -2100,7 +2084,7 @@ getRegPerm (TypedReg x) = getVarPerm x
 -- | Eliminate any disjunctions, existentials, or recursive permissions for a
 -- register and then return the resulting "simple" permission, leaving it on the
 -- top of the stack
-getPushSimpleRegPerm :: PermCheckExtC ext => TypedReg a ->
+getPushSimpleRegPerm :: PermCheckExtC ext exprExt => TypedReg a ->
                         StmtPermCheckM ext cblocks blocks tops rets
                         (ps :> a) ps (ValuePerm a)
 getPushSimpleRegPerm r =
@@ -2112,7 +2096,7 @@ getPushSimpleRegPerm r =
 
 -- | Eliminate any disjunctions, existentials, or recursive permissions for a
 -- register and then return the resulting "simple" permission
-getSimpleRegPerm :: PermCheckExtC ext => TypedReg a ->
+getSimpleRegPerm :: PermCheckExtC ext exprExt => TypedReg a ->
                     StmtPermCheckM ext cblocks blocks tops rets ps ps
                     (ValuePerm a)
 getSimpleRegPerm r =
@@ -2121,7 +2105,7 @@ getSimpleRegPerm r =
 
 -- | A version of 'getEqualsExpr' for 'TypedReg's
 getRegEqualsExpr ::
-  PermCheckExtC ext => TypedReg a ->
+  PermCheckExtC ext exprExt => TypedReg a ->
   StmtPermCheckM ext cblocks blocks tops rets ps ps (PermExpr a)
 getRegEqualsExpr r =
   snd <$> pcmEmbedImplM TypedImplStmt emptyCruCtx (getEqualsExpr $
@@ -2133,7 +2117,7 @@ getRegEqualsExpr r =
 -- case, leave the resulting permission on the top of the stack and return its
 -- contents as the return value.
 getAtomicOrWordLLVMPerms ::
-  (1 <= w, KnownNat w, PermCheckExtC ext) => TypedReg (LLVMPointerType w) ->
+  (1 <= w, KnownNat w, PermCheckExtC ext exprExt) => TypedReg (LLVMPointerType w) ->
   StmtPermCheckM ext cblocks blocks tops rets
   (ps :> LLVMPointerType w)
   ps
@@ -2184,7 +2168,7 @@ getAtomicOrWordLLVMPerms r =
 
 -- | Like 'getAtomicOrWordLLVMPerms', but fail if an equality permission to a
 -- bitvector word is found
-getAtomicLLVMPerms :: (1 <= w, KnownNat w, PermCheckExtC ext) =>
+getAtomicLLVMPerms :: (1 <= w, KnownNat w, PermCheckExtC ext exprExt) =>
                       TypedReg (LLVMPointerType w) ->
                       StmtPermCheckM ext cblocks blocks tops rets
                       (ps :> LLVMPointerType w)
@@ -2269,8 +2253,8 @@ dbgStringPP Nothing    Nothing  tp = typeBaseName tp
 -- | After all variables have been added to the context, unify all unit-typed
 -- variables by lifting through the ImplM monad
 stmtHandleUnitVars :: forall (tps :: RList CrucibleType)
-                             ext cblocks blocks tops ret ps.
-                      PermCheckExtC ext =>
+                             ext cblocks blocks tops ret ps exprExt.
+                      PermCheckExtC ext exprExt =>
                       RAssign Name tps ->
                       StmtPermCheckM ext cblocks blocks tops ret ps ps ()
 stmtHandleUnitVars ns =
@@ -2448,7 +2432,7 @@ pcmEmbedImplM f_impl vars m = pcmEmbedImplWithErrM f_impl vars mempty m
 -- @vars@ is empty
 stmtEmbedImplM ::
   HasCallStack =>
-  NuMatchingExtC ext =>
+  NuMatchingExtC ext exprExt =>
   ImplM RNil (InnerPermCheckState
               blocks tops rets) (TypedStmtSeq ext blocks tops rets) ps_out ps_in a ->
   StmtPermCheckM ext cblocks blocks tops rets ps_out ps_in a
@@ -2458,7 +2442,7 @@ stmtEmbedImplM m = snd <$> pcmEmbedImplM TypedImplStmt emptyCruCtx m
 -- permission set, in the context of type-checking statements
 stmtRecombinePerms ::
   HasCallStack =>
-  PermCheckExtC ext =>
+  PermCheckExtC ext exprExt =>
   StmtPermCheckM ext cblocks blocks tops rets RNil ps_in ()
 stmtRecombinePerms =
   get >>>= \(!st) ->
@@ -2473,7 +2457,7 @@ ppProofError ppInfo mb_ps =
 
 -- | Prove a sequence of permissions over some existential variables and append
 -- them to the top of the stack
-stmtProvePermsAppend :: PermCheckExtC ext =>
+stmtProvePermsAppend :: PermCheckExtC ext exprExt =>
                         CruCtx vars -> ExDistPerms vars ps ->
                         StmtPermCheckM ext cblocks blocks tops rets
                         (ps_in :++: ps) ps_in (PermSubst vars)
@@ -2484,7 +2468,7 @@ stmtProvePermsAppend vars ps =
 
 -- | Prove a sequence of permissions over some existential variables in the
 -- context of the empty permission stack
-stmtProvePerms :: PermCheckExtC ext =>
+stmtProvePerms :: PermCheckExtC ext exprExt =>
                   CruCtx vars -> ExDistPerms vars ps ->
                   StmtPermCheckM ext cblocks blocks tops rets
                   ps RNil (PermSubst vars)
@@ -2496,7 +2480,7 @@ stmtProvePerms vars ps =
 -- | Prove a sequence of permissions over some existential variables in the
 -- context of the empty permission stack, but first generate fresh lifetimes for
 -- any existential lifetime variables
-stmtProvePermsFreshLs :: PermCheckExtC ext =>
+stmtProvePermsFreshLs :: PermCheckExtC ext exprExt =>
                          CruCtx vars -> ExDistPerms vars ps ->
                          StmtPermCheckM ext cblocks blocks tops rets
                          ps RNil (PermSubst vars)
@@ -2507,7 +2491,7 @@ stmtProvePermsFreshLs vars ps =
             (instantiateLifetimeVars ps >>> proveVarsImpl ps)
 
 -- | Prove a single permission in the context of type-checking statements
-stmtProvePerm :: (PermCheckExtC ext, KnownRepr CruCtx vars) =>
+stmtProvePerm :: (PermCheckExtC ext exprExt, KnownRepr CruCtx vars) =>
                  TypedReg a -> Mb vars (ValuePerm a) ->
                  StmtPermCheckM ext cblocks blocks tops rets
                  (ps :> a) ps (PermSubst vars)
@@ -2551,7 +2535,7 @@ resolveConstant = helper . PExpr_Var . typedRegVar where
 
 
 -- | Convert a register of one type to one of another type, if possible
-convertRegType :: PermCheckExtC ext => ExtRepr ext -> ProgramLoc ->
+convertRegType :: PermCheckExtC ext exprExt => ExtRepr ext -> ProgramLoc ->
                   TypedReg tp1 -> TypeRepr tp1 -> TypeRepr tp2 ->
                   StmtPermCheckM ext cblocks blocks tops rets RNil RNil
                   (TypedReg tp2)
@@ -2654,7 +2638,7 @@ extractBVBytes loc sz off_bytes (reg :: TypedReg (BVType w)) =
 -- freshly-bound names for the return values. Return those freshly-bound names
 -- for the return values.
 emitStmt ::
-  PermCheckExtC ext =>
+  PermCheckExtC ext exprExt =>
   CruCtx stmt_rets ->
   RAssign (Constant (Maybe String)) stmt_rets ->
   ProgramLoc ->
@@ -2667,7 +2651,7 @@ emitStmt tps names loc stmt =
     (mbPure (cruCtxProxies tps) ()) >>>= \(ns, ()) ->
   setVarTypes Nothing names ns tps >>>
   gmodify (modifySTCurPerms (applyTypedStmt stmt ns)) >>>
-  gets (view distPerms . stCurPerms) >>>= \perms_out ->  
+  gets (view distPerms . stCurPerms) >>>= \perms_out ->
   stmtVerbTraceM (\i ->
                    pretty "Created new variables: "
                    <+> permPretty i ns <> line <>
@@ -2704,7 +2688,7 @@ tcReg :: CtxTrans ctx -> Reg ctx tp -> TypedReg tp
 tcReg ctx (Reg ix) = ctx ! ix
 
 -- | Type-check a Crucible register and also look up its value, if known
-tcRegWithVal :: PermCheckExtC ext => CtxTrans ctx -> Reg ctx tp ->
+tcRegWithVal :: PermCheckExtC ext exprExt => CtxTrans ctx -> Reg ctx tp ->
                 StmtPermCheckM ext cblocks blocks tops rets ps ps
                 (RegWithVal tp)
 tcRegWithVal ctx r_untyped =
@@ -2823,8 +2807,8 @@ tcBlockID blkID = stLookupBlockID blkID <$> top_get
 -- 'PermExpr' value that we can use as an @eq(e)@ permission on the output of
 -- the expression
 tcExpr ::
-  forall ext tp cblocks blocks tops rets ps.
-  (PermCheckExtC ext, KnownRepr ExtRepr ext) =>
+  forall ext tp cblocks blocks tops rets ps exprExt.
+  (PermCheckExtC ext exprExt, KnownRepr ExtRepr ext) =>
   App ext RegWithVal tp ->
   StmtPermCheckM ext cblocks blocks tops rets ps ps (Maybe (PermExpr tp))
 tcExpr (ExtensionApp _e_ext :: App ext RegWithVal tp)
@@ -3004,7 +2988,7 @@ tcExpr _ = pure Nothing
 -- | Test if a sequence of arguments could potentially satisfy some function
 -- input permissions. This is an overapproximation, meaning that we might return
 -- 'True' even if the arguments do not satisfy the permissions.
-couldSatisfyPermsM :: PermCheckExtC ext => CruCtx args -> TypedRegs args ->
+couldSatisfyPermsM :: PermCheckExtC ext exprExt => CruCtx args -> TypedRegs args ->
                       Mb ghosts (ValuePerms args) ->
                       StmtPermCheckM ext cblocks blocks tops rets ps ps Bool
 couldSatisfyPermsM CruCtxNil _ _ = pure True
@@ -3029,7 +3013,7 @@ couldSatisfyPermsM (CruCtxCons tps _) (TypedRegsCons args _)
 -- | Typecheck a statement and emit it in the current statement sequence,
 -- starting and ending with an empty stack of distinguished permissions
 tcEmitStmt ::
-  (PermCheckExtC ext, KnownRepr ExtRepr ext) =>
+  (PermCheckExtC ext exprExt, KnownRepr ExtRepr ext) =>
   CtxTrans ctx ->
   ProgramLoc ->
   Stmt ext ctx ctx' ->
@@ -3050,8 +3034,8 @@ tcEmitStmt ctx loc stmt =
 
 
 tcEmitStmt' ::
-  forall ext ctx ctx' cblocks blocks tops rets.
-  (PermCheckExtC ext, KnownRepr ExtRepr ext) =>
+  forall ext ctx ctx' cblocks blocks tops rets exprExt.
+  (PermCheckExtC ext exprExt, KnownRepr ExtRepr ext) =>
   CtxTrans ctx ->
   ProgramLoc ->
   Stmt ext ctx ctx' ->
@@ -3288,7 +3272,7 @@ tcEmitLLVMSetExpr _ctx _loc X86Expr{} =
 -- supplied lifetime has been proved to be current using the supplied
 -- 'LifetimeCurrentPerms'
 withLifetimeCurrentPerms ::
-  PermCheckExtC ext => PermExpr LifetimeType ->
+  PermCheckExtC ext exprExt => PermExpr LifetimeType ->
   (forall ps_l. LifetimeCurrentPerms ps_l ->
    StmtPermCheckM ext cblocks blocks tops rets (ps_out :++: ps_l)
    (ps_in :++: ps_l) a) ->
@@ -3915,7 +3899,7 @@ generalizeUnneededEqPerms =
 
 
 -- | Type-check a Crucible jump target
-tcJumpTarget :: PermCheckExtC ext => CtxTrans ctx -> JumpTarget cblocks ctx ->
+tcJumpTarget :: PermCheckExtC ext exprExt => CtxTrans ctx -> JumpTarget cblocks ctx ->
                 StmtPermCheckM ext cblocks blocks tops rets RNil RNil
                 (AnnotPermImpl (TypedJumpTarget blocks tops) RNil)
 tcJumpTarget ctx (JumpTarget blkID args_tps args) =
@@ -4044,7 +4028,7 @@ tcJumpTarget ctx (JumpTarget blkID args_tps args) =
 
 
 -- | Type-check a termination statement
-tcTermStmt :: PermCheckExtC ext => CtxTrans ctx ->
+tcTermStmt :: PermCheckExtC ext exprExt => CtxTrans ctx ->
               TermStmt cblocks ret ctx ->
               StmtPermCheckM ext cblocks blocks tops (gouts :> ret) RNil RNil
               (TypedTermStmt blocks tops (gouts :> ret) RNil)
@@ -4115,7 +4099,7 @@ tcTermStmt _ tstmt =
 -- | Translate and emit a Crucible statement sequence, starting and ending with
 -- an empty stack of distinguished permissions
 tcEmitStmtSeq ::
-  (PermCheckExtC ext, KnownRepr ExtRepr ext) =>
+  (PermCheckExtC ext exprExt, KnownRepr ExtRepr ext) =>
   [Maybe String] ->
   CtxTrans ctx ->
   StmtSeq ext cblocks ret ctx ->
@@ -4133,7 +4117,7 @@ tcEmitStmtSeq names ctx (TermStmt loc tstmt) =
 
 -- | Type-check the body of a Crucible block as the body of an entrypoint
 tcBlockEntryBody ::
-  (PermCheckExtC ext, KnownRepr ExtRepr ext) =>
+  (PermCheckExtC ext exprExt, KnownRepr ExtRepr ext) =>
   [Maybe String] ->
   Block ext cblocks ret args ->
   TypedEntry TCPhase ext blocks tops (gouts :> ret) (CtxToRList args) ghosts ->
@@ -4211,7 +4195,7 @@ callSiteSetGhosts _ (TypedCallSite {..}) =
 -- | Visit a call site, proving its implication of the entrypoint input
 -- permissions if that implication does not already exist
 visitCallSite ::
-  (PermCheckExtC ext, KnownRepr ExtRepr ext) =>
+  (PermCheckExtC ext exprExt, KnownRepr ExtRepr ext) =>
   TypedEntry TCPhase ext blocks tops rets args ghosts ->
   TypedCallSite TCPhase blocks tops args ghosts vars ->
   TopPermCheckM ext cblocks blocks tops rets
@@ -4228,7 +4212,7 @@ visitCallSite (TypedEntry {..}) site@(TypedCallSite {..})
 
 -- | Widen the permissions held by all callers of an entrypoint to compute new,
 -- weaker input permissions that can hopefully be satisfied by them
-widenEntry :: PermCheckExtC ext => DebugLevel -> PermEnv ->
+widenEntry :: PermCheckExtC ext exprExt => DebugLevel -> PermEnv ->
               TypedEntry TCPhase ext blocks tops rets args ghosts ->
               Some (TypedEntry TCPhase ext blocks tops rets args)
 widenEntry dlevel env (TypedEntry {..}) =
@@ -4250,7 +4234,7 @@ widenEntry dlevel env (TypedEntry {..}) =
 -- If any of the call site implications fail, and the input "can widen" flag is
 -- 'True', recompute the entrypoint input permissions using widening.
 visitEntry ::
-  (PermCheckExtC ext, CtxToRList cargs ~ args, KnownRepr ExtRepr ext) =>
+  (PermCheckExtC ext exprExt, CtxToRList cargs ~ args, KnownRepr ExtRepr ext) =>
   [Maybe String] ->
   Bool -> Block ext cblocks ret cargs ->
   TypedEntry TCPhase ext blocks tops (gouts :> ret) args ghosts ->
@@ -4298,7 +4282,7 @@ visitEntry names can_widen blk entry =
 
 -- | Visit a block by visiting all its entrypoints
 visitBlock ::
-  (PermCheckExtC ext, KnownRepr ExtRepr ext) =>
+  (PermCheckExtC ext exprExt, KnownRepr ExtRepr ext) =>
   Bool -> {- ^ Whether widening can be applied in type-checking this block -}
   TypedBlock TCPhase ext blocks tops rets args ->
   TopPermCheckM ext cblocks blocks tops rets
@@ -4338,8 +4322,8 @@ maxWideningIters = 5
 
 -- | Type-check a Crucible CFG
 tcCFG ::
-  forall w ext cblocks ghosts inits gouts ret.
-  (PermCheckExtC ext, KnownRepr ExtRepr ext, 1 <= w, 16 <= w) =>
+  forall w ext cblocks ghosts inits gouts ret exprExt.
+  (PermCheckExtC ext exprExt, KnownRepr ExtRepr ext, 1 <= w, 16 <= w) =>
   NatRepr w ->
   PermEnv -> EndianForm -> DebugLevel ->
   FunPerm ghosts (CtxToRList inits) gouts ret ->


### PR DESCRIPTION
This makes the necessary changes to adapt to eddywestbrook/hobbits#8, which turns `NuMatchingAny1` into an alias for a quantified `NuMatching` constraint. See #1742 and https://gitlab.haskell.org/ghc/ghc/-/issues/22492 for the motivation behind this.

One unfortunate hiccup with this patch is that combining quantified superclasses and `TypeFamilies` doesn't quite work out of the box on pre-9.2 GHCs due to https://gitlab.haskell.org/ghc/ghc/-/issues/14860. As a result, I have to introduce explicit equality constraints to work around the issue. I have added a `Note [QuantifiedConstraints + TypeFamilies trick]` to describe why the workaround is necessary.

Credit goes to Matthew Pickering for helping me identify this issue and for authoring a separate fix. I have tweaked his fix and turned it into this patch, adding him as a co-author in the process.

Fixes #1742.