### PR TITLE
CI: Switch from `macos-12` to `macos-13`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ env:
   # ./saw-remote-api/Dockerfile
   # ./s2nTests/scripts/blst-entrypoint.sh
   # ./s2nTests/docker/saw.dockerfile
-  SOLVER_PKG_VERSION: "snapshot-20240212"
+  SOLVER_PKG_VERSION: "snapshot-20241119"
 
 jobs:
   config:
@@ -96,13 +96,13 @@ jobs:
             hpc: true
           # Windows and macOS CI runners are more expensive than Linux runners,
           # so we only build one particular GHC version to test them on. We
-          # include both an x86-64 macOS runner (macos-12) as well as an AArch64
+          # include both an x86-64 macOS runner (macos-13) as well as an AArch64
           # macOS runner (macos-14).
           - os: windows-2019
             ghc: 9.4.8
             run-tests: true
             hpc: false
-          - os: macos-12
+          - os: macos-13
             ghc: 9.4.8
             run-tests: true
             hpc: false

--- a/saw-remote-api/Dockerfile
+++ b/saw-remote-api/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /home/saw//rootfs/usr/local/bin
 # The URL here is based on the same logic used to specify BUILD_TARGET_OS and
 # BUILD_TARGET_ARCH in `.github/workflow/ci.yml`, but specialized to x86-64
 # Ubuntu.
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20240212/ubuntu-22.04-X64-bin.zip"
+RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20241119/ubuntu-22.04-X64-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 USER root
 RUN chown -R root:root /home/saw/rootfs

--- a/saw/Dockerfile
+++ b/saw/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /home/saw//rootfs/usr/local/bin
 # The URL here is based on the same logic used to specify BUILD_TARGET_OS and
 # BUILD_TARGET_ARCH in `.github/workflow/ci.yml`, but specialized to x86-64
 # Ubuntu.
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20240212/ubuntu-22.04-X64-bin.zip"
+RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20241119/ubuntu-22.04-X64-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 USER root
 RUN chown -R root:root /home/saw/rootfs


### PR DESCRIPTION
GitHub Actions is removing support for `macos-12` (see https://github.com/actions/runner-images/issues/10721), so this switches SAW's CI from `macos-12` to `macos-13` in order to support an x86-64 version of macOS.