### PR TITLE
Bump `crucible` submodule to bring in changes from GaloisInc/crucible#1297 and GaloisInc/crucible#1305 

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -22,6 +22,7 @@ packages:
     deps/language-sally
     deps/crucible/crucible
     deps/crucible/crucible-concurrency
+    deps/crucible/crucible-debug
     deps/crucible/crucible-jvm
     deps/crucible/crucible-llvm
     deps/crucible/crucible-mir


### PR DESCRIPTION
This bumps the `crucible` submodule to bring in the changes from:

* https://github.com/GaloisInc/crucible/pull/1297. Now that `crux` incurs a dependency on the newly added `crucible-debug` library, we need to declare this in the `cabal.project` file.
* https://github.com/GaloisInc/crucible/pull/1305. This fixes a bug seen in the wild in a large SAW proof development (unfortunately, minimizing this into a test case proves infeasible).