### PR TITLE
Fix `tupleOpenTerm'`

### DIFF
--- a/saw-core/src/Verifier/SAW/OpenTerm.hs
+++ b/saw-core/src/Verifier/SAW/OpenTerm.hs
@@ -223,7 +223,7 @@ projTupleOpenTerm i t = projTupleOpenTerm (i-1) (pairRightOpenTerm t)
 -- as the right-most element
 tupleOpenTerm' :: [OpenTerm] -> OpenTerm
 tupleOpenTerm' [] = unitOpenTerm
-tupleOpenTerm' ts = foldr1 pairTypeOpenTerm ts
+tupleOpenTerm' ts = foldr1 pairOpenTerm ts
 
 -- | Build a right-nested tuple type as an 'OpenTerm'
 tupleTypeOpenTerm' :: [OpenTerm] -> OpenTerm


### PR DESCRIPTION
Fix a typo in `Verifier.SAW.OpenTerm.tupleOpenTerm'` which made it construct the type of tuples instead of tuples themselves (compare this function and `tupleTypeOpenTerm'` below with `tupleOpenTerm` and `tupleTypeOpenTerm` a few lines above).