### PR TITLE
Change circuit translation to tuple the state instead of adding it to a record type

### DIFF
--- a/intTests/test_comp_bisim/build.sh
+++ b/intTests/test_comp_bisim/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+ghdl analyze vhdl/add10.vhd
+yosys -m ghdl -s yosys/add10.ys
+
+ghdl analyze vhdl/pow4.vhd
+yosys -m ghdl -s yosys/pow4.ys
+
+ghdl analyze vhdl/comp.vhd
+yosys -m ghdl -s yosys/comp.ys

--- a/intTests/test_comp_bisim/clean.sh
+++ b/intTests/test_comp_bisim/clean.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -rf *.cf
+rm -rf *.json

--- a/intTests/test_comp_bisim/comp.json
+++ b/intTests/test_comp_bisim/comp.json
@@ -1,0 +1,1429 @@
+{
+  "creator": "Yosys 0.28 (git sha1 0d6f4b068, clang 10.0.0-4ubuntu1 -fPIC -Os)",
+  "modules": {
+    "add10": {
+      "attributes": {
+      },
+      "ports": {
+        "clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "enable": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "x": {
+          "direction": "input",
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 ]
+        },
+        "busy": {
+          "direction": "output",
+          "bits": [ 20 ]
+        },
+        "ready": {
+          "direction": "output",
+          "bits": [ 21 ]
+        },
+        "y": {
+          "direction": "output",
+          "bits": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ]
+        }
+      },
+      "cells": {
+        "\\100": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000010000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53 ],
+            "B": [ 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69 ],
+            "S": [ 70 ],
+            "Y": [ 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86 ]
+          }
+        },
+        "\\104": {
+          "hide_name": 0,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "00000000000000000000000000000001",
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 2 ],
+            "D": [ 87, 88, 89, 90, 91, 92, 93, 94 ],
+            "Q": [ 95, 96, 97, 98, 99, 100, 101, 102 ]
+          }
+        },
+        "\\105": {
+          "hide_name": 0,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "00000000000000000000000000000001",
+            "WIDTH": "00000000000000000000000000010000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 2 ],
+            "D": [ 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86 ],
+            "Q": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ]
+          }
+        },
+        "\\72": {
+          "hide_name": 0,
+          "type": "$eq",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000001000",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000001000",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 95, 96, 97, 98, 99, 100, 101, 102 ],
+            "B": [ "1", "1", "0", "1", "0", "0", "0", "0" ],
+            "Y": [ 103 ]
+          }
+        },
+        "\\73": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ "0" ],
+            "B": [ "1" ],
+            "S": [ 103 ],
+            "Y": [ 21 ]
+          }
+        },
+        "\\77": {
+          "hide_name": 0,
+          "type": "$gt",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000001",
+            "A_WIDTH": "00000000000000000000000000001000",
+            "B_SIGNED": "00000000000000000000000000000001",
+            "B_WIDTH": "00000000000000000000000000001000",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 95, 96, 97, 98, 99, 100, 101, 102 ],
+            "B": [ "0", "0", "0", "0", "0", "0", "0", "0" ],
+            "Y": [ 104 ]
+          }
+        },
+        "\\78": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ "0" ],
+            "B": [ "1" ],
+            "S": [ 104 ],
+            "Y": [ 20 ]
+          }
+        },
+        "\\83": {
+          "hide_name": 0,
+          "type": "$eq",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000001000",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000001000",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 95, 96, 97, 98, 99, 100, 101, 102 ],
+            "B": [ "0", "0", "0", "0", "0", "0", "0", "0" ],
+            "Y": [ 70 ]
+          }
+        },
+        "\\86": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ "0", "0", "0", "0", "0", "0", "0", "0" ],
+            "B": [ "1", "0", "0", "0", "0", "0", "0", "0" ],
+            "S": [ 3 ],
+            "Y": [ 105, 106, 107, 108, 109, 110, 111, 112 ]
+          }
+        },
+        "\\88": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000010000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0" ],
+            "B": [ 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 ],
+            "S": [ 3 ],
+            "Y": [ 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69 ]
+          }
+        },
+        "\\90": {
+          "hide_name": 0,
+          "type": "$lt",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000001",
+            "A_WIDTH": "00000000000000000000000000001000",
+            "B_SIGNED": "00000000000000000000000000000001",
+            "B_WIDTH": "00000000000000000000000000001000",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 95, 96, 97, 98, 99, 100, 101, 102 ],
+            "B": [ "1", "1", "0", "1", "0", "0", "0", "0" ],
+            "Y": [ 113 ]
+          }
+        },
+        "\\92": {
+          "hide_name": 0,
+          "type": "$add",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000001000",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000001000",
+            "Y_WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 95, 96, 97, 98, 99, 100, 101, 102 ],
+            "B": [ "1", "0", "0", "0", "0", "0", "0", "0" ],
+            "Y": [ 114, 115, 116, 117, 118, 119, 120, 121 ]
+          }
+        },
+        "\\94": {
+          "hide_name": 0,
+          "type": "$add",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000010000",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000010000",
+            "Y_WIDTH": "00000000000000000000000000010000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ],
+            "B": [ "1", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0" ],
+            "Y": [ 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137 ]
+          }
+        },
+        "\\96": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ "0", "0", "0", "0", "0", "0", "0", "0" ],
+            "B": [ 114, 115, 116, 117, 118, 119, 120, 121 ],
+            "S": [ 113 ],
+            "Y": [ 138, 139, 140, 141, 142, 143, 144, 145 ]
+          }
+        },
+        "\\98": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000010000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0" ],
+            "B": [ 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137 ],
+            "S": [ 113 ],
+            "Y": [ 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53 ]
+          }
+        },
+        "\\99": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 138, 139, 140, 141, 142, 143, 144, 145 ],
+            "B": [ 105, 106, 107, 108, 109, 110, 111, 112 ],
+            "S": [ 70 ],
+            "Y": [ 87, 88, 89, 90, 91, 92, 93, 94 ]
+          }
+        }
+      },
+      "netnames": {
+        "$auto$ghdl.cc:806:import_module$29": {
+          "hide_name": 1,
+          "bits": [ 103 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$30": {
+          "hide_name": 1,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$31": {
+          "hide_name": 1,
+          "bits": [ 104 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$32": {
+          "hide_name": 1,
+          "bits": [ 20 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$33": {
+          "hide_name": 1,
+          "bits": [ 70 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$34": {
+          "hide_name": 1,
+          "bits": [ 105, 106, 107, 108, 109, 110, 111, 112 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$35": {
+          "hide_name": 1,
+          "bits": [ 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$36": {
+          "hide_name": 1,
+          "bits": [ 113 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$37": {
+          "hide_name": 1,
+          "bits": [ 114, 115, 116, 117, 118, 119, 120, 121 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$38": {
+          "hide_name": 1,
+          "bits": [ 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$39": {
+          "hide_name": 1,
+          "bits": [ 138, 139, 140, 141, 142, 143, 144, 145 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$40": {
+          "hide_name": 1,
+          "bits": [ 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$41": {
+          "hide_name": 1,
+          "bits": [ 87, 88, 89, 90, 91, 92, 93, 94 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$42": {
+          "hide_name": 1,
+          "bits": [ 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$43": {
+          "hide_name": 1,
+          "bits": [ 95, 96, 97, 98, 99, 100, 101, 102 ],
+          "attributes": {
+            "init": "00000000"
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$44": {
+          "hide_name": 1,
+          "bits": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ],
+          "attributes": {
+            "init": "0000000000000000"
+          }
+        },
+        "buff": {
+          "hide_name": 0,
+          "bits": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ],
+          "attributes": {
+          }
+        },
+        "busy": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+          }
+        },
+        "clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+          }
+        },
+        "counter": {
+          "hide_name": 0,
+          "bits": [ 95, 96, 97, 98, 99, 100, 101, 102 ],
+          "attributes": {
+          }
+        },
+        "enable": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+          }
+        },
+        "ready": {
+          "hide_name": 0,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "x": {
+          "hide_name": 0,
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 ],
+          "attributes": {
+          }
+        },
+        "y": {
+          "hide_name": 0,
+          "bits": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ],
+          "attributes": {
+          }
+        }
+      }
+    },
+    "comp": {
+      "attributes": {
+      },
+      "ports": {
+        "clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "enable": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "x": {
+          "direction": "input",
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 ]
+        },
+        "busy": {
+          "direction": "output",
+          "bits": [ 20 ]
+        },
+        "ready": {
+          "direction": "output",
+          "bits": [ 21 ]
+        },
+        "y": {
+          "direction": "output",
+          "bits": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ]
+        }
+      },
+      "cells": {
+        "\\10": {
+          "hide_name": 0,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 38 ],
+            "Y": [ 39 ]
+          }
+        },
+        "\\11": {
+          "hide_name": 0,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "B": [ 39 ],
+            "Y": [ 40 ]
+          }
+        },
+        "\\12": {
+          "hide_name": 0,
+          "type": "$or",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 41 ],
+            "B": [ 42 ],
+            "Y": [ 20 ]
+          }
+        },
+        "\\16": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 38 ],
+            "B": [ "1" ],
+            "S": [ 3 ],
+            "Y": [ 43 ]
+          }
+        },
+        "\\18": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 43 ],
+            "B": [ "0" ],
+            "S": [ 21 ],
+            "Y": [ 44 ]
+          }
+        },
+        "\\21": {
+          "hide_name": 0,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "00000000000000000000000000000001",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 2 ],
+            "D": [ 44 ],
+            "Q": [ 38 ]
+          }
+        },
+        "a": {
+          "hide_name": 0,
+          "type": "pow4",
+          "parameters": {
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "busy": "output",
+            "clk": "input",
+            "enable": "input",
+            "ready": "output",
+            "x": "input",
+            "y": "output"
+          },
+          "connections": {
+            "busy": [ 41 ],
+            "clk": [ 2 ],
+            "enable": [ 40 ],
+            "ready": [ 45 ],
+            "x": [ 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 ],
+            "y": [ 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61 ]
+          }
+        },
+        "b": {
+          "hide_name": 0,
+          "type": "add10",
+          "parameters": {
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "busy": "output",
+            "clk": "input",
+            "enable": "input",
+            "ready": "output",
+            "x": "input",
+            "y": "output"
+          },
+          "connections": {
+            "busy": [ 42 ],
+            "clk": [ 2 ],
+            "enable": [ 45 ],
+            "ready": [ 21 ],
+            "x": [ 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61 ],
+            "y": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ]
+          }
+        }
+      },
+      "netnames": {
+        "$auto$ghdl.cc:806:import_module$1": {
+          "hide_name": 1,
+          "bits": [ 41 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$10": {
+          "hide_name": 1,
+          "bits": [ 43 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$11": {
+          "hide_name": 1,
+          "bits": [ 44 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$12": {
+          "hide_name": 1,
+          "bits": [ 38 ],
+          "attributes": {
+            "init": "1"
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$2": {
+          "hide_name": 1,
+          "bits": [ 45 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$3": {
+          "hide_name": 1,
+          "bits": [ 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$4": {
+          "hide_name": 1,
+          "bits": [ 42 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$5": {
+          "hide_name": 1,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$6": {
+          "hide_name": 1,
+          "bits": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$7": {
+          "hide_name": 1,
+          "bits": [ 39 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$8": {
+          "hide_name": 1,
+          "bits": [ 40 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$9": {
+          "hide_name": 1,
+          "bits": [ 20 ],
+          "attributes": {
+          }
+        },
+        "a_busy": {
+          "hide_name": 0,
+          "bits": [ 41 ],
+          "attributes": {
+          }
+        },
+        "a_enable": {
+          "hide_name": 0,
+          "bits": [ 40 ],
+          "attributes": {
+          }
+        },
+        "a_ready": {
+          "hide_name": 0,
+          "bits": [ 45 ],
+          "attributes": {
+          }
+        },
+        "a_y": {
+          "hide_name": 0,
+          "bits": [ 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61 ],
+          "attributes": {
+          }
+        },
+        "b_busy": {
+          "hide_name": 0,
+          "bits": [ 42 ],
+          "attributes": {
+          }
+        },
+        "b_ready": {
+          "hide_name": 0,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "b_y": {
+          "hide_name": 0,
+          "bits": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ],
+          "attributes": {
+          }
+        },
+        "blocked": {
+          "hide_name": 0,
+          "bits": [ 38 ],
+          "attributes": {
+          }
+        },
+        "busy": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+          }
+        },
+        "clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+          }
+        },
+        "enable": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+          }
+        },
+        "ready": {
+          "hide_name": 0,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "x": {
+          "hide_name": 0,
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 ],
+          "attributes": {
+          }
+        },
+        "y": {
+          "hide_name": 0,
+          "bits": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ],
+          "attributes": {
+          }
+        }
+      }
+    },
+    "pow4": {
+      "attributes": {
+      },
+      "ports": {
+        "clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "enable": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "x": {
+          "direction": "input",
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 ]
+        },
+        "busy": {
+          "direction": "output",
+          "bits": [ 20 ]
+        },
+        "ready": {
+          "direction": "output",
+          "bits": [ 21 ]
+        },
+        "y": {
+          "direction": "output",
+          "bits": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ]
+        }
+      },
+      "cells": {
+        "\\29": {
+          "hide_name": 0,
+          "type": "$eq",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000001000",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000001000",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 38, 39, 40, 41, 42, 43, 44, 45 ],
+            "B": [ "1", "1", "0", "0", "0", "0", "0", "0" ],
+            "Y": [ 46 ]
+          }
+        },
+        "\\30": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ "0" ],
+            "B": [ "1" ],
+            "S": [ 46 ],
+            "Y": [ 21 ]
+          }
+        },
+        "\\34": {
+          "hide_name": 0,
+          "type": "$gt",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000001",
+            "A_WIDTH": "00000000000000000000000000001000",
+            "B_SIGNED": "00000000000000000000000000000001",
+            "B_WIDTH": "00000000000000000000000000001000",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 38, 39, 40, 41, 42, 43, 44, 45 ],
+            "B": [ "0", "0", "0", "0", "0", "0", "0", "0" ],
+            "Y": [ 47 ]
+          }
+        },
+        "\\35": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ "0" ],
+            "B": [ "1" ],
+            "S": [ 47 ],
+            "Y": [ 20 ]
+          }
+        },
+        "\\39": {
+          "hide_name": 0,
+          "type": "$mul",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000001",
+            "A_WIDTH": "00000000000000000000000000100000",
+            "B_SIGNED": "00000000000000000000000000000001",
+            "B_WIDTH": "00000000000000000000000000100000",
+            "Y_WIDTH": "00000000000000000000000000100000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37 ],
+            "B": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37 ],
+            "Y": [ 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79 ]
+          }
+        },
+        "\\43": {
+          "hide_name": 0,
+          "type": "$eq",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000001000",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000001000",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 38, 39, 40, 41, 42, 43, 44, 45 ],
+            "B": [ "0", "0", "0", "0", "0", "0", "0", "0" ],
+            "Y": [ 80 ]
+          }
+        },
+        "\\46": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ "0", "0", "0", "0", "0", "0", "0", "0" ],
+            "B": [ "1", "0", "0", "0", "0", "0", "0", "0" ],
+            "S": [ 3 ],
+            "Y": [ 81, 82, 83, 84, 85, 86, 87, 88 ]
+          }
+        },
+        "\\48": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000010000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0" ],
+            "B": [ 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 ],
+            "S": [ 3 ],
+            "Y": [ 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104 ]
+          }
+        },
+        "\\50": {
+          "hide_name": 0,
+          "type": "$lt",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000001",
+            "A_WIDTH": "00000000000000000000000000001000",
+            "B_SIGNED": "00000000000000000000000000000001",
+            "B_WIDTH": "00000000000000000000000000001000",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 38, 39, 40, 41, 42, 43, 44, 45 ],
+            "B": [ "1", "1", "0", "0", "0", "0", "0", "0" ],
+            "Y": [ 105 ]
+          }
+        },
+        "\\52": {
+          "hide_name": 0,
+          "type": "$add",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000001000",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000001000",
+            "Y_WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 38, 39, 40, 41, 42, 43, 44, 45 ],
+            "B": [ "1", "0", "0", "0", "0", "0", "0", "0" ],
+            "Y": [ 106, 107, 108, 109, 110, 111, 112, 113 ]
+          }
+        },
+        "\\55": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ "0", "0", "0", "0", "0", "0", "0", "0" ],
+            "B": [ 106, 107, 108, 109, 110, 111, 112, 113 ],
+            "S": [ 105 ],
+            "Y": [ 114, 115, 116, 117, 118, 119, 120, 121 ]
+          }
+        },
+        "\\57": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000010000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0" ],
+            "B": [ 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63 ],
+            "S": [ 105 ],
+            "Y": [ 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137 ]
+          }
+        },
+        "\\58": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 114, 115, 116, 117, 118, 119, 120, 121 ],
+            "B": [ 81, 82, 83, 84, 85, 86, 87, 88 ],
+            "S": [ 80 ],
+            "Y": [ 138, 139, 140, 141, 142, 143, 144, 145 ]
+          }
+        },
+        "\\59": {
+          "hide_name": 0,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000010000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137 ],
+            "B": [ 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104 ],
+            "S": [ 80 ],
+            "Y": [ 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161 ]
+          }
+        },
+        "\\63": {
+          "hide_name": 0,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "00000000000000000000000000000001",
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 2 ],
+            "D": [ 138, 139, 140, 141, 142, 143, 144, 145 ],
+            "Q": [ 38, 39, 40, 41, 42, 43, 44, 45 ]
+          }
+        },
+        "\\64": {
+          "hide_name": 0,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "00000000000000000000000000000001",
+            "WIDTH": "00000000000000000000000000010000"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 2 ],
+            "D": [ 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161 ],
+            "Q": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ]
+          }
+        }
+      },
+      "netnames": {
+        "$auto$ghdl.cc:806:import_module$13": {
+          "hide_name": 1,
+          "bits": [ 46 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$14": {
+          "hide_name": 1,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$15": {
+          "hide_name": 1,
+          "bits": [ 47 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$16": {
+          "hide_name": 1,
+          "bits": [ 20 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$17": {
+          "hide_name": 1,
+          "bits": [ 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$18": {
+          "hide_name": 1,
+          "bits": [ 80 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$19": {
+          "hide_name": 1,
+          "bits": [ 81, 82, 83, 84, 85, 86, 87, 88 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$20": {
+          "hide_name": 1,
+          "bits": [ 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$21": {
+          "hide_name": 1,
+          "bits": [ 105 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$22": {
+          "hide_name": 1,
+          "bits": [ 106, 107, 108, 109, 110, 111, 112, 113 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$23": {
+          "hide_name": 1,
+          "bits": [ 114, 115, 116, 117, 118, 119, 120, 121 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$24": {
+          "hide_name": 1,
+          "bits": [ 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$25": {
+          "hide_name": 1,
+          "bits": [ 138, 139, 140, 141, 142, 143, 144, 145 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$26": {
+          "hide_name": 1,
+          "bits": [ 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$27": {
+          "hide_name": 1,
+          "bits": [ 38, 39, 40, 41, 42, 43, 44, 45 ],
+          "attributes": {
+            "init": "00000000"
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$28": {
+          "hide_name": 1,
+          "bits": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ],
+          "attributes": {
+            "init": "0000000000000000"
+          }
+        },
+        "buff": {
+          "hide_name": 0,
+          "bits": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ],
+          "attributes": {
+          }
+        },
+        "busy": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+          }
+        },
+        "clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+          }
+        },
+        "counter": {
+          "hide_name": 0,
+          "bits": [ 38, 39, 40, 41, 42, 43, 44, 45 ],
+          "attributes": {
+          }
+        },
+        "enable": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+          }
+        },
+        "ready": {
+          "hide_name": 0,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "sq": {
+          "hide_name": 0,
+          "bits": [ 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79 ],
+          "attributes": {
+          }
+        },
+        "x": {
+          "hide_name": 0,
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 ],
+          "attributes": {
+          }
+        },
+        "y": {
+          "hide_name": 0,
+          "bits": [ 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37 ],
+          "attributes": {
+          }
+        }
+      }
+    }
+  }
+}

--- a/intTests/test_comp_bisim/cryptol/feedback.cry
+++ b/intTests/test_comp_bisim/cryptol/feedback.cry
@@ -1,0 +1,51 @@
+module Feedback where
+
+///////////////////////////////
+// -- SEQUENTIAL CIRCUITS -- //
+///////////////////////////////
+
+// Run a circuit for a pre-specified number of steps.
+run : {s, i, o, n} (Zero o) => ((s, i) -> (s, o)) // mealy machine transition function
+                            -> (s, [n]i)          // initial state and list of inputs
+			    -> [n](s, o)          // list of n (state, output) pairs
+run circuit (state, inputs) = take (drop`{1} steps)
+  where steps = [(state, zero)] # [ circuit (state', input) | (state', _) <- steps | input <- inputs ]
+
+/////////////////////////////
+// -- FEEDBACK CIRCUITS -- //
+/////////////////////////////
+
+// A ``feedback'' circuit is a special type of sequential circuit that
+// takes an input on the first clock cycle, then performs some
+// iterative operation on that input for some fixed number of cycles,
+// then produces an output. We use an enable bit on the input, and a
+// ready bit on the output to determine when the computation is
+// completed.
+
+type feedback_input w = { clk : [1], enable : [1], x : [w] }
+
+type feedback_output w = { busy : [1], ready : [1], y : [w] }
+
+// // A counter for n iterations. Needs to be wide enough to store the
+// // value n+1.
+// type counter n = [width (n+2)]
+
+// s is the ``buffer'' state type, n is the number of iterations.
+type feedback_state w c = { buff : [w], counter : [c] }
+
+feedback_spec : {w, n, c} (fin w, fin n, fin c, n >= 1, c >= width (n+2)) =>
+                ([w] -> [w]) -> // specification function
+		(feedback_state w c, feedback_input w) ->
+		(feedback_state w c, feedback_output w)
+feedback_spec f (state, input) = (state', output)
+  where
+    state' =
+      if state.counter == 0
+        then if input.enable @ 0
+	  then { counter = 1, buff = input.x }
+	  else state
+	| state.counter <= `(n)
+	  then { counter = state.counter + 1, buff = state.buff }
+	else { counter = 0, buff = 0 }
+    ready = [state.counter == `(n) + 1]
+    output = { busy = [state.counter > 0], ready = ready, y = reverse (f (reverse state.buff)) }

--- a/intTests/test_comp_bisim/cryptol/spec.cry
+++ b/intTests/test_comp_bisim/cryptol/spec.cry
@@ -1,0 +1,24 @@
+module Spec where
+
+import Feedback
+
+type input  = feedback_input 16
+type output = feedback_output 16
+
+// add10 spec
+type add10_state  = feedback_state 16 8
+add10_spec : (add10_state, input) -> (add10_state, output)
+add10_spec = feedback_spec`{n=10} f
+  where f x = x + 10
+
+// pow4 spec
+type pow4_state  = feedback_state 16 8
+pow4_spec : (pow4_state, input) -> (pow4_state, output)
+pow4_spec = feedback_spec`{n=2} f
+  where f x = x ^^ 4
+
+// comp spec
+type comp_spec_state = feedback_state 16 8
+comp_spec : (comp_spec_state, input) -> (comp_spec_state, output)
+comp_spec = feedback_spec `{n=13} f
+  where f x = (x ^^ 4) + 10

--- a/intTests/test_comp_bisim/feedback.saw
+++ b/intTests/test_comp_bisim/feedback.saw
@@ -1,0 +1,94 @@
+enable_experimental;
+import "cryptol/Feedback.cry";
+import "cryptol/Spec.cry";
+/*
+yosys_add10 <- yosys_import "add10.json";
+yosys_pow4 <- yosys_import "pow4.json";
+*/
+impls <- yosys_import "comp.json";
+
+
+let {{
+type add10_impl_state = {zr104 : [8], zr105 : [16]}
+
+add10_impl : (add10_impl_state, input) -> (add10_impl_state, output)
+add10_impl = impls.add10
+
+add10_srel : add10_impl_state -> add10_state -> Bit
+add10_srel impl_state spec_state =
+  (spec_state.counter <= 11) &&
+  (impl_state == ([zero] # iterate f impl_state_init) @ spec_state.counter)
+  where f s = (add10_impl (s, {clk = 1, enable = 0, x = zero })).0
+        impl_state_init = (add10_impl (zero, {clk = 1, enable = 1, x = spec_state.buff})).0
+
+
+add10_orel : (add10_impl_state, output) -> (add10_state, output) -> Bit
+add10_orel (impl_state, impl_output) (spec_state, spec_output) =
+  add10_srel impl_state spec_state &&
+  (impl_output.busy == spec_output.busy) &&
+  (impl_output.ready == spec_output.ready) &&
+  (impl_output.ready @ 0 ==> impl_output.y == spec_output.y)
+
+}};
+
+add10_thm <- prove_bisim z3 [] {{add10_srel}} {{add10_orel}} {{add10_impl}} {{add10_spec}};
+
+
+let
+{{
+type pow4_impl_state = {zr63 : [8], zr64 : [16]}
+
+pow4_impl : (pow4_impl_state, input) -> (pow4_impl_state, output)
+pow4_impl = impls.pow4
+}};
+
+let pow4_srel = {{
+\ impl_state spec_state ->
+  (spec_state.counter <= 3) &&
+  (impl_state == ([zero] # iterate f (impl_state_init spec_state)) @ spec_state.counter)
+  where f impl_state = (pow4_impl (impl_state, {clk = 1, enable = 0, x = zero })).0
+  	impl_state_init (spec_state:pow4_state) = (pow4_impl (zero, {clk = 1, enable = 1, x = spec_state.buff})).0
+}};
+
+let pow4_orel = {{
+\ (impl_state, (impl_output:output)) (spec_state, (spec_output:output)) ->
+  pow4_srel impl_state spec_state &&
+  (impl_output.busy == spec_output.busy) &&
+  (impl_output.ready == spec_output.ready) &&
+  (impl_output.ready @ 0 ==> impl_output.y == spec_output.y)
+}};
+
+pow4_thm <- prove_bisim z3 [] {{pow4_srel}} {{pow4_orel}} {{pow4_impl}} {{pow4_spec}};
+
+
+
+let
+{{
+
+type comp_state = { a : add10_state, b : pow4_state, blocked : [1] }
+type comp_impl_state = {a : {zr63 : [8], zr64 : [16]},
+                        b : {zr104 : [8], zr105 : [16]}, zr21 : [1]}
+
+comp_impl : (comp_impl_state, input) -> (comp_impl_state, output)
+comp_impl = impls.comp
+
+}};
+
+
+let comp_srel = {{
+\ impl_state spec_state ->
+  (spec_state.counter <= 14) &&
+  (impl_state == ([zero] # iterate f (impl_state_init spec_state)) @ spec_state.counter)
+  where f impl_state = (comp_impl (impl_state, {clk = 1, enable = 0, x = zero })).0
+  	impl_state_init (spec_state:comp_spec_state) = (comp_impl (zero, {clk = 1, enable = 1, x = spec_state.buff})).0
+}};
+
+let comp_orel = {{
+\ (impl_state, (impl_output:output)) (spec_state, (spec_output:output)) ->
+  comp_srel impl_state spec_state &&
+  (impl_output.busy == spec_output.busy) &&
+  (impl_output.ready == spec_output.ready) &&
+  (impl_output.ready @ 0 ==> impl_output.y == spec_output.y)
+}};
+
+comp_thm <- prove_bisim z3 [add10_thm, pow4_thm] {{comp_srel}} {{comp_orel}} {{comp_impl}} {{comp_spec}};

--- a/intTests/test_comp_bisim/test.sh
+++ b/intTests/test_comp_bisim/test.sh
@@ -1,0 +1,3 @@
+set -e
+
+$SAW Feedback.saw

--- a/intTests/test_comp_bisim/vhdl/add10.vhd
+++ b/intTests/test_comp_bisim/vhdl/add10.vhd
@@ -1,0 +1,47 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity add10 is
+    port(
+        clk: in std_logic;
+        enable: in std_logic;
+        x: in signed(15 downto 0);
+
+        busy: out std_logic;
+        ready: out std_logic;
+        y: out signed(15 downto 0)
+    );
+end entity;
+
+architecture rtl of add10 is
+    --SIGNALS
+    signal counter: signed(7 downto 0) := (others => '0');
+    signal buff: signed(15 downto 0) := (others => '0');
+
+    begin
+        ready <= '1' when (counter = "00001011") else '0';
+        busy  <= '1' when (counter > "00000000") else '0';
+        y <= buff;
+        
+        st: process(clk)
+        begin
+          if rising_edge(clk) then
+            if counter = "00000000" then
+              if enable = '1' then
+                counter <= "00000001";
+                buff <= x;
+              else
+                counter <= "00000000";
+                buff <= "0000000000000000";
+              end if;
+            elsif counter < "00001011" then
+              counter <= counter + 1;
+              buff <= buff + 1;
+            else
+              counter <= "00000000";
+              buff <= "0000000000000000";
+            end if;
+          end if;
+        end process;
+    end rtl;

--- a/intTests/test_comp_bisim/vhdl/comp.vhd
+++ b/intTests/test_comp_bisim/vhdl/comp.vhd
@@ -1,0 +1,49 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity comp is
+    port(
+        clk: in std_logic;
+        enable: in std_logic;
+        x: in signed(15 downto 0);
+
+        busy: out std_logic;
+        ready: out std_logic;
+        y: out signed(15 downto 0)
+    );
+end entity;
+
+architecture rtl of comp is
+
+  signal blocked: std_logic := '1';
+  
+  signal A_busy: std_logic;
+  signal A_ready: std_logic;
+  signal A_y: signed(15 downto 0);
+  signal B_busy : std_logic;
+  signal B_ready : std_logic;
+  signal B_y : signed (15 downto 0);
+
+  signal A_enable : std_logic;
+  
+    begin
+      A : entity work.pow4 port map(clk, A_enable, x, A_busy, A_ready, A_y);
+      B : entity work.add10 port map (clk, A_ready, A_y, B_busy, B_ready, B_y);
+
+      A_enable <= enable and (not blocked);
+      busy <= A_busy or B_busy;
+      ready <= B_ready;
+      y <= B_y;
+
+      st: process(clk)
+      begin
+        if rising_edge(clk) then
+          if B_ready = '1' then
+            blocked <= '0';
+          elsif enable = '1' then
+            blocked <= '1';
+          end if;
+        end if;
+      end process;
+    end rtl;

--- a/intTests/test_comp_bisim/vhdl/pow4.vhd
+++ b/intTests/test_comp_bisim/vhdl/pow4.vhd
@@ -1,0 +1,50 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity pow4 is
+    port(
+        clk: in std_logic;
+        enable: in std_logic;
+        x: in signed(15 downto 0);
+
+        busy: out std_logic;
+        ready: out std_logic;
+        y: out signed(15 downto 0)
+    );
+end entity;
+
+architecture rtl of pow4 is
+    --SIGNALS
+    signal counter: signed(7 downto 0) := (others => '0');
+    signal buff: signed(15 downto 0) := (others => '0');
+    signal sq : signed (31 downto 0);
+
+    begin
+        ready <= '1' when (counter = "00000011") else '0';
+        busy  <= '1' when (counter > "00000000") else '0';
+        y <= buff;
+        sq <= buff * buff;
+        
+        st: process(clk)
+        begin
+          if rising_edge(clk) then
+            if counter = "00000000" then
+              if enable = '1' then
+                counter <= "00000001";
+                buff <= x;
+              else
+                counter <= "00000000";
+                buff <= "0000000000000000";
+              end if;
+            elsif counter < "00000011" then
+              counter <= counter + 1;
+              buff <= sq(15 downto 0);
+            else
+              counter <= "00000000";
+              buff <= "0000000000000000";
+            end if;
+          end if;
+        end process;
+    end rtl;
+

--- a/intTests/test_comp_bisim/vhdl/quad.vhd
+++ b/intTests/test_comp_bisim/vhdl/quad.vhd
@@ -1,0 +1,57 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity quad is
+    port(
+        reset: in std_logic;
+        clk: in std_logic;
+
+        start: in std_logic;
+        busy: out std_logic;
+
+        a: in signed(7 downto 0);
+        res: out signed(7 downto 0)
+    );
+end entity;
+
+architecture rtl of quad is
+    --SIGNALS
+    signal counter: integer := 0;
+    signal buff: signed(7 downto 0) := (others => '0');
+    signal start_latch: std_logic := '0';
+
+    begin
+        mult: process(clk)
+        variable buff2: signed(15 downto 0) := (others => '0');
+        begin
+            if rising_edge(clk) then
+                if reset = '1' then
+                    buff <= (others => '0');
+                    res <= (others => '0');
+                    busy <= '0';
+                    start_latch <= '0';
+                    counter <= 0;
+                else
+                    if start_latch = '0' then
+                        if start = '1' then
+                            counter <= 0;
+                            busy <= '1';
+                            buff(7 downto 0) <= a;
+                            start_latch <= '1';
+                        end if;
+                    elsif start_latch = '1' then
+                        if counter < 2 then
+                            buff2 := (buff*2);
+                            buff <= buff2(7 downto 0);
+                            counter <= counter + 1;
+                        elsif counter = 2 then
+                            busy <= '0';
+                            res <= buff;
+                        end if;
+                    end if;
+                end if;
+            end if;
+        end process;
+    end rtl;
+

--- a/src/SAWScript/Yosys/CompositionalTranslation.hs
+++ b/src/SAWScript/Yosys/CompositionalTranslation.hs
@@ -85,7 +85,8 @@ data TranslationContext m = TranslationContext
   }
 makeLenses ''TranslationContext
 
--- | Given a module and the context of previously-translated modules, construct a mapping from cell names to state information
+-- | Given a module and the context of previously-translated modules, construct
+-- a mapping from cell names to state information
 buildTranslationContextStateTypes ::
   MonadIO m =>
   SC.SharedContext ->
@@ -377,9 +378,12 @@ translateModule sc mods m = do
                 _ -> panic "translateModule" ["expected output state from submodule"]
         _ -> panic "translateModule" ["Malformed stateful cell type"]
 
-  -- build a record for the new value of the state
-  outst <- cryptolRecord sc outstMap
-          
+  -- build a record for the new value of the state; note that the record fields
+  -- must be mapped to valid identifiers by cellIdentifier so that converting
+  -- the record to SAW will put the fields in the same order as when stateFields
+  -- is converted to a record type
+  outst <- cryptolRecord sc $ Map.mapKeys cellIdentifier outstMap
+
   -- for each module output, collect a term for the output
   let outputPorts = moduleOutputPorts m
   outs <- fmap Map.fromList . forM (Map.toList outputPorts) $ \(onm, pat) ->

--- a/src/SAWScript/Yosys/CompositionalTranslation.hs
+++ b/src/SAWScript/Yosys/CompositionalTranslation.hs
@@ -33,10 +33,11 @@ module SAWScript.Yosys.CompositionalTranslation
 import Control.Lens.TH (makeLenses)
 
 import Control.Lens ((^.))
-import Control.Monad (forM, (>=>), void)
+import Control.Monad (forM, (>=>))
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Exception (throw)
 
+import Data.Maybe (isJust, isNothing)
 import Data.Bifunctor (bimap)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -104,7 +105,8 @@ buildTranslationContextStateTypes sc mods m = do
         pure $ Just CellStateInfo{..}
       _ -> pure Nothing
 
--- | Fetch the actual state term for a cell name, given the term for the __state__ input and information about what stateful cells exist
+-- | Fetch the actual state term for a cell name, given the term for the input
+-- state and information about what stateful cells exist
 lookupStateFor ::
   forall m.
   MonadIO m =>
@@ -117,40 +119,52 @@ lookupStateFor sc states inpst cnm = do
   let fieldnm = cellIdentifier cnm
   cryptolRecordSelect sc (Map.mapKeys cellIdentifier states) inpst fieldnm
 
--- | Add a record-typed field named __states__ to the given mapping of field names to types.
-insertStateField ::
-  MonadIO m =>
-  SC.SharedContext ->
-  Map Text (SC.Term, C.Type) {- ^ The field types of __states__ -} ->
-  Map Text (SC.Term, C.Type) {- ^ The mapping to update -} ->
-  m (Map Text (SC.Term, C.Type))
-insertStateField sc stateFields fields = do
-  stateRecordType <- fieldsToType sc stateFields
-  stateRecordCryptolType <- fieldsToCryptolType stateFields
-  pure $ Map.insert "__state__" (stateRecordType, stateRecordCryptolType) fields
+-- | Apply the function for a submodule to an optional state term and a map from
+-- input fields to terms, returning the optional output state term and output
+-- record term of all the output values
+applySubmodule ::
+  SC.SharedContext -> TranslatedModule ->
+  Maybe SC.Term -> Map Text SC.Term -> IO (Maybe SC.Term, SC.Term)
+applySubmodule sc subm (Just inpst) inps | isJust (subm ^. translatedModuleStateInfo) =
+  do inpsTerm <- cryptolRecord sc inps
+     argTerm <- SC.scPairValue sc inpst inpsTerm
+     retTerm <- SC.scApply sc (subm ^. translatedModuleTerm) argTerm
+     stOutTerm <- SC.scPairLeft sc retTerm
+     outTerm <- SC.scPairRight sc retTerm
+     return (Just stOutTerm, outTerm)
+applySubmodule sc subm _ inps | isNothing (subm ^. translatedModuleStateInfo) =
+  (Nothing,) <$>
+  (cryptolRecord sc inps >>= SC.scApply sc (subm ^. translatedModuleTerm))
+applySubmodule _ _ _ _ =
+  panic "applySubmodule"
+  ["no input state provided when to a submodule that requires it"]
 
--- | Construct a mapping from patterns to functions that construct terms for those patterns, given functions that construct terms for other patterns
--- We later "tie the knot" on this mapping given a few known patterns (e.g. module inputs and constants) to obtain actual terms for each pattern.
+-- | Construct a mapping from patterns to functions that construct terms for
+-- those patterns, given functions that construct terms for other patterns. We
+-- later "tie the knot" on this mapping given a few known patterns (e.g. module
+-- inputs and constants) to obtain actual terms for each pattern.
 buildPatternMap ::
   forall m.
   MonadIO m =>
   SC.SharedContext ->
   Map ModuleName TranslatedModule {- ^ All previously-translated modules -} ->
   Map CellName CellStateInfo {- ^ State type info for each cell -} ->
-  SC.Term {- ^ Record term mapping inputs to terms (including a field __state__, a record mapping (zenc-ed) cell names to cell states) -} ->
+  SC.Term {- ^ Term for the input value of a circuit of type (state, ins) -} ->
   Module {- ^ The module being translated -} ->
   m (PatternMap m)
 buildPatternMap sc mods states inp m = do
   let inputPorts = moduleInputPorts m
-  let inputFields = if Map.null states then void inputPorts else Map.insert "__state__" () $ void inputPorts
+  -- Project out the input state value as the left-hand projection of inp and
+  -- the input record as the right-hand projection of inp, if there is an input
+  -- state; otherwise the input record is just inp
+  (minpst, inpRec) <-
+    if Map.null states then return (Nothing, inp) else
+      liftIO ((,) <$> (Just <$> SC.scPairLeft sc inp) <*> SC.scPairRight sc inp)
 
   -- obtain a term for each input port by looking up their names in the input record
   inpTerms <- forM (Map.assocs inputPorts) $ \(nm, pat) -> do
-    t <- liftIO $ cryptolRecordSelect sc inputFields inp nm
+    t <- liftIO $ cryptolRecordSelect sc inputPorts inpRec nm
     fmap (const . pure) <$> deriveTermsByIndices sc pat t
-
-  -- grab the __state__ field from the input record
-  minpst <- if Map.null states then pure Nothing else Just <$> cryptolRecordSelect sc inputFields inp "__state__"
 
   -- for each cell, construct a term for each output pattern, parameterized by a lookup function for other patterns
   ms <- forM (Map.toList $ m ^. moduleCells) $ \(cnm, c) -> do
@@ -171,18 +185,9 @@ buildPatternMap sc mods states inp m = do
       CellTypeUserType submoduleName ->
         case Map.lookup submoduleName mods of
           Just subm -> pure $ \inps -> do
-            (domainFields, codomainFields) <- case (subm ^. translatedModuleStateInfo, minpst) of
-              (Just _, Just inpst) -> do
-                subinpst <- lookupStateFor sc states inpst cnm
-                pure
-                  ( Map.insert "__state__" subinpst inps
-                  , Map.insert "__state__" () $ void outPatterns
-                  )
-              _ -> pure (inps, void outPatterns)
-            domainRec <- cryptolRecord sc domainFields
-            codomainRec <- liftIO $ SC.scApply sc (subm ^. translatedModuleTerm) domainRec
+            (_, outsRec) <- liftIO $ applySubmodule sc subm minpst inps
             fmap (Just . Map.fromList) . forM (Map.toList outPatterns) $ \(onm, _opat) -> do
-              (onm,) <$> cryptolRecordSelect sc codomainFields codomainRec onm
+              (onm,) <$> cryptolRecordSelect sc outPatterns outsRec onm
           Nothing -> pure $ \_ -> pure Nothing
       CellTypeDff | Just inpst <- minpst -> pure $ \_ -> do
         cst <- lookupStateFor sc states inpst cnm
@@ -230,8 +235,9 @@ buildPatternMap sc mods states inp m = do
       ]
     ]
 
--- | Given a translation context (consisting of the previously translated modules, state information, and pattern map),
--- lookup the term for a given pattern in the pattern map.
+-- | Given a translation context (consisting of the previously translated
+-- modules, state information, and pattern map), lookup the term for a given
+-- pattern in the pattern map.
 translatePattern ::
   MonadIO m =>
   SC.SharedContext ->
@@ -242,11 +248,14 @@ translatePattern ::
 translatePattern sc ctx c p = do
   let pmap = ctx ^. translationContextPatternMap
   case Map.lookup p pmap of
-    -- if we find the pattern directly, use it (recursively calling translatePattern if other lookups are necessary)
+    -- if we find the pattern directly, use it (recursively calling
+    -- translatePattern if other lookups are necessary)
     Just f -> f $ translatePattern sc ctx
-    -- otherwise, we look up each bit individually and concatenate to construct the term.
-    -- this is not an optimal scheme (e.g. you can imagine patterns [1, 2] and [3, 4] being present and looking up [1, 2, 3, 4])
-    -- but it works well enough for now, and I suspect the resulting term size is easy to rewrite away in most cases
+    -- Otherwise, we look up each bit individually and concatenate to construct
+    -- the term. This is not an optimal scheme (e.g. you can imagine patterns
+    -- [1, 2] and [3, 4] being present and looking up [1, 2, 3, 4]) but it works
+    -- well enough for now, and I suspect the resulting term size is easy to
+    -- rewrite away in most cases
     Nothing -> do
       one <- liftIO $ SC.scNat sc 1
       boolty <- liftIO $ SC.scBoolType sc
@@ -259,7 +268,30 @@ translatePattern sc ctx c p = do
       vecBits <- liftIO $ SC.scVector sc onety bits
       liftIO $ SC.scJoin sc many one boolty vecBits
 
--- ^ Given previously translated modules, translate a module.
+-- | Combine the state info for all cells in a circuit with the (input or
+-- output) ports in a circuit into the corresponding SAW and Cryptol types,
+-- which should either be of the form @(st, ports)@ where both @st@ and @ports@
+-- are Cryptol record types for all the fields in the state and ports,
+-- respectively, or just @ports@ is there are no state components, i.e., if this
+-- is a combinational circuit.
+stateAndPortsToTypes :: MonadIO m => SC.SharedContext ->
+                        Map Text (SC.Term, C.Type) -> Map Text [Bitrep] ->
+                        m (SC.Term, C.Type)
+stateAndPortsToTypes sc stateFields ports =
+  do portsFields <- forM ports $ \p -> do
+       ty <- liftIO . SC.scBitvector sc . fromIntegral $ length p
+       let cty = C.tWord . C.tNum $ length p
+       pure (ty, cty)
+     portsType <- fieldsToType sc portsFields
+     portsCryType <- fieldsToCryptolType portsFields
+     if Map.null stateFields then return (portsType, portsCryType) else
+       do statesType <- fieldsToType sc stateFields
+          statesCryType <- fieldsToCryptolType stateFields
+          ty <- liftIO $ SC.scPairType sc statesType portsType
+          let cty = C.tTuple [statesCryType, portsCryType]
+          return (ty, cty)
+
+-- | Given previously translated modules, translate a module.
 -- (This is the exported interface to the functionality implemented here.)
 translateModule ::
   MonadIO m =>
@@ -270,7 +302,9 @@ translateModule ::
 translateModule sc mods m = do
   -- gather information about the stateful cells of the module
   states <- buildTranslationContextStateTypes sc mods m
-  let stateFields = Map.fromList $ bimap cellIdentifier (\cs -> (cs ^. cellStateInfoType, cs ^. cellStateInfoCryptolType)) <$> Map.toList states
+  let stateFields = Map.fromList $
+        bimap cellIdentifier (\cs -> (cs ^. cellStateInfoType,
+                                      cs ^. cellStateInfoCryptolType)) <$> Map.toList states
   _translatedModuleStateInfo <- if Map.null states
     then pure Nothing
     else do
@@ -282,32 +316,28 @@ translateModule sc mods m = do
       , _cellStateInfoFields = Just stateFields
       }
 
-  -- construct the module function's domain type (a record of all inputs, and optionally state)
+  -- construct the module function's domain type, which is either the pair type
+  -- (states, inputFields) or just inputFields if states is empty
   let inputPorts = moduleInputPorts m
-  inputFields <- forM inputPorts $ \inp -> do
-    ty <- liftIO . SC.scBitvector sc . fromIntegral $ length inp
-    let cty = C.tWord . C.tNum $ length inp
-    pure (ty, cty)
-  domainFields <- if Map.null states
-    then pure inputFields
-    else insertStateField sc stateFields inputFields
-  domainRecordType <- fieldsToType sc domainFields
-  domainRecordCryptolType <- fieldsToCryptolType domainFields
+  (domainType, domainCryType) <- stateAndPortsToTypes sc stateFields inputPorts
 
-  -- construct a fresh variable of that type (this will become the parameter to the module function)
-  domainRecordEC <- liftIO $ SC.scFreshEC sc "input" domainRecordType
-  domainRecord <- liftIO $ SC.scExtCns sc domainRecordEC
+  -- construct a fresh variable of that type (this will become the parameter to
+  -- the module function)
+  domainEC <- liftIO $ SC.scFreshEC sc "input" domainType
+  domainTerm <- liftIO $ SC.scExtCns sc domainEC
 
   -- construct a pattern map from that domain record
-  pmap <- buildPatternMap sc mods states domainRecord m
+  pmap <- buildPatternMap sc mods states domainTerm m
   let ctx = TranslationContext
         { _translationContextModules = mods
         , _translationContextStateTypes = states
         , _translationContextPatternMap = pmap
         }
 
-  -- if this module is stateful, grab the __state__ field from the domain record
-  minpst <- if Map.null states then pure Nothing else Just <$> cryptolRecordSelect sc domainFields domainRecord "__state__"
+  -- if this module is stateful, grab the first projection of the domain term as
+  -- the state
+  minpst <- if Map.null states then pure Nothing else
+              Just <$> liftIO (SC.scPairLeft sc domainTerm)
 
   -- for each stateful cell, build a term representing the new state for that cell
   outstMap <- fmap Map.fromList . forM (Map.toList states) $ \(cnm, _cs) -> do
@@ -319,27 +349,19 @@ translateModule sc mods m = do
               (cnm,) <$> translatePattern sc ctx (YosysBitvecConsumerCell cnm "D") pat
         CellTypeUserType submoduleName
           | Just subm <- Map.lookup submoduleName (ctx ^. translationContextModules) -> do
-              -- otherwise, the cell is a stateful submodule: the new state is obtained from the submodules's update function applied to the inputs and old state
+              -- otherwise, the cell is a stateful submodule: the new state is
+              -- obtained from the submodules's update function applied to the
+              -- inputs and old state
               let inpPatterns = cellInputConnections c
               -- lookup the term for each input to the cell
               inps <- fmap Map.fromList . forM (Map.toList inpPatterns) $ \(inm, pat) ->
                 (inm,) <$> translatePattern sc ctx (YosysBitvecConsumerCell cnm inm) pat
-              let outPatterns = cellOutputConnections c
-              -- build a record containing all of the cell's inputs, and (if stateful) the appropriate state field
-              sdomainFields <- case minpst of
-                Nothing -> pure inps
-                Just inpst -> do
-                  subinpst <- lookupStateFor sc states inpst cnm
-                  pure $ Map.insert "__state__" subinpst inps
-              let scodomainFields = if Map.null states then void outPatterns else Map.insert "__state__" () $ void outPatterns
-              sdomainRec <- cryptolRecord sc sdomainFields
-              -- apply the cell's function to the domain record
-              scodomainRec <- liftIO $ SC.scApply sc (subm ^. translatedModuleTerm) sdomainRec
-              -- grab the state field from the codomain record
-              (cellIdentifier cnm,) <$> cryptolRecordSelect sc scodomainFields scodomainRec "__state__"
+              liftIO (applySubmodule sc subm minpst inps) >>= \case
+                (Just st_out, _) -> return (cellIdentifier cnm, st_out)
+                _ -> panic "translateModule" ["expected output state from submodule"]
         _ -> panic "translateModule" ["Malformed stateful cell type"]
 
-  -- build a record for the new value of __state__
+  -- build a record for the new value of the state
   outst <- cryptolRecord sc outstMap
           
   -- for each module output, collect a term for the output
@@ -347,24 +369,22 @@ translateModule sc mods m = do
   outs <- fmap Map.fromList . forM (Map.toList outputPorts) $ \(onm, pat) ->
     (onm,) <$> translatePattern sc ctx (YosysBitvecConsumerOutputPort onm) pat
 
-  -- construct the return value of the module
-  codomainRecord <- cryptolRecord sc $ if Map.null states then outs else Map.insert "__state__" outst outs
+  -- construct the return value of the module as a pair of an optional output
+  -- state value paired with a record of all output values
+  outsTerm <- cryptolRecord sc outs
+  codomainTerm <-
+    if Map.null states then return outsTerm else
+      liftIO (SC.scPairValue sc outst outsTerm)
 
-  -- construct the module function's codomain type (a record of all outputs, and optionally state)
-  -- (this is the type of codomainRecord)
-  outputFields <- forM outputPorts $ \inp -> do
-    ty <- liftIO . SC.scBitvector sc . fromIntegral $ length inp
-    let cty = C.tWord . C.tNum $ length inp
-    pure (ty, cty)
-  codomainFields <- if Map.null states then pure outputFields else insertStateField sc stateFields outputFields
-  codomainRecordType <- fieldsToType sc codomainFields
-  codomainRecordCryptolType <- fieldsToCryptolType codomainFields
+  -- construct the module function's codomain type as an optional state type paired
+  -- with a record of all outputs; this is the type of codomainTerm
+  (codomainType, codomainCryType) <- stateAndPortsToTypes sc stateFields outputPorts
 
-  -- abstract over the return value - this binds the free variable domainRecord with a lambda
-  _translatedModuleTerm <- liftIO $ SC.scAbstractExts sc [domainRecordEC] codomainRecord
-  -- the type of _translatedModuleTerm - a function from domainRecordType to codomainRecordType
-  _translatedModuleType <- liftIO $ SC.scFun sc domainRecordType codomainRecordType
+  -- abstract over the return value - this binds the free variable domainEC with a lambda
+  _translatedModuleTerm <- liftIO $ SC.scAbstractExts sc [domainEC] codomainTerm
+  -- the type of _translatedModuleTerm - a function from domainType to codomainType
+  _translatedModuleType <- liftIO $ SC.scFun sc domainType codomainType
   -- the same type as a Cryptol type
-  let _translatedModuleCryptolType = C.tFun domainRecordCryptolType codomainRecordCryptolType
+  let _translatedModuleCryptolType = C.tFun domainCryType codomainCryType
 
   pure TranslatedModule{..}

--- a/src/SAWScript/Yosys/CompositionalTranslation.hs
+++ b/src/SAWScript/Yosys/CompositionalTranslation.hs
@@ -403,4 +403,9 @@ translateModule sc mods m = do
   -- the same type as a Cryptol type
   let _translatedModuleCryptolType = C.tFun domainCryType codomainCryType
 
+  -- Double-check that we created a term of the correct type
+  validateTermAtType sc
+    (Text.pack "type-checking the SAW core translation of a module")
+    _translatedModuleTerm _translatedModuleType
+
   pure TranslatedModule{..}


### PR DESCRIPTION
The way circuits are translated into SAW is that each circuit is translated into a SAW core term for a function from a Cryptol record of all the inputs, keyed by name, to a Cryptol record of all the outputs. For sequential circuits (i.e., circuits with state, such as flip-flops), the old value of the state is considered an input, with name "`__state__`", and the new value of the state is considered an output, with the same name.

E.g., a sequential circuit with inputs `a` and `b` and outputs `x` and `y`, all of 8 bits, that also has an 8-bit internal state, would have a Cryptol type that looks something like this, noting that the elements of the state type are assigned numeric names that are generated from internal details of the circuit:

```
{ __state__ : { z25 : [8] }, a : [8], b : [8] }  ->  { __state__ : { z25 : [8] }, x : [8], y : [8] }
```

The problem with this approach is that it does not allow a user to define operations over circuit representations where the operations are polymorphic in the input and output types. For instance, if we want to define a Cryptol function that maps a circuit to property of that circuit, we have to define one instance of that function for each list of input and output fields.

To solve this problem, the current PR changes the circuit translation to tuple the state with the inputs and outputs, rather than add it as a field in the records of the inputs and outputs. For instance, the above described circuit now has a Cryptol type that looks like this:

```
({ z25 : [8] }, { a : [8], b : [8] }  ->  ({ z25 : [8] }, { x : [8], y : [8] })
```

This makes it possible to write Cryptol functions that are polymorphic in the input, output, and state type of a circuit. And, indeed, there is a new example of doing this in concert with the `prove_bisim` command to verify circuits in the newly added `intTests/test_comp_bisim` test case added in this PR.
