### PR TITLE
Build crux-mir-comp by default in build.sh.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,12 +5,13 @@ function install() {
   cp $(find dist-newstyle -type f -name $1 | sort -g | tail -1) bin/
 }
 
-cabal build exe:cryptol exe:saw exe:saw-remote-api
+cabal build exe:cryptol exe:saw exe:saw-remote-api exe:crux-mir-comp
 
 rm -rf bin && mkdir bin
 install cryptol
 install saw
 install saw-remote-api
+install crux-mir-comp
 
 echo
 echo "COPIED EXECUTABLES TO `pwd`/bin."

--- a/build.sh
+++ b/build.sh
@@ -5,13 +5,16 @@ function install() {
   cp $(find dist-newstyle -type f -name $1 | sort -g | tail -1) bin/
 }
 
-cabal build exe:cryptol exe:saw exe:saw-remote-api exe:crux-mir-comp
+cabal build exe:cryptol exe:saw exe:saw-remote-api \
+            exe:crux-mir-comp exe:extcore-info exe:verif-viewer
 
 rm -rf bin && mkdir bin
 install cryptol
 install saw
 install saw-remote-api
 install crux-mir-comp
+install extcore-info
+install verif-viewer
 
 echo
 echo "COPIED EXECUTABLES TO `pwd`/bin."


### PR DESCRIPTION
Build crux-mir-comp by default in build.sh. Closes #2060.