### PR TITLE
Bump the entree-specs version used by heapster-tests again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,7 @@ jobs:
 
         # If you change the entree-specs commit below, make sure you update the
         # documentation in saw-core-coq/README.md accordingly.
-      - run: opam pin -y entree-specs https://github.com/GaloisInc/entree-specs.git#2ec3cab68797922dc2825bb6295dbdf6cfab9fbf
+      - run: opam pin -y entree-specs https://github.com/GaloisInc/entree-specs.git#d871d0af37ffee757e3be1f8d776bd7e84399712
 
       # FIXME: the following steps generate Coq libraries for the SAW core to
       # Coq translator and builds them; if we do other Coq tests, these steps

--- a/saw-core-coq/README.md
+++ b/saw-core-coq/README.md
@@ -31,7 +31,7 @@ sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.
 opam init
 opam repo add coq-released https://coq.inria.fr/opam/released
 opam install -y coq-bits
-opam pin -y entree-specs https://github.com/GaloisInc/entree-specs.git#2ec3cab68797922dc2825bb6295dbdf6cfab9fbf
+opam pin -y entree-specs https://github.com/GaloisInc/entree-specs.git#d871d0af37ffee757e3be1f8d776bd7e84399712
 ```
 
 We have pinned the `entree-specs` dependency's commit to ensure that it points


### PR DESCRIPTION
This has no further content change, but tightens its deps so that we won't accidentally roll back to where the previous changes aren't needed. (Then one of them wouldn't work. The other one will though.)