### PR TITLE
Bump `cryptol` submodule, add regression test for #2043

### DIFF
--- a/intTests/test2043/A.cry
+++ b/intTests/test2043/A.cry
@@ -1,0 +1,9 @@
+module A where
+
+parameter
+  type N : #
+  foo : [N]
+
+bar : {n, a} (Zero a) => [n]a
+bar | n == 1 => zero
+    | n != 1 => zero

--- a/intTests/test2043/B.cry
+++ b/intTests/test2043/B.cry
@@ -1,0 +1,6 @@
+module B where
+
+import `A as A
+
+b : {n, a} (Zero a) => [n]a
+b = A::bar`{32} { foo = zero }

--- a/intTests/test2043/test.saw
+++ b/intTests/test2043/test.saw
@@ -1,0 +1,1 @@
+import "B.cry";

--- a/intTests/test2043/test.sh
+++ b/intTests/test2043/test.sh
@@ -1,0 +1,3 @@
+set -e
+
+$SAW test.saw


### PR DESCRIPTION
This bumps the `cryptol` submodule to bring in the changes from https://github.com/GaloisInc/cryptol/pull/1648. As a result, this fixes #2043. I have added a regression test to ensure that the issue remains fixed.