### PR TITLE
Fix up the aws-lc-verification and blst-verification CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
   # older .so files are cached, which can have various effects
   # (e.g. cabal complains it can't find a valid version of the "happy"
   # tool).
-  CABAL_CACHE_VERSION: 2
+  CABAL_CACHE_VERSION: 3
   SOLVER_CACHE_VERSION: 1
 
   DISABLED_TESTS: "test0000 test_FNV_a1_rev test0010_jss_cnf_exp test0039_rust test_boilerplate test_external_abc"

--- a/s2nTests/docker/awslc.dockerfile
+++ b/s2nTests/docker/awslc.dockerfile
@@ -6,11 +6,24 @@ RUN curl -OL https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0
     tar xf clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz && \
     cp -r clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04/* /usr
 
+# The commit we check out is now the head of the saw-test-runs branch,
+# because we added that commit (and branch) specifically to fix up
+# some problems with this test run. Prior to that the commit was the
+# head of the sb/functors-ci-pin branch. It is no longer clear at this
+# point (January 2025) why that particular branch was chosen (there
+# are many) or how it relates to the upstream state of the repository
+# (our copy in GaloisInc is a fork repo).
+#
+# We're using the specific commit hash rather than the branch (even
+# though the branch is now specific to what we're doing here) so it
+# doesn't silently update on us if/when we start tidying up over
+# there.
+
 WORKDIR /saw-script
 RUN mkdir -p /saw-script && \
     git clone https://github.com/GaloisInc/aws-lc-verification.git && \
     cd aws-lc-verification && \
-    git checkout 9e9dde6882ade1f5d01c6d088e6dcca181358a74 && \
+    git checkout f2570467f0d8ce21df00b3cf3ccc325656d77b4e && \
     git config --file=.gitmodules submodule.src.url https://github.com/awslabs/aws-lc && \
     git submodule sync && \
     git submodule update --init

--- a/s2nTests/docker/blst.dockerfile
+++ b/s2nTests/docker/blst.dockerfile
@@ -6,9 +6,14 @@ RUN curl -OL https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0
     tar xf clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz && \
     cp -r clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04/* /usr
 
+# The commit we check out is the head of the main branch.
+#
+# We're using the specific commit hash (rather than checking out main)
+# so it doesn't update under us unexpectedly.
+
 RUN git clone https://github.com/GaloisInc/blst-verification.git /workdir && \
     cd /workdir && \
-    git checkout f7c50e400d18066cc4849513418c3f407ba3c608 && \
+    git checkout 9895c023e510c4e89dec098db0467a28ba14785b && \
     git config --file=.gitmodules submodule.blst.url https://github.com/supranational/blst && \
     git config --file=.gitmodules submodule.blst_patched.url https://github.com/supranational/blst && \
     git config --file=.gitmodules submodule.blst_bulk_addition.url https://github.com/supranational/blst && \

--- a/s2nTests/scripts/awslc-entrypoint.sh
+++ b/s2nTests/scripts/awslc-entrypoint.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -xe
 
+export IN_SAW_CI=yes
+
 cd /saw-script/aws-lc-verification/SAW
 ./scripts/install.sh
-rm bin/saw
+rm -f bin/saw
 cp /saw-bin/saw bin/saw
 cp /saw-bin/abc bin/abc
 cp /saw-bin/yices bin/yices

--- a/s2nTests/scripts/blst-entrypoint.sh
+++ b/s2nTests/scripts/blst-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -xe
 
+export IN_SAW_CI=yes
+
 cd /workdir
 ./scripts/install.sh
 cp /saw-bin/cryptol bin/cryptol


### PR DESCRIPTION
Refer to new commits in both repositories that both respond to ```$IN_SAW_CI``` to avoid downloading and also, when downloading, don't try to fetch ancient nightlies that have disappeared.

Closes #2166.