### PR TITLE
Remove obsolete CI logic to mangle Version.hs only on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,15 +161,6 @@ jobs:
           restore-keys: |
             ${{ env.CABAL_CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-
 
-      - if: needs.config.outputs.release == 'true'
-        shell: bash
-        run: |
-          sed -i.bak \
-            -e 's/^hashText = .*$/hashText = ""/' \
-            -e '/import GitRev.*$/d' \
-            saw/SAWScript/Version.hs
-          rm -f saw/SAWScript/Version.hs.bak
-
       - shell: bash
         run: .github/ci.sh build
         env:


### PR DESCRIPTION
(cherry picked from commit ea4d21f649d62452e3be91a5384e8bc72566972b)

Should fix the release build.