### PR TITLE
Use -v0 with cabal list-bin in build.sh.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ set -e
 git submodule update --init
 
 install() {
-  PROG=$(cabal list-bin exe:$1)
+  PROG=$(cabal list-bin -v0 exe:$1)
   cp $PROG bin/
 }
 


### PR DESCRIPTION
Otherwise cabal will sometimes print extraneous output; we then end up passing that to cp and things become sad.