### PR TITLE
CI: Upgrade `{upload,download}-artifact` actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,11 +187,20 @@ jobs:
             prover_tests
           dest: dist-tests
 
+      # In the next 2 steps, we upload to different names depending on whether
+      # the binaries were compiled using HPC or not. This is done to ensure that
+      # the HPC-enabled binaries do not clobber the non-HPC-enabled binaries.
       - uses: actions/upload-artifact@v4
-        if: "matrix.ghc == '9.4.8'"
+        if: matrix.ghc == '9.4.8' && matrix.hpc == false
         with:
           path: dist-tests
           name: dist-tests-${{ matrix.os }}
+
+      - uses: actions/upload-artifact@v4
+        if: matrix.ghc == '9.4.8' && matrix.hpc == true
+        with:
+          path: dist-tests
+          name: dist-tests-${{ matrix.os }}-hpc
 
       - shell: bash
         run: .github/ci.sh setup_dist_bins
@@ -556,7 +565,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: dist-tests-${{ matrix.os }}
+          name: dist-tests-${{ matrix.os }}-hpc
           path: dist-tests
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
             prover_tests
           dest: dist-tests
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: "matrix.ghc == '9.4.8'"
         with:
           path: dist-tests
@@ -238,7 +238,7 @@ jobs:
       # distribution version matches the HPC version, the HPC build artifacts do
       # not clobber the non-HPC distribution artifacts.
       - if: matrix.ghc == '9.4.8' && matrix.hpc == false
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.config.outputs.name }} (GHC ${{ matrix.ghc }})
           path: "${{ steps.config.outputs.name }}.tar.gz*"
@@ -246,7 +246,7 @@ jobs:
           retention-days: ${{ needs.config.outputs.retention-days }}
 
       - if: matrix.ghc == '9.4.8' && matrix.hpc == false
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.config.outputs.name }}-with-solvers (GHC ${{ matrix.ghc }})
           path: "${{ steps.config.outputs.name }}-with-solvers.tar.gz*"
@@ -254,7 +254,7 @@ jobs:
           retention-days: ${{ needs.config.outputs.retention-days }}
 
       - if: matrix.ghc == '9.4.8' && matrix.run-tests && matrix.hpc == false
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: dist/bin
           name: ${{ matrix.os }}-bins
@@ -264,7 +264,7 @@ jobs:
         run: .github/ci.sh collect_hpc_files
 
       - if: matrix.hpc == true
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: hpc.tar.gz
           name: ${{ matrix.os }}-hpc.tar.gz
@@ -296,7 +296,7 @@ jobs:
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: "${{ matrix.os }}-bins"
           path: dist/bin
@@ -331,7 +331,7 @@ jobs:
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: "${{ matrix.os }}-bins"
           path: dist/bin
@@ -398,7 +398,7 @@ jobs:
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: "${{ matrix.os }}-bins"
           path: dist/bin
@@ -461,7 +461,7 @@ jobs:
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: "${{ matrix.os }}-bins"
           path: dist/bin
@@ -474,7 +474,7 @@ jobs:
         if: runner.os != 'Windows'
         run: chmod +x bin/*
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: dist-tests-${{ matrix.os }}
           path: dist-tests
@@ -554,12 +554,12 @@ jobs:
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: dist-tests-${{ matrix.os }}
           path: dist-tests
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: "${{ matrix.os }}-hpc.tar.gz"
 
@@ -609,7 +609,7 @@ jobs:
         run: |
           ./compute-coverage.sh
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: hpc-html
           name: coverage-html-${{ github.event.number }}
@@ -755,7 +755,7 @@ jobs:
           mkdir -p s2nTests/bin
 
       - name: Download previously-built SAW
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: "${{ matrix.os }}-bins"
           path: ./s2nTests/bin
@@ -809,7 +809,7 @@ jobs:
           mkdir -p exercises/bin
 
       - name: Download previously-built SAW
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: "${{ matrix.os }}-bins"
           path: ./exercises/bin


### PR DESCRIPTION
By upgrading the `upload-artifact` versions in particular, this fixes #2117.