### PR TITLE
`saw-remote-api`: Don't hardcode version number in project description

### DIFF
--- a/saw-remote-api/python/pyproject.toml
+++ b/saw-remote-api/python/pyproject.toml
@@ -2,7 +2,7 @@
 name = "saw-client"
 version = "1.0.0"
 readme = "README.md"
-description = "SAW client for the SAW 0.9 RPC server"
+description = "SAW client for the SAW RPC server"
 authors = ["Galois, Inc. <saw@galois.com>"]
 license = "BSD License"
 include = [


### PR DESCRIPTION
It's easy to forget to update this. In addition, the version number is specified elsewhere in the pyproject.toml file, so putting the version number in the description is redundant.

Fixes #1888.