### PR TITLE
Allow importing Cryptol `foreign` functions

### DIFF
--- a/src/SAWScript/AutoMatch/Cryptol.hs
+++ b/src/SAWScript/AutoMatch/Cryptol.hs
@@ -81,9 +81,9 @@ whereBindings _                       = Nothing
 --   We can't handle primitives currently
 declDefExpr :: AST.DeclDef -> Maybe AST.Expr
 declDefExpr = \case
-   AST.DPrim      -> Nothing
-   AST.DForeign {} -> Nothing
-   AST.DExpr expr -> Just expr
+   AST.DPrim            -> Nothing
+   AST.DForeign _ mexpr -> mexpr
+   AST.DExpr expr       -> Just expr
 
 -- | If a lambda is of the form @\(a,b,...,z) -> ...)@ then give the list of names bound in the tuple
 tupleLambdaBindings :: AST.Expr -> Maybe [AST.Name]


### PR DESCRIPTION
If there exists a Cryptol implementation of the `foreign` function, then we import it into SAWCore as a Cryptol expression, in the same way that we do for normal Cryptol bindings. If not, then we introduce it as an opaque constant with no definition, the same way we deal with unknown primitives.

This requires an update of the `cryptol` submodule so that we have support for Cryptol implementations of `foreign` functions.