### PR TITLE
Toplevel rust translation

### DIFF
--- a/heapster-saw/examples/rust_just_translation.saw
+++ b/heapster-saw/examples/rust_just_translation.saw
@@ -1,0 +1,87 @@
+// This file demonstrates how to use the `heapster_trans_rust_type`
+// command to translate rust signatures to heapster.
+enable_experimental;
+
+// Integer types This is wrong... we don't need an environment. 
+env <- heapster_init_env_from_file "rust_data.sawcore" "rust_data.bc";
+
+print "Define Rust types.";
+/***
+ *** Types
+ ***/
+
+// Integer types
+heapster_define_perm env "int64" " " "llvmptr 64" "exists x:bv 64.eq(llvmword(x))";
+heapster_define_perm env "int32" " " "llvmptr 32" "exists x:bv 32.eq(llvmword(x))";
+heapster_define_perm env "int8" " " "llvmptr 8" "exists x:bv 8.eq(llvmword(x))";
+heapster_define_perm env "int1" " " "llvmptr 1" "exists x:bv 1.eq(llvmword(x))";
+
+heapster_define_llvmshape env "u64" 64 "" "fieldsh(int64<>)";
+heapster_define_llvmshape env "u32" 64 "" "fieldsh(32,int32<>)";
+heapster_define_llvmshape env "u8" 64 "" "fieldsh(8,int8<>)";
+
+heapster_define_llvmshape env "usize" 64 "" "fieldsh(int64<>)";
+heapster_define_llvmshape env "char" 64 "" "fieldsh(32,int32<>)";
+
+// bool type
+heapster_define_llvmshape env "bool" 64 "" "fieldsh(1,int1<>)";
+
+// Box type
+heapster_define_llvmshape env "Box" 64 "T:llvmshape 64" "ptrsh(T)";
+
+// Result type
+heapster_define_rust_type env "pub enum Result<X,Y> { Ok (X), Err (Y) }";
+
+// Infallable type
+heapster_define_llvmshape env "Infallible" 64 "" "falsesh";
+
+// Sum type
+heapster_define_rust_type env "pub enum Sum<X,Y> { Left (X), Right (Y) }";
+
+// The Option type
+heapster_define_rust_type env "pub enum Option<X> { None, Some (X) }";
+
+
+print "";
+print "-----------------------------------------------";
+print "Translate 'unit'";
+print "Rust: \n<> fn () -> ()";
+print "Heapster:";
+heapster_trans_rust_type env "<> fn () -> ()";
+
+print "";
+print "-----------------------------------------------";
+print "Translate 'add'";
+print "Rust: \n<> fn (x:u64, y:u64) -> u64";
+print "Heapster:";
+heapster_trans_rust_type env "<> fn (x:u64, y:u64) -> u64";
+
+
+print "";
+print "-----------------------------------------------";
+print "Translate 'Ptr add'";
+print "Rust: \n<'a,'b> fn (x:&'a u64, y:&'a u64) -> u64";
+print "Heapster:";
+heapster_trans_rust_type env "<'a,'b> fn (x:&'a u64, y:&'a u64) -> u64";
+
+print "";
+print "-----------------------------------------------";
+print "Translate 'array length'";
+print "Rust: \n<'a> fn (x:&'a [u64]) -> u64";
+print "Heapster:";
+heapster_trans_rust_type env "<'a> fn (x:&'a [u64]) -> u64";
+
+
+print "";
+print "-----------------------------------------------";
+print "Translate 'add two array'";
+print "Rust: \n<'a, 'b, 'c> fn (l1:&'a [u64], l2:&'b [u64]) -> &'c [u64]";
+print "Heapster:";
+heapster_trans_rust_type env "<'a, 'b, 'c> fn (l1:&'a [u64], l2:&'b [u64]) -> &'c [u64]";
+
+print "";
+print "-----------------------------------------------";
+print "Translate 'add two array in place'";
+print "Rust: \n<'a, 'b> fn (l1:&'a mut[u64], l2:&'b [u64]) -> ()";
+print "Heapster:";
+heapster_trans_rust_type env "<'a, 'b> fn (l1:&'a mut[u64], l2:&'b [u64]) -> ()";

--- a/heapster-saw/src/Verifier/SAW/Heapster/PermParser.hs
+++ b/heapster-saw/src/Verifier/SAW/Heapster/PermParser.hs
@@ -211,20 +211,6 @@ parseFunPermStringMaybeRust nm w env args ret str =
     Just '<' -> parseFunPermFromRust env w args ret str
     _ -> parseFunPermString nm env args ret str
 
--- -- | Just like `parseFunPermStringMaybeRust` but usese `parseSome3FunFromRust`
--- parseSome3FunPermStringMaybeRust ::
---   (1 <= w, KnownNat w, Fail.MonadFail m) =>
---   String                {- ^ object name                -} ->
---   prx w                 {- ^ pointer bit-width proxy    -} ->
---   PermEnv               {- ^ permission environment     -} ->
---   String                {- ^ input text                 -} ->
---   m Some3FunPerm
--- parseSome3FunPermStringMaybeRust nm w env str =
---   case find (\c -> c == '<' || c == '(') str of
---     Just '<' -> parseSome3FunPermFromRust env w str
---     _ -> parseFunPermString nm env args ret str
-
-
 -- | Parse a 'SomeNamedShape' from the given 'String'. This 'SomeNamedShape'
 -- must be a valid Rust @struct@ or @enum@ declaration given in Rust syntax.
 -- The @w@ argument gives the bit width of pointers in the current\

--- a/heapster-saw/src/Verifier/SAW/Heapster/PermParser.hs
+++ b/heapster-saw/src/Verifier/SAW/Heapster/PermParser.hs
@@ -211,6 +211,20 @@ parseFunPermStringMaybeRust nm w env args ret str =
     Just '<' -> parseFunPermFromRust env w args ret str
     _ -> parseFunPermString nm env args ret str
 
+-- -- | Just like `parseFunPermStringMaybeRust` but usese `parseSome3FunFromRust`
+-- parseSome3FunPermStringMaybeRust ::
+--   (1 <= w, KnownNat w, Fail.MonadFail m) =>
+--   String                {- ^ object name                -} ->
+--   prx w                 {- ^ pointer bit-width proxy    -} ->
+--   PermEnv               {- ^ permission environment     -} ->
+--   String                {- ^ input text                 -} ->
+--   m Some3FunPerm
+-- parseSome3FunPermStringMaybeRust nm w env str =
+--   case find (\c -> c == '<' || c == '(') str of
+--     Just '<' -> parseSome3FunPermFromRust env w str
+--     _ -> parseFunPermString nm env args ret str
+
+
 -- | Parse a 'SomeNamedShape' from the given 'String'. This 'SomeNamedShape'
 -- must be a valid Rust @struct@ or @enum@ declaration given in Rust syntax.
 -- The @w@ argument gives the bit width of pointers in the current\

--- a/heapster-saw/src/Verifier/SAW/Heapster/RustTypes.hs
+++ b/heapster-saw/src/Verifier/SAW/Heapster/RustTypes.hs
@@ -905,17 +905,17 @@ un3SomeFunPerm args ret (Some3FunPerm fun_perm)
   , Just Refl <- testEquality ret (funPermRet fun_perm) =
     return $ SomeFunPerm fun_perm
 un3SomeFunPerm args ret (Some3FunPerm fun_perm) =
-  (return emptyPPInfo) >>= \ppInfo ->
-  fail $ renderDoc $ vsep
-  [ pretty "Unexpected LLVM type for function permission:"
-  , permPretty ppInfo fun_perm
-  , pretty "Actual LLVM type of function:"
-    <+> PP.group (permPretty ppInfo args) <+> pretty "=>"
-    <+> PP.group (permPretty ppInfo ret)
-  , pretty "Expected LLVM type of function:"
-    <+> PP.group (permPretty ppInfo (funPermArgs fun_perm))
-    <+> pretty "=>"
-    <+> PP.group (permPretty ppInfo (funPermRet fun_perm)) ]
+  let ppInfo = emptyPPInfo in
+    fail $ renderDoc $ vsep
+    [ pretty "Unexpected LLVM type for function permission:"
+    , permPretty ppInfo fun_perm
+    , pretty "Actual LLVM type of function:"
+      <+> PP.group (permPretty ppInfo args) <+> pretty "=>"
+      <+> PP.group (permPretty ppInfo ret)
+    , pretty "Expected LLVM type of function:"
+      <+> PP.group (permPretty ppInfo (funPermArgs fun_perm))
+      <+> pretty "=>"
+      <+> PP.group (permPretty ppInfo (funPermRet fun_perm)) ]
 
 -- | This is the more general form of 'funPerm3FromArgLayout, where there can be
 -- ghost variables in the 'ArgLayout'

--- a/heapster-saw/src/Verifier/SAW/Heapster/RustTypes.hs
+++ b/heapster-saw/src/Verifier/SAW/Heapster/RustTypes.hs
@@ -1549,8 +1549,8 @@ parseFunPermFromRust :: (Fail.MonadFail m, 1 <= w, KnownNat w) =>
                         PermEnv -> prx w -> CruCtx args -> TypeRepr ret ->
                         String -> m (SomeFunPerm args ret)
 parseFunPermFromRust env w args ret str =
-  do getSome3FunPerm <- parseSome3FunPermFromRust
-     un3SomeFunPerm args ret getSome3FunPerm
+  do get3SomeFunPerm <- parseSome3FunPermFromRust env w str
+     runLiftRustConvM (mkRustConvInfo env) $ un3SomeFunPerm args ret get3SomeFunPerm
   
 
 -- | Just like `parseFunPermFromRust`, but returns a `Some3FunPerm`

--- a/heapster-saw/src/Verifier/SAW/Heapster/RustTypes.hs
+++ b/heapster-saw/src/Verifier/SAW/Heapster/RustTypes.hs
@@ -898,14 +898,14 @@ instance PermPretty Some3FunPerm where
   permPrettyM (Some3FunPerm fun_perm) = permPrettyM fun_perm
 
 -- | Try to convert a 'Some3FunPerm' to a 'SomeFunPerm' at a specific type
-un3SomeFunPerm :: CruCtx args -> TypeRepr ret -> Some3FunPerm ->
-                  RustConvM (SomeFunPerm args ret)
+un3SomeFunPerm :: (Fail.MonadFail m) => CruCtx args -> TypeRepr ret -> Some3FunPerm ->
+                  m (SomeFunPerm args ret)
 un3SomeFunPerm args ret (Some3FunPerm fun_perm)
   | Just Refl <- testEquality args (funPermArgs fun_perm)
   , Just Refl <- testEquality ret (funPermRet fun_perm) =
     return $ SomeFunPerm fun_perm
 un3SomeFunPerm args ret (Some3FunPerm fun_perm) =
-  rsPPInfo >>= \ppInfo ->
+  (return emptyPPInfo) >>= \ppInfo ->
   fail $ renderDoc $ vsep
   [ pretty "Unexpected LLVM type for function permission:"
   , permPretty ppInfo fun_perm
@@ -1550,7 +1550,7 @@ parseFunPermFromRust :: (Fail.MonadFail m, 1 <= w, KnownNat w) =>
                         String -> m (SomeFunPerm args ret)
 parseFunPermFromRust env w args ret str =
   do get3SomeFunPerm <- parseSome3FunPermFromRust env w str
-     runLiftRustConvM (mkRustConvInfo env) $ un3SomeFunPerm args ret get3SomeFunPerm
+     un3SomeFunPerm args ret get3SomeFunPerm
   
 
 -- | Just like `parseFunPermFromRust`, but returns a `Some3FunPerm`

--- a/src/SAWScript/HeapsterBuiltins.hs
+++ b/src/SAWScript/HeapsterBuiltins.hs
@@ -48,6 +48,7 @@ module SAWScript.HeapsterBuiltins
        , heapster_find_trait_method_symbol
        , heapster_assume_fun
        , heapster_assume_fun_rename
+       , heapster_translate_rust_type
        , heapster_assume_fun_rename_prim
        , heapster_assume_fun_multi
        , heapster_set_event_type
@@ -124,6 +125,7 @@ import Verifier.SAW.Heapster.Permissions
 import Verifier.SAW.Heapster.SAWTranslation
 import Verifier.SAW.Heapster.IRTTranslation
 import Verifier.SAW.Heapster.PermParser
+import Verifier.SAW.Heapster.RustTypes (parseSome3FunPermFromRust, Some3FunPerm(..))
 import Verifier.SAW.Heapster.ParsedCtx
 import qualified Verifier.SAW.Heapster.IDESupport as HIDE
 import Verifier.SAW.Heapster.LLVMGlobalConst
@@ -1020,7 +1022,7 @@ heapster_assume_fun_rename _bic _opts henv nm nm_to perms_string term_string =
   do Some lm <- failOnNothing ("Could not find symbol: " ++ nm)
                               (lookupModContainingSym henv nm)
      sc <- getSharedContext
-     let w = llvmModuleArchReprWidth lm
+     let w = llvmModuleArchReprWidth lm -- Should hardcode 64
      leq_proof <- case decideLeq (knownNat @1) w of
        Left pf -> return pf
        Right _ -> fail "LLVM arch width is 0!"
@@ -1043,20 +1045,18 @@ heapster_assume_fun_rename _bic _opts henv nm nm_to perms_string term_string =
 heapster_translate_rust_type :: BuiltinContext -> Options -> HeapsterEnv ->
                                 String -> TopLevel ()
 heapster_translate_rust_type _bic _opts henv perms_string =
-  do Some lm <- failOnNothing ("Could not find symbol: " ++ nm)
-                              (lookupModContainingSym henv nm)
-     sc <- getSharedContext
-     let w = llvmModuleArchReprWidth lm
-     leq_proof <- case decideLeq (knownNat @1) w of
+  do env <- liftIO $ readIORef $ heapsterEnvPermEnvRef henv
+     let w64 = (knownNat @64::NatRepr 64)
+     leq_proof <- case decideLeq (knownNat @1) w64 of
        Left pf -> return pf
        Right _ -> fail "LLVM arch width is 0!"
-     env <- liftIO $ readIORef $ heapsterEnvPermEnvRef henv
-     (Some cargs, Some ret) <- lookupFunctionType lm nm
-     let args = mkCruCtx cargs
-     withKnownNat w $ withLeqProof leq_proof $ do
-        SomeFunPerm fun_perm <-
-          parseFunPermStringMaybeRust "permissions" w env args ret perms_string
-        liftIO $ -- Lookup a how to print to io & and, looking into permissions.hs
+     withKnownNat w64 $ withLeqProof leq_proof $ do
+        Some3FunPerm fun_perm <-
+          parseSome3FunPermFromRust env w64 perms_string
+          --parseFunPermStringMaybeRust "permissions" w64 env args ret perms_string
+        liftIO $ putStrLn $ permPrettyString emptyPPInfo fun_perm
+        
+        -- Lookup a how to print to io & and, looking into permissions.hs
           -- for permPrettyString and pass an empty ppInfo to print 'fun_perm'
 
 -- | Create a new SAW core primitive named @nm@ with type @tp@ in the module

--- a/src/SAWScript/HeapsterBuiltins.hs
+++ b/src/SAWScript/HeapsterBuiltins.hs
@@ -1022,7 +1022,7 @@ heapster_assume_fun_rename _bic _opts henv nm nm_to perms_string term_string =
   do Some lm <- failOnNothing ("Could not find symbol: " ++ nm)
                               (lookupModContainingSym henv nm)
      sc <- getSharedContext
-     let w = llvmModuleArchReprWidth lm -- Should hardcode 64
+     let w = llvmModuleArchReprWidth lm
      leq_proof <- case decideLeq (knownNat @1) w of
        Left pf -> return pf
        Right _ -> fail "LLVM arch width is 0!"
@@ -1053,12 +1053,8 @@ heapster_translate_rust_type _bic _opts henv perms_string =
      withKnownNat w64 $ withLeqProof leq_proof $ do
         Some3FunPerm fun_perm <-
           parseSome3FunPermFromRust env w64 perms_string
-          --parseFunPermStringMaybeRust "permissions" w64 env args ret perms_string
         liftIO $ putStrLn $ permPrettyString emptyPPInfo fun_perm
         
-        -- Lookup a how to print to io & and, looking into permissions.hs
-          -- for permPrettyString and pass an empty ppInfo to print 'fun_perm'
-
 -- | Create a new SAW core primitive named @nm@ with type @tp@ in the module
 -- associated with the supplied Heapster environment, and return its identifier
 insPrimitive :: HeapsterEnv -> String -> Term -> TopLevel Ident

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -4253,6 +4253,13 @@ primitives = Map.fromList
     [ "Tell Heapster whether to perform its translation-time checks of the "
     , "well-formedness of type-checking proofs" ]
 
+  , prim "heapster_trans_rust_type"
+    "String -> TopLevel ()"
+    (bicVal heapster_translate_rust_type)
+    Experimental
+    [ "Parse and print back a set of Heapster permissions for a function"
+    ]
+
   , prim "heapster_parse_test"
     "LLVMModule -> String -> String -> TopLevel ()"
     (bicVal heapster_parse_test)

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -4254,7 +4254,7 @@ primitives = Map.fromList
     , "well-formedness of type-checking proofs" ]
 
   , prim "heapster_trans_rust_type"
-    "String -> TopLevel ()"
+    "HeapsterEnv -> String -> TopLevel ()"
     (bicVal heapster_translate_rust_type)
     Experimental
     [ "Parse and print back a set of Heapster permissions for a function"

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -4264,7 +4264,7 @@ primitives = Map.fromList
     "LLVMModule -> String -> String -> TopLevel ()"
     (bicVal heapster_parse_test)
     Experimental
-    [ "Parse and print back a set of Heapster permissions for a function"
+    [ "Parse the Rust signature for a function and print the equivalent Heapser type. Ideal for learning how Rust types are translated into Heapster. "
     ]
 
   , prim "heapster_dump_ide_info"

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -4264,7 +4264,7 @@ primitives = Map.fromList
     "LLVMModule -> String -> String -> TopLevel ()"
     (bicVal heapster_parse_test)
     Experimental
-    [ "Parse the Rust signature for a function and print the equivalent Heapser type. Ideal for learning how Rust types are translated into Heapster. "
+    [ "Parse a Rust function type and print the equivalent Heapser type. Ideal for learning how Rust types are translated into Heapster. "
     ]
 
   , prim "heapster_dump_ide_info"

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -4257,7 +4257,8 @@ primitives = Map.fromList
     "HeapsterEnv -> String -> TopLevel ()"
     (bicVal heapster_translate_rust_type)
     Experimental
-    [ "Parse a Rust function type and print the equivalent Heapser type. Ideal for learning how Rust types are translated into Heapster. "
+    [ "Parse a Rust function type and print the equivalent Heapser type. "
+    , "Ideal for learning how Rust types are translated into Heapster. "
     ]
 
   , prim "heapster_parse_test"

--- a/src/SAWScript/Interpreter.hs
+++ b/src/SAWScript/Interpreter.hs
@@ -4257,14 +4257,14 @@ primitives = Map.fromList
     "HeapsterEnv -> String -> TopLevel ()"
     (bicVal heapster_translate_rust_type)
     Experimental
-    [ "Parse and print back a set of Heapster permissions for a function"
+    [ "Parse a Rust function type and print the equivalent Heapser type. Ideal for learning how Rust types are translated into Heapster. "
     ]
 
   , prim "heapster_parse_test"
     "LLVMModule -> String -> String -> TopLevel ()"
     (bicVal heapster_parse_test)
     Experimental
-    [ "Parse a Rust function type and print the equivalent Heapser type. Ideal for learning how Rust types are translated into Heapster. "
+    [ "Parse and print back a set of Heapster permissions for a function"
     ]
 
   , prim "heapster_dump_ide_info"

--- a/src/SAWScript/Value.hs
+++ b/src/SAWScript/Value.hs
@@ -977,7 +977,7 @@ instance FromValue a => FromValue (TopLevel a) where
       v1 <- withPosition pos (fromValue m1)
       m2 <- applyValue v2 v1
       fromValue m2
-    fromValue _ = error "fromValue TopLevel"
+    fromValue v = error $ "fromValue TopLevel:" <> show v
 
 instance IsValue a => IsValue (ProofScript a) where
     toValue m = VProofScript (fmap toValue m)


### PR DESCRIPTION
This PR adds a new command 

```
heapster_trans_rust_type : HeapsterEnv -> String -> TopLevel ()
```

takes the Rust signature for a function and prints the equivalent Heapser type. It is ideal for learning and experimenting with the `Rust -> Heapster` translation. 

The PR includes the file `rust_just_translation.saw` which demonstrates how to use the command to translate various functions. The file also demonstrates how to (a) create the necessary definitions to support rust and (b) create a proper, empty environment for the command to work. 

The example can be ran from the examples folder with 

```
cabal run saw rust_just_translation.saw
``` 
 