### PR TITLE
Fix two minor CI artifact issues discovered during SAW 1.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
       - if: matrix.ghc == '8.10.7'
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.config.outputs.name }} (GHC ${{ matrix.ghc }})
+          name: ${{ steps.config.outputs.name }}-with-solvers (GHC ${{ matrix.ghc }})
           path: "${{ steps.config.outputs.name }}-with-solvers.tar.gz*"
           if-no-files-found: error
           retention-days: ${{ needs.config.outputs.retention-days }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-latest]
+        os: [ubuntu-22.04, macos-12, windows-2019]
         cabal: ["3.10.1.0"]
         ghc: ["8.10.7", "9.2.7", "9.4.4"]
         run-tests: [true]
@@ -372,7 +372,7 @@ jobs:
             os: macos-12
             continue-on-error: true  # https://github.com/GaloisInc/saw-script/issues/1135
           - suite: integration_tests
-            os: windows-latest
+            os: windows-2019
             timeout-minutes: 60
             continue-on-error: true  # https://github.com/GaloisInc/saw-script/issues/1135
         exclude:
@@ -380,7 +380,7 @@ jobs:
             os: macos-12
             continue-on-error: false
           - suite: integration_tests
-            os: windows-latest
+            os: windows-2019
             continue-on-error: false
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## CI: Pin to windows-2019 instead of windows-latest

It is worthwhile to pin the version number explicitly since:

1. The `windows-latest` alias could change at any time, so pinning the version avoids unwanted breakages that arise from new OS versions.

2. The name "`windows-latest`" leaks into bindist names, which doesn't look as nice as using the name "`windows-2019`".

We use `windows-2019` instead of `windows-2022` for now, since that is what `what4-solvers` currently uses.

## CI: Put solver bindists in separate artifact from non-solver bindists

Fixes https://github.com/GaloisInc/saw-script/issues/1884.