### PR TITLE
Make the CI more robust w.r.t. the `test_comp_bisim` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,6 +572,8 @@ jobs:
         run: |
           export PATH="$PWD/bin:$PWD/dist/bin:$PATH"
           dist-tests/integration_tests
+        env:
+          ENABLE_HPC: true
 
       - name: Compute coverage
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -804,6 +804,7 @@ jobs:
       - heapster-tests
       - saw-remote-api-tests
       - cabal-test
+      - coverage
       - s2n-tests
       - exercises
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,6 +519,11 @@ jobs:
         with:
           submodules: true
 
+      - uses: haskell/actions/setup@v2
+        id: setup-haskell
+        with:
+          ghc-version: "9.4.8"
+
       - name: Install system dependencies
         shell: bash
         run: .github/ci.sh install_system_deps

--- a/intTests/disabled_tests_hpc.txt
+++ b/intTests/disabled_tests_hpc.txt
@@ -1,0 +1,7 @@
+# Tests that are not run when running the `coverage` CI job, which builds SAW
+# with HPC code coverage enabled. Unfortunately, Haskell executables compiled
+# with coverage enabled have a tendency to use greater amounts of memory, and
+# when running these test cases, the difference in memory is enough to exceed
+# the maximum memory requirements imposed by GitHub Actions CI runners.
+
+test_comp_bisim

--- a/intTests/test_comp_bisim/cryptol/spec.cry
+++ b/intTests/test_comp_bisim/cryptol/spec.cry
@@ -6,19 +6,19 @@ type input  = feedback_input 16
 type output = feedback_output 16
 
 // add10 spec
-type add10_state  = feedback_state 16 8
+type add10_state  = feedback_state 16 4
 add10_spec : (add10_state, input) -> (add10_state, output)
 add10_spec = feedback_spec`{n=10} f
   where f x = x + 10
 
 // pow4 spec
-type pow4_state  = feedback_state 16 8
+type pow4_state  = feedback_state 16 3
 pow4_spec : (pow4_state, input) -> (pow4_state, output)
 pow4_spec = feedback_spec`{n=2} f
   where f x = x ^^ 4
 
 // comp spec
-type comp_spec_state = feedback_state 16 8
+type comp_spec_state = feedback_state 16 4
 comp_spec : (comp_spec_state, input) -> (comp_spec_state, output)
 comp_spec = feedback_spec `{n=13} f
   where f x = (x ^^ 4) + 10


### PR DESCRIPTION
A collection of various CI and test case–related fixes, observed in the aftermath of https://github.com/GaloisInc/saw-script/pull/2023:

## Mergify: Require `coverage` test job to pass

Not doing so gives Mergify the freedom to merge a PR even if the `coverage` CI test job fails, as observed in https://github.com/GaloisInc/saw-script/pull/2023.

## Make `test_comp_bisim` complete in slightly less time

Locally, this shaves off about 10 seconds from the overall verification time, and it should make this test case finish more reliably within the CI's time limits.

## Skip test_comp_bisim test with coverage enabled

Sadly, building SAW with coverage enabled causes it to use noticeably more memory at runtime, which is enough to exceed the GitHub Actions CI runners' maximum memory and cause the job to be SIGKILL'ed when running the `test_comp_bisim` job. It's not obvious how to fix this, so we simply disable the `test_comp_bisim` job in CI when running with coverage enabled.

## CI: Install specific HPC version on coverage job

This ensures that the default GHC version that GitHub Actions provides (which is not fixed and is likely not to match the version that was used to build SAW with coverage) does not influence which version of `hpc` is fixed to compute code coverage.