### PR TITLE
Update test reference outputs after the saw-core prelude changes

### DIFF
--- a/intTests/test2049/test.log.1.good
+++ b/intTests/test2049/test.log.1.good
@@ -13,12 +13,12 @@ Literal equality postcondition
 Expected term: 
 let { x@1 = Prelude.Vec 8 Prelude.Bool
     }
- in fresh:zero::table#804
+ in fresh:zero::table#806
 Actual term:
 let { x@1 = Prelude.Vec 8 Prelude.Bool
     }
- in Cryptol.ecArrayUpdate x@1 x@1 fresh:zero::table#804
-      fresh:zero::k#805
+ in Cryptol.ecArrayUpdate x@1 x@1 fresh:zero::table#806
+      fresh:zero::k#807
       (Prelude.bvNat 8 0)
 
  SolverStats {solverStatsSolvers = fromList ["W4 ->z3"], solverStatsGoalSize = 334}

--- a/intTests/test2049/test.log.2.good
+++ b/intTests/test2049/test.log.2.good
@@ -13,12 +13,12 @@ Literal equality postcondition
 Expected term: 
 let { x@1 = Prelude.Vec 8 Prelude.Bool
     }
- in fresh:zero::table#804
+ in fresh:zero::table#806
 Actual term:
 let { x@1 = Prelude.Vec 8 Prelude.Bool
     }
- in Cryptol.ecArrayUpdate x@1 x@1 fresh:zero::table#804
-      fresh:zero::k#805
+ in Cryptol.ecArrayUpdate x@1 x@1 fresh:zero::table#806
+      fresh:zero::k#807
       (Prelude.bvNat 8 0)
 
  SolverStats {solverStatsSolvers = fromList ["W4 ->z3"], solverStatsGoalSize = 334}

--- a/intTests/test_llvm_errors/err001.log.good
+++ b/intTests/test_llvm_errors/err001.log.good
@@ -8,11 +8,11 @@ Expected term:
 let { x@1 = Prelude.Vec 32 Prelude.Bool
       x@2 = Cryptol.TCNum 32
     }
- in Cryptol.ecMul x@1 (Cryptol.PRingSeqBool x@2) fresh:x#801
+ in Cryptol.ecMul x@1 (Cryptol.PRingSeqBool x@2) fresh:x#803
       (Cryptol.ecNumber (Cryptol.TCNum 3) x@1
          (Cryptol.PLiteralSeqBool x@2))
 Actual term:
-Prelude.bvMul 32 (Prelude.bvNat 32 2) fresh:x#801
+Prelude.bvMul 32 (Prelude.bvNat 32 2) fresh:x#803
 
  SolverStats {solverStatsSolvers = fromList ["SBV->Z3"], solverStatsGoalSize = 389}
  ----------Counterexample----------


### PR DESCRIPTION
Closes #2251.