### PR TITLE
CI: Don't run code coverage job on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,7 +542,10 @@ jobs:
     name: "Run integration tests with coverage reporting"
     needs: build
     runs-on: ${{ matrix.os }}
-    if: github.event_name == 'pull_request'
+    # Do not run this job in forks, as the deploy-pages step will fail unless it
+    # has GITHUB_TOKEN permissions from a user within the GaloisInc organization
+    # (see #2216).
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
The code coverage job uses `deploy-pages` to publish the code coverage results, but this requires `GITHUB_TOKEN` permissions from someone within the GaloisInc GitHub organization. As such, this job cannot reasonably work on a fork of the `saw-script` repo, so we disable this job if a fork is detected.

Fixes #2216.