### PR TITLE
Remove the short option -t for --detect-vacuity

### DIFF
--- a/src/SAWScript/Options.hs
+++ b/src/SAWScript/Options.hs
@@ -114,7 +114,7 @@ options =
      "path"
     )
     pathDesc
-  , Option "t" ["detect-vacuity"]
+  , Option "" ["detect-vacuity"]
     (NoArg
      (\opts -> return opts { detectVacuity = True }))
     "Checks and warns the user about contradictory assumptions. (default: false)"


### PR DESCRIPTION
It turns out -t was already in use, meaning that neither -t option has worked since it was added.

We don't think --detect-vacuity needs a short option.

Fixes the first part of #1363. (The second part is to improve the layout of the options table so this kind of accident is harder.)