### PR TITLE
CI: Build artifacts using GHC 9.2.7, exclude Windows GHC 8.10.7 job

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -47,6 +47,10 @@ build() {
   if [[ "$ENABLE_HPC" == "true" ]]; then
     cat cabal.project.ci-hpc >> cabal.project.local
   fi
+  # In the distant past, we had to retry the `cabal build` command to work
+  # around issues with caching dylib files on macOS. These issues appear to
+  # be less likely with modern GitHub Actions caching, so we have removed the
+  # retry logic.
   cabal v2-build "$@" "${pkgs[@]}"
 }
 

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -18,25 +18,6 @@ extract_exe() {
   $IS_WIN || chmod +x "$2/$name"
 }
 
-retry() {
-  echo "Attempting with retry:" "$@"
-  local n=1
-  while true; do
-    if "$@"; then
-      break
-    else
-      if [[ $n -lt 3 ]]; then
-        sleep $n # don't retry immediately
-        ((n++))
-        echo "Command failed. Attempt $n/3:"
-      else
-        echo "The command has failed after $n attempts."
-        return 1
-      fi
-    fi
-  done
-}
-
 setup_dist_bins() {
   if $IS_WIN; then
     is_exe "dist/bin" "saw" && return
@@ -66,15 +47,7 @@ build() {
   if [[ "$ENABLE_HPC" == "true" ]]; then
     cat cabal.project.ci-hpc >> cabal.project.local
   fi
-  if ! retry cabal v2-build "$@" "${pkgs[@]}"; then
-    if [[ "$RUNNER_OS" == "macOS" ]]; then
-      echo "Working around a dylib issue on macos by removing the cache and trying again"
-      cabal v2-clean
-      retry cabal v2-build "$@" "${pkgs[@]}"
-    else
-      return 1
-    fi
-  fi
+  cabal v2-build "$@" "${pkgs[@]}"
 }
 
 # Gather and tar up all HPC coverage files and binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,18 @@ jobs:
             cabal: "3.10.1.0"
             run-tests: true
             hpc: true
+        exclude:
+          # We exclude the GHC 8.10.7 job on Windows, as it is known to suffer
+          # from a hard-to-diagnose memory-related issue that does not affect
+          # later versions of GHC on Windows. (See
+          # https://github.com/GaloisInc/saw-script/issues/1961.) When we drop
+          # support for 8.10 entirely from SAW's support Window, we can remove
+          # this part of the matrix entirely.
+          - os: windows-2019
+            ghc: "8.10.7"
+            cabal: "3.10.1.0"
+            run-tests: true
+            hpc: false
     outputs:
       cabal-test-suites-json: ${{ steps.cabal-test-suites.outputs.targets-json }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # Overall configuration notes:
-# - Artifact uploads for binaries are from GHC 8.10.7
+# - Artifact uploads for binaries are from GHC 9.2.7
 # - Builds for Ubuntu happen on 22.04. We also include a single configuration
 #   for 20.04 to increase our Linux coverage.
 # - Docker builds happen nightly, on manual invocation, and on release branch commits
@@ -86,7 +86,7 @@ jobs:
           # coverage of possible Linux configurations. Since we already run the
           # tests with the newest LTS release, we won't bother testing this one.
           - os: ubuntu-20.04
-            ghc: "8.10.7"
+            ghc: "9.2.7"
             cabal: "3.10.1.0"
             run-tests: false
             hpc: false
@@ -171,7 +171,7 @@ jobs:
           dest: dist-tests
 
       - uses: actions/upload-artifact@v2
-        if: "matrix.ghc == '8.10.7'"
+        if: "matrix.ghc == '9.2.7'"
         with:
           path: dist-tests
           name: dist-tests-${{ matrix.os }}
@@ -188,14 +188,14 @@ jobs:
       - shell: bash
         run: .github/ci.sh zip_dist_with_solvers $NAME-with-solvers
 
-      - if: matrix.ghc == '8.10.7' && github.event.pull_request.head.repo.fork == false
+      - if: matrix.ghc == '9.2.7' && github.event.pull_request.head.repo.fork == false
         shell: bash
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
         run: .github/ci.sh sign $NAME.tar.gz
 
-      - if: matrix.ghc == '8.10.7' && github.event.pull_request.head.repo.fork == false
+      - if: matrix.ghc == '9.2.7' && github.event.pull_request.head.repo.fork == false
         shell: bash
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
@@ -205,7 +205,7 @@ jobs:
       ##########################################################################
       # We upload an archive containing SAW, and also and archive containing SAW
       # and the set of possible SMT solvers, but only for our "primary"
-      # distribution (currently: GHC 8.10.7).  These archives are utilized in
+      # distribution (currently: GHC 9.2.7).  These archives are utilized in
       # subsequent CI jobs, but are also published for external users, and are
       # therefore signed.
       #
@@ -220,7 +220,7 @@ jobs:
       # In the next 3 steps we check that `matrix.hpc == false` so that if the
       # distribution version matches the HPC version, the HPC build artifacts do
       # not clobber the non-HPC distribution artifacts.
-      - if: matrix.ghc == '8.10.7' && matrix.hpc == false
+      - if: matrix.ghc == '9.2.7' && matrix.hpc == false
         uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.config.outputs.name }} (GHC ${{ matrix.ghc }})
@@ -228,7 +228,7 @@ jobs:
           if-no-files-found: error
           retention-days: ${{ needs.config.outputs.retention-days }}
 
-      - if: matrix.ghc == '8.10.7' && matrix.hpc == false
+      - if: matrix.ghc == '9.2.7' && matrix.hpc == false
         uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.config.outputs.name }}-with-solvers (GHC ${{ matrix.ghc }})
@@ -236,7 +236,7 @@ jobs:
           if-no-files-found: error
           retention-days: ${{ needs.config.outputs.retention-days }}
 
-      - if: matrix.ghc == '8.10.7' && matrix.run-tests && matrix.hpc == false
+      - if: matrix.ghc == '9.2.7' && matrix.run-tests && matrix.hpc == false
         uses: actions/upload-artifact@v2
         with:
           path: dist/bin
@@ -715,7 +715,7 @@ jobs:
           - hmac-failure
           - awslc
           - blst
-        ghc: ["8.10.7"]
+        ghc: ["9.2.7"]
     steps:
       - uses: actions/checkout@v2
       - run: |
@@ -768,7 +768,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        ghc: ["8.10.7"]
+        ghc: ["9.2.7"]
     steps:
       - uses: actions/checkout@v2
       - run: |

--- a/saw-remote-api/Dockerfile
+++ b/saw-remote-api/Dockerfile
@@ -14,7 +14,7 @@ USER saw
 WORKDIR /home/saw
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
-COPY cabal.GHC-8.10.7.config cabal.project.freeze
+COPY cabal.GHC-9.2.7.config cabal.project.freeze
 ENV PATH=/home/saw/ghcup-download/bin:/home/saw/.ghcup/bin:$PATH
 RUN mkdir -p /home/saw/ghcup-download/bin && \
     curl -L https://downloads.haskell.org/~ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 -o /home/saw/ghcup-download/bin/ghcup && \
@@ -22,8 +22,8 @@ RUN mkdir -p /home/saw/ghcup-download/bin && \
 RUN mkdir -p /home/saw/.ghcup && \
     ghcup --version && \
     ghcup install cabal 3.8.1.0 && \
-    ghcup install ghc 8.10.7 && \
-    ghcup set ghc 8.10.7
+    ghcup install ghc 9.2.7 && \
+    ghcup set ghc 9.2.7
 RUN cabal v2-update && cabal v2-build -j exe:saw-remote-api
 RUN mkdir -p /home/saw/rootfs/usr/local/bin
 RUN cp $(cabal v2-exec which saw-remote-api) /home/saw/rootfs/usr/local/bin/saw-remote-api

--- a/saw/Dockerfile
+++ b/saw/Dockerfile
@@ -14,7 +14,7 @@ USER saw
 WORKDIR /home/saw
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
-COPY cabal.GHC-8.10.7.config cabal.project.freeze
+COPY cabal.GHC-9.2.7.config cabal.project.freeze
 ENV PATH=/home/saw/ghcup-download/bin:/home/saw/.ghcup/bin:$PATH
 RUN mkdir -p /home/saw/ghcup-download/bin && \
     curl -L https://downloads.haskell.org/~ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 -o /home/saw/ghcup-download/bin/ghcup && \
@@ -22,8 +22,8 @@ RUN mkdir -p /home/saw/ghcup-download/bin && \
 RUN mkdir -p /home/saw/.ghcup && \
     ghcup --version && \
     ghcup install cabal 3.8.1.0 && \
-    ghcup install ghc 8.10.7 && \
-    ghcup set ghc 8.10.7
+    ghcup install ghc 9.2.7 && \
+    ghcup set ghc 9.2.7
 RUN cabal v2-update
 RUN cabal v2-build
 RUN mkdir -p /home/saw/rootfs/usr/local/bin


### PR DESCRIPTION
Resolves https://github.com/GaloisInc/saw-script/issues/1961, in the sense that the issue is now worked around.