### PR TITLE
Fix parse error on `\n`

### DIFF
--- a/src/SAWScript/Lexer.x
+++ b/src/SAWScript/Lexer.x
@@ -71,7 +71,6 @@ $charesc     = [abfnrtv\\\"\'\&]
 sawTokens :-
 
 $white+                          ;
-"\n"                             ;
 "//".*                           ;
 "/*"                             { cnst TCmntS           }
 "*/"                             { cnst TCmntE           }


### PR DESCRIPTION
By deleting the `"\n"` match in the lexer as suggested by @yav

Fixes #1894