### PR TITLE
Clean up documentation minutiae

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -72,7 +72,7 @@ This directory contains utility scripts (and the documentation's
 
 1. If the build succeeds, but you aren't seeing all of the expected changes:
 
-   Try running `make mostlyclean` before rebuilding; Sphinx may have failed to
+   Try running `make clean` before rebuilding; Sphinx may have failed to
    detect the changes you made, and you're seeing stale/cached output.
 2. If you have unresolved reference warnings:
 
@@ -82,7 +82,7 @@ This directory contains utility scripts (and the documentation's
    documentation](https://myst-parser.readthedocs.io/en/latest/syntax/cross-referencing.html).
 3. If the build fails:
 
-   Try a full `make clean` to wipe out the `.venv/` directory and start again in
+   Try a full `make distclean` to wipe out the `.venv/` directory and start again in
    a fresh environment.
 
 If you still have trouble, you've likely uncovered a bug in the system.

--- a/doc/README.md
+++ b/doc/README.md
@@ -51,9 +51,6 @@ The following targets are available:
   documentation.
   This tries not to do unnecessary work: If you already have a `doc/.venv/`, it
   will simply install the dependencies the build requires.
-- `package-code`: Create tar.gz archives of all `doc/**/code/` directories.
-  This can be used to provide downloads in the HTML rendering of the
-  documentation (see [below](#code-examples)).
 - `install-pdf`: Build and install PDF renderings to `doc/pdfs/`.
 - `clean`: Clear out all packaged code and Sphinx-generated files.
 - `distclean`: All of the above, plus the Python environment.
@@ -70,10 +67,6 @@ This directory contains utility scripts (and the documentation's
   It uses the sibling `requirements.txt` file, and can be run anywhere you want
   to create a `.venv/` suitable for building SAW documentation (though in most
   cases, you'll just be running `make setup-env` in `doc/`).
-- `scripts/package_code.sh` finds all directories named `code` in the file tree,
-  and if there is no sibling `code.tar.gz`, creates it.
-  This is the implementation of `make package-code`, but like
-  `scripts/setup_env.sh` can be run anywhere.
 
 ### Troubleshooting
 

--- a/doc/developer/releasing.md
+++ b/doc/developer/releasing.md
@@ -25,7 +25,7 @@ The release process is:
 
    - successful build artifacts across all platforms,
    - successful tests on all test suites,
-   - an up-to-date [`SOURCE_DATE_EPOCH`](../.env) for documentation builds,
+   - an up-to-date [`SOURCE_DATE_EPOCH`](../scripts/epoch.mk) for documentation builds,
    - up-to-date [documentation PDFs](../pdfs), and
    - an up-to-date [CHANGES.md](../../CHANGES.md) file.
 


### PR DESCRIPTION
There were a small handful of 'bugs' introduced in `doc/README.md` (and the release process documentation) after the last few corrections I made in #2202:

- I missed a use of the old cleanup make target names `mostlyclean` and `clean` in the README
- There were still references to `package_code.sh` and the `package-code` make target in the README
- `releasing.md` incorrectly linked to `../.env`, which was moved/renamed to `../scripts/epoch.mk`

I didn't catch anything else for now -- these were just obvious-enough mistakes that I wanted to get them cleaned up ASAP.