### PR TITLE
Update the issue-reporting URL for saw-core-what4

### DIFF
--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4/Panic.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4/Panic.hs
@@ -15,7 +15,7 @@ panic = Panic.panic SAWCoreWhat4
 
 instance PanicComponent SAWCoreWhat4 where
   panicComponentName _ = "SAWCoreWhat4"
-  panicComponentIssues _ = "https://github.com/GaloisInc/saw-core-what4/issues"
+  panicComponentIssues _ = "https://github.com/GaloisInc/saw-script/issues"
 
   {-# Noinline panicComponentRevision #-}
   panicComponentRevision = $useGitRevision


### PR DESCRIPTION
It seems to have not been updated when saw-core-what4 was merged into saw-script.

Closes #2048.