### PR TITLE
Adapt to changes from GaloisInc/cryptol#1751, GaloisInc/cryptol#1526, and friends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -628,13 +628,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: all-html
 
       - name: Deploy to github pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
 
   build-push-image:
     runs-on: ubuntu-22.04

--- a/cabal.GHC-9.4.8.config
+++ b/cabal.GHC-9.4.8.config
@@ -336,7 +336,7 @@ constraints: any.BoundedChan ==1.0.3.0,
              any.simple-get-opt ==0.4,
              any.simple-sendfile ==0.2.32,
              simple-sendfile +allow-bsd -fallback,
-             any.simple-smt ==0.9.7,
+             any.simple-smt ==0.9.8,
              any.smallcheck ==1.2.1.1,
              any.split ==0.2.5,
              any.splitmix ==0.1.0.5,
@@ -440,4 +440,4 @@ constraints: any.BoundedChan ==1.0.3.0,
              any.zenc ==0.1.2,
              any.zlib ==0.7.1.0,
              any.zlib-bindings ==0.1.1.5
-index-state: hackage.haskell.org 2024-08-02T09:23:27Z
+index-state: hackage.haskell.org 2024-12-30T16:38:21Z

--- a/cabal.GHC-9.6.6.config
+++ b/cabal.GHC-9.6.6.config
@@ -334,7 +334,7 @@ constraints: any.BoundedChan ==1.0.3.0,
              any.simple-get-opt ==0.4,
              any.simple-sendfile ==0.2.32,
              simple-sendfile +allow-bsd -fallback,
-             any.simple-smt ==0.9.7,
+             any.simple-smt ==0.9.8,
              any.smallcheck ==1.2.1.1,
              any.split ==0.2.5,
              any.splitmix ==0.1.0.5,
@@ -438,4 +438,4 @@ constraints: any.BoundedChan ==1.0.3.0,
              any.zenc ==0.1.2,
              any.zlib ==0.7.1.0,
              any.zlib-bindings ==0.1.1.5
-index-state: hackage.haskell.org 2024-08-02T09:23:27Z
+index-state: hackage.haskell.org 2024-12-30T16:38:21Z

--- a/cabal.GHC-9.8.2.config
+++ b/cabal.GHC-9.8.2.config
@@ -335,7 +335,7 @@ constraints: any.BoundedChan ==1.0.3.0,
              any.simple-get-opt ==0.4,
              any.simple-sendfile ==0.2.32,
              simple-sendfile +allow-bsd -fallback,
-             any.simple-smt ==0.9.7,
+             any.simple-smt ==0.9.8,
              any.smallcheck ==1.2.1.1,
              any.split ==0.2.5,
              any.splitmix ==0.1.0.5,
@@ -441,4 +441,4 @@ constraints: any.BoundedChan ==1.0.3.0,
              any.zenc ==0.1.2,
              any.zlib ==0.7.1.0,
              any.zlib-bindings ==0.1.1.5
-index-state: hackage.haskell.org 2024-08-02T09:23:27Z
+index-state: hackage.haskell.org 2024-12-30T16:38:21Z


### PR DESCRIPTION
GaloisInc/cryptol#1751 removed the width field from word values, which requires mechanical changes on the `cryptol-saw-core` side to make it build. This bumps the `cryptol` submodule and makes the corresponding code changes.

https://github.com/GaloisInc/cryptol/pull/1526 requires updating the freeze files used in the CI files to make them able to download `simple-smt-0.9.8`.