### PR TITLE
Run deploy-docs on pushes

### DIFF
--- a/.github/save_doc_publish_dir.py
+++ b/.github/save_doc_publish_dir.py
@@ -13,7 +13,6 @@ import re
 # is the case in GitHub actions.
 
 github_ref = os.environ.get("GITHUB_REF")
-branch_name = os.environ.get("BRANCH_NAME")
 
 # Matches vx.y or vx.y.z
 m = re.match(r"^refs/tags/v?([0-9]+\.[0-9]+(?:\.[0-9]+)?)$", github_ref)
@@ -21,8 +20,6 @@ if m:
     target = m.group(1)
 elif github_ref == "refs/heads/master":
     target = "master"
-elif branch_name is not None:
-    target = branch_name
 else:
     target = ""
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,8 +357,6 @@ jobs:
       - name: Determine documentation publishing directory
         id: doc-publish-dir
         run: python3 .github/save_doc_publish_dir.py
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
       # Using peaceiris/actions-gh-pages, as it allows us to specify specific
       # target directories to publish to, where the built-in actions are

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
     # Do not run this job in forks, as the deployment to GitHub pages will fail
     # unless it has GITHUB_TOKEN permissions from a user within the GaloisInc
     # organization (see #2216).
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc')
     strategy:
       matrix:
         os: [ubuntu-22.04]


### PR DESCRIPTION
Previously, because of the condition on it, the deploy-docs job would _only_ run for `pull_request` events on non-forks.

This updates the condition to allow the job to run when the event is 'push', meaning we will also deploy for merges to `master`, `release-*` branches, and `vM.m`/`vM.m.p` tags (as intended).