### PR TITLE
Fix the build with `alex-3.2.7.2`

### DIFF
--- a/saw-core/src/Verifier/SAW/Lexer.x
+++ b/saw-core/src/Verifier/SAW/Lexer.x
@@ -2,6 +2,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}


### PR DESCRIPTION
`alex-3.2.7.2` generates code that uses `PatternGuards`, but because `saw-core` does not specify a `default-language` in its `.cabal` file, it defaults to `Haskell98`, which does not include `PatternGuards`. Arguably, we should make `saw-core`'s `default-language` be `Haskell2010` (which _does_ include `PatternGuards`), but that would be a somewhat larger change. For the sake of restoring the build, this applies the simplest possible fix of enabling `PatternGuards` in the affected file.

Fixes #1854.