### PR TITLE
Bump `s2nTests` time limit slightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,7 +540,7 @@ jobs:
 
   s2n-tests:
     name: "Test s2n proofs"
-    timeout-minutes: 120
+    timeout-minutes: 150
     needs: build
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
The `awslc` proofs have been _just_ on the edge of timing out for a long time. This commit bumps the time limit by 30 minutes in the hopes of making the job pass consistently.