### PR TITLE
Don't run deploy-docs on release-* branch pushes or any pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,14 @@ jobs:
     name: "Deploy SAW documentation to GitHub Pages"
     needs: [build-docs]
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release-') }}
+    # Only run for pushes to `master` and version tags, but not in forks.
+    # This is to avoid issues with missing permissions on GITHUB_TOKEN, needed
+    # when actually deploying the documentation to the `gh-pages` branch.
+    #
+    # Note that pushing a tag results in a github.ref of the form
+    # `refs/tags/...`: Even if the tag refers to `HEAD` of a `release-*` branch,
+    # only a workflow for the `refs/tags/...` ref will be started.
+    if: github.event_name == 'push' && needs.config.outputs.release == 'false' && github.repository_owner == 'GaloisInc'
     strategy:
       matrix:
         os: [ubuntu-22.04]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,9 @@ jobs:
     # Do not run this job in forks, as the deployment to GitHub pages will fail
     # unless it has GITHUB_TOKEN permissions from a user within the GaloisInc
     # organization (see #2216).
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc')
+    if: |
+      (github.event_name == 'push' && ${{ ! startsWith(github.ref, 'refs/heads/release-') }}) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc')
     strategy:
       matrix:
         os: [ubuntu-22.04]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
     name: "Deploy SAW documentation to GitHub Pages"
     needs: [build-docs]
     runs-on: ${{ matrix.os }}
-    if: github.event_name == 'push' && ${{ ! startsWith(github.ref, 'refs/heads/release-') }}
+    if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/heads/release-') }}
     strategy:
       matrix:
         os: [ubuntu-22.04]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,12 +333,7 @@ jobs:
     name: "Deploy SAW documentation to GitHub Pages"
     needs: [build-docs]
     runs-on: ${{ matrix.os }}
-    # Do not run this job in forks, as the deployment to GitHub pages will fail
-    # unless it has GITHUB_TOKEN permissions from a user within the GaloisInc
-    # organization (see #2216).
-    if: |
-      (github.event_name == 'push' && ${{ ! startsWith(github.ref, 'refs/heads/release-') }}) ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc')
+    if: github.event_name == 'push' && ${{ ! startsWith(github.ref, 'refs/heads/release-') }}
     strategy:
       matrix:
         os: [ubuntu-22.04]


### PR DESCRIPTION
This prevents an awkward "partial run" for such branches -- previously, this _job_ would run for release-* branches, but the _step_ pushing documentation to the gh-pages branch would be skipped (due to the destination directory determination returning an empty string).

Since we already restrict the CI workflow to pushes to tags / master / release branches, it is easiest to specify the condition as a denial of branches starting with release- than acceptance of master / all version tags.