### PR TITLE
Retire the type alias Bind from src/SAWScript/AST.hs

### DIFF
--- a/src/SAWScript/AST.hs
+++ b/src/SAWScript/AST.hs
@@ -17,7 +17,6 @@ Stability   : provisional
 module SAWScript.AST
        ( Name
        , LName
-       , Bind
        , Located(..)
        , Import(..)
        , Expr(..)
@@ -58,8 +57,6 @@ import qualified Cryptol.Utils.Ident as P (identText, modNameChunks)
 -- Names {{{
 
 type Name = String
-
-type Bind a = (Name,a)
 
 -- }}}
 

--- a/src/SAWScript/MGU.hs
+++ b/src/SAWScript/MGU.hs
@@ -660,7 +660,10 @@ checkE m e t = do
   unify m t t'
   return e'
 
-inferField :: LName -> Bind Expr -> TI (Bind OutExpr,Bind Type)
+-- Take a struct field binding (name and expression) and return the
+-- updated binding as well as the member entry for the enclosing
+-- struct type.
+inferField :: LName -> (Name, Expr) -> TI ((Name, OutExpr), (Name, Type))
 inferField m (n,e) = do
   (e',t) <- inferE (m,e)
   return ((n,e'),(n,t))

--- a/src/SAWScript/Parser.y
+++ b/src/SAWScript/Parser.y
@@ -213,7 +213,7 @@ Type :: { Type }
  : BaseType                             { $1                      }
  | BaseType '->' Type                   { LType (maxSpan [$1, $3]) (tFun $1 $3) }
 
-FieldType :: { Bind Type }
+FieldType :: { (Name, Type) }
   : name ':' BaseType                   { (tokStr $1, $3)         }
 
 BaseType :: { Type }


### PR DESCRIPTION
It's only used in a couple places, and what minor documentation value it has is outweighed by having to look it up to see what it means. Furthermore it isn't actually part of the AST and doesn't belong with it.