### PR TITLE
Bump `crucible` submodule to bring in `rotate_left` override

### DIFF
--- a/src/SAWScript/Crucible/LLVM/Builtins.hs
+++ b/src/SAWScript/Crucible/LLVM/Builtins.hs
@@ -1313,8 +1313,9 @@ registerOverride opts cc sim_ctx _top_loc mdMap cs =
                 $ methodSpecHandler opts sc cc mdMap cs h
               mem <- Crucible.readGlobal mvar
               let bindPtr m decl =
-                    do printOutLn opts Info $ "  variant `" ++ show (L.decName decl) ++ "`"
-                       Crucible.bindLLVMFunPtr bak decl h m
+                    do let declName = L.decName decl
+                       printOutLn opts Info $ "  variant `" ++ show declName ++ "`"
+                       Crucible.bindLLVMFunPtr bak declName h m
               mem' <- liftIO $ foldM bindPtr mem (d:ds)
               Crucible.writeGlobal mvar mem'
               return (Crucible.SomeHandle h)


### PR DESCRIPTION
This bumps the `crucible` submodule to a commit that brings in the changes from https://github.com/GaloisInc/crucible/pull/1158. Among other things, this adds an override for the Rust `rotate_left` function, which is crucial to making the SAW Rust tutorial work.

Fixes https://github.com/GaloisInc/saw-script/issues/2003.