### PR TITLE
CI: Bump `entree-specs` commit to include fix for GaloisInc/entree-specs#5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,7 +352,7 @@ jobs:
 
         # If you change the entree-specs commit below, make sure you update the
         # documentation in saw-core-coq/README.md accordingly.
-      - run: opam pin -y entree-specs https://github.com/GaloisInc/entree-specs.git#5cf91e69c08376bcb17a95a8d2bf2daf406ae8cd
+      - run: opam pin -y entree-specs https://github.com/GaloisInc/entree-specs.git#62e916fe308d7b215363b80edf9e6d6d1602c737
 
       # FIXME: the following steps generate Coq libraries for the SAW core to
       # Coq translator and builds them; if we do other Coq tests, these steps

--- a/saw-core-coq/README.md
+++ b/saw-core-coq/README.md
@@ -31,7 +31,7 @@ sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.
 opam init
 opam repo add coq-released https://coq.inria.fr/opam/released
 opam install -y coq-bits
-opam pin -y entree-specs https://github.com/GaloisInc/entree-specs.git#5cf91e69c08376bcb17a95a8d2bf2daf406ae8cd
+opam pin -y entree-specs https://github.com/GaloisInc/entree-specs.git#62e916fe308d7b215363b80edf9e6d6d1602c737
 ```
 
 We have pinned the `entree-specs` dependency's commit to ensure that it points


### PR DESCRIPTION
This bumps the pinned `entree-specs` commit to bring in the changes from GaloisInc/entree-specs#6, which requires `entree-specs` to build with `coq-itree.5.2.*`. Doing so is necessary to fix the CI failure observed in GaloisInc/entree-specs#5. Moreover, GaloisInc/entree-specs#6 adds upper version bounds to `coq-itree` in `entree-specs`' `opam` file, minimizing the likelihood of such a breakage happening again in the future.