### PR TITLE
`SetupValue`: Use proper TTG-style extension fields

### DIFF
--- a/saw-script.cabal
+++ b/saw-script.cabal
@@ -146,6 +146,7 @@ library
     SAWScript.Crucible.Common.ResolveSetupValue
     SAWScript.Crucible.Common.Setup.Builtins
     SAWScript.Crucible.Common.Setup.Type
+    SAWScript.Crucible.Common.Setup.Value
 
     SAWScript.Crucible.LLVM.Builtins
     SAWScript.Crucible.LLVM.Boilerplate

--- a/saw-script.cabal
+++ b/saw-script.cabal
@@ -154,6 +154,7 @@ library
     SAWScript.Crucible.LLVM.Override
     SAWScript.Crucible.LLVM.MethodSpecIR
     SAWScript.Crucible.LLVM.ResolveSetupValue
+    SAWScript.Crucible.LLVM.Setup.Value
     SAWScript.Crucible.LLVM.Skeleton
     SAWScript.Crucible.LLVM.Skeleton.Builtins
     SAWScript.Crucible.LLVM.X86
@@ -163,11 +164,13 @@ library
     SAWScript.Crucible.JVM.MethodSpecIR
     SAWScript.Crucible.JVM.Override
     SAWScript.Crucible.JVM.ResolveSetupValue
+    SAWScript.Crucible.JVM.Setup.Value
 
     SAWScript.Crucible.MIR.Builtins
     SAWScript.Crucible.MIR.MethodSpecIR
     SAWScript.Crucible.MIR.Override
     SAWScript.Crucible.MIR.ResolveSetupValue
+    SAWScript.Crucible.MIR.Setup.Value
     SAWScript.Crucible.MIR.TypeShape
 
     SAWScript.Prover.Mode

--- a/src/SAWScript/Crucible/Common/MethodSpec.hs
+++ b/src/SAWScript/Crucible/Common/MethodSpec.hs
@@ -21,7 +21,95 @@ Grow\", and is prevalent across the Crucible codebase.
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module SAWScript.Crucible.Common.MethodSpec where
+module SAWScript.Crucible.Common.MethodSpec
+  ( AllocIndex(..)
+  , nextAllocIndex
+
+  , PrePost(..)
+  , stateCond
+
+  , CrucibleContext
+  , AllocSpec
+  , TypeName
+  , ExtType
+  , CastType
+  , PointsTo
+  , AllocGlobal
+  , ResolvedState
+
+  , BoolToType
+  , B
+
+  , HasSetupNull
+  , HasSetupStruct
+  , HasSetupArray
+  , HasSetupElem
+  , HasSetupField
+  , HasSetupGlobal
+  , HasSetupCast
+  , HasSetupUnion
+  , HasSetupGlobalInitializer
+
+  , SetupValue(..)
+  , SetupValueHas
+
+  , ppSetupValue
+  , ppAllocIndex
+  , ppTypedTerm
+  , ppTypedTermType
+  , ppTypedExtCns
+
+  , setupToTypedTerm
+  , setupToTerm
+
+  , HasGhostState
+  , GhostValue
+  , GhostType
+  , GhostGlobal
+
+  , ConditionMetadata(..)
+
+  , SetupCondition(..)
+  , StateSpec(..)
+  , csAllocs
+  , csPointsTos
+  , csConditions
+  , csFreshVars
+  , csVarTypeNames
+  , initialStateSpec
+
+  , MethodId
+  , Codebase
+
+  , CrucibleMethodSpecIR(..)
+  , csMethod
+  , csArgs
+  , csRet
+  , csPreState
+  , csPostState
+  , csArgBindings
+  , csRetValue
+  , csGlobalAllocs
+  , csCodebase
+  , csLoc
+  , ProofMethod(..)
+  , SpecNonce
+  , VCStats(..)
+  , ProvedSpec(..)
+  , psSpecIdent
+  , psProofMethod
+  , psSpec
+  , psSolverStats
+  , psVCStats
+  , psSpecDeps
+  , psElapsedTime
+  , mkProvedSpec
+  , prettyPosition
+  , ppMethodSpec
+  , csAllocations
+  , csTypeNames
+  , makeCrucibleMethodSpecIR
+  ) where
 
 import           Data.Constraint (Constraint)
 import           Data.Map (Map)

--- a/src/SAWScript/Crucible/Common/MethodSpec.hs
+++ b/src/SAWScript/Crucible/Common/MethodSpec.hs
@@ -111,17 +111,14 @@ module SAWScript.Crucible.Common.MethodSpec
   , makeCrucibleMethodSpecIR
   ) where
 
-import           Data.Constraint (Constraint)
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Set (Set)
 import           Data.Time.Clock
-import           Data.Void (Void)
 
 import           Control.Monad.Trans.Maybe
 import           Control.Monad.Trans (lift)
 import           Control.Lens
-import           Data.Kind (Type)
 import qualified Prettyprinter as PP
 
 import           Data.Parameterized.Nonce
@@ -138,17 +135,11 @@ import qualified Cryptol.Utils.PP as Cryptol
 import           Verifier.SAW.TypedTerm as SAWVerifier
 import           Verifier.SAW.SharedTerm as SAWVerifier
 
+import           SAWScript.Crucible.Common.Setup.Value
 import           SAWScript.Options
 import           SAWScript.Prover.SolverStats
 import           SAWScript.Utils (bullets)
 import           SAWScript.Proof (TheoremNonce, TheoremSummary)
-
--- | How many allocations have we made in this method spec?
-newtype AllocIndex = AllocIndex Int
-  deriving (Eq, Ord, Show)
-
-nextAllocIndex :: AllocIndex -> AllocIndex
-nextAllocIndex (AllocIndex n) = AllocIndex (n + 1)
 
 -- | Are we writing preconditions or postconditions?
 data PrePost
@@ -160,95 +151,7 @@ stateCond PreState = "precondition"
 stateCond PostState = "postcondition"
 
 --------------------------------------------------------------------------------
--- *** Extension-specific information
-
-type family CrucibleContext ext :: Type
-
--- | How to specify allocations in this syntax extension
-type family AllocSpec ext :: Type
-
--- | The type of identifiers for types in this syntax extension
-type family TypeName ext :: Type
-
--- | The type of types of the syntax extension we're dealing with
-type family ExtType ext :: Type
-
--- | The types that can appear in casts
-type family CastType ext :: Type
-
--- | The type of points-to assertions
-type family PointsTo ext :: Type
-
--- | The type of global allocations
-type family AllocGlobal ext :: Type
-
--- | The type of \"resolved\" state
-type family ResolvedState ext :: Type
-
---------------------------------------------------------------------------------
 -- ** SetupValue
-
--- | An injective type family mapping type-level booleans to types
-type family BoolToType (b :: Bool) = (t :: Type) | t -> b where
-  BoolToType 'True  = ()
-  BoolToType 'False = Void
-
-type B b = BoolToType b
-
- -- The following type families describe what SetupValues are legal for which
- -- languages.
-type family HasSetupNull ext :: Bool
-type family HasSetupStruct ext :: Bool
-type family HasSetupArray ext :: Bool
-type family HasSetupElem ext :: Bool
-type family HasSetupField ext :: Bool
-type family HasSetupGlobal ext :: Bool
-type family HasSetupCast ext :: Bool
-type family HasSetupUnion ext :: Bool
-type family HasSetupGlobalInitializer ext :: Bool
-
--- | From the manual: \"The SetupValue type corresponds to values that can occur
--- during symbolic execution, which includes both 'Term' values, pointers, and
--- composite types consisting of either of these (both structures and arrays).\"
-data SetupValue ext where
-  SetupVar    :: AllocIndex -> SetupValue ext
-  SetupTerm   :: TypedTerm -> SetupValue ext
-  SetupNull   :: B (HasSetupNull ext) -> SetupValue ext
-  -- | If the 'Bool' is 'True', it's a (LLVM) packed struct
-  SetupStruct :: B (HasSetupStruct ext) -> Bool -> [SetupValue ext] -> SetupValue ext
-  SetupArray  :: B (HasSetupArray ext) -> [SetupValue ext] -> SetupValue ext
-  SetupElem   :: B (HasSetupElem ext) -> SetupValue ext -> Int -> SetupValue ext
-  SetupField  :: B (HasSetupField ext) -> SetupValue ext -> String -> SetupValue ext
-  SetupCast   :: B (HasSetupCast ext) -> SetupValue ext -> CastType ext -> SetupValue ext
-  SetupUnion  :: B (HasSetupUnion ext) -> SetupValue ext -> String -> SetupValue ext
-
-  -- | A pointer to a global variable
-  SetupGlobal :: B (HasSetupGlobal ext) -> String -> SetupValue ext
-  -- | This represents the value of a global's initializer.
-  SetupGlobalInitializer ::
-    B (HasSetupGlobalInitializer ext) -> String -> SetupValue ext
-
--- | This constraint can be solved for any ext so long as '()' and 'Void' have
---   the constraint. Unfortunately, GHC can't (yet?) reason over the equations
---   in our closed type family, and realize that
-type SetupValueHas (c :: Type -> Constraint) ext =
-  ( c (B (HasSetupNull ext))
-  , c (B (HasSetupStruct ext))
-  , c (B (HasSetupArray ext))
-  , c (B (HasSetupElem ext))
-  , c (B (HasSetupField ext))
-  , c (B (HasSetupCast ext))
-  , c (B (HasSetupUnion ext))
-  , c (B (HasSetupGlobal ext))
-  , c (B (HasSetupGlobalInitializer ext))
-  , c (CastType ext)
-  )
-
-deriving instance (SetupValueHas Show ext) => Show (SetupValue ext)
-
--- TypedTerm is neither Eq nor Ord
--- deriving instance (SetupValueHas Eq ext) => Eq (SetupValue ext)
--- deriving instance (SetupValueHas Ord ext) => Ord (SetupValue ext)
 
 -- | Note that most 'SetupValue' concepts (like allocation indices)
 --   are implementation details and won't be familiar to users.
@@ -357,28 +260,9 @@ setupToTerm opts sc =
 --------------------------------------------------------------------------------
 -- ** Ghost state
 
--- TODO: This is language-independent, it should be always-true rather than a
--- toggle.
-
--- TODO: documentation
-
-type family HasGhostState ext :: Bool
-
 type GhostValue  = "GhostValue"
 type GhostType   = Crucible.IntrinsicType GhostValue Crucible.EmptyCtx
 type GhostGlobal = Crucible.GlobalVar GhostType
-
---------------------------------------------------------------------------------
--- ** Pre- and post-conditions
-
-data ConditionMetadata =
-  ConditionMetadata
-  { conditionLoc  :: ProgramLoc
-  , conditionTags :: Set String
-  , conditionType :: String
-  , conditionContext :: String
-  }
- deriving (Show, Eq, Ord)
 
 --------------------------------------------------------------------------------
 -- *** StateSpec
@@ -423,14 +307,6 @@ initialStateSpec =  StateSpec
 
 --------------------------------------------------------------------------------
 -- *** Method specs
-
--- | How to identify methods in a codebase
-type family MethodId ext :: Type
-
--- | A body of code in which a method resides
---
--- Examples: An 'LLVMModule', a Java 'Codebase'
-type family Codebase ext :: Type
 
 data CrucibleMethodSpecIR ext =
   CrucibleMethodSpec

--- a/src/SAWScript/Crucible/Common/Override.hs
+++ b/src/SAWScript/Crucible/Common/Override.hs
@@ -20,7 +20,7 @@ Stability   : provisional
 
 module SAWScript.Crucible.Common.Override
   ( Pointer
-  , Pointer'
+  , MS.Pointer'
   , OverrideState
   , OverrideState'(..)
   , osAsserts
@@ -68,7 +68,6 @@ import qualified Control.Monad.Fail as Fail
 import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Class
 import           Control.Monad.IO.Class
-import           Data.Kind (Type)
 import qualified Data.Map as Map
 import           Data.Map (Map)
 import           Data.Set (Set)
@@ -96,6 +95,7 @@ import qualified What4.ProgramLoc as W4
 import           SAWScript.Exceptions
 import           SAWScript.Crucible.Common (Sym)
 import           SAWScript.Crucible.Common.MethodSpec as MS
+import           SAWScript.Crucible.Common.Setup.Value as MS
 
 -- TODO, not sure this is the best place for this definition
 type MetadataMap =
@@ -106,13 +106,11 @@ type MetadataMap =
 
 type LabeledPred sym = W4.LabeledPred (W4.Pred sym) Crucible.SimError
 
-type family Pointer' ext sym :: Type
-
-type Pointer ext = Pointer' ext Sym
+type Pointer ext = MS.Pointer' ext Sym
 
 data OverrideState' sym ext = OverrideState
   { -- | Substitution for memory allocations
-    _setupValueSub :: Map AllocIndex (Pointer' ext sym)
+    _setupValueSub :: Map AllocIndex (MS.Pointer' ext sym)
 
     -- | Substitution for SAW Core external constants
   , _termSub :: Map VarIndex Term

--- a/src/SAWScript/Crucible/Common/Setup/Value.hs
+++ b/src/SAWScript/Crucible/Common/Setup/Value.hs
@@ -1,0 +1,202 @@
+{- |
+Module      : SAWScript.Crucible.Common.Setup.Value
+Description : Language-neutral method specifications
+License     : BSD3
+Maintainer  : langston
+Stability   : provisional
+
+This module uses GADTs & type families to distinguish syntax-extension- (source
+language-) specific code. This technique is described in the paper \"Trees That
+Grow\", and is prevalent across the Crucible codebase.
+
+The module exists separately from "SAWScript.Crucible.Common.MethodSpecIR"
+primarily to avoid import cycles. You probably want to import
+"SAWScript.Crucible.Common.MethodSpecIR" (which re-exports everything from this
+module, plus additional functionality) instead.
+-}
+
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module SAWScript.Crucible.Common.Setup.Value
+  ( AllocIndex(..)
+  , nextAllocIndex
+
+  , CrucibleContext
+  , AllocSpec
+  , TypeName
+  , ExtType
+  , CastType
+  , PointsTo
+  , AllocGlobal
+  , ResolvedState
+
+  , BoolToType
+  , B
+
+  , HasSetupNull
+  , HasSetupStruct
+  , HasSetupArray
+  , HasSetupElem
+  , HasSetupField
+  , HasSetupGlobal
+  , HasSetupCast
+  , HasSetupUnion
+  , HasSetupGlobalInitializer
+
+  , SetupValue(..)
+  , SetupValueHas
+
+  , HasGhostState
+
+  , ConditionMetadata(..)
+
+  , MethodId
+  , Codebase
+  ) where
+
+import           Data.Constraint (Constraint)
+import           Data.Kind (Type)
+import           Data.Set (Set)
+import           Data.Void (Void)
+
+import           What4.ProgramLoc (ProgramLoc)
+
+import           Verifier.SAW.TypedTerm
+
+-- | How many allocations have we made in this method spec?
+newtype AllocIndex = AllocIndex Int
+  deriving (Eq, Ord, Show)
+
+nextAllocIndex :: AllocIndex -> AllocIndex
+nextAllocIndex (AllocIndex n) = AllocIndex (n + 1)
+
+--------------------------------------------------------------------------------
+-- *** Extension-specific information
+
+type family CrucibleContext ext :: Type
+
+-- | How to specify allocations in this syntax extension
+type family AllocSpec ext :: Type
+
+-- | The type of identifiers for types in this syntax extension
+type family TypeName ext :: Type
+
+-- | The type of types of the syntax extension we're dealing with
+type family ExtType ext :: Type
+
+-- | The types that can appear in casts
+type family CastType ext :: Type
+
+-- | The type of points-to assertions
+type family PointsTo ext :: Type
+
+-- | The type of global allocations
+type family AllocGlobal ext :: Type
+
+-- | The type of \"resolved\" state
+type family ResolvedState ext :: Type
+
+--------------------------------------------------------------------------------
+-- ** SetupValue
+
+-- | An injective type family mapping type-level booleans to types
+type family BoolToType (b :: Bool) = (t :: Type) | t -> b where
+  BoolToType 'True  = ()
+  BoolToType 'False = Void
+
+type B b = BoolToType b
+
+ -- The following type families describe what SetupValues are legal for which
+ -- languages.
+type family HasSetupNull ext :: Bool
+type family HasSetupStruct ext :: Bool
+type family HasSetupArray ext :: Bool
+type family HasSetupElem ext :: Bool
+type family HasSetupField ext :: Bool
+type family HasSetupGlobal ext :: Bool
+type family HasSetupCast ext :: Bool
+type family HasSetupUnion ext :: Bool
+type family HasSetupGlobalInitializer ext :: Bool
+
+-- | From the manual: \"The SetupValue type corresponds to values that can occur
+-- during symbolic execution, which includes both 'Term' values, pointers, and
+-- composite types consisting of either of these (both structures and arrays).\"
+data SetupValue ext where
+  SetupVar    :: AllocIndex -> SetupValue ext
+  SetupTerm   :: TypedTerm -> SetupValue ext
+  SetupNull   :: B (HasSetupNull ext) -> SetupValue ext
+  -- | If the 'Bool' is 'True', it's a (LLVM) packed struct
+  SetupStruct :: B (HasSetupStruct ext) -> Bool -> [SetupValue ext] -> SetupValue ext
+  SetupArray  :: B (HasSetupArray ext) -> [SetupValue ext] -> SetupValue ext
+  SetupElem   :: B (HasSetupElem ext) -> SetupValue ext -> Int -> SetupValue ext
+  SetupField  :: B (HasSetupField ext) -> SetupValue ext -> String -> SetupValue ext
+  SetupCast   :: B (HasSetupCast ext) -> SetupValue ext -> CastType ext -> SetupValue ext
+  SetupUnion  :: B (HasSetupUnion ext) -> SetupValue ext -> String -> SetupValue ext
+
+  -- | A pointer to a global variable
+  SetupGlobal :: B (HasSetupGlobal ext) -> String -> SetupValue ext
+  -- | This represents the value of a global's initializer.
+  SetupGlobalInitializer ::
+    B (HasSetupGlobalInitializer ext) -> String -> SetupValue ext
+
+-- | This constraint can be solved for any ext so long as '()' and 'Void' have
+--   the constraint. Unfortunately, GHC can't (yet?) reason over the equations
+--   in our closed type family, and realize that
+type SetupValueHas (c :: Type -> Constraint) ext =
+  ( c (B (HasSetupNull ext))
+  , c (B (HasSetupStruct ext))
+  , c (B (HasSetupArray ext))
+  , c (B (HasSetupElem ext))
+  , c (B (HasSetupField ext))
+  , c (B (HasSetupCast ext))
+  , c (B (HasSetupUnion ext))
+  , c (B (HasSetupGlobal ext))
+  , c (B (HasSetupGlobalInitializer ext))
+  , c (CastType ext)
+  )
+
+deriving instance (SetupValueHas Show ext) => Show (SetupValue ext)
+
+-- TypedTerm is neither Eq nor Ord
+-- deriving instance (SetupValueHas Eq ext) => Eq (SetupValue ext)
+-- deriving instance (SetupValueHas Ord ext) => Ord (SetupValue ext)
+
+--------------------------------------------------------------------------------
+-- ** Ghost state
+
+-- TODO: This is language-independent, it should be always-true rather than a
+-- toggle.
+
+-- TODO: documentation
+
+type family HasGhostState ext :: Bool
+
+--------------------------------------------------------------------------------
+-- ** Pre- and post-conditions
+
+data ConditionMetadata =
+  ConditionMetadata
+  { conditionLoc  :: ProgramLoc
+  , conditionTags :: Set String
+  , conditionType :: String
+  , conditionContext :: String
+  }
+ deriving (Show, Eq, Ord)
+
+--------------------------------------------------------------------------------
+-- *** Method specs
+
+-- | How to identify methods in a codebase
+type family MethodId ext :: Type
+
+-- | A body of code in which a method resides
+--
+-- Examples: An 'LLVMModule', a Java 'Codebase'
+type family Codebase ext :: Type

--- a/src/SAWScript/Crucible/Common/Setup/Value.hs
+++ b/src/SAWScript/Crucible/Common/Setup/Value.hs
@@ -175,11 +175,10 @@ deriving instance (SetupValueHas Show ext) => Show (SetupValue ext)
 --------------------------------------------------------------------------------
 -- ** Ghost state
 
--- TODO: This is language-independent, it should be always-true rather than a
--- toggle.
-
--- TODO: documentation
-
+-- | This extension field controls whether ghost state is enabled for a
+-- particular language backend. At the moment, ghost state is only enabled for
+-- the LLVM backend, but we want to expand this to cover other language backends
+-- in the future. See <https://github.com/GaloisInc/saw-script/issues/1929>.
 type family XGhostState ext
 
 --------------------------------------------------------------------------------

--- a/src/SAWScript/Crucible/Common/Setup/Value.hs
+++ b/src/SAWScript/Crucible/Common/Setup/Value.hs
@@ -59,6 +59,8 @@ module SAWScript.Crucible.Common.Setup.Value
 
   , MethodId
   , Codebase
+
+  , Pointer'
   ) where
 
 import           Data.Constraint (Constraint)
@@ -200,3 +202,8 @@ type family MethodId ext :: Type
 --
 -- Examples: An 'LLVMModule', a Java 'Codebase'
 type family Codebase ext :: Type
+
+--------------------------------------------------------------------------------
+-- *** Pointers
+
+type family Pointer' ext sym :: Type

--- a/src/SAWScript/Crucible/JVM/MethodSpecIR.hs
+++ b/src/SAWScript/Crucible/JVM/MethodSpecIR.hs
@@ -61,8 +61,6 @@ import qualified Prettyprinter as PPL
 -- what4
 import           What4.ProgramLoc (ProgramLoc)
 
-import qualified Lang.Crucible.FunctionHandle as Crucible (HandleAllocator)
-
 -- crucible-jvm
 import qualified Lang.Crucible.JVM as CJ
 import qualified Lang.JVM.Codebase as CB
@@ -70,47 +68,13 @@ import qualified Lang.JVM.Codebase as CB
 -- jvm-parser
 import qualified Language.JVM.Parser as J
 
--- cryptol-saw-core
-import           Verifier.SAW.TypedTerm (TypedTerm)
-
 import           SAWScript.Crucible.Common
 import qualified SAWScript.Crucible.Common.MethodSpec as MS
 import qualified SAWScript.Crucible.Common.Setup.Type as Setup
-
---------------------------------------------------------------------------------
--- ** Language features
-
-type instance MS.HasSetupNull CJ.JVM = 'True
-type instance MS.HasSetupGlobal CJ.JVM = 'False
-type instance MS.HasSetupStruct CJ.JVM = 'False
-type instance MS.HasSetupArray CJ.JVM = 'False
-type instance MS.HasSetupElem CJ.JVM = 'False
-type instance MS.HasSetupField CJ.JVM = 'False
-type instance MS.HasSetupCast CJ.JVM = 'False
-type instance MS.HasSetupUnion CJ.JVM = 'False
-type instance MS.HasSetupGlobalInitializer CJ.JVM = 'False
-
-type instance MS.HasGhostState CJ.JVM = 'False
-
-type JIdent = String -- FIXME(huffman): what to put here?
-
-type instance MS.TypeName CJ.JVM = JIdent
-
-type instance MS.ExtType CJ.JVM = J.Type
-type instance MS.CastType CJ.JVM = ()
-type instance MS.ResolvedState CJ.JVM = ()
+import           SAWScript.Crucible.JVM.Setup.Value
 
 --------------------------------------------------------------------------------
 -- *** JVMMethodId
-
-data JVMMethodId =
-  JVMMethodId
-    { _jvmMethodKey :: J.MethodKey
-    , _jvmClassName  :: J.ClassName
-    }
-  deriving (Eq, Ord, Show)
-
-makeLenses ''JVMMethodId
 
 jvmMethodName :: Getter JVMMethodId String
 jvmMethodName = jvmMethodKey . to J.methodKeyName
@@ -121,20 +85,8 @@ csMethodKey = MS.csMethod . jvmMethodKey
 csMethodName :: Getter (MS.CrucibleMethodSpecIR CJ.JVM) String
 csMethodName = MS.csMethod . jvmMethodName
 
--- TODO: avoid intermediate 'String' values
-instance PPL.Pretty JVMMethodId where
-  pretty (JVMMethodId methKey className) =
-    PPL.pretty (concat [J.unClassName className ,".", J.methodKeyName methKey])
-
-type instance MS.MethodId CJ.JVM = JVMMethodId
-
 --------------------------------------------------------------------------------
 -- *** Allocation
-
-data Allocation
-  = AllocObject J.ClassName
-  | AllocArray Int J.Type
-  deriving (Eq, Ord, Show)
 
 allocationType :: Allocation -> J.Type
 allocationType alloc =
@@ -142,20 +94,8 @@ allocationType alloc =
     AllocObject cname -> J.ClassType cname
     AllocArray _len ty -> J.ArrayType ty
 
-
--- TODO: We should probably use a more structured datatype (record), like in LLVM
-type instance MS.AllocSpec CJ.JVM = (MS.ConditionMetadata, Allocation)
-
 --------------------------------------------------------------------------------
 -- *** PointsTo
-
-type instance MS.PointsTo CJ.JVM = JVMPointsTo
-
-data JVMPointsTo
-  = JVMPointsToField MS.ConditionMetadata MS.AllocIndex J.FieldId (Maybe (MS.SetupValue CJ.JVM))
-  | JVMPointsToStatic MS.ConditionMetadata J.FieldId (Maybe (MS.SetupValue CJ.JVM))
-  | JVMPointsToElem MS.ConditionMetadata MS.AllocIndex Int (Maybe (MS.SetupValue CJ.JVM))
-  | JVMPointsToArray MS.ConditionMetadata MS.AllocIndex (Maybe TypedTerm)
 
 overlapPointsTo :: JVMPointsTo -> JVMPointsTo -> Bool
 overlapPointsTo =
@@ -206,22 +146,6 @@ instance PPL.Pretty JVMPointsTo where
 
 --------------------------------------------------------------------------------
 -- *** JVMCrucibleContext
-
-type instance MS.Codebase CJ.JVM = CB.Codebase
-
-data JVMCrucibleContext =
-  JVMCrucibleContext
-  { _jccJVMClass       :: J.Class
-  , _jccCodebase       :: CB.Codebase
-  , _jccJVMContext     :: CJ.JVMContext
-  , _jccBackend        :: SomeOnlineBackend
-  , _jccHandleAllocator :: Crucible.HandleAllocator
-  }
-
-makeLenses ''JVMCrucibleContext
-
-type instance MS.CrucibleContext CJ.JVM = JVMCrucibleContext
-
 
 jccWithBackend ::
   JVMCrucibleContext ->

--- a/src/SAWScript/Crucible/JVM/MethodSpecIR.hs
+++ b/src/SAWScript/Crucible/JVM/MethodSpecIR.hs
@@ -25,7 +25,35 @@ Stability   : provisional
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 
-module SAWScript.Crucible.JVM.MethodSpecIR where
+module SAWScript.Crucible.JVM.MethodSpecIR
+  ( JIdent
+
+  , JVMMethodId(..)
+  , jvmMethodKey
+  , jvmClassName
+  , jvmMethodName
+  , csMethodKey
+  , csMethodName
+
+  , Allocation(..)
+  , allocationType
+
+  , JVMPointsTo(..)
+  , overlapPointsTo
+  , ppPointsTo
+
+  , JVMCrucibleContext(..)
+  , jccJVMClass
+  , jccCodebase
+  , jccJVMContext
+  , jccBackend
+  , jccHandleAllocator
+  , jccWithBackend
+  , jccSym
+
+  , initialDefCrucibleMethodSpecIR
+  , initialCrucibleSetupState
+  ) where
 
 import           Control.Lens
 import qualified Prettyprinter as PPL

--- a/src/SAWScript/Crucible/JVM/Override.hs
+++ b/src/SAWScript/Crucible/JVM/Override.hs
@@ -109,6 +109,7 @@ import qualified SAWScript.Crucible.Common.Override as Ov (getSymInterface)
 import qualified SAWScript.Crucible.Common.MethodSpec as MS
 import           SAWScript.Crucible.JVM.MethodSpecIR
 import           SAWScript.Crucible.JVM.ResolveSetupValue
+import           SAWScript.Crucible.JVM.Setup.Value ()
 import           SAWScript.Options
 import           SAWScript.Panic
 import           SAWScript.Utils (handleException)
@@ -121,7 +122,6 @@ type SetupValue = MS.SetupValue CJ.JVM
 type CrucibleMethodSpecIR = MS.CrucibleMethodSpecIR CJ.JVM
 type StateSpec = MS.StateSpec CJ.JVM
 type SetupCondition = MS.SetupCondition CJ.JVM
-type instance Pointer' CJ.JVM Sym = JVMRefVal
 
 -- TODO: Improve?
 ppJVMVal :: JVMVal -> PP.Doc ann

--- a/src/SAWScript/Crucible/JVM/Override.hs
+++ b/src/SAWScript/Crucible/JVM/Override.hs
@@ -964,11 +964,11 @@ instantiateSetupValue sc s v =
     MS.SetupTerm tt                   -> MS.SetupTerm <$> doTerm tt
     MS.SetupNull ()                   -> return v
     MS.SetupGlobal empty _            -> absurd empty
-    MS.SetupStruct empty _ _          -> absurd empty
+    MS.SetupStruct empty _            -> absurd empty
     MS.SetupArray empty _             -> absurd empty
     MS.SetupElem empty _ _            -> absurd empty
     MS.SetupField empty _ _           -> absurd empty
-    MS.SetupCast empty _ _            -> absurd empty
+    MS.SetupCast empty _              -> absurd empty
     MS.SetupUnion empty _ _           -> absurd empty
     MS.SetupGlobalInitializer empty _ -> absurd empty
   where

--- a/src/SAWScript/Crucible/JVM/ResolveSetupValue.hs
+++ b/src/SAWScript/Crucible/JVM/ResolveSetupValue.hs
@@ -139,11 +139,11 @@ typeOfSetupValue _cc env _nameEnv val =
       -- type-safe field accesses.
       return (J.ClassType (J.mkClassName "java/lang/Object"))
     MS.SetupGlobal empty _            -> absurd empty
-    MS.SetupStruct empty _ _          -> absurd empty
+    MS.SetupStruct empty _            -> absurd empty
     MS.SetupArray empty _             -> absurd empty
     MS.SetupElem empty _ _            -> absurd empty
     MS.SetupField empty _ _           -> absurd empty
-    MS.SetupCast empty _ _            -> absurd empty
+    MS.SetupCast empty _              -> absurd empty
     MS.SetupUnion empty _ _           -> absurd empty
     MS.SetupGlobalInitializer empty _ -> absurd empty
 
@@ -170,11 +170,11 @@ resolveSetupVal cc env _tyenv _nameEnv val =
     MS.SetupNull () ->
       return (RVal (W4.maybePartExpr sym Nothing))
     MS.SetupGlobal empty _            -> absurd empty
-    MS.SetupStruct empty _ _          -> absurd empty
+    MS.SetupStruct empty _            -> absurd empty
     MS.SetupArray empty _             -> absurd empty
     MS.SetupElem empty _ _            -> absurd empty
     MS.SetupField empty _ _           -> absurd empty
-    MS.SetupCast empty _ _            -> absurd empty
+    MS.SetupCast empty _              -> absurd empty
     MS.SetupUnion empty _ _           -> absurd empty
     MS.SetupGlobalInitializer empty _ -> absurd empty
   where

--- a/src/SAWScript/Crucible/JVM/ResolveSetupValue.hs
+++ b/src/SAWScript/Crucible/JVM/ResolveSetupValue.hs
@@ -68,6 +68,7 @@ import SAWScript.Crucible.Common.MethodSpec (AllocIndex(..))
 
 import SAWScript.Panic
 import SAWScript.Crucible.JVM.MethodSpecIR
+import SAWScript.Crucible.JVM.Setup.Value (JVMRefVal)
 import qualified SAWScript.Crucible.Common.MethodSpec as MS
 import SAWScript.Crucible.Common.ResolveSetupValue (resolveBoolTerm)
 
@@ -81,8 +82,6 @@ instance Show JVMVal where
   show (RVal _) = "RVal"
   show (IVal _) = "IVal"
   show (LVal _) = "LVal"
-
-type JVMRefVal = Crucible.RegValue Sym CJ.JVMRefType
 
 type SetupValue = MS.SetupValue CJ.JVM
 

--- a/src/SAWScript/Crucible/JVM/Setup/Value.hs
+++ b/src/SAWScript/Crucible/JVM/Setup/Value.hs
@@ -28,6 +28,7 @@ module, plus additional functionality) instead.
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module SAWScript.Crucible.JVM.Setup.Value
@@ -47,6 +48,8 @@ module SAWScript.Crucible.JVM.Setup.Value
   , jccJVMContext
   , jccBackend
   , jccHandleAllocator
+
+  , JVMRefVal
   ) where
 
 import           Control.Lens
@@ -55,6 +58,7 @@ import qualified Prettyprinter as PPL
 import qualified Lang.Crucible.FunctionHandle as Crucible (HandleAllocator)
 
 -- crucible-jvm
+import qualified Lang.Crucible.Simulator as CS
 import qualified Lang.Crucible.JVM as CJ
 import qualified Lang.JVM.Codebase as CB
 
@@ -65,7 +69,7 @@ import qualified Language.JVM.Parser as J
 import           Verifier.SAW.TypedTerm (TypedTerm)
 
 import           SAWScript.Crucible.Common
-import qualified SAWScript.Crucible.Common.MethodSpec as MS
+import qualified SAWScript.Crucible.Common.Setup.Value as MS
 
 --------------------------------------------------------------------------------
 -- ** Language features
@@ -148,3 +152,10 @@ data JVMCrucibleContext =
 makeLenses ''JVMCrucibleContext
 
 type instance MS.CrucibleContext CJ.JVM = JVMCrucibleContext
+
+--------------------------------------------------------------------------------
+-- *** Pointers
+
+type instance MS.Pointer' CJ.JVM Sym = JVMRefVal
+
+type JVMRefVal = CS.RegValue Sym CJ.JVMRefType

--- a/src/SAWScript/Crucible/JVM/Setup/Value.hs
+++ b/src/SAWScript/Crucible/JVM/Setup/Value.hs
@@ -53,6 +53,7 @@ module SAWScript.Crucible.JVM.Setup.Value
   ) where
 
 import           Control.Lens
+import           Data.Void (Void)
 import qualified Prettyprinter as PPL
 
 import qualified Lang.Crucible.FunctionHandle as Crucible (HandleAllocator)
@@ -74,24 +75,23 @@ import qualified SAWScript.Crucible.Common.Setup.Value as MS
 --------------------------------------------------------------------------------
 -- ** Language features
 
-type instance MS.HasSetupNull CJ.JVM = 'True
-type instance MS.HasSetupGlobal CJ.JVM = 'False
-type instance MS.HasSetupStruct CJ.JVM = 'False
-type instance MS.HasSetupArray CJ.JVM = 'False
-type instance MS.HasSetupElem CJ.JVM = 'False
-type instance MS.HasSetupField CJ.JVM = 'False
-type instance MS.HasSetupCast CJ.JVM = 'False
-type instance MS.HasSetupUnion CJ.JVM = 'False
-type instance MS.HasSetupGlobalInitializer CJ.JVM = 'False
+type instance MS.XSetupNull CJ.JVM = ()
+type instance MS.XSetupGlobal CJ.JVM = Void
+type instance MS.XSetupStruct CJ.JVM = Void
+type instance MS.XSetupArray CJ.JVM = Void
+type instance MS.XSetupElem CJ.JVM = Void
+type instance MS.XSetupField CJ.JVM = Void
+type instance MS.XSetupCast CJ.JVM = Void
+type instance MS.XSetupUnion CJ.JVM = Void
+type instance MS.XSetupGlobalInitializer CJ.JVM = Void
 
-type instance MS.HasGhostState CJ.JVM = 'False
+type instance MS.XGhostState CJ.JVM = Void
 
 type JIdent = String -- FIXME(huffman): what to put here?
 
 type instance MS.TypeName CJ.JVM = JIdent
 
 type instance MS.ExtType CJ.JVM = J.Type
-type instance MS.CastType CJ.JVM = ()
 type instance MS.ResolvedState CJ.JVM = ()
 
 --------------------------------------------------------------------------------

--- a/src/SAWScript/Crucible/JVM/Setup/Value.hs
+++ b/src/SAWScript/Crucible/JVM/Setup/Value.hs
@@ -1,0 +1,150 @@
+{- |
+Module      : SAWScript.Crucible.JVM.Setup.Value
+Description : Data types and type family instances for JVM-specific code
+License     : BSD3
+Maintainer  : Ryan Scott <rscott@galois.com>
+Stability   : provisional
+
+The module exists separately from "SAWScript.Crucible.JVM.MethodSpecIR"
+primarily to avoid import cycles. You probably want to import
+"SAWScript.Crucible.JVM.MethodSpecIR" (which re-exports everything from this
+module, plus additional functionality) instead.
+-}
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module SAWScript.Crucible.JVM.Setup.Value
+  ( JIdent
+
+  , JVMMethodId(..)
+  , jvmMethodKey
+  , jvmClassName
+
+  , Allocation(..)
+
+  , JVMPointsTo(..)
+
+  , JVMCrucibleContext(..)
+  , jccJVMClass
+  , jccCodebase
+  , jccJVMContext
+  , jccBackend
+  , jccHandleAllocator
+  ) where
+
+import           Control.Lens
+import qualified Prettyprinter as PPL
+
+import qualified Lang.Crucible.FunctionHandle as Crucible (HandleAllocator)
+
+-- crucible-jvm
+import qualified Lang.Crucible.JVM as CJ
+import qualified Lang.JVM.Codebase as CB
+
+-- jvm-parser
+import qualified Language.JVM.Parser as J
+
+-- cryptol-saw-core
+import           Verifier.SAW.TypedTerm (TypedTerm)
+
+import           SAWScript.Crucible.Common
+import qualified SAWScript.Crucible.Common.MethodSpec as MS
+
+--------------------------------------------------------------------------------
+-- ** Language features
+
+type instance MS.HasSetupNull CJ.JVM = 'True
+type instance MS.HasSetupGlobal CJ.JVM = 'False
+type instance MS.HasSetupStruct CJ.JVM = 'False
+type instance MS.HasSetupArray CJ.JVM = 'False
+type instance MS.HasSetupElem CJ.JVM = 'False
+type instance MS.HasSetupField CJ.JVM = 'False
+type instance MS.HasSetupCast CJ.JVM = 'False
+type instance MS.HasSetupUnion CJ.JVM = 'False
+type instance MS.HasSetupGlobalInitializer CJ.JVM = 'False
+
+type instance MS.HasGhostState CJ.JVM = 'False
+
+type JIdent = String -- FIXME(huffman): what to put here?
+
+type instance MS.TypeName CJ.JVM = JIdent
+
+type instance MS.ExtType CJ.JVM = J.Type
+type instance MS.CastType CJ.JVM = ()
+type instance MS.ResolvedState CJ.JVM = ()
+
+--------------------------------------------------------------------------------
+-- *** JVMMethodId
+
+data JVMMethodId =
+  JVMMethodId
+    { _jvmMethodKey :: J.MethodKey
+    , _jvmClassName  :: J.ClassName
+    }
+  deriving (Eq, Ord, Show)
+
+makeLenses ''JVMMethodId
+
+-- TODO: avoid intermediate 'String' values
+instance PPL.Pretty JVMMethodId where
+  pretty (JVMMethodId methKey className) =
+    PPL.pretty (concat [J.unClassName className ,".", J.methodKeyName methKey])
+
+type instance MS.MethodId CJ.JVM = JVMMethodId
+
+--------------------------------------------------------------------------------
+-- *** Allocation
+
+data Allocation
+  = AllocObject J.ClassName
+  | AllocArray Int J.Type
+  deriving (Eq, Ord, Show)
+
+-- TODO: We should probably use a more structured datatype (record), like in LLVM
+type instance MS.AllocSpec CJ.JVM = (MS.ConditionMetadata, Allocation)
+
+--------------------------------------------------------------------------------
+-- *** PointsTo
+
+type instance MS.PointsTo CJ.JVM = JVMPointsTo
+
+data JVMPointsTo
+  = JVMPointsToField MS.ConditionMetadata MS.AllocIndex J.FieldId (Maybe (MS.SetupValue CJ.JVM))
+  | JVMPointsToStatic MS.ConditionMetadata J.FieldId (Maybe (MS.SetupValue CJ.JVM))
+  | JVMPointsToElem MS.ConditionMetadata MS.AllocIndex Int (Maybe (MS.SetupValue CJ.JVM))
+  | JVMPointsToArray MS.ConditionMetadata MS.AllocIndex (Maybe TypedTerm)
+
+--------------------------------------------------------------------------------
+-- *** JVMCrucibleContext
+
+type instance MS.Codebase CJ.JVM = CB.Codebase
+
+data JVMCrucibleContext =
+  JVMCrucibleContext
+  { _jccJVMClass       :: J.Class
+  , _jccCodebase       :: CB.Codebase
+  , _jccJVMContext     :: CJ.JVMContext
+  , _jccBackend        :: SomeOnlineBackend
+  , _jccHandleAllocator :: Crucible.HandleAllocator
+  }
+
+makeLenses ''JVMCrucibleContext
+
+type instance MS.CrucibleContext CJ.JVM = JVMCrucibleContext

--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -2215,7 +2215,7 @@ constructExpandedSetupValue cc sc loc t =
          traverse (constructExpandedSetupValue cc sc loc)
                   (Crucible.siFieldTypes si)
       -- FIXME: should this always be unpacked?
-      pure $ mkAllLLVM $ SetupStruct () False $ map (\a -> getAllLLVM a) fields
+      pure $ mkAllLLVM $ SetupStruct False $ map (\a -> getAllLLVM a) fields
 
     Crucible.PtrType symTy ->
       case Crucible.asMemType symTy of
@@ -2503,7 +2503,7 @@ llvm_fresh_pointer lty =
      constructFreshPointer (llvmTypeAlias lty) loc memTy
 
 llvm_cast_pointer :: AllLLVM SetupValue -> L.Type -> AllLLVM SetupValue
-llvm_cast_pointer ptr lty = mkAllLLVM (SetupCast () (getAllLLVM ptr) lty)
+llvm_cast_pointer ptr lty = mkAllLLVM (SetupCast lty (getAllLLVM ptr))
 
 constructFreshPointer ::
   Crucible.HasPtrWidth (Crucible.ArchWidth arch) =>

--- a/src/SAWScript/Crucible/LLVM/MethodSpecIR.hs
+++ b/src/SAWScript/Crucible/LLVM/MethodSpecIR.hs
@@ -121,16 +121,10 @@ module SAWScript.Crucible.LLVM.MethodSpecIR
 import           Control.Lens
 import           Control.Monad (when)
 import           Data.Functor.Compose (Compose(..))
-import           Data.Map ( Map )
 import qualified Data.Map as Map
-import qualified Data.Text as Text
-import           Data.Type.Equality (TestEquality(..))
 import qualified Prettyprinter as PPL
 import qualified Text.LLVM.AST as L
 import qualified Text.LLVM.PP as L
-import qualified Text.PrettyPrint.HughesPJ as PP
-
-import qualified Data.LLVM.BitCode as LLVM
 
 import qualified Cryptol.TypeCheck.AST as Cryptol
 import qualified Cryptol.Utils.PP as Cryptol (pp)
@@ -141,9 +135,6 @@ import qualified Data.Parameterized.Map as MapF
 
 import           What4.ProgramLoc (ProgramLoc)
 
-import qualified Lang.Crucible.FunctionHandle as Crucible (HandleAllocator)
-import qualified Lang.Crucible.Simulator.ExecutionTree as Crucible (SimContext)
-import qualified Lang.Crucible.Simulator.GlobalState as Crucible (SymGlobalState)
 import qualified Lang.Crucible.Types as Crucible (SymbolRepr, knownSymbol)
 import qualified Lang.Crucible.Simulator.Intrinsics as Crucible
   (IntrinsicClass(Intrinsic, muxIntrinsic), IntrinsicMuxFn(IntrinsicMuxFn))
@@ -153,47 +144,16 @@ import qualified SAWScript.Crucible.Common.MethodSpec as MS
 import qualified SAWScript.Crucible.Common.Setup.Type as Setup
 
 import qualified SAWScript.Crucible.LLVM.CrucibleLLVM as CL
-
-import           SAWScript.Proof (TheoremNonce)
+import           SAWScript.Crucible.LLVM.Setup.Value
 
 import           Verifier.SAW.Simulator.What4.ReturnTrip ( toSC, saw_ctx )
 
-import           Verifier.SAW.Rewriter (Simpset)
 import           Verifier.SAW.SharedTerm
 import           Verifier.SAW.TypedTerm
 
 
 --------------------------------------------------------------------------------
--- ** Language features
-
-data LLVM (arch :: CL.LLVMArch)
-
-type instance MS.HasSetupNull (LLVM _) = 'True
-type instance MS.HasSetupStruct (LLVM _) = 'True
-type instance MS.HasSetupArray (LLVM _) = 'True
-type instance MS.HasSetupElem (LLVM _) = 'True
-type instance MS.HasSetupField (LLVM _) = 'True
-type instance MS.HasSetupCast (LLVM _) = 'True
-type instance MS.HasSetupUnion (LLVM _) = 'True
-type instance MS.HasSetupGlobal (LLVM _) = 'True
-type instance MS.HasSetupGlobalInitializer (LLVM _) = 'True
-
-type instance MS.HasGhostState (LLVM _) = 'True
-
-type instance MS.TypeName (LLVM arch) = CL.Ident
-type instance MS.ExtType (LLVM arch) = CL.MemType
-type instance MS.CastType (LLVM arch) = L.Type
-
---------------------------------------------------------------------------------
 -- *** LLVMMethodId
-
-data LLVMMethodId =
-  LLVMMethodId
-    { _llvmMethodName   :: String
-    , _llvmMethodParent :: Maybe String -- ^ Something to do with breakpoints...
-    } deriving (Eq, Ord, Show)
-
-makeLenses ''LLVMMethodId
 
 csName :: Lens' (MS.CrucibleMethodSpecIR (LLVM arch)) String
 csName = MS.csMethod . llvmMethodName
@@ -201,37 +161,8 @@ csName = MS.csMethod . llvmMethodName
 csParentName :: Lens' (MS.CrucibleMethodSpecIR (LLVM arch)) (Maybe String)
 csParentName = MS.csMethod . llvmMethodParent
 
-instance PPL.Pretty LLVMMethodId where
-  pretty = PPL.pretty . view llvmMethodName
-
-type instance MS.MethodId (LLVM _) = LLVMMethodId
-
 --------------------------------------------------------------------------------
 -- *** LLVMAllocSpec
-
--- | Allocation initialization policy
-data LLVMAllocSpecInit
-  = LLVMAllocSpecSymbolicInitialization
-    -- ^ allocation is initialized with a fresh symbolic array of bytes
-  | LLVMAllocSpecNoInitialization
-    -- ^ allocation not initialized
-  deriving (Eq, Ord, Show)
-
-data LLVMAllocSpec =
-  LLVMAllocSpec
-    { _allocSpecMut   :: CL.Mutability
-    , _allocSpecType  :: CL.MemType
-    , _allocSpecAlign :: CL.Alignment
-    , _allocSpecBytes :: Term
-    , _allocSpecMd    :: MS.ConditionMetadata
-    , _allocSpecFresh :: Bool -- ^ Whether declared with @crucible_fresh_pointer@
-    , _allocSpecInit :: LLVMAllocSpecInit
-    }
-  deriving (Eq, Show)
-
-makeLenses ''LLVMAllocSpec
-
-type instance MS.AllocSpec (LLVM _) = LLVMAllocSpec
 
 mutIso :: Iso' CL.Mutability Bool
 mutIso =
@@ -245,86 +176,6 @@ mutIso =
 
 isMut :: Lens' LLVMAllocSpec Bool
 isMut = allocSpecMut . mutIso
-
---------------------------------------------------------------------------------
--- *** LLVMModule
-
--- | An 'LLVMModule' contains an LLVM module that has been parsed from
--- a bitcode file and translated to Crucible.
-data LLVMModule arch =
-  LLVMModule
-  { _modFilePath :: FilePath
-  , _modAST :: L.Module
-  , _modTrans :: CL.ModuleTranslation arch
-  }
--- NOTE: Type 'LLVMModule' is exported as an abstract type, and we
--- maintain the invariant that the 'FilePath', 'Module', and
--- 'ModuleTranslation' fields are all consistent with each other;
--- 'loadLLVMModule' is the only function that is allowed to create
--- values of type 'LLVMModule'.
-
--- | The file path that the LLVM module was loaded from.
-modFilePath :: LLVMModule arch -> FilePath
-modFilePath = _modFilePath
-
--- | The parsed AST of the LLVM module.
-modAST :: LLVMModule arch -> L.Module
-modAST = _modAST
-
--- | The Crucible translation of an LLVM module.
-modTrans :: LLVMModule arch -> CL.ModuleTranslation arch
-modTrans = _modTrans
-
--- | Load an LLVM module from the given bitcode file, then parse and
--- translate to Crucible.
-loadLLVMModule ::
-  (?transOpts :: CL.TranslationOptions) =>
-  FilePath ->
-  Crucible.HandleAllocator ->
-  IO (Either LLVM.Error (Some LLVMModule))
-loadLLVMModule file halloc =
-  do parseResult <- LLVM.parseBitCodeFromFile file
-     case parseResult of
-       Left err -> return (Left err)
-       Right llvm_mod ->
-         do memVar <- CL.mkMemVar (Text.pack "saw:llvm_memory") halloc
-            Some mtrans <- CL.translateModule halloc memVar llvm_mod
-            return (Right (Some (LLVMModule file llvm_mod mtrans)))
-
-instance TestEquality LLVMModule where
-  -- As 'LLVMModule' is an abstract type, we know that the values must
-  -- have been created by a call to 'loadLLVMModule'. Furthermore each
-  -- call to 'translateModule' generates a 'ModuleTranslation' that
-  -- contains a fresh nonce; thus comparison of the 'modTrans' fields
-  -- is sufficient to guarantee equality of two 'LLVMModule' values.
-  testEquality m1 m2 = testEquality (modTrans m1) (modTrans m2)
-
-type instance MS.Codebase (LLVM arch) = LLVMModule arch
-
-showLLVMModule :: LLVMModule arch -> String
-showLLVMModule (LLVMModule name m _) =
-  unlines [ "Module: " ++ name
-          , "Types:"
-          , showParts L.ppTypeDecl (L.modTypes m)
-          , "Globals:"
-          , showParts ppGlobal' (L.modGlobals m)
-          , "External references:"
-          , showParts L.ppDeclare (L.modDeclares m)
-          , "Definitions:"
-          , showParts ppDefine' (L.modDefines m)
-          ]
-  where
-    showParts pp xs = unlines $ map (show . PP.nest 2 . pp) xs
-    ppGlobal' g =
-      L.ppSymbol (L.globalSym g) PP.<+> PP.char '=' PP.<+>
-      L.ppGlobalAttrs (L.globalAttrs g) PP.<+>
-      L.ppType (L.globalType g)
-    ppDefine' d =
-      L.ppMaybe L.ppLinkage (L.defLinkage d) PP.<+>
-      L.ppType (L.defRetType d) PP.<+>
-      L.ppSymbol (L.defName d) PP.<>
-      L.ppArgList (L.defVarArgs d) (map (L.ppTyped L.ppIdent) (L.defArgs d)) PP.<+>
-      L.ppMaybe (\gc -> PP.text "gc" PP.<+> L.ppGC gc) (L.defGC d)
 
 --------------------------------------------------------------------------------
 -- ** Ghost state
@@ -346,19 +197,6 @@ instance Crucible.IntrinsicClass Sym MS.GhostValue where
 
 --------------------------------------------------------------------------------
 -- ** CrucibleContext
-
-type instance MS.CrucibleContext (LLVM arch) = LLVMCrucibleContext arch
-
-data LLVMCrucibleContext arch =
-  LLVMCrucibleContext
-  { _ccLLVMModule      :: LLVMModule arch
-  , _ccBackend         :: SomeOnlineBackend
-  , _ccLLVMSimContext  :: Crucible.SimContext (SAWCruciblePersonality Sym) Sym CL.LLVM
-  , _ccLLVMGlobals     :: Crucible.SymGlobalState Sym
-  , _ccBasicSS         :: Simpset TheoremNonce
-  }
-
-makeLenses ''LLVMCrucibleContext
 
 ccLLVMModuleAST :: LLVMCrucibleContext arch -> L.Module
 ccLLVMModuleAST = modAST . _ccLLVMModule
@@ -385,19 +223,6 @@ ccSym = to (\cc -> ccWithBackend cc backendGetSym)
 --------------------------------------------------------------------------------
 -- ** PointsTo
 
-type instance MS.PointsTo (LLVM arch) = LLVMPointsTo arch
-
-data LLVMPointsTo arch
-  = LLVMPointsTo MS.ConditionMetadata (Maybe TypedTerm) (MS.SetupValue (LLVM arch)) (LLVMPointsToValue arch)
-    -- | A variant of 'LLVMPointsTo' tailored to the @llvm_points_to_bitfield@
-    -- command, which doesn't quite fit into the 'LLVMPointsToValue' paradigm.
-    -- The 'String' represents the name of the field within the bitfield.
-  | LLVMPointsToBitfield MS.ConditionMetadata (MS.SetupValue (LLVM arch)) String (MS.SetupValue (LLVM arch))
-
-data LLVMPointsToValue arch
-  = ConcreteSizeValue (MS.SetupValue (LLVM arch))
-  | SymbolicSizeValue TypedTerm TypedTerm
-
 -- | Return the 'ProgramLoc' corresponding to an 'LLVMPointsTo' statement.
 llvmPointsToProgramLoc :: LLVMPointsTo arch -> ProgramLoc
 llvmPointsToProgramLoc (LLVMPointsTo md _ _ _) = MS.conditionLoc md
@@ -422,21 +247,6 @@ instance PPL.Pretty (LLVMPointsToValue arch) where
     ConcreteSizeValue val -> MS.ppSetupValue val
     SymbolicSizeValue arr sz ->
       MS.ppTypedTerm arr PPL.<+> PPL.pretty "[" PPL.<+> MS.ppTypedTerm sz PPL.<+> PPL.pretty "]"
-
---------------------------------------------------------------------------------
--- ** AllocGlobal
-
-type instance MS.AllocGlobal (LLVM arch) = LLVMAllocGlobal arch
-
-data LLVMAllocGlobal arch = LLVMAllocGlobal ProgramLoc L.Symbol
-
-ppAllocGlobal :: LLVMAllocGlobal arch -> PPL.Doc ann
-ppAllocGlobal (LLVMAllocGlobal _loc (L.Symbol name)) =
-  PPL.pretty "allocate global"
-  PPL.<+> PPL.pretty name
-
-instance PPL.Pretty (LLVMAllocGlobal arch) where
-  pretty = ppAllocGlobal
 
 --------------------------------------------------------------------------------
 -- ** ???
@@ -621,43 +431,6 @@ getSomeLLVM x = All (Compose x)
 
 --------------------------------------------------------------------------------
 -- *** ResolvedState
-
-type instance MS.ResolvedState (LLVM arch) = LLVMResolvedState
-
-data ResolvedPathItem
-  = ResolvedField String
-  | ResolvedElem Int
-  | ResolvedCast L.Type
- deriving (Show, Eq, Ord)
-
-type ResolvedPath = [ResolvedPathItem]
-
--- | A datatype to keep track of which parts of the simulator state
--- have been initialized already. For each allocation unit or global,
--- we keep a list of element-paths that identify the initialized
--- sub-components.
---
--- Note that the data collected and maintained by this datatype
--- represents a \"best-effort\" check that attempts to prevent
--- the user from stating unsatisfiable method specifications.
---
--- It will not prevent all cases of overlapping points-to
--- specifications, especially in the presence of pointer casts.
--- A typical result of overlapping specifications will be
--- successful (vacuous) verifications of functions resulting in
--- overrides that cannot be used at call sites (as their
--- preconditions are unsatisfiable).
-data LLVMResolvedState =
-  ResolvedState
-    { _rsAllocs :: Map MS.AllocIndex [ResolvedPath]
-    , _rsGlobals :: Map String [ResolvedPath]
-    }
-  deriving (Eq, Ord, Show)
-
-emptyResolvedState :: LLVMResolvedState
-emptyResolvedState = ResolvedState Map.empty Map.empty
-
-makeLenses ''LLVMResolvedState
 
 -- | Record the initialization of the pointer represented by the given
 -- SetupValue.

--- a/src/SAWScript/Crucible/LLVM/MethodSpecIR.hs
+++ b/src/SAWScript/Crucible/LLVM/MethodSpecIR.hs
@@ -382,13 +382,13 @@ anySetupArray :: [AllLLVM MS.SetupValue] -> AllLLVM MS.SetupValue
 anySetupArray vals = mkAllLLVM (MS.SetupArray () $ map (\a -> getAllLLVM a) vals)
 
 anySetupStruct :: Bool -> [AllLLVM MS.SetupValue] -> AllLLVM MS.SetupValue
-anySetupStruct b vals = mkAllLLVM (MS.SetupStruct () b $ map (\a -> getAllLLVM a) vals)
+anySetupStruct b vals = mkAllLLVM (MS.SetupStruct b $ map (\a -> getAllLLVM a) vals)
 
 anySetupElem :: AllLLVM MS.SetupValue -> Int -> AllLLVM MS.SetupValue
 anySetupElem val idx = mkAllLLVM (MS.SetupElem () (getAllLLVM val) idx)
 
 anySetupCast :: AllLLVM MS.SetupValue -> L.Type -> AllLLVM MS.SetupValue
-anySetupCast val ty = mkAllLLVM (MS.SetupCast () (getAllLLVM val) ty)
+anySetupCast val ty = mkAllLLVM (MS.SetupCast ty (getAllLLVM val))
 
 anySetupField :: AllLLVM MS.SetupValue -> String -> AllLLVM MS.SetupValue
 anySetupField val field = mkAllLLVM (MS.SetupField () (getAllLLVM val) field)
@@ -447,7 +447,7 @@ markResolved val0 path0 rs = go path0 val0
         MS.SetupGlobal _ name -> rs & rsGlobals %~ Map.alter (ins path) name
         MS.SetupElem _ v idx  -> go (ResolvedElem idx : path) v
         MS.SetupField _ v fld -> go (ResolvedField fld : path) v
-        MS.SetupCast _ v tp   -> go (ResolvedCast tp : path) v
+        MS.SetupCast tp v     -> go (ResolvedCast tp : path) v
         _                     -> rs
 
     ins path Nothing = Just [path]
@@ -468,7 +468,7 @@ testResolved val0 path0 rs = go path0 val0
         MS.SetupGlobal _ c    -> test path (Map.lookup c (_rsGlobals rs))
         MS.SetupElem _ v idx  -> go (ResolvedElem idx : path) v
         MS.SetupField _ v fld -> go (ResolvedField fld : path) v
-        MS.SetupCast _ v tp   -> go (ResolvedCast tp : path) v
+        MS.SetupCast tp v     -> go (ResolvedCast tp : path) v
         _                     -> False
 
     test _ Nothing = False

--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -134,13 +134,12 @@ import           SAWScript.Crucible.Common.Override hiding (getSymInterface)
 import qualified SAWScript.Crucible.Common.Override as Ov (getSymInterface)
 import           SAWScript.Crucible.LLVM.MethodSpecIR
 import           SAWScript.Crucible.LLVM.ResolveSetupValue
+import           SAWScript.Crucible.LLVM.Setup.Value ()
 import           SAWScript.Options
 import           SAWScript.Panic
 import           SAWScript.Utils (bullets, handleException)
 
 type LabeledPred sym = W4.LabeledPred (W4.Pred sym) Crucible.SimError
-
-type instance Pointer' (LLVM arch) Sym = LLVMPtr (Crucible.ArchWidth arch)
 
 -- | An override packaged together with its preconditions, labeled with some
 --   human-readable info about each condition.

--- a/src/SAWScript/Crucible/LLVM/Override.hs
+++ b/src/SAWScript/Crucible/LLVM/Override.hs
@@ -1116,11 +1116,11 @@ matchPointsTos opts sc cc spec prepost = go False []
     setupVars v =
       case v of
         SetupVar i                 -> Set.singleton i
-        SetupStruct _ _ xs         -> foldMap setupVars xs
+        SetupStruct _ xs           -> foldMap setupVars xs
         SetupArray _ xs            -> foldMap setupVars xs
         SetupElem _ x _            -> setupVars x
         SetupField _ x _           -> setupVars x
-        SetupCast _ x _            -> setupVars x
+        SetupCast _ x              -> setupVars x
         SetupUnion _ x _           -> setupVars x
         SetupTerm _                -> Set.empty
         SetupNull _                -> Set.empty
@@ -1291,7 +1291,7 @@ matchArg opts sc cc cs prepost md actual expectedTy expected =
           | (x, z) <- zip (V.toList xs) zs ]
 
     -- match the fields of struct point-wise
-    (Crucible.LLVMValStruct xs, Crucible.StructType fields, SetupStruct () _ zs) ->
+    (Crucible.LLVMValStruct xs, Crucible.StructType fields, SetupStruct _ zs) ->
       sequence_
         [ matchArg opts sc cc cs prepost md x y z
         | ((_,x),y,z) <- zip3 (V.toList xs)
@@ -2470,9 +2470,9 @@ instantiateSetupValue ::
 instantiateSetupValue sc s v =
   case v of
     SetupVar{}               -> return v
-    SetupTerm tt             -> SetupTerm        <$> doTerm tt
-    SetupStruct () p vs      -> SetupStruct () p <$> mapM (instantiateSetupValue sc s) vs
-    SetupArray () vs         -> SetupArray ()    <$> mapM (instantiateSetupValue sc s) vs
+    SetupTerm tt             -> SetupTerm     <$> doTerm tt
+    SetupStruct p vs         -> SetupStruct p <$> mapM (instantiateSetupValue sc s) vs
+    SetupArray () vs         -> SetupArray () <$> mapM (instantiateSetupValue sc s) vs
     SetupElem{}              -> return v
     SetupField{}             -> return v
     SetupCast{}              -> return v

--- a/src/SAWScript/Crucible/LLVM/ResolveSetupValue.hs
+++ b/src/SAWScript/Crucible/LLVM/ResolveSetupValue.hs
@@ -84,11 +84,11 @@ import           SAWScript.Crucible.Common (Sym, sawCoreState, HasSymInterface(.
 import           SAWScript.Crucible.Common.MethodSpec (AllocIndex(..), SetupValue(..), ppTypedTermType)
 
 import SAWScript.Crucible.LLVM.MethodSpecIR
+import SAWScript.Crucible.LLVM.Setup.Value (LLVMPtr)
 import qualified SAWScript.Proof as SP
 
 
 type LLVMVal = Crucible.LLVMVal Sym
-type LLVMPtr wptr = Crucible.LLVMPtr Sym wptr
 
 
 

--- a/src/SAWScript/Crucible/LLVM/Setup/Value.hs
+++ b/src/SAWScript/Crucible/LLVM/Setup/Value.hs
@@ -1,0 +1,340 @@
+{- |
+Module      : SAWScript.Crucible.LLVM.Setup.Value
+Description : Data types and type family instances for LLVM-specific code
+License     : BSD3
+Maintainer  : Ryan Scott <rscott@galois.com>
+Stability   : provisional
+
+The module exists separately from "SAWScript.Crucible.LLVM.MethodSpecIR"
+primarily to avoid import cycles. You probably want to import
+"SAWScript.Crucible.LLVM.MethodSpecIR" (which re-exports everything from this
+module, plus additional functionality) instead.
+-}
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module SAWScript.Crucible.LLVM.Setup.Value
+  ( LLVM
+    -- * LLVMMethodId
+  , LLVMMethodId(..)
+  , llvmMethodParent
+  , llvmMethodName
+    -- * LLVMAllocSpec
+  , LLVMAllocSpec(..)
+  , LLVMAllocSpecInit(..)
+  , allocSpecType
+  , allocSpecAlign
+  , allocSpecMut
+  , allocSpecMd
+  , allocSpecBytes
+  , allocSpecFresh
+  , allocSpecInit
+    -- * LLVMModule
+  , LLVMModule -- abstract
+  , modFilePath
+  , modAST
+  , modTrans
+  , loadLLVMModule
+  , showLLVMModule
+    -- * CrucibleContext
+  , LLVMCrucibleContext(..)
+  , ccLLVMSimContext
+  , ccLLVMModule
+  , ccLLVMGlobals
+  , ccBasicSS
+  , ccBackend
+    -- * PointsTo
+  , LLVMPointsTo(..)
+  , LLVMPointsToValue(..)
+    -- * AllocGlobal
+  , LLVMAllocGlobal(..)
+  , ppAllocGlobal
+    -- * ResolvedState
+  , LLVMResolvedState(..)
+  , ResolvedPath
+  , ResolvedPathItem(..)
+  , emptyResolvedState
+  , rsAllocs
+  , rsGlobals
+  ) where
+
+import           Control.Lens
+import           Data.Map ( Map )
+import qualified Data.Map as Map
+import qualified Data.Text as Text
+import           Data.Type.Equality (TestEquality(..))
+import qualified Prettyprinter as PPL
+import qualified Text.LLVM.AST as L
+import qualified Text.LLVM.PP as L
+import qualified Text.PrettyPrint.HughesPJ as PP
+
+import qualified Data.LLVM.BitCode as LLVM
+
+import           Data.Parameterized.Some (Some(Some))
+
+import           What4.ProgramLoc (ProgramLoc)
+
+import qualified Lang.Crucible.FunctionHandle as Crucible (HandleAllocator)
+import qualified Lang.Crucible.Simulator.ExecutionTree as Crucible (SimContext)
+import qualified Lang.Crucible.Simulator.GlobalState as Crucible (SymGlobalState)
+
+import           SAWScript.Crucible.Common
+import qualified SAWScript.Crucible.Common.Setup.Value as Setup
+
+import qualified SAWScript.Crucible.LLVM.CrucibleLLVM as CL
+
+import           SAWScript.Proof (TheoremNonce)
+
+import           Verifier.SAW.Rewriter (Simpset)
+import           Verifier.SAW.SharedTerm
+import           Verifier.SAW.TypedTerm
+
+--------------------------------------------------------------------------------
+-- ** Language features
+
+data LLVM (arch :: CL.LLVMArch)
+
+type instance Setup.HasSetupNull (LLVM _) = 'True
+type instance Setup.HasSetupStruct (LLVM _) = 'True
+type instance Setup.HasSetupArray (LLVM _) = 'True
+type instance Setup.HasSetupElem (LLVM _) = 'True
+type instance Setup.HasSetupField (LLVM _) = 'True
+type instance Setup.HasSetupCast (LLVM _) = 'True
+type instance Setup.HasSetupUnion (LLVM _) = 'True
+type instance Setup.HasSetupGlobal (LLVM _) = 'True
+type instance Setup.HasSetupGlobalInitializer (LLVM _) = 'True
+
+type instance Setup.HasGhostState (LLVM _) = 'True
+
+type instance Setup.TypeName (LLVM arch) = CL.Ident
+type instance Setup.ExtType (LLVM arch) = CL.MemType
+type instance Setup.CastType (LLVM arch) = L.Type
+
+--------------------------------------------------------------------------------
+-- *** LLVMMethodId
+
+data LLVMMethodId =
+  LLVMMethodId
+    { _llvmMethodName   :: String
+    , _llvmMethodParent :: Maybe String -- ^ Something to do with breakpoints...
+    } deriving (Eq, Ord, Show)
+
+makeLenses ''LLVMMethodId
+
+instance PPL.Pretty LLVMMethodId where
+  pretty = PPL.pretty . view llvmMethodName
+
+type instance Setup.MethodId (LLVM _) = LLVMMethodId
+
+--------------------------------------------------------------------------------
+-- *** LLVMAllocSpec
+
+-- | Allocation initialization policy
+data LLVMAllocSpecInit
+  = LLVMAllocSpecSymbolicInitialization
+    -- ^ allocation is initialized with a fresh symbolic array of bytes
+  | LLVMAllocSpecNoInitialization
+    -- ^ allocation not initialized
+  deriving (Eq, Ord, Show)
+
+data LLVMAllocSpec =
+  LLVMAllocSpec
+    { _allocSpecMut   :: CL.Mutability
+    , _allocSpecType  :: CL.MemType
+    , _allocSpecAlign :: CL.Alignment
+    , _allocSpecBytes :: Term
+    , _allocSpecMd    :: Setup.ConditionMetadata
+    , _allocSpecFresh :: Bool -- ^ Whether declared with @crucible_fresh_pointer@
+    , _allocSpecInit :: LLVMAllocSpecInit
+    }
+  deriving (Eq, Show)
+
+makeLenses ''LLVMAllocSpec
+
+type instance Setup.AllocSpec (LLVM _) = LLVMAllocSpec
+
+--------------------------------------------------------------------------------
+-- *** LLVMModule
+
+-- | An 'LLVMModule' contains an LLVM module that has been parsed from
+-- a bitcode file and translated to Crucible.
+data LLVMModule arch =
+  LLVMModule
+  { _modFilePath :: FilePath
+  , _modAST :: L.Module
+  , _modTrans :: CL.ModuleTranslation arch
+  }
+-- NOTE: Type 'LLVMModule' is exported as an abstract type, and we
+-- maintain the invariant that the 'FilePath', 'Module', and
+-- 'ModuleTranslation' fields are all consistent with each other;
+-- 'loadLLVMModule' is the only function that is allowed to create
+-- values of type 'LLVMModule'.
+
+-- | The file path that the LLVM module was loaded from.
+modFilePath :: LLVMModule arch -> FilePath
+modFilePath = _modFilePath
+
+-- | The parsed AST of the LLVM module.
+modAST :: LLVMModule arch -> L.Module
+modAST = _modAST
+
+-- | The Crucible translation of an LLVM module.
+modTrans :: LLVMModule arch -> CL.ModuleTranslation arch
+modTrans = _modTrans
+
+-- | Load an LLVM module from the given bitcode file, then parse and
+-- translate to Crucible.
+loadLLVMModule ::
+  (?transOpts :: CL.TranslationOptions) =>
+  FilePath ->
+  Crucible.HandleAllocator ->
+  IO (Either LLVM.Error (Some LLVMModule))
+loadLLVMModule file halloc =
+  do parseResult <- LLVM.parseBitCodeFromFile file
+     case parseResult of
+       Left err -> return (Left err)
+       Right llvm_mod ->
+         do memVar <- CL.mkMemVar (Text.pack "saw:llvm_memory") halloc
+            Some mtrans <- CL.translateModule halloc memVar llvm_mod
+            return (Right (Some (LLVMModule file llvm_mod mtrans)))
+
+instance TestEquality LLVMModule where
+  -- As 'LLVMModule' is an abstract type, we know that the values must
+  -- have been created by a call to 'loadLLVMModule'. Furthermore each
+  -- call to 'translateModule' generates a 'ModuleTranslation' that
+  -- contains a fresh nonce; thus comparison of the 'modTrans' fields
+  -- is sufficient to guarantee equality of two 'LLVMModule' values.
+  testEquality m1 m2 = testEquality (modTrans m1) (modTrans m2)
+
+type instance Setup.Codebase (LLVM arch) = LLVMModule arch
+
+showLLVMModule :: LLVMModule arch -> String
+showLLVMModule (LLVMModule name m _) =
+  unlines [ "Module: " ++ name
+          , "Types:"
+          , showParts L.ppTypeDecl (L.modTypes m)
+          , "Globals:"
+          , showParts ppGlobal' (L.modGlobals m)
+          , "External references:"
+          , showParts L.ppDeclare (L.modDeclares m)
+          , "Definitions:"
+          , showParts ppDefine' (L.modDefines m)
+          ]
+  where
+    showParts pp xs = unlines $ map (show . PP.nest 2 . pp) xs
+    ppGlobal' g =
+      L.ppSymbol (L.globalSym g) PP.<+> PP.char '=' PP.<+>
+      L.ppGlobalAttrs (L.globalAttrs g) PP.<+>
+      L.ppType (L.globalType g)
+    ppDefine' d =
+      L.ppMaybe L.ppLinkage (L.defLinkage d) PP.<+>
+      L.ppType (L.defRetType d) PP.<+>
+      L.ppSymbol (L.defName d) PP.<>
+      L.ppArgList (L.defVarArgs d) (map (L.ppTyped L.ppIdent) (L.defArgs d)) PP.<+>
+      L.ppMaybe (\gc -> PP.text "gc" PP.<+> L.ppGC gc) (L.defGC d)
+
+--------------------------------------------------------------------------------
+-- ** CrucibleContext
+
+type instance Setup.CrucibleContext (LLVM arch) = LLVMCrucibleContext arch
+
+data LLVMCrucibleContext arch =
+  LLVMCrucibleContext
+  { _ccLLVMModule      :: LLVMModule arch
+  , _ccBackend         :: SomeOnlineBackend
+  , _ccLLVMSimContext  :: Crucible.SimContext (SAWCruciblePersonality Sym) Sym CL.LLVM
+  , _ccLLVMGlobals     :: Crucible.SymGlobalState Sym
+  , _ccBasicSS         :: Simpset TheoremNonce
+  }
+
+makeLenses ''LLVMCrucibleContext
+
+--------------------------------------------------------------------------------
+-- ** PointsTo
+
+type instance Setup.PointsTo (LLVM arch) = LLVMPointsTo arch
+
+data LLVMPointsTo arch
+  = LLVMPointsTo Setup.ConditionMetadata (Maybe TypedTerm) (Setup.SetupValue (LLVM arch)) (LLVMPointsToValue arch)
+    -- | A variant of 'LLVMPointsTo' tailored to the @llvm_points_to_bitfield@
+    -- command, which doesn't quite fit into the 'LLVMPointsToValue' paradigm.
+    -- The 'String' represents the name of the field within the bitfield.
+  | LLVMPointsToBitfield Setup.ConditionMetadata (Setup.SetupValue (LLVM arch)) String (Setup.SetupValue (LLVM arch))
+
+data LLVMPointsToValue arch
+  = ConcreteSizeValue (Setup.SetupValue (LLVM arch))
+  | SymbolicSizeValue TypedTerm TypedTerm
+
+--------------------------------------------------------------------------------
+-- ** AllocGlobal
+
+type instance Setup.AllocGlobal (LLVM arch) = LLVMAllocGlobal arch
+
+data LLVMAllocGlobal arch = LLVMAllocGlobal ProgramLoc L.Symbol
+
+ppAllocGlobal :: LLVMAllocGlobal arch -> PPL.Doc ann
+ppAllocGlobal (LLVMAllocGlobal _loc (L.Symbol name)) =
+  PPL.pretty "allocate global"
+  PPL.<+> PPL.pretty name
+
+instance PPL.Pretty (LLVMAllocGlobal arch) where
+  pretty = ppAllocGlobal
+
+--------------------------------------------------------------------------------
+-- *** ResolvedState
+
+type instance Setup.ResolvedState (LLVM arch) = LLVMResolvedState
+
+data ResolvedPathItem
+  = ResolvedField String
+  | ResolvedElem Int
+  | ResolvedCast L.Type
+ deriving (Show, Eq, Ord)
+
+type ResolvedPath = [ResolvedPathItem]
+
+-- | A datatype to keep track of which parts of the simulator state
+-- have been initialized already. For each allocation unit or global,
+-- we keep a list of element-paths that identify the initialized
+-- sub-components.
+--
+-- Note that the data collected and maintained by this datatype
+-- represents a \"best-effort\" check that attempts to prevent
+-- the user from stating unsatisfiable method specifications.
+--
+-- It will not prevent all cases of overlapping points-to
+-- specifications, especially in the presence of pointer casts.
+-- A typical result of overlapping specifications will be
+-- successful (vacuous) verifications of functions resulting in
+-- overrides that cannot be used at call sites (as their
+-- preconditions are unsatisfiable).
+data LLVMResolvedState =
+  ResolvedState
+    { _rsAllocs :: Map Setup.AllocIndex [ResolvedPath]
+    , _rsGlobals :: Map String [ResolvedPath]
+    }
+  deriving (Eq, Ord, Show)
+
+emptyResolvedState :: LLVMResolvedState
+emptyResolvedState = ResolvedState Map.empty Map.empty
+
+makeLenses ''LLVMResolvedState

--- a/src/SAWScript/Crucible/LLVM/Setup/Value.hs
+++ b/src/SAWScript/Crucible/LLVM/Setup/Value.hs
@@ -116,21 +116,21 @@ import           Verifier.SAW.TypedTerm
 
 data LLVM (arch :: CL.LLVMArch)
 
-type instance Setup.HasSetupNull (LLVM _) = 'True
-type instance Setup.HasSetupStruct (LLVM _) = 'True
-type instance Setup.HasSetupArray (LLVM _) = 'True
-type instance Setup.HasSetupElem (LLVM _) = 'True
-type instance Setup.HasSetupField (LLVM _) = 'True
-type instance Setup.HasSetupCast (LLVM _) = 'True
-type instance Setup.HasSetupUnion (LLVM _) = 'True
-type instance Setup.HasSetupGlobal (LLVM _) = 'True
-type instance Setup.HasSetupGlobalInitializer (LLVM _) = 'True
+type instance Setup.XSetupNull (LLVM _) = ()
+-- 'True' if this is an LLVM packed struct, 'False' otherwise.
+type instance Setup.XSetupStruct (LLVM _) = Bool
+type instance Setup.XSetupArray (LLVM _) = ()
+type instance Setup.XSetupElem (LLVM _) = ()
+type instance Setup.XSetupField (LLVM _) = ()
+type instance Setup.XSetupCast (LLVM _) = L.Type
+type instance Setup.XSetupUnion (LLVM _) = ()
+type instance Setup.XSetupGlobal (LLVM _) = ()
+type instance Setup.XSetupGlobalInitializer (LLVM _) = ()
 
-type instance Setup.HasGhostState (LLVM _) = 'True
+type instance Setup.XGhostState (LLVM _) = ()
 
 type instance Setup.TypeName (LLVM arch) = CL.Ident
 type instance Setup.ExtType (LLVM arch) = CL.MemType
-type instance Setup.CastType (LLVM arch) = L.Type
 
 --------------------------------------------------------------------------------
 -- *** LLVMMethodId

--- a/src/SAWScript/Crucible/LLVM/Setup/Value.hs
+++ b/src/SAWScript/Crucible/LLVM/Setup/Value.hs
@@ -30,6 +30,7 @@ module, plus additional functionality) instead.
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module SAWScript.Crucible.LLVM.Setup.Value
@@ -75,6 +76,8 @@ module SAWScript.Crucible.LLVM.Setup.Value
   , emptyResolvedState
   , rsAllocs
   , rsGlobals
+    -- * @LLVMPtr@
+  , LLVMPtr
   ) where
 
 import           Control.Lens
@@ -338,3 +341,10 @@ emptyResolvedState :: LLVMResolvedState
 emptyResolvedState = ResolvedState Map.empty Map.empty
 
 makeLenses ''LLVMResolvedState
+
+--------------------------------------------------------------------------------
+-- *** Pointers
+
+type instance Setup.Pointer' (LLVM arch) Sym = LLVMPtr (CL.ArchWidth arch)
+
+type LLVMPtr wptr = CL.LLVMPtr Sym wptr

--- a/src/SAWScript/Crucible/MIR/Override.hs
+++ b/src/SAWScript/Crucible/MIR/Override.hs
@@ -181,11 +181,11 @@ instantiateSetupValue sc s v =
     MS.SetupTerm tt                   -> MS.SetupTerm <$> doTerm tt
     MS.SetupNull empty                -> absurd empty
     MS.SetupGlobal empty _            -> absurd empty
-    MS.SetupStruct _ _ _              -> return v
+    MS.SetupStruct _ _                -> return v
     MS.SetupArray _ _                 -> return v
     MS.SetupElem _ _ _                -> return v
     MS.SetupField _ _ _               -> return v
-    MS.SetupCast empty _ _            -> absurd empty
+    MS.SetupCast empty _              -> absurd empty
     MS.SetupUnion empty _ _           -> absurd empty
     MS.SetupGlobalInitializer empty _ -> absurd empty
   where
@@ -308,7 +308,7 @@ matchArg opts sc cc cs _prepost md actual@(MIRVal (RefShape _refTy pointeeTy mut
 
     MS.SetupNull empty                -> absurd empty
     MS.SetupGlobal empty _            -> absurd empty
-    MS.SetupCast empty _ _            -> absurd empty
+    MS.SetupCast empty _              -> absurd empty
     MS.SetupUnion empty _ _           -> absurd empty
     MS.SetupGlobalInitializer empty _ -> absurd empty
 

--- a/src/SAWScript/Crucible/MIR/ResolveSetupValue.hs
+++ b/src/SAWScript/Crucible/MIR/ResolveSetupValue.hs
@@ -123,11 +123,11 @@ typeOfSetupValue _mcc env _nameEnv val =
 
     MS.SetupNull empty                -> absurd empty
     MS.SetupGlobal empty _            -> absurd empty
-    MS.SetupStruct _ _ _              -> panic "typeOfSetupValue" ["structs not yet implemented"]
+    MS.SetupStruct _ _                -> panic "typeOfSetupValue" ["structs not yet implemented"]
     MS.SetupArray _ _                 -> panic "typeOfSetupValue" ["arrays not yet implemented"]
     MS.SetupElem _ _ _                -> panic "typeOfSetupValue" ["elems not yet implemented"]
     MS.SetupField _ _ _               -> panic "typeOfSetupValue" ["fields not yet implemented"]
-    MS.SetupCast empty _ _            -> absurd empty
+    MS.SetupCast empty _              -> absurd empty
     MS.SetupUnion empty _ _           -> absurd empty
     MS.SetupGlobalInitializer empty _ -> absurd empty
 
@@ -160,7 +160,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
     MS.SetupTerm tm -> resolveTypedTerm mcc tm
     MS.SetupNull empty                -> absurd empty
     MS.SetupGlobal empty _            -> absurd empty
-    MS.SetupStruct _ _ _              -> panic "resolveSetupValue" ["structs not yet implemented"]
+    MS.SetupStruct _ _                -> panic "resolveSetupValue" ["structs not yet implemented"]
     MS.SetupArray () [] -> fail "resolveSetupVal: invalid empty array"
     MS.SetupArray () vs -> do
       vals <- V.mapM (resolveSetupVal mcc env tyenv nameEnv) (V.fromList vs)
@@ -186,7 +186,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
                       (Mir.MirVector_Vector vals')
     MS.SetupElem _ _ _                -> panic "resolveSetupValue" ["elems not yet implemented"]
     MS.SetupField _ _ _               -> panic "resolveSetupValue" ["fields not yet implemented"]
-    MS.SetupCast empty _ _            -> absurd empty
+    MS.SetupCast empty _              -> absurd empty
     MS.SetupUnion empty _ _           -> absurd empty
     MS.SetupGlobalInitializer empty _ -> absurd empty
 

--- a/src/SAWScript/Crucible/MIR/Setup/Value.hs
+++ b/src/SAWScript/Crucible/MIR/Setup/Value.hs
@@ -46,6 +46,7 @@ import Control.Lens (makeLenses)
 import Data.Parameterized.Classes
 import Data.Parameterized.Some
 import Data.Text (Text)
+import Data.Void (Void)
 
 import Lang.Crucible.FunctionHandle (HandleAllocator)
 import Lang.Crucible.Types
@@ -57,17 +58,17 @@ import qualified Mir.Mir as M
 import           SAWScript.Crucible.Common
 import qualified SAWScript.Crucible.Common.Setup.Value as MS
 
-type instance MS.HasSetupNull MIR = 'False
-type instance MS.HasSetupGlobal MIR = 'False
-type instance MS.HasSetupStruct MIR = 'True
-type instance MS.HasSetupArray MIR = 'True
-type instance MS.HasSetupElem MIR = 'True
-type instance MS.HasSetupField MIR = 'True
-type instance MS.HasSetupCast MIR = 'False
-type instance MS.HasSetupUnion MIR = 'False
-type instance MS.HasSetupGlobalInitializer MIR = 'False
+type instance MS.XSetupNull MIR = Void
+type instance MS.XSetupGlobal MIR = Void
+type instance MS.XSetupStruct MIR = ()
+type instance MS.XSetupArray MIR = ()
+type instance MS.XSetupElem MIR = ()
+type instance MS.XSetupField MIR = ()
+type instance MS.XSetupCast MIR = Void
+type instance MS.XSetupUnion MIR = Void
+type instance MS.XSetupGlobalInitializer MIR = Void
 
-type instance MS.HasGhostState MIR = 'False
+type instance MS.XGhostState MIR = Void
 
 type instance MS.TypeName MIR = Text
 type instance MS.ExtType MIR = M.Ty
@@ -76,7 +77,6 @@ type instance MS.MethodId MIR = DefId
 type instance MS.AllocSpec MIR = Some MirAllocSpec
 type instance MS.PointsTo MIR = MirPointsTo
 type instance MS.ResolvedState MIR = ()
-type instance MS.CastType MIR = ()
 
 type instance MS.Codebase MIR = CollectionState
 

--- a/src/SAWScript/Crucible/MIR/Setup/Value.hs
+++ b/src/SAWScript/Crucible/MIR/Setup/Value.hs
@@ -1,0 +1,122 @@
+{- |
+Module      : SAWScript.Crucible.MIR.Setup.Value
+Description : Data types and type family instances for MIR-specific code
+License     : BSD3
+Maintainer  : Ryan Scott <rscott@galois.com>
+Stability   : provisional
+
+The module exists separately from "SAWScript.Crucible.MIR.MethodSpecIR"
+primarily to avoid import cycles. You probably want to import
+"SAWScript.Crucible.MIR.MethodSpecIR" (which re-exports everything from this
+module, plus additional functionality) instead.
+-}
+
+{-# Language DataKinds #-}
+{-# Language OverloadedStrings #-}
+{-# Language RankNTypes #-}
+{-# Language TemplateHaskell #-}
+{-# Language TypeFamilies #-}
+
+module SAWScript.Crucible.MIR.Setup.Value
+  ( -- * @MIRCrucibleContext@
+    MIRCrucibleContext(..)
+  , mccRustModule
+  , mccBackend
+  , mccHandleAllocator
+
+    -- * @MirPointsTo@
+  , MirPointsTo(..)
+
+    -- * @MirAllocSpec@
+  , MirAllocSpec(..)
+  , maType
+  , maMutbl
+  , maMirType
+  , maLen
+
+    -- * @MirPointer@
+  , MirPointer(..)
+  , mpType
+  , mpMutbl
+  , mpMirType
+  , mpRef
+  ) where
+
+import Control.Lens (makeLenses)
+import Data.Parameterized.Classes
+import Data.Parameterized.Some
+import Data.Text (Text)
+
+import Lang.Crucible.FunctionHandle (HandleAllocator)
+import Lang.Crucible.Types
+import Mir.DefId
+import Mir.Generator
+import Mir.Intrinsics
+import qualified Mir.Mir as M
+
+import           SAWScript.Crucible.Common
+import qualified SAWScript.Crucible.Common.Setup.Value as MS
+
+type instance MS.HasSetupNull MIR = 'False
+type instance MS.HasSetupGlobal MIR = 'False
+type instance MS.HasSetupStruct MIR = 'True
+type instance MS.HasSetupArray MIR = 'True
+type instance MS.HasSetupElem MIR = 'True
+type instance MS.HasSetupField MIR = 'True
+type instance MS.HasSetupCast MIR = 'False
+type instance MS.HasSetupUnion MIR = 'False
+type instance MS.HasSetupGlobalInitializer MIR = 'False
+
+type instance MS.HasGhostState MIR = 'False
+
+type instance MS.TypeName MIR = Text
+type instance MS.ExtType MIR = M.Ty
+
+type instance MS.MethodId MIR = DefId
+type instance MS.AllocSpec MIR = Some MirAllocSpec
+type instance MS.PointsTo MIR = MirPointsTo
+type instance MS.ResolvedState MIR = ()
+type instance MS.CastType MIR = ()
+
+type instance MS.Codebase MIR = CollectionState
+
+data MIRCrucibleContext =
+  MIRCrucibleContext
+  { _mccRustModule      :: RustModule
+  , _mccBackend         :: SomeOnlineBackend
+  , _mccHandleAllocator :: HandleAllocator
+  }
+
+type instance MS.CrucibleContext MIR = MIRCrucibleContext
+
+type instance MS.Pointer' MIR sym = Some (MirPointer sym)
+
+-- | Unlike @LLVMPointsTo@ and @JVMPointsTo@, 'MirPointsTo' contains a /list/ of
+-- 'MS.SetupValue's on the right-hand side. This is due to how slices are
+-- represented in @crucible-mir-comp@, which stores the list of values
+-- referenced by the slice. The @mir_points_to@ command, on the other hand,
+-- always creates 'MirPointsTo' values with exactly one value in the list (see
+-- the @firstPointsToReferent@ function in "SAWScript.Crucible.MIR.Override").
+data MirPointsTo = MirPointsTo MS.ConditionMetadata MS.AllocIndex [MS.SetupValue MIR]
+    deriving (Show)
+
+data MirAllocSpec tp = MirAllocSpec
+    { _maType :: TypeRepr tp
+    , _maMutbl :: M.Mutability
+    , _maMirType :: M.Ty
+    , _maLen :: Int
+    }
+  deriving (Show)
+
+instance ShowF MirAllocSpec where
+
+data MirPointer sym tp = MirPointer
+    { _mpType :: TypeRepr tp
+    , _mpMutbl :: M.Mutability
+    , _mpMirType :: M.Ty
+    , _mpRef :: MirReferenceMux sym tp
+    }
+
+makeLenses ''MIRCrucibleContext
+makeLenses ''MirAllocSpec
+makeLenses ''MirPointer


### PR DESCRIPTION
This removes all of the `HasSetup* :: Bool` type families in favor of new `X* :: Type` type families. These largely serve the same purpose of distinguishing which constructors of `SetupValue` are permissible in each language backend, but they also permit bundling additional, language-specific information into a `SetupValue`. For instance, the `XSetupStruct` instance for `LLVM` evaluates to `Bool`, representing whether we are dealing with an LLVM packed struct or not, and the `XSetupCast` instance for `LLVM` evaluates to an LLVM `Type` to represent the type to cast to.

One consequence of this design, aside from some `SetupValue` fields moving around, is that `ppSetupValue` now must perform case analysis on which language backend is currently in use in order to pretty-print any backend-specific data. This is accomplished with the new `SAWExt` data type and the corresponding `IsExt` class.

There is a lot of code that shifts around in this patch, but everything is still functionally equivalent. In subsequent patches, I will introduce additional data into MIR-specific extension fields.

Fixes https://github.com/GaloisInc/saw-script/issues/1914.