### PR TITLE
MRSolver SpecM bugfixes

### DIFF
--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol/Monadify.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol/Monadify.hs
@@ -92,7 +92,7 @@ import Verifier.SAW.SharedTerm
 import Verifier.SAW.OpenTerm
 import Verifier.SAW.TypedTerm
 import Verifier.SAW.Cryptol (Env)
--- import Verifier.SAW.SCTypeCheck
+import Verifier.SAW.SCTypeCheck
 import Verifier.SAW.Recognizer
 -- import Verifier.SAW.Position
 import Verifier.SAW.Cryptol.PreludeM
@@ -608,7 +608,9 @@ fromCompTerm mtp t = ArgMonTerm $ fromArgTerm mtp t
 
 -- | Take a function of type @A1 -> ... -> An -> SpecM E emptyFunStack B@ and
 -- lift the stack of the output type to an arbitrary @stack@ parameter using
--- @liftStackS@
+-- @liftStackS@. Note that @liftStackS@ is only added if the stack of the
+-- output type is non-empty, i.e. not @emptyFunStack@. Otherwise, this operation
+-- leaves the function unchanged.
 class LiftCompStack a where
   liftCompStack :: HasSpecMParams => a -> a
 
@@ -623,10 +625,14 @@ instance LiftCompStack ArgMonTerm where
 
 instance LiftCompStack MonTerm where
   liftCompStack (ArgMonTerm amtrm) = ArgMonTerm $ liftCompStack amtrm
-  liftCompStack (CompMonTerm mtp trm) =
-    CompMonTerm mtp $
-    applyGlobalOpenTerm "Prelude.liftStackS"
-    [specMEvType ?specMParams, specMStack ?specMParams, toArgType mtp, trm]
+  liftCompStack (CompMonTerm mtp trm) = CompMonTerm mtp $ OpenTerm $ do
+    -- Only add @liftStackS@ when the stack is not @emptyFunStack@
+    empty_stk <- typedVal <$> unOpenTerm emptyStackOpenTerm
+    curr_stk  <- typedVal <$> unOpenTerm (specMStack ?specMParams)
+    curr_stk_empty <- liftTCM scConvertible False empty_stk curr_stk
+    unOpenTerm $ if curr_stk_empty then trm else
+      applyGlobalOpenTerm "Prelude.liftStackS"
+      [specMEvType ?specMParams, specMStack ?specMParams, toArgType mtp, trm]
 
 -- | Test if a monadification type @tp@ is pure, meaning @MT(tp)=tp@
 monTypeIsPure :: MonType -> Bool
@@ -708,8 +714,8 @@ applyMonTermMulti :: HasCallStack => MonTerm -> [Either MonType ArgMonTerm] ->
 applyMonTermMulti = foldl applyMonTerm
 
 -- | Build a 'MonTerm' from a global of a given argument type, applying it to
--- the current 'SpecMParams' if the 'Bool' flag is 'True' and lifting it using
--- @liftStackS@ if it is 'False'
+-- the current 'SpecMParams' if the 'Bool' flag is 'True' or lifting it using
+-- @liftStackS@ if it is 'False' and the stack is non-empty
 mkGlobalArgMonTerm :: HasSpecMParams => MonType -> Ident -> Bool -> ArgMonTerm
 mkGlobalArgMonTerm tp ident params_p =
   (if params_p then id else liftCompStack) $
@@ -747,9 +753,11 @@ data MonMacro = MonMacro {
   macroNumArgs :: Int,
   macroApply :: GlobalDef -> [Term] -> MonadifyM MonTerm }
 
--- | Make a simple 'MonMacro' that inspects 0 arguments and just returns a term
+-- | Make a simple 'MonMacro' that inspects 0 arguments and just returns a term,
+-- lifted with @liftStackS@ if the outer stack is non-empty
 monMacro0 :: MonTerm -> MonMacro
-monMacro0 mtrm = MonMacro 0 (\_ _ -> return mtrm)
+monMacro0 mtrm = MonMacro 0 $ \_ _ -> usingSpecMParams $
+  return $ liftCompStack mtrm
 
 -- | Make a 'MonMacro' that maps a named global to a global of semi-pure type.
 -- (See 'fromSemiPureTermFun'.) Because we can't get access to the type of the
@@ -773,7 +781,7 @@ semiPureGlobalMacro from to params_p =
 -- indicates whether the "to" global is polymorphic in the event type and
 -- function stack; if so, the current 'SpecMParams' are passed as its first two
 -- arguments, and otherwise the returned computation is lifted with
--- @liftStackS@.
+-- @liftStackS@ if the outer stack is non-empty.
 argGlobalMacro :: NameInfo -> Ident -> Bool -> MonMacro
 argGlobalMacro from to params_p =
   MonMacro 0 $ \glob args -> usingSpecMParams $

--- a/heapster-saw/examples/Makefile
+++ b/heapster-saw/examples/Makefile
@@ -41,7 +41,7 @@ endif
 	$(SAW) $<
 
 # Lists all the Mr Solver tests, without their ".saw" suffix
-MR_SOLVER_TESTS = exp_explosion_mr_solver # arrays_mr_solver linked_list_mr_solver sha512_mr_solver
+MR_SOLVER_TESTS = exp_explosion_mr_solver linked_list_mr_solver # arrays_mr_solver sha512_mr_solver
 
 .PHONY: mr-solver-tests $(MR_SOLVER_TESTS)
 mr-solver-tests: $(MR_SOLVER_TESTS)

--- a/heapster-saw/examples/Makefile
+++ b/heapster-saw/examples/Makefile
@@ -41,7 +41,7 @@ endif
 	$(SAW) $<
 
 # Lists all the Mr Solver tests, without their ".saw" suffix
-MR_SOLVER_TESTS = exp_explosion_mr_solver linked_list_mr_solver sha512_mr_solver # arrays_mr_solver
+MR_SOLVER_TESTS = exp_explosion_mr_solver linked_list_mr_solver arrays_mr_solver sha512_mr_solver
 
 .PHONY: mr-solver-tests $(MR_SOLVER_TESTS)
 mr-solver-tests: $(MR_SOLVER_TESTS)

--- a/heapster-saw/examples/Makefile
+++ b/heapster-saw/examples/Makefile
@@ -41,7 +41,7 @@ endif
 	$(SAW) $<
 
 # Lists all the Mr Solver tests, without their ".saw" suffix
-MR_SOLVER_TESTS = exp_explosion_mr_solver linked_list_mr_solver # arrays_mr_solver sha512_mr_solver
+MR_SOLVER_TESTS = exp_explosion_mr_solver linked_list_mr_solver sha512_mr_solver # arrays_mr_solver
 
 .PHONY: mr-solver-tests $(MR_SOLVER_TESTS)
 mr-solver-tests: $(MR_SOLVER_TESTS)

--- a/heapster-saw/examples/SpecPrims.cry
+++ b/heapster-saw/examples/SpecPrims.cry
@@ -2,25 +2,25 @@ module SpecPrims where
 
 /* Specification primitives */
 
-// The specification that holds for f x for some input x
-exists : {a, b} (a -> b) -> b
-exists f = error "Cannot run exists"
+// The specification that holds for for some element of type a
+exists : {a} a
+exists = error "Cannot run exists"
 
-// The specification that holds for f x for all inputs x
-forall : {a, b} (a -> b) -> b
-forall f = error "Cannot run forall"
+// The specification that holds for for all elements of type a
+forall : {a} a
+forall = error "Cannot run forall"
 
-// The specification that a computation returns some value with no errors
-returnsSpec : {a} a
-returnsSpec = exists (\x -> x)
+// The specification that a computation has no errors
+noErrors : {a} a
+noErrors = exists
 
 // The specification that matches any computation. This calls exists at the
-// function type () -> a, which is monadified to () -> CompM a. This means that
+// function type () -> a, which is monadified to () -> SpecM a. This means that
 // the exists does not just quantify over all values of type a like noErrors,
 // but it quantifies over all computations of type a, including those that
 // contain errors.
 anySpec : {a} a
-anySpec = exists (\f -> f ())
+anySpec = exists ()
 
 // The specification which asserts that the first argument is True and then
 // returns the second argument

--- a/heapster-saw/examples/SpecPrims.cry
+++ b/heapster-saw/examples/SpecPrims.cry
@@ -2,11 +2,11 @@ module SpecPrims where
 
 /* Specification primitives */
 
-// The specification that holds for for some element of type a
+// The specification that holds for some element of type a
 exists : {a} a
 exists = error "Cannot run exists"
 
-// The specification that holds for for all elements of type a
+// The specification that holds for all elements of type a
 forall : {a} a
 forall = error "Cannot run forall"
 

--- a/heapster-saw/examples/arrays.sawcore
+++ b/heapster-saw/examples/arrays.sawcore
@@ -3,39 +3,41 @@ module arrays where
 
 import Prelude;
 
+-- The LetRecType of noErrorsContains0
+noErrorsContains0LRT : LetRecType;
+noErrorsContains0LRT =
+  LRT_Fun (Vec 64 Bool) (\ (len:Vec 64 Bool) ->
+  LRT_Fun (Vec 64 Bool) (\ (_:Vec 64 Bool) ->
+  LRT_Fun (BVVec 64 len (Vec 64 Bool)) (\ (_:BVVec 64 len (Vec 64 Bool)) ->
+  LRT_Ret (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool))));
+
 -- The helper function for noErrorsContains0
 --
 -- noErrorsContains0H len i v =
---   orM (exists x. returnM x) (noErrorsContains0H len (i+1) v)
+--   orS (existsS x. x) (noErrorsContains0H len (i+1) v)
 noErrorsContains0H : (len i:Vec 64 Bool) -> BVVec 64 len (Vec 64 Bool) ->
-                     CompM (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool);
-noErrorsContains0H len_top i_top v_top =
-  letRecM
-    (LRT_Cons
-     (LRT_Fun (Vec 64 Bool) (\ (len:Vec 64 Bool) ->
-      LRT_Fun (Vec 64 Bool) (\ (_:Vec 64 Bool) ->
-      LRT_Fun (BVVec 64 len (Vec 64 Bool)) (\ (_:BVVec 64 len (Vec 64 Bool)) ->
-      LRT_Ret (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool)))))
-     LRT_Nil)
-    (BVVec 64 len_top (Vec 64 Bool) * Vec 64 Bool)
+                     SpecM VoidEv emptyFunStack
+                           (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool);
+noErrorsContains0H =
+  multiArgFixS VoidEv emptyFunStack noErrorsContains0LRT
     (\ (f : (len i:Vec 64 Bool) -> BVVec 64 len (Vec 64 Bool) ->
-            CompM (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool)) ->
-       ((\ (len:Vec 64 Bool) (i:Vec 64 Bool) (v:BVVec 64 len (Vec 64 Bool)) ->
-           invariantHint
-             (CompM (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool))
-             (and (bvsle 64 0x0000000000000000 i)
-                  (bvsle 64 i 0x0fffffffffffffff))
-             (orM (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool)
-                  (existsM (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool)
-                           (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool)
-                           (returnM (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool)))
-                  (f len (bvAdd 64 i 0x0000000000000001) v))), ()))
-    (\ (f : (len i:Vec 64 Bool) -> BVVec 64 len (Vec 64 Bool) ->
-            CompM (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool)) ->
-       f len_top i_top v_top);
+            SpecM VoidEv (pushFunStack (singletonFrame noErrorsContains0LRT) emptyFunStack)
+                         (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool)) ->
+       (\ (len:Vec 64 Bool) (i:Vec 64 Bool) (v:BVVec 64 len (Vec 64 Bool)) ->
+          invariantHint
+            (SpecM VoidEv (pushFunStack (singletonFrame noErrorsContains0LRT) emptyFunStack)
+                          (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool))
+            (and (bvsle 64 0x0000000000000000 i)
+                 (bvsle 64 i 0x0fffffffffffffff))
+            (orS VoidEv (pushFunStack (singletonFrame noErrorsContains0LRT) emptyFunStack)
+                 (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool)
+                 (existsS VoidEv (pushFunStack (singletonFrame noErrorsContains0LRT) emptyFunStack)
+                          (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool))
+                 (f len (bvAdd 64 i 0x0000000000000001) v))));
 
 -- The specification that contains0 has no errors
 noErrorsContains0 : (len:Vec 64 Bool) -> BVVec 64 len (Vec 64 Bool) ->
-                    CompM (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool);
+                    SpecM VoidEv emptyFunStack
+                          (BVVec 64 len (Vec 64 Bool) * Vec 64 Bool);
 noErrorsContains0 len v =
   noErrorsContains0H len 0x0000000000000000 v;

--- a/heapster-saw/examples/arrays_mr_solver.saw
+++ b/heapster-saw/examples/arrays_mr_solver.saw
@@ -11,6 +11,9 @@ prove_extcore mrsolver (refines [] contains0 noErrorsContains0);
 include "specPrims.saw";
 import "arrays.cry";
 
-zero_array <- parse_core_mod "arrays" "zero_array";
-prove_extcore mrsolver (refines [] zero_array {{ zero_array_loop_spec }});
-prove_extcore mrsolver (refines [] zero_array {{ zero_array_spec }});
+monadify_term {{ zero_array_spec }};
+
+// FIXME: Uncomment once FunStacks are removed
+// zero_array <- parse_core_mod "arrays" "zero_array";
+// prove_extcore mrsolver (refines [] zero_array {{ zero_array_loop_spec }});
+// prove_extcore mrsolver (refines [] zero_array {{ zero_array_spec }});

--- a/heapster-saw/examples/specPrims.saw
+++ b/heapster-saw/examples/specPrims.saw
@@ -2,9 +2,8 @@
 
 import "SpecPrims.cry";
 
-set_monadification "exists" "Prelude.existsM";
-set_monadification "forall" "Prelude.forallM";
-set_monadification "anySpec" "Prelude.anySpec";
-set_monadification "asserting" "Prelude.asserting";
-set_monadification "assuming" "Prelude.assuming";
-set_monadification "invariantHint" "Prelude.invariantHint";
+set_monadification "exists" "Prelude.existsS" true;
+set_monadification "forall" "Prelude.forallS" true;
+set_monadification "asserting" "Prelude.asserting" true;
+set_monadification "assuming" "Prelude.assuming" true;
+set_monadification "invariantHint" "Prelude.invariantHint" true;

--- a/src/SAWScript/Prover/MRSolver/Monad.hs
+++ b/src/SAWScript/Prover/MRSolver/Monad.hs
@@ -1090,7 +1090,8 @@ mrGetFunAssump nm = lookupFunAssump nm <$> mrRefnset
 withFunAssump :: FunName -> [Term] -> Term -> MRM t a -> MRM t a
 withFunAssump fname args rhs m =
   do k <- mkCompFunReturn <$> mrFunOutType fname args
-     mrDebugPPPrefixSep 1 "withFunAssump" (FunBind fname args k) "|=" rhs
+     mrDebugPPPrefixSep 1 "withFunAssump" (FunBind fname args Unlifted k)
+                                     "|=" rhs
      ctx <- mrUVars
      rs <- mrRefnset
      let assump = FunAssump ctx fname args (RewriteFunAssump rhs) Nothing

--- a/src/SAWScript/Prover/MRSolver/Monad.hs
+++ b/src/SAWScript/Prover/MRSolver/Monad.hs
@@ -546,10 +546,6 @@ liftSC5 f a b c d e = mrSC >>= \sc -> liftIO (f sc a b c d e)
 -- * Functions for Building Terms
 ----------------------------------------------------------------------
 
--- | Create a term representing the type @IsFinite n@
-mrIsFinite :: Term -> MRM t Term
-mrIsFinite n = liftSC2 scGlobalApply "CryptolM.isFinite" [n]
-
 -- | Create a term representing an application of @Prelude.error@
 mrErrorTerm :: Term -> T.Text -> MRM t Term
 mrErrorTerm a str =

--- a/src/SAWScript/Prover/MRSolver/Solver.hs
+++ b/src/SAWScript/Prover/MRSolver/Solver.hs
@@ -149,7 +149,7 @@ import Data.Either
 import Numeric.Natural (Natural)
 import Data.List (find, findIndices)
 import Data.Foldable (foldlM)
--- import Data.Bits (shiftL)
+import Data.Bits (shiftL)
 import Control.Monad.Reader
 import Control.Monad.Except
 import qualified Data.Map as Map
@@ -388,59 +388,57 @@ normComp (CompTerm t) =
 
     -- Convert `atM (bvToNat ...) ... (bvToNat ...)` into the unfolding of
     -- `bvVecAtM`
-    (asGlobalDef -> Just "CryptolM.atM", [(asBvToNat -> Just (_w1, _n)), _a, _xs,
-                                          (asBvToNat -> Just (_w2, _i))]) ->
-      error "FIXME HERE NOW: need SpecM version of atM"
-      {-
+    (asGlobalDef -> Just "CryptolM.atM", [ev, stack,
+                                          (asBvToNat -> Just (w1, n)), a, xs,
+                                          (asBvToNat -> Just (w2, i))]) ->
       do body <- mrGlobalDefBody "CryptolM.bvVecAtM"
          ws_are_eq <- mrConvertible w1 w2
          if ws_are_eq then
-           mrApplyAll body [w1, n, a, xs, i] >>= normCompTerm
-         else throwMRFailure (MalformedComp t) -}
+           mrApplyAll body [ev, stack, w1, n, a, xs, i] >>= normCompTerm
+         else throwMRFailure (MalformedComp t)
 
     -- Convert `atM n ... xs (bvToNat ...)` for a constant `n` into the
     -- unfolding of `bvVecAtM` after converting `n` to a bitvector constant
     -- and applying `genBVVecFromVec` to `xs`
-    (asGlobalDef -> Just "CryptolM.atM", [_n_tm@(asNat -> Just _n), _a, _xs,
+    (asGlobalDef -> Just "CryptolM.atM", [ev, stack,
+                                          n_tm@(asNat -> Just n), a, xs,
                                           (asBvToNat ->
-                                             Just (_w_tm@(asNat -> Just _w),
-                                                   _i))]) ->
-      error "FIXME HERE NOW: need SpecM version of atM"
-      {-
+                                             Just (w_tm@(asNat -> Just w),
+                                                   i))]) ->
       do body <- mrGlobalDefBody "CryptolM.bvVecAtM"
          if n < 1 `shiftL` fromIntegral w then do
            n' <- liftSC2 scBvLit w (toInteger n)
            xs' <- mrGenBVVecFromVec n_tm a xs "normComp (atM)" w_tm n'
-           mrApplyAll body [w_tm, n', a, xs', i] >>= normCompTerm
-         else throwMRFailure (MalformedComp t) -}
+           mrApplyAll body [ev, stack, w_tm, n', a, xs', i] >>= normCompTerm
+         else throwMRFailure (MalformedComp t)
 
     -- Convert `updateM (bvToNat ...) ... (bvToNat ...)` into the unfolding of
     -- `bvVecUpdateM`
-    (asGlobalDef -> Just "CryptolM.updateM", [(asBvToNat -> Just (_w1, _n)), _a, _xs,
-                                              (asBvToNat -> Just (_w2, _i)), _x]) ->
-      error "FIXME HERE NOW: need SpecM version of updateM"
-      {-
+    (asGlobalDef -> Just "CryptolM.updateM", [ev, stack,
+                                              (asBvToNat -> Just (w1, n)), a, xs,
+                                              (asBvToNat -> Just (w2, i)), x]) ->
       do body <- mrGlobalDefBody "CryptolM.bvVecUpdateM"
          ws_are_eq <- mrConvertible w1 w2
          if ws_are_eq then
-           mrApplyAll body [w1, n, a, xs, i, x] >>= normCompTerm
-         else throwMRFailure (MalformedComp t) -}
+           mrApplyAll body [ev, stack, w1, n, a, xs, i, x] >>= normCompTerm
+         else throwMRFailure (MalformedComp t)
 
     -- Convert `updateM n ... xs (bvToNat ...)` for a constant `n` into the
     -- unfolding of `bvVecUpdateM` after converting `n` to a bitvector constant
     -- and applying `genBVVecFromVec` to `xs`
-    (asGlobalDef -> Just "CryptolM.updateM",
-     [_n_tm@(asNat -> Just _n), _a, _xs, (asBvToNat ->
-                                      Just (_w_tm@(asNat -> Just _w), _i)), _x]) ->
-      error "FIXME HERE NOW: need SpecM version of updateM"
-      {-
+    (asGlobalDef -> Just "CryptolM.updateM", [ev, stack,
+                                              n_tm@(asNat -> Just n), a, xs,
+                                              (asBvToNat ->
+                                                 Just (w_tm@(asNat -> Just w),
+                                                       i)), x]) ->
       do body <- mrGlobalDefBody "CryptolM.fromBVVecUpdateM"
          if n < 1 `shiftL` fromIntegral w then do
            n' <- liftSC2 scBvLit w (toInteger n)
            xs' <- mrGenBVVecFromVec n_tm a xs "normComp (updateM)" w_tm n'
            err_tm <- mrErrorTerm a "normComp (updateM)"
-           mrApplyAll body [w_tm, n', a, xs', i, x, err_tm, n_tm] >>= normCompTerm
-         else throwMRFailure (MalformedComp t) -}
+           mrApplyAll body [ev, stack, w_tm, n', a, xs', i, x, err_tm, n_tm]
+             >>= normCompTerm
+         else throwMRFailure (MalformedComp t)
 
     -- Always unfold: sawLet, multiArgFixM, invariantHint, Num_rec
     (f@(asGlobalDef -> Just ident), args)

--- a/src/SAWScript/Prover/MRSolver/Term.hs
+++ b/src/SAWScript/Prover/MRSolver/Term.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE EmptyCase #-}
@@ -171,6 +172,10 @@ mrVarCtxFromOuterToInner = mrVarCtxFromInnerToOuter . reverse
 specMParamsArgs :: SpecMParams Term -> [Term]
 specMParamsArgs (SpecMParams ev stack) = [ev, stack]
 
+-- | A datatype indicating whether an application of a 'FunName' is wrapped in
+-- a call to @liftStackS@ - used in the 'FunBind' constructor of 'NormComp'
+data IsLifted = Lifted | Unlifted deriving (Generic, Eq, Show)
+
 -- | A Haskell representation of a @SpecM@ in "monadic normal form"
 data NormComp
   = RetS Term -- ^ A term @retS _ _ a x@
@@ -183,8 +188,9 @@ data NormComp
   | AssumeBoolBind Term CompFun -- ^ the bind of an @assumeBoolS@ computation
   | ExistsBind Type CompFun -- ^ the bind of an @existsS@ computation
   | ForallBind Type CompFun -- ^ the bind of a @forallS@ computation
-  | FunBind FunName [Term] CompFun
-    -- ^ Bind a monadic function with @N@ arguments in an @a -> SpecM b@ term
+  | FunBind FunName [Term] IsLifted CompFun
+    -- ^ Bind a monadic function with @N@ arguments, possibly wrapped in a call
+    -- to @liftStackS@, in an @a -> SpecM b@ term
   deriving (Generic, Show)
 
 -- | An eliminator for an @Eithers@ type is a pair of the type of the disjunct
@@ -418,6 +424,7 @@ instance TermLike Natural where
 
 deriving anyclass instance TermLike Type
 deriving instance TermLike (SpecMParams Term)
+deriving instance TermLike IsLifted
 deriving instance TermLike NormComp
 deriving instance TermLike CompFun
 deriving instance TermLike Comp
@@ -532,7 +539,8 @@ instance PrettyInCtx Comp where
   prettyInCtx (CompBind c f) =
     prettyAppList [prettyInCtx c, return ">>=", prettyInCtx f]
   prettyInCtx (CompReturn t) =
-    prettyAppList [ return "returnM", return "_", parens <$> prettyInCtx t]
+    prettyAppList [return "retS", return "_", return "_",
+                   parens <$> prettyInCtx t]
 
 instance PrettyInCtx CompFun where
   prettyInCtx (CompFunTerm _ t) = prettyInCtx t
@@ -576,10 +584,21 @@ instance PrettyInCtx NormComp where
   prettyInCtx (ForallBind tp k) =
     prettyAppList [return "forallS", return "_", return "_", prettyInCtx tp,
                    return ">>=", parens <$> prettyInCtx k]
-  prettyInCtx (FunBind f args (CompFunReturn _ _)) =
-    prettyTermApp (funNameTerm f) args
-  prettyInCtx (FunBind f [] k) =
-    prettyAppList [prettyInCtx f, return ">>=", prettyInCtx k]
-  prettyInCtx (FunBind f args k) =
-    prettyAppList [parens <$> prettyTermApp (funNameTerm f) args,
-                   return ">>=", prettyInCtx k]
+  prettyInCtx (FunBind f args isLifted (CompFunReturn _ _)) =
+    snd $ prettyInCtxFunBindH f args isLifted
+  prettyInCtx (FunBind f args isLifted k)
+    | (g, m) <- prettyInCtxFunBindH f args isLifted =
+    prettyAppList [g <$> m, return ">>=", prettyInCtx k]
+
+-- | A helper function for the 'FunBind' case of 'prettyInCtx'. Returns the
+-- string you would get if the associated 'CompFun' is 'CompFunReturn', as well
+-- as a 'SawDoc' function (which is either 'id' or 'parens') to apply in the
+-- case where the associated 'CompFun' is something else.
+prettyInCtxFunBindH :: FunName -> [Term] -> IsLifted ->
+                       (SawDoc -> SawDoc, PPInCtxM SawDoc)
+prettyInCtxFunBindH f [] Unlifted = (id, prettyInCtx f)
+prettyInCtxFunBindH f args Unlifted = (parens,) $
+  prettyTermApp (funNameTerm f) args
+prettyInCtxFunBindH f args Lifted = (parens,) $
+  prettyAppList [return "liftStackS", return "_", return "_", return "_",
+                 parens <$> prettyTermApp (funNameTerm f) args]

--- a/src/SAWScript/Prover/MRSolver/Term.hs
+++ b/src/SAWScript/Prover/MRSolver/Term.hs
@@ -246,6 +246,8 @@ data Comp = CompTerm Term | CompBind Comp CompFun | CompReturn Term
 asSpecM :: Term -> Maybe (SpecMParams Term, Term)
 asSpecM (asApplyAll -> (isGlobalDef "Prelude.SpecM" -> Just (), [ev, stack, tp])) =
   return (SpecMParams { specMEvType = ev, specMStack = stack }, tp)
+asSpecM (asApplyAll -> (isGlobalDef "Prelude.CompM" -> Just (), _)) =
+  error "CompM found instead of SpecM"
 asSpecM _ = fail "not a SpecM type!"
 
 -- | Test if a type normalizes to a monadic function type of 0 or more arguments


### PR DESCRIPTION
This PR makes bugfixes to MRSolver to get as many of the `heapster-saw/examples` as we can working with the current definition of SpecM. Namely:

- Abstracting uvars at the proper time in `mrFreshCallVars`
- Giving the proper type to the dummy proof object made in the `MaybeElim` case of `mrRefines`
- Adding `liftCompStack` to `monMacro0`
- Adding `IsLifted` argument to `FunBind`, adding `liftStackS` case to `normComp`, and lifting when using `normBind` in `mrRefines'`
- Updating `SpecPrims.cry`, `specPrims.saw`, and `arrays.sawcore` to use `SpecM` instead of `CompM`
- Adding back MRSolver logic for `atM`/`updateM`

This PR also uncomments all the MRSolver tests from the `heapster-saw/examples/Makefile`, commenting out the only two tests that we aren't able to get working with the current definition of `SpecM`: `zero_array |= zero_array_loop_spec` and `zero_array |= zero_array_spec` from `arrays_mr_solver.saw`. 