### PR TITLE
Normalize Cryptol types on import

### DIFF
--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -44,6 +44,7 @@ import qualified Cryptol.Eval.Value as V
 import qualified Cryptol.Eval.Concrete as V
 import Cryptol.Eval.Type (evalValType)
 import qualified Cryptol.TypeCheck.AST as C
+import qualified Cryptol.TypeCheck.SimpType as ST
 import qualified Cryptol.TypeCheck.Subst as C (Subst, apSubst, listSubst, singleTParamSubst)
 import qualified Cryptol.ModuleSystem.Name as C
   (asPrim, asParamName, nameUnique, nameIdent, nameInfo, NameInfo(..))
@@ -230,10 +231,11 @@ importPC sc pc =
     C.PFLiteral        -> panic "importPC PFLiteral" []
     C.PValidFloat      -> panic "importPC PValidFloat" []
 
--- | Translate size types to SAW values of type Num, value types to SAW types of sort 0.
+-- | Normalize according to Cryptol's rules, then translate size types to SAW
+-- values of type Num and value types to SAW types of sort 0.
 importType :: SharedContext -> Env -> C.Type -> IO Term
 importType sc env ty =
-  case ty of
+  case ST.tRebuild ty of
     C.TVar tvar ->
       case tvar of
         C.TVFree{} {- Int Kind (Set TVar) Doc -} -> unimplemented "TVFree"

--- a/intTests/test_join_split/README.md
+++ b/intTests/test_join_split/README.md
@@ -1,0 +1,7 @@
+This test addresses the issue resolved in [#1790](https://github.com/GaloisInc/saw-script/pull/1790). 
+
+In this script, we prove the same theorem - that ```join`{each=32, parts=4, a=Bool} (split x) == x``` - twice; once purely via `z3`, and once via manual rewriting, trying to use the former to prove the latter. 
+
+Lack of type normalization introduces reflexive type coercions in the SAWCore representation of the expression under proof. The manual proof proceeds by eliminating any extant reflexive coercions, then attempting to use the `z3`-proven theorem as a simplification. When no coercions existed in the first place, the simplification applies cleanly. When coercions existed, the simplification does not apply cleanly, since we eliminated them from the goal, but not from the simplification.
+
+Since this proof is possible to resolve in its entirety via evaluation/appeal to `z3`, we need to maintain the core `join` and `split` functions uninterpreted when manually massaging (via `goal_normalize` and `goal_eval_unint`) the goal into a `trivial`ly resolvable form.

--- a/intTests/test_join_split/join_split.saw
+++ b/intTests/test_join_split/join_split.saw
@@ -1,0 +1,10 @@
+enable_experimental; // for `goal_normalize`
+
+join_split_thm_z3 <- prove_print z3 {{ \x -> join`{each=32, parts=4, a=Bool} (split x) == x }};
+
+join_split_thm_manual <- prove_print (do {
+    goal_normalize ["ecJoin", "ecSplit"];
+    simplify (addsimp join_split_thm_z3 empty_ss);
+    goal_eval_unint ["ecJoin", "ecSplit"];
+    trivial;
+}) {{ \x -> join`{each=32, parts=4, a=Bool} (split x) == x }};

--- a/intTests/test_join_split/test.sh
+++ b/intTests/test_join_split/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$SAW join_split.saw


### PR DESCRIPTION
Cryptol has a normalization procedure for types. One of the things this procedure does is to put constants in types on the left. For example, if partial instantiation leads to a type that looks like `n * 3`, the type will be rewritten to `3 * n`. Consider partially instantiating `split`:
```
Cryptol> :t split
split : {parts, each, a} (fin each) => [parts * each]a -> [parts][each]a
Cryptol> :t split`{parts=4}
split`{parts = 4} : {n, a} (fin n) => [4 * n]a -> [4][n]a
Cryptol> :t split`{each=3}
split`{each = 3} : {n, a} [3 * n]a -> [n][3]a
```

Now consider the Cryptol term ```\x -> split`{each=3} x``` - in particular, consider importing this term into SAWCore. Cryptol typechecking and type normalization is performed on the term at large. SAW then steps in to convert this expression to a term in Core, which involves lightweight interaction with the type environment Cryptol has built. 

When SAW sees ```split`{each=10}``` and needs its type, it uses `Cryptol.TypeCheck.TypeOf.fastTypeOf`, which reports that it is `[parts * each]a -> [parts][each]a` instantiated where `each` maps to `3`. That instantiation is performed *without normalization* (via `Cryptol.TypeCheck.TypeOf.simpleSubst`), leading to a type that looks like `[parts * 3]a -> [parts][3]a`.

When SAW sees `x` in argument or value position, it uses `fastTypeOf` again, which delegates to the typing environment that Cryptol has built *with normalization*, and reports that `x`'s type is `[3 * parts]a`.

Since these terms are not "the same", SAW resorts to type coercion to construct its Core representation, and ends up with something that looks like this:
```hs
\(u1229 : Num) ->
  \(u1230 : isort 0) ->
    \(x : seq (tcMul (TCNum 3) u1229) u1230) ->
      ecSplit 
        u1229 
        (TCNum 3) 
        u1230
        (coerce 
          (seq (tcMul (TCNum 3) u1229) u1230) 
          (seq (tcMul u1229 (TCNum 3)) u1230)
          (seq_cong1 
            (tcMul (TCNum 3) u1229) 
            (tcMul u1229 (TCNum 3)) 
            u1230 
            (unsafeAssert 
              Num 
              (tcMul (TCNum 3) u1229) 
              (tcMul u1229 (TCNum 3))))
          x)
```

These coercions are plainly unnecessary, though not technically unsound. Whether or not this constitutes a bug, it is certainly unexpected behavior, and impacts usability of conducting Cryptol proofs in SAW. I see two ways to fix this.

The first, which I've done here, is to apply Cryptol's type normalization procedure (via `Cryptol.TypeCheck.SimpType.tRebuild`) when SAW imports Cryptol types as Core terms. This doesn't actually avoid generating coercions during the conversion process, but causes coercions to cite `Refl` as evidence for their validity, which (it seems) lets them be eliminated automatically elsewhere in the conversion process. With this fix in place, SAW now generates Core for ```\x -> split`{each=3} x``` that looks like:
```hs
\(u1229 : Num) ->
  \(u1230 : isort 0) ->
    \(x : seq (tcMul (TCNum 3) u1229) u1230) -> 
      ecSplit u1229 (TCNum 3) u1230 x
```

The second is to apply the same normalization in `fastTypeOf`, within Cryptol. I didn't do this for fear that it would subvert the "fast" nature of that function, and because I don't have a good sense of the ripple effect that change might produce, but it may be better at encapsulating Cryptol's notion of type normalization than my fix here.

(Forgive the amount of text accompanying such a small change - writing this helped me better understand SAWCore and Cryptol, and I hope it may do the same for others.)