### PR TITLE
Coq translator: fix array literal support

### DIFF
--- a/cryptol-saw-core/src/Verifier/SAW/TypedTerm.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/TypedTerm.hs
@@ -19,7 +19,7 @@ import Cryptol.Utils.PP (pretty)
 import qualified Cryptol.Utils.Ident as C (mkIdent)
 import qualified Cryptol.Utils.RecordMap as C (recordFromFields)
 
-import Verifier.SAW.Cryptol (scCryptolType)
+import Verifier.SAW.Cryptol (scCryptolType, Env, importKind, importSchema)
 import Verifier.SAW.FiniteValue
 import Verifier.SAW.Recognizer (asExtCns)
 import Verifier.SAW.SharedTerm
@@ -48,6 +48,13 @@ data TypedTermType
   | TypedTermOther  Term
  deriving Show
 
+
+-- | Convert the 'ttTerm' field of a 'TypedTerm' to a SAW core term
+ttTypeAsTerm :: SharedContext -> Env -> TypedTerm -> IO Term
+ttTypeAsTerm sc env (TypedTerm (TypedTermSchema schema) _) =
+  importSchema sc env schema
+ttTypeAsTerm sc _ (TypedTerm (TypedTermKind k) _) = importKind sc k
+ttTypeAsTerm _ _ (TypedTerm (TypedTermOther tp) _) = return tp
 
 ttTermLens :: Functor f => (Term -> f Term) -> TypedTerm -> f TypedTerm
 ttTermLens f tt = tt `seq` fmap (\x -> tt{ttTerm = x}) (f (ttTerm tt))

--- a/saw-core-coq/src/Verifier/SAW/Translation/Coq.hs
+++ b/saw-core-coq/src/Verifier/SAW/Translation/Coq.hs
@@ -32,12 +32,13 @@ import           Verifier.SAW.Module
 import           Verifier.SAW.SharedTerm
 import           Verifier.SAW.Term.Functor
 -- import Verifier.SAW.Term.CtxTerm
-import qualified Verifier.SAW.Translation.Coq.CryptolModule    as CryptolModuleTranslation
+import qualified Verifier.SAW.Translation.Coq.CryptolModule    as CMT
 import qualified Verifier.SAW.Translation.Coq.SAWModule        as SAWModuleTranslation
 import           Verifier.SAW.Translation.Coq.Monad
 import           Verifier.SAW.Translation.Coq.SpecialTreatment
 import qualified Verifier.SAW.Translation.Coq.Term             as TermTranslation
 import           Verifier.SAW.TypedTerm
+import           Verifier.SAW.Cryptol (Env)
 --import Verifier.SAW.Term.Pretty
 -- import qualified Verifier.SAW.UntypedAST as Un
 
@@ -102,7 +103,7 @@ From Coq Require Import String.
 From Coq Require Import Vectors.Vector.
 From CryptolToCoq Require Import SAWCoreScaffolding.
 From CryptolToCoq Require Import #{vectorModule}.
-Import ListNotations.
+Import VectorNotations.
 
 (** Post-preamble section specified by you *)
 #{postPreamble}
@@ -111,13 +112,14 @@ Import ListNotations.
 |]
 
 translateTermAsDeclImports ::
-  TranslationConfiguration -> Coq.Ident -> Term -> Either (TranslationError Term) (Doc ann)
-translateTermAsDeclImports configuration name t = do
+  TranslationConfiguration -> Coq.Ident -> Term -> Term ->
+  Either (TranslationError Term) (Doc ann)
+translateTermAsDeclImports configuration name t tp = do
   doc <-
     TermTranslation.translateDefDoc
       configuration
       (TermTranslation.TranslationReader Nothing)
-      [] name t
+      [] name t tp
   return $ vcat [preamble configuration, hardline <> doc]
 
 translateSAWModule :: TranslationConfiguration -> Module -> Doc ann
@@ -135,19 +137,16 @@ translateSAWModule configuration m =
      ]
 
 translateCryptolModule ::
+  SharedContext -> Env ->
   Coq.Ident {- ^ Section name -} ->
   TranslationConfiguration ->
   -- | List of already translated global declarations
   [String] ->
   CryptolModule ->
-  Either (TranslationError Term) (Doc ann)
-translateCryptolModule nm configuration globalDecls m =
-  let decls = CryptolModuleTranslation.translateCryptolModule
-              configuration
-              globalDecls
-              m
-  in
-  Coq.ppDecl . Coq.Section nm <$> decls
+  IO (Either (TranslationError Term) (Doc ann))
+translateCryptolModule sc env nm configuration globalDecls m =
+  fmap (fmap (Coq.ppDecl . Coq.Section nm)) $
+  CMT.translateCryptolModule sc env configuration globalDecls m
 
 moduleDeclName :: ModuleDecl -> Maybe String
 moduleDeclName (TypeDecl (DataType { dtName })) = Just (identName dtName)

--- a/saw-core-coq/src/Verifier/SAW/Translation/Coq/CryptolModule.hs
+++ b/saw-core-coq/src/Verifier/SAW/Translation/Coq/CryptolModule.hs
@@ -12,23 +12,26 @@ import           Cryptol.ModuleSystem.Name          (Name, nameIdent)
 import           Cryptol.Utils.Ident                (unpackIdent)
 import qualified Language.Coq.AST                   as Coq
 import           Verifier.SAW.Term.Functor          (Term)
+import           Verifier.SAW.SharedTerm            (SharedContext)
 import           Verifier.SAW.Translation.Coq.Monad
 import qualified Verifier.SAW.Translation.Coq.Term  as TermTranslation
 import           Verifier.SAW.TypedTerm
+import           Verifier.SAW.Cryptol (Env)
 
 
-
+-- | Translate a list of named terms with their types to a Coq definitions
 translateTypedTermMap ::
-  TermTranslation.TermTranslationMonad m => Map.Map Name TypedTerm -> m [Coq.Decl]
-translateTypedTermMap tm = forM (Map.assocs tm) translateAndRegisterEntry
+  TermTranslation.TermTranslationMonad m => [(Name,Term,Term)] -> m [Coq.Decl]
+translateTypedTermMap defs = forM defs translateAndRegisterEntry
   where
-    translateAndRegisterEntry (name, symbol) = do
-      let t = ttTerm symbol
+    translateAndRegisterEntry (name, t, tp) = do
       let nameStr = unpackIdent (nameIdent name)
-      term <- TermTranslation.withLocalTranslationState $ do
-        modify $ set TermTranslation.localEnvironment [nameStr]
-        TermTranslation.translateTerm t
-      let decl = TermTranslation.mkDefinition nameStr term
+      decl <-
+        TermTranslation.withLocalTranslationState $
+        do modify $ set TermTranslation.localEnvironment [nameStr]
+           t_trans <- TermTranslation.translateTerm t
+           tp_trans <- TermTranslation.translateTerm tp
+           return $ TermTranslation.mkDefinition nameStr t_trans tp_trans
       modify $ over TermTranslation.globalDeclarations (nameStr :)
       return decl
 
@@ -37,16 +40,22 @@ translateTypedTermMap tm = forM (Map.assocs tm) translateAndRegisterEntry
 -- terms, and accumulating the translated declarations of all top-level
 -- declarations encountered.
 translateCryptolModule ::
+  SharedContext -> Env ->
   TranslationConfiguration ->
   -- | List of already translated global declarations
   [String] ->
   CryptolModule ->
-  Either (TranslationError Term) [Coq.Decl]
-translateCryptolModule configuration globalDecls (CryptolModule _ tm) =
-  reverse . view TermTranslation.topLevelDeclarations . snd
-  <$> TermTranslation.runTermTranslationMonad
-      configuration
-      (TermTranslation.TranslationReader Nothing) -- TODO: this should be Just no?
-      globalDecls
-      []
-      (translateTypedTermMap tm)
+  IO (Either (TranslationError Term) [Coq.Decl])
+translateCryptolModule sc env configuration globalDecls (CryptolModule _ tm) =
+  do defs <-
+       forM (Map.assocs tm) $ \(nm, t) ->
+       do tp <- ttTypeAsTerm sc env t
+          return (nm, ttTerm t, tp)
+     return
+       (reverse . view TermTranslation.topLevelDeclarations . snd <$>
+        TermTranslation.runTermTranslationMonad
+        configuration
+        (TermTranslation.TranslationReader Nothing) -- TODO: this should be Just no?
+        globalDecls
+        []
+        (translateTypedTermMap defs))


### PR DESCRIPTION
This PR addresses issue #1813 by changing the translation of SAW core array literals to use Coq vector literals, rather than using `Vector.of_list` applied to an array literal. This ensures that the type of the generated vector literal does not depend on its input (which was the problem noted by #1813).

As also suggested in the discussion in that issue, this PR adds output types to Coq `Definition`s that are generated by translating cryptol modules.