### PR TITLE
Expose term hashes in memoization

### DIFF
--- a/saw-core/src/Verifier/SAW/Term/Pretty.hs
+++ b/saw-core/src/Verifier/SAW/Term/Pretty.hs
@@ -22,6 +22,7 @@ module Verifier.SAW.Term.Pretty
   , renderSawDoc
   , SawStyle(..)
   , PPOpts(..)
+  , MemoStyle(..)
   , defaultPPOpts
   , depthPPOpts
   , ppNat
@@ -147,6 +148,9 @@ defaultPPOpts =
     , ppMaxDepth = Nothing
     , ppMinSharing = 2
     , ppMemoStyle = Incremental }
+    -- If 'ppMemoStyle' changes its default, be sure to update the help text in
+    -- the interpreter functions that control the memoization style to reflect
+    -- this change to users.
 
 -- | Options for printing with a maximum depth
 depthPPOpts :: Int -> PPOpts

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -478,7 +478,7 @@ print_goal_inline noInline =
   execTactic $ tacticId $ \goal ->
     do
       opts <- getTopLevelPPOpts
-      let opts' = opts { ppNoInlineMemo = sort noInline }
+      let opts' = opts { ppNoInlineMemoFresh = sort noInline }
       sc <- getSharedContext
       nenv <- io (scGetNamingEnv sc)
       let output = prettySequent opts' nenv (goalSequent goal)

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -80,6 +80,7 @@ import qualified Verifier.SAW.SCTypeCheck as TC (TypedTerm(..))
 import Verifier.SAW.Recognizer
 import Verifier.SAW.Prelude (scEq)
 import Verifier.SAW.SharedTerm
+import Verifier.SAW.Term.Pretty (MemoStyle(..))
 import Verifier.SAW.TypedTerm
 import qualified Verifier.SAW.Simulator.Concrete as Concrete
 import Verifier.SAW.Prim (rethrowEvalError)
@@ -478,11 +479,22 @@ print_goal_inline noInline =
   execTactic $ tacticId $ \goal ->
     do
       opts <- getTopLevelPPOpts
-      let opts' = opts { ppNoInlineMemoFresh = sort noInline }
+      opts' <-
+        case ppMemoStyle opts of
+          Incremental -> pure opts { ppNoInlineMemoFresh = sort noInline }
+          HashIncremental _ -> pure opts { ppNoInlineMemoFresh = sort noInline }
+          Hash _ -> warnIncremental >> pure opts
       sc <- getSharedContext
       nenv <- io (scGetNamingEnv sc)
       let output = prettySequent opts' nenv (goalSequent goal)
       printOutLnTop Info (unlines [goalSummary goal, output])
+  where
+    warnIncremental =
+      printOutLnTop Warn $
+        unlines
+          [ "`print_goal_inline` is incompatible with non-incremental"
+          , "memoization strategies. Printing goal without inlining..."
+          ]
 
 print_goal_summary :: ProofScript ()
 print_goal_summary =

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -85,6 +85,7 @@ import Verifier.SAW.Conversion
 import Verifier.SAW.Prim (rethrowEvalError)
 import Verifier.SAW.Rewriter (emptySimpset, rewritingSharedContext, scSimpset)
 import Verifier.SAW.SharedTerm
+import Verifier.SAW.Term.Pretty (MemoStyle(..))
 import Verifier.SAW.TypedAST hiding (FlatTermF(..))
 import Verifier.SAW.TypedTerm
 import qualified Verifier.SAW.CryptolEnv as CEnv
@@ -871,6 +872,37 @@ set_min_sharing b = do
   rw <- getTopLevelRW
   putTopLevelRW rw { rwPPOpts = (rwPPOpts rw) { ppOptsMinSharing = b } }
 
+-- | 'set_memoization_hash i' changes the memoization strategy for terms:
+-- memoization identifiers will include the first 'i' digits of the hash of the
+-- term they memoize. This is useful to help keep memoization identifiers of the
+-- same term as constant as possible across different executions of a proof
+-- script over the course of its development.
+set_memoization_hash :: Int -> TopLevel ()
+set_memoization_hash i = do
+  rw <- getTopLevelRW
+  putTopLevelRW rw { rwPPOpts = (rwPPOpts rw) {ppOptsMemoStyle = Hash i } }
+
+-- | 'set_memoization_hash_incremental i' changes the memoization strategy for
+-- terms: memoization identifiers will include the first 'i' digits of the hash
+-- of the term they memoize, as well as the value of a global counter that
+-- increments each time a term is memoized. This is useful to help keep
+-- memoization identifiers of the same term as constant as possible across
+-- different executions of a proof script over the course of its development, as
+-- well as to freshen memoization identifiers in the unlikely case of term hash
+-- collisions.
+set_memoization_hash_incremental :: Int -> TopLevel ()
+set_memoization_hash_incremental i = do
+  rw <- getTopLevelRW
+  putTopLevelRW rw { rwPPOpts = (rwPPOpts rw) {ppOptsMemoStyle = HashIncremental i } }
+
+-- | `set_memoization_incremental` changes the memoization strategy for terms:
+-- memoization identifiers will only include the value of a global counter that
+-- increments each time a term is memoized.
+set_memoization_incremental :: TopLevel ()
+set_memoization_incremental = do
+  rw <- getTopLevelRW
+  putTopLevelRW rw { rwPPOpts = (rwPPOpts rw) {ppOptsMemoStyle = Incremental } }
+
 print_value :: Value -> TopLevel ()
 print_value (VString s) = printOutLnTop Info (Text.unpack s)
 print_value (VTerm t) = do
@@ -1377,6 +1409,40 @@ primitives = Map.fromList
     Current
     [ "Set the number times a subterm must be shared for it to be"
     ,  "let-bound in printer output." ]
+
+  , prim "set_memoization_hash" "Int -> TopLevel ()"
+    (pureVal set_memoization_hash)
+    Current
+    [ "`set_memoization_hash i` changes the memoization strategy "
+    , "for terms: memoization identifiers will include the first `i` "
+    , "digits of the hash of the term they memoize. This is useful "
+    , "to help keep memoization identifiers of the same term as "
+    , "constant as possible across different executions of a proof "
+    , "script over the course of its development."
+    ]
+
+  , prim "set_memoization_hash_incremental" "Int -> TopLevel ()"
+    (pureVal set_memoization_hash_incremental)
+    Current
+    [ "`set_memoization_hash_incremental i` changes the memoization "
+    , "strategy for terms: memoization identifiers will include the "
+    , "first `i` digits of the hash of the term they memoize, as well "
+    , "as the value of a global counter that increments each time a "
+    , "term is memoized. This is useful to help keep memoization "
+    , "identifiers of the same term as constant as possible across "
+    , "different executions of a proof script over the course of its "
+    , "development, as well as to freshen memoization identifiers in "
+    , "the unlikely case of term hash collisions."
+    ]
+
+  , prim "set_memoization_incremental" "TopLevel ()"
+    (pureVal set_memoization_incremental)
+    Current
+    [ "`set_memoization_incremental` changes the memoization strategy "
+    , "for terms: memoization identifiers will only include the value "
+    , "of a global counter that increments each time a term is memoized. "
+    , "This is the default."
+    ]
 
   , prim "set_timeout"         "Int -> ProofScript ()"
     (pureVal set_timeout)

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -2230,6 +2230,9 @@ primitives = Map.fromList
     , " `x@9`, and `x@3`. These indices are assigned deterministically with"
     , "regard to a particular goal, but are not persistent across goals. As"
     , "such, this should be used primarily when debugging a proof."
+    , ""
+    , "Note: incompatible with non-incremental memoization strategies - see"
+    , "`set_memoization_incremental` and `set_memoization_hash_incremental`."
     ]
   , prim "write_goal" "String -> ProofScript ()"
     (pureVal write_goal)

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -246,10 +246,11 @@ data PPOpts = PPOpts
   , ppOptsBase :: Int
   , ppOptsColor :: Bool
   , ppOptsMinSharing :: Int
+  , ppOptsMemoStyle :: SAWCorePP.MemoStyle
   }
 
 defaultPPOpts :: PPOpts
-defaultPPOpts = PPOpts False False 10 False 2
+defaultPPOpts = PPOpts False False 10 False 2 SAWCorePP.Incremental
 
 cryptolPPOpts :: PPOpts -> C.PPOpts
 cryptolPPOpts opts =
@@ -264,6 +265,7 @@ sawPPOpts opts =
     { SAWCorePP.ppBase = ppOptsBase opts
     , SAWCorePP.ppColor = ppOptsColor opts
     , SAWCorePP.ppMinSharing = ppOptsMinSharing opts
+    , SAWCorePP.ppMemoStyle = ppOptsMemoStyle opts
     }
 
 quietEvalOpts :: C.EvalOpts


### PR DESCRIPTION
`persistent-term-hashing` (the subject of #1830) allows computation of term hashes that depend on term structure. These changes leverage that functionality, allowing users to change term printing behavior to use these hashes as part of the memoization identifiers generated for a reused subterm. 

This PR uses `persistent-term-hashing` as its base branch - assuming #1830 is merged into `master` before this is, I will reset the base branch to `master`.