### PR TITLE
Clean out the saw-core lexer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,8 @@
 ## Bug fixes
 
 * SAW now accepts Unicode input beyond characters 0..255, including in
-  embedded Cryptol fragments, and allows the same Unicode code points
-  in identifiers as Cryptol.
+  embedded Cryptol fragments and saw-core modules, and allows the same
+  Unicode code points in identifiers as Cryptol.
   It is thus now possible to refer to Cryptol objects whose names
   include extended characters.
   (#2042)

--- a/intTests/support/test-and-diff.sh
+++ b/intTests/support/test-and-diff.sh
@@ -106,11 +106,19 @@ run-tests() {
         # We also need to shorten pathnames that contain the current
         # directory, because saw feels the need to expand pathnames
         # (see also saw-script #2082).
+        #
+        # In addition to that we also need to remove the current
+        # directory when it appears in double quotes, at least for
+        # now, because many error prints at the saw-core level seem to
+        # use default Show instances and the saw-core positions carry
+        # the directory and filename separately. This becomes
+        # "interesting" from a quoting perspective...
         sed < $TEST.rawlog > $TEST.log '
             /^\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9][0-9][0-9]\] /{
                 s/^..............//
             }
             s,'"$CURDIR"'/,,g
+            s,"'"$CURDIR"'",".",g
         '
 
         # Check the output against the expected version.

--- a/intTests/test1225/test.sh
+++ b/intTests/test1225/test.sh
@@ -1,0 +1,5 @@
+set -e
+
+! $SAW test1.saw
+$SAW test2.saw
+! $SAW test3.saw

--- a/intTests/test1225/test.sh
+++ b/intTests/test1225/test.sh
@@ -2,4 +2,4 @@ set -e
 
 ! $SAW test1.saw
 $SAW test2.saw
-! $SAW test3.saw
+$SAW test3.saw

--- a/intTests/test1225/test1.saw
+++ b/intTests/test1225/test1.saw
@@ -1,0 +1,2 @@
+let x = parse_core_mod "Prelude" "True {- ";
+print_term x;

--- a/intTests/test1225/test2.saw
+++ b/intTests/test1225/test2.saw
@@ -1,0 +1,2 @@
+let x = parse_core_mod "Prelude" " {- -} True";
+print_term x;

--- a/intTests/test1225/test3.saw
+++ b/intTests/test1225/test3.saw
@@ -1,0 +1,2 @@
+let x = parse_core_mod "Prelude" " {--- ---} True";
+print_term x;

--- a/intTests/test2042/test.sh
+++ b/intTests/test2042/test.sh
@@ -4,3 +4,7 @@ $SAW test1.saw
 ! $SAW test2.saw
 ! $SAW test3.saw
 
+$SAW test4.saw
+! $SAW test5.saw
+! $SAW test6.saw
+

--- a/intTests/test2042/test4.saw
+++ b/intTests/test2042/test4.saw
@@ -1,0 +1,2 @@
+enable_experimental;
+load_sawcore_from_file "test4.sawcore";

--- a/intTests/test2042/test4.sawcore
+++ b/intTests/test2042/test4.sawcore
@@ -1,0 +1,5 @@
+-- We should now be able to have non-ascii identifiers in saw-core
+module test4 where
+import Prelude;
+lá : Bool;
+lá = True;

--- a/intTests/test2042/test5.saw
+++ b/intTests/test2042/test5.saw
@@ -1,0 +1,2 @@
+enable_experimental;
+load_sawcore_from_file "test5.sawcore";

--- a/intTests/test2042/test5.sawcore
+++ b/intTests/test2042/test5.sawcore
@@ -1,0 +1,5 @@
+-- However, we shouldn't be able to use just anything as an identifier.
+module test5 where
+import Prelude;
+😸 : Bool;
+😸 = True;

--- a/intTests/test2042/test6.saw
+++ b/intTests/test2042/test6.saw
@@ -1,0 +1,2 @@
+enable_experimental;
+load_sawcore_from_file "test6.sawcore";

--- a/intTests/test2042/test6.sawcore
+++ b/intTests/test2042/test6.sawcore
@@ -1,0 +1,7 @@
+-- Nor should we be able to use just anything _in_ an identifier.
+module test5 where
+import Prelude;
+thingy_hook : Bool;
+thingy_hook = True;
+thingy_🪝 : Bool;
+thingy_🪝 = False;

--- a/intTests/test_parse_errors/corelexer001.log.good
+++ b/intTests/test_parse_errors/corelexer001.log.good
@@ -1,0 +1,7 @@
+ Loading file "corelexer001.saw"
+ Stack trace:
+"load_sawcore_from_file" (corelexer001.saw:2:1-2:23)
+Module parsing failed:
+PosPair {_pos = Pos {posBase = ".", posPath = "corelexer001.sawcore", posLine = 1, posCol = 46}, val = UnexpectedToken TEnd}
+
+FAILED

--- a/intTests/test_parse_errors/corelexer001.saw
+++ b/intTests/test_parse_errors/corelexer001.saw
@@ -1,0 +1,2 @@
+enable_experimental;
+load_sawcore_from_file "corelexer001.sawcore";

--- a/intTests/test_parse_errors/corelexer001.sawcore
+++ b/intTests/test_parse_errors/corelexer001.sawcore
@@ -1,0 +1,1 @@
+-- line comment with no newline at end of file

--- a/intTests/test_parse_errors/corelexer002.log.good
+++ b/intTests/test_parse_errors/corelexer002.log.good
@@ -2,6 +2,6 @@
  Stack trace:
 "load_sawcore_from_file" (corelexer002.saw:2:1-2:23)
 Module parsing failed:
-PosPair {_pos = Pos {posBase = ".", posPath = "corelexer002.sawcore", posLine = 4, posCol = 0}, val = ParseError "Unclosed Comment"}
+PosPair {_pos = Pos {posBase = ".", posPath = "corelexer002.sawcore", posLine = 1, posCol = 0}, val = ParseError "Unclosed Comment"}
 
 FAILED

--- a/intTests/test_parse_errors/corelexer002.log.good
+++ b/intTests/test_parse_errors/corelexer002.log.good
@@ -1,0 +1,7 @@
+ Loading file "corelexer002.saw"
+ Stack trace:
+"load_sawcore_from_file" (corelexer002.saw:2:1-2:23)
+Module parsing failed:
+PosPair {_pos = Pos {posBase = ".", posPath = "corelexer002.sawcore", posLine = 4, posCol = 0}, val = ParseError "Unclosed Comment"}
+
+FAILED

--- a/intTests/test_parse_errors/corelexer002.saw
+++ b/intTests/test_parse_errors/corelexer002.saw
@@ -1,0 +1,2 @@
+enable_experimental;
+load_sawcore_from_file "corelexer002.sawcore";

--- a/intTests/test_parse_errors/corelexer002.sawcore
+++ b/intTests/test_parse_errors/corelexer002.sawcore
@@ -1,0 +1,3 @@
+{-
+ - Unclosed comment
+ -

--- a/saw-core/src/Verifier/SAW/Grammar.y
+++ b/saw-core/src/Verifier/SAW/Grammar.y
@@ -272,6 +272,10 @@ lexer f = do
   let issue (pos, msg) = case msg of
         InvalidInput chars -> addError pos $ UnexpectedLex chars
         UnclosedComment -> addError pos $ ParseError "Unclosed Comment"
+        MissingEOL ->
+          -- XXX: this should be a warning but we have no such ability here yet
+          --addWarning pos $ "No newline at end of file"
+          return ()
   mapM issue errors
   f result
 

--- a/saw-core/src/Verifier/SAW/Grammar.y
+++ b/saw-core/src/Verifier/SAW/Grammar.y
@@ -262,14 +262,16 @@ addError p err = Parser $ throwError (PosPair p err)
 parsePos :: Parser Pos
 parsePos = Parser $ gets pos
 
+newtype LexerError = LexerError [Word8]
+
 lexer :: (PosPair Token -> Parser a) -> Parser a
 lexer f = do
-  let go :: Maybe (Pos, [Word8]) -> AlexInput -> (AlexInput -> PosPair Token -> Either () (AlexInput, [(Pos, ParseError)], PosPair Token)) -> Either () (AlexInput, [(Pos, ParseError)], PosPair Token)
+  let go :: Maybe (Pos, [Word8]) -> AlexInput -> (AlexInput -> PosPair Token -> Either () (AlexInput, [(Pos, LexerError)], PosPair Token)) -> Either () (AlexInput, [(Pos, LexerError)], PosPair Token)
       go prevErr inp next = do
         let collectErrors errors =
               case prevErr of
                 Nothing -> errors
-                Just (pos, chars) -> (pos, UnexpectedLex (reverse chars)) : errors
+                Just (pos, chars) -> (pos, LexerError (reverse chars)) : errors
         let (PosPair p (Buffer _ b)) = inp
             end = do
               (inp', errors, tok) <- next inp (PosPair p TEnd)
@@ -290,13 +292,13 @@ lexer f = do
             let v = act (B.toString (B.take (fromIntegral l) b))
             (inp'', errors, tok) <- next inp' (PosPair p v)
             return (inp'', collectErrors errors, tok)
-  let read :: Integer -> AlexInput -> PosPair Token -> Either () (AlexInput, [(Pos, ParseError)], PosPair Token)
+  let read :: Integer -> AlexInput -> PosPair Token -> Either () (AlexInput, [(Pos, LexerError)], PosPair Token)
       read i inp tkn =
         case val tkn of
           TCmntS -> go Nothing inp (read (i+1))
           TCmntE | i > 0 -> go Nothing inp (read (i-1))
                  | otherwise -> do
-                     let err = (pos tkn, UnexpectedLex (fmap (fromIntegral . fromEnum) "-}"))
+                     let err = (pos tkn, LexerError (fmap (fromIntegral . fromEnum) "-}"))
                      (inp', errors, tok) <- go Nothing inp (read 0)
                      return (inp', err : errors, tok)
           _ | i > 0 -> go Nothing inp (read i)
@@ -309,7 +311,7 @@ lexer f = do
   Parser $ put inp'
   -- XXX: this can only actually throw one error. Fix this up when we
   -- clean out the error printing infrastructure.
-  mapM (\(pos, err) -> addError pos err) (reverse errors)
+  mapM (\(pos, LexerError chars) -> addError pos $ UnexpectedLex chars) (reverse errors)
   f result
 
 -- | Run parser given a directory for the base (used for making pathname relative),

--- a/saw-core/src/Verifier/SAW/Grammar.y
+++ b/saw-core/src/Verifier/SAW/Grammar.y
@@ -25,6 +25,7 @@ import qualified Data.ByteString.Lazy.UTF8 as B
 import Data.Maybe (isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LText
 import Data.Traversable
 import Data.Word
 import Numeric.Natural
@@ -281,14 +282,14 @@ lexer = do
 
 -- | Run parser given a directory for the base (used for making pathname relative),
 -- bytestring to parse, and parser to run.
-runParser :: Parser a -> FilePath -> FilePath -> B.ByteString -> Either (PosPair ParseError) a
-runParser (Parser m) base path b = evalState (runExceptT m) initState
-  where initState = initialLexerState base path b
+runParser :: Parser a -> FilePath -> FilePath -> LText.Text -> Either (PosPair ParseError) a
+runParser (Parser m) base path txt = evalState (runExceptT m) initState
+  where initState = initialLexerState base path txt
 
-parseSAW :: FilePath -> FilePath -> B.ByteString -> Either (PosPair ParseError) Module
+parseSAW :: FilePath -> FilePath -> LText.Text -> Either (PosPair ParseError) Module
 parseSAW = runParser parseSAW2
 
-parseSAWTerm :: FilePath -> FilePath -> B.ByteString -> Either (PosPair ParseError) Term
+parseSAWTerm :: FilePath -> FilePath -> LText.Text -> Either (PosPair ParseError) Term
 parseSAWTerm = runParser parseSAWTerm2
 
 parseError :: PosPair Token -> Parser a

--- a/saw-core/src/Verifier/SAW/Grammar.y
+++ b/saw-core/src/Verifier/SAW/Grammar.y
@@ -268,8 +268,6 @@ lexer = do
   inp <- Parser get
   let (inp', errors, result) = lexSAWCore inp
   Parser $ put inp'
-  -- XXX: this can only actually throw one error. Fix this up when we
-  -- clean out the error printing infrastructure.
   let issue (pos, msg) = case msg of
         InvalidInput chars -> addError pos $ UnexpectedLex chars
         UnclosedComment -> addError pos $ ParseError "Unclosed Comment"
@@ -277,6 +275,8 @@ lexer = do
           -- XXX: this should be a warning but we have no such ability here yet
           --addWarning pos $ "No newline at end of file"
           return ()
+  -- XXX: this can only actually throw one error. Fix this up when we
+  -- clean out the error printing infrastructure.
   mapM issue errors
   return result
 

--- a/saw-core/src/Verifier/SAW/Grammar.y
+++ b/saw-core/src/Verifier/SAW/Grammar.y
@@ -249,7 +249,7 @@ rlist1(p) :: { [p] }
 
 {
 data ParseError
-  = UnexpectedLex [Word8]
+  = UnexpectedLex Text
   | UnexpectedToken Token
   | ParseError String
   deriving (Show)

--- a/saw-core/src/Verifier/SAW/Grammar.y
+++ b/saw-core/src/Verifier/SAW/Grammar.y
@@ -269,7 +269,10 @@ lexer f = do
   Parser $ put inp'
   -- XXX: this can only actually throw one error. Fix this up when we
   -- clean out the error printing infrastructure.
-  mapM (\(pos, LexerError chars) -> addError pos $ UnexpectedLex chars) errors
+  let issue (pos, msg) = case msg of
+        InvalidInput chars -> addError pos $ UnexpectedLex chars
+        UnclosedComment -> addError pos $ ParseError "Unclosed Comment"
+  mapM issue errors
   f result
 
 -- | Run parser given a directory for the base (used for making pathname relative),

--- a/saw-core/src/Verifier/SAW/Grammar.y
+++ b/saw-core/src/Verifier/SAW/Grammar.y
@@ -13,11 +13,8 @@ Portability : non-portable (language extensions)
 -}
 
 module Verifier.SAW.Grammar
-  ( Decl(..)
-  , Term(..)
-  , parseSAW
+  ( parseSAW
   , parseSAWTerm
-  , lexer
   ) where
 
 import Control.Applicative ((<$>))

--- a/saw-core/src/Verifier/SAW/Grammar.y
+++ b/saw-core/src/Verifier/SAW/Grammar.y
@@ -43,7 +43,7 @@ import Verifier.SAW.Lexer
 
 %tokentype { PosPair Token }
 %monad { Parser }
-%lexer { lexer } { PosPair _ TEnd }
+%lexer { lexer >>= } { PosPair _ TEnd }
 %error { parseError }
 %expect 0
 
@@ -262,8 +262,8 @@ addError p err = Parser $ throwError (PosPair p err)
 parsePos :: Parser Pos
 parsePos = Parser $ gets pos
 
-lexer :: (PosPair Token -> Parser a) -> Parser a
-lexer f = do
+lexer :: Parser (PosPair Token)
+lexer = do
   inp <- Parser get
   let (inp', errors, result) = lexSAWCore inp
   Parser $ put inp'
@@ -277,7 +277,7 @@ lexer f = do
           --addWarning pos $ "No newline at end of file"
           return ()
   mapM issue errors
-  f result
+  return result
 
 -- | Run parser given a directory for the base (used for making pathname relative),
 -- bytestring to parse, and parser to run.

--- a/saw-core/src/Verifier/SAW/Lexer.x
+++ b/saw-core/src/Verifier/SAW/Lexer.x
@@ -122,21 +122,6 @@ readHexBV =
 readBinBV :: String -> [Bool]
 readBinBV = map (\c -> c == '1')
 
-ppToken :: Token -> String
-ppToken tkn =
-  case tkn of
-    TIdent s -> s
-    TRecursor s -> s ++ "#rec"
-    TNat n -> show n
-    TBitvector bits ->
-      "0b" ++ map (\b -> if b then '1' else '0') bits
-    TString s -> show s
-    TKey s -> s
-    TEnd -> "END"
-    TCmntS -> "XXXS"
-    TCmntE -> "XXXE"
-    TIllegal s -> "illegal " ++ show s
-
 data Buffer = Buffer Char !B.ByteString
 
 type AlexInput = PosPair Buffer

--- a/saw-core/src/Verifier/SAW/Lexer.x
+++ b/saw-core/src/Verifier/SAW/Lexer.x
@@ -153,8 +153,8 @@ alexGetByte (PosPair p (Buffer _ b)) = fmap fn (B.uncons b)
                 isNew = c == '\n'
                 p'    = if isNew then incLine p else incCol p
 
-lexSAWCore :: AlexInput -> (AlexInput, [(Pos, LexerError)], PosPair Token)
-lexSAWCore inp0 =
+scanToken :: AlexInput -> Either () (AlexInput, [(Pos, LexerError)], PosPair Token)
+scanToken inp0 =
   let go :: Maybe (Pos, [Word8]) -> AlexInput -> Either () (AlexInput, [(Pos, LexerError)], PosPair Token)
       go prevErr inp = do
         let collectErrors errors =
@@ -181,9 +181,14 @@ lexSAWCore inp0 =
             let v = act (BU.toString (BU.take (fromIntegral l) b))
             let tok = PosPair p v
             return (inp', collectErrors [], tok)
-      read :: Integer -> AlexInput -> Either () (AlexInput, [(Pos, LexerError)], PosPair Token)
+  in
+  go Nothing inp0
+
+lexSAWCore :: AlexInput -> (AlexInput, [(Pos, LexerError)], PosPair Token)
+lexSAWCore inp0 =
+  let read :: Integer -> AlexInput -> Either () (AlexInput, [(Pos, LexerError)], PosPair Token)
       read i inp = do
-        (inp', errors, tkn) <- go Nothing inp
+        (inp', errors, tkn) <- scanToken inp
         case val tkn of
           TCmntS -> do
                 (inp'', errors2, tok') <- read (i+1) inp'

--- a/saw-core/src/Verifier/SAW/Lexer.x
+++ b/saw-core/src/Verifier/SAW/Lexer.x
@@ -181,8 +181,9 @@ scanToken inp0 =
   in
   go inp0 [] Nothing
 
-lexSAWCore :: AlexInput -> (AlexInput, [(Pos, LexerError)], PosPair Token)
-lexSAWCore inp0 =
+
+scanSkipComments :: AlexInput -> Either () (AlexInput, [(Pos, LexerError)], PosPair Token)
+scanSkipComments inp0 =
   let read :: Integer -> AlexInput -> [(Pos, LexerError)] -> Either () (AlexInput, [(Pos, LexerError)], PosPair Token)
       read i inp errors = do
         let (inp', moreErrors, tkn) = scanToken inp
@@ -200,8 +201,13 @@ lexSAWCore inp0 =
                 read i inp' errors'
             | otherwise ->
                 return (inp', errors', tkn)
-      result = do
-        (inp0', errors, tok) <- read (0::Integer) inp0 []
+  in
+  read (0::Integer) inp0 []
+
+lexSAWCore :: AlexInput -> (AlexInput, [(Pos, LexerError)], PosPair Token)
+lexSAWCore inp0 =
+  let result = do
+        (inp0', errors, tok) <- scanSkipComments inp0
         return (inp0', reverse errors, tok)
   in
   case result of

--- a/saw-core/src/Verifier/SAW/Lexer.x
+++ b/saw-core/src/Verifier/SAW/Lexer.x
@@ -22,16 +22,10 @@ Portability : non-portable (language extensions)
 -}
 
 module Verifier.SAW.Lexer
-  ( module Verifier.SAW.Position
-  , Token(..)
-  , ppToken
-  , Buffer(..)
-  , AlexInput
-  , initialAlexInput
-  , alexScan
-  , alexGetByte
-  , AlexReturn(..)
+  ( Token(..)
   , LexerError(..)
+  , LexerState
+  , initialLexerState
   , lexSAWCore
   ) where
 
@@ -156,6 +150,11 @@ initialAlexInput base path b = PosPair pos input
                   }
         prevChar = error "internal: runLexer prev char undefined"
         input = Buffer prevChar b
+
+-- Wrap the input type for export, in case we end up wanting other state
+type LexerState = AlexInput
+initialLexerState :: FilePath -> FilePath -> B.ByteString -> LexerState
+initialLexerState = initialAlexInput
 
 alexInputPrevChar :: AlexInput -> Char
 alexInputPrevChar (val -> Buffer c _) = c

--- a/saw-core/src/Verifier/SAW/ParserUtils.hs
+++ b/saw-core/src/Verifier/SAW/ParserUtils.hs
@@ -30,12 +30,10 @@ import Control.Applicative
 import Control.Monad (forM_)
 import Control.Monad.State (StateT, execStateT, modify)
 import Control.Monad.Trans.Class (MonadTrans(..))
-import qualified Data.ByteString.Lazy as BL
-#if !MIN_VERSION_template_haskell(2,8,0)
-import qualified Data.ByteString.Lazy.UTF8 as UTF8
-#endif
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.IO as TLIO
 import Language.Haskell.TH
 #if MIN_VERSION_template_haskell(2,7,0)
 import Language.Haskell.TH.Syntax (qAddDependentFile)
@@ -49,8 +47,8 @@ import Verifier.SAW.SharedTerm
 import Verifier.SAW.TypedAST
 import Verifier.SAW.Typechecker (tcInsertModule)
 
--- | Parse an untyped module declaration from a byte-string
-readModule :: FilePath -> FilePath -> BL.ByteString -> Un.Module
+-- | Parse an untyped module declaration from a (lazy) Text
+readModule :: FilePath -> FilePath -> TL.Text -> Un.Module
 readModule base path b =
   case Un.parseSAW base path b of
     Right m -> m
@@ -60,8 +58,8 @@ readModule base path b =
 readModuleFromFile :: FilePath -> IO Un.Module
 readModuleFromFile path = do
   base <- getCurrentDirectory
-  b <- BL.readFile path
-  return $ readModule base path b
+  txt <- TLIO.readFile path
+  return $ readModule base path txt
 
 
 -- | Monad for defining TH declarations

--- a/src/SAWScript/Builtins.hs
+++ b/src/SAWScript/Builtins.hs
@@ -37,7 +37,6 @@ import qualified Control.Exception as Ex
 import Data.Char (toLower)
 import qualified Data.ByteString as StrictBS
 import qualified Data.ByteString.Lazy as BS
-import qualified Data.ByteString.Lazy.UTF8 as B
 import qualified Data.IntMap as IntMap
 import Data.IORef
 import Data.List (isPrefixOf, isInfixOf, sort)
@@ -48,6 +47,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LText
 import Data.Time.Clock
 import Data.Typeable
 
@@ -2013,7 +2013,7 @@ parseCoreMod mnm_str input =
      let base = "<interactive>"
          path = "<interactive>"
      uterm <-
-       case parseSAWTerm base path (B.fromString input) of
+       case parseSAWTerm base path (LText.pack input) of
          Right uterm -> return uterm
          Left err ->
            do let msg = show err

--- a/src/SAWScript/HeapsterBuiltins.hs
+++ b/src/SAWScript/HeapsterBuiltins.hs
@@ -72,10 +72,10 @@ import Control.Monad
 import Control.Monad.Reader
 import qualified Control.Monad.Fail as Fail
 import System.Directory
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.ByteString.Lazy.UTF8 as BL
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.IO as TLIO
 
 import Data.Binding.Hobbits hiding (sym)
 
@@ -274,8 +274,8 @@ heapster_default_env = emptyPermEnv
 readModuleFromFile :: FilePath -> TopLevel (Un.Module, ModuleName)
 readModuleFromFile path = do
   base <- liftIO getCurrentDirectory
-  b <- liftIO $ BL.readFile path
-  case Un.parseSAW base path b of
+  txt <- liftIO $ TLIO.readFile path
+  case Un.parseSAW base path txt of
     Right m@(Un.Module (Un.PosPair _ mnm) _ _) -> pure (m, mnm)
     Left err -> fail $ "Module parsing failed:\n" ++ show err
 
@@ -285,7 +285,7 @@ parseTermFromString :: String -> String -> TopLevel Un.Term
 parseTermFromString nm term_string = do
   let base = ""
       path = "<" ++ nm ++ ">"
-  case Un.parseSAWTerm base path (BL.fromString term_string) of
+  case Un.parseSAWTerm base path (TL.pack term_string) of
     Right term -> pure term
     Left err -> fail $ "Term parsing failed:\n" ++ show err
 

--- a/src/SAWScript/Lexer.x
+++ b/src/SAWScript/Lexer.x
@@ -170,6 +170,9 @@ startPos = AlexPos { apLine = 1, apCol = 1 }
 -- feed alex a byte describing the current char
 -- this came from Cryptol's lexer, which came from LexerUtils, which
 -- adapted the technique used in GHC's lexer.
+--
+-- FUTURE: it would be nice to share this with the saw-core lexer
+-- (and maybe also the Cryptol lexer) instead of pasting it repeatedly
 byteForChar :: Char -> Word8
 byteForChar c
   | c <= '\7' = non_graphic


### PR DESCRIPTION
Unwind confusing code, tidy up, improve modularity, add Unicode support to match Cryptol and saw-script. Also fixes the interaction of block and line comments, and closes #1225.