### PR TITLE
Remove more obsolete CI logic to mangle Version.hs only on release branches.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -801,15 +801,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - if: needs.config.outputs.release == 'true'
-        shell: bash
-        run: |
-          sed -i.bak \
-            -e 's/^hashText = .*$/hashText = ""/' \
-            -e '/import GitRev.*$/d' \
-            saw/SAWScript/Version.hs
-          rm -f saw/SAWScript/Version.hs.bak
-
       - uses: docker/build-push-action@v2
         with:
           context: .


### PR DESCRIPTION
Turns out there were two copies of the offending seddery in ci.yml. The second one breaks the Docker image.
