### PR TITLE
Update the what4-solvers snapshot to 20250227 (`release-1.3` backport)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,7 @@ env:
   # Solver package snapshot date - also update in the following locations:
   # ./saw/Dockerfile
   # ./saw-remote-api/Dockerfile
-  # ./s2nTests/scripts/blst-entrypoint.sh
-  # ./s2nTests/docker/saw.dockerfile
-  SOLVER_PKG_VERSION: "snapshot-20241119"
+  SOLVER_PKG_VERSION: "snapshot-20250227"
 
 jobs:
   config:

--- a/saw-remote-api/Dockerfile
+++ b/saw-remote-api/Dockerfile
@@ -31,7 +31,8 @@ WORKDIR /home/saw//rootfs/usr/local/bin
 # The URL here is based on the same logic used to specify BUILD_TARGET_OS and
 # BUILD_TARGET_ARCH in `.github/workflow/ci.yml`, but specialized to x86-64
 # Ubuntu.
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20241119/ubuntu-22.04-X64-bin.zip"
+# If updating the snapshot version, update ci.yml and saw/Dockerfile too.
+RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250227/ubuntu-22.04-X64-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 USER root
 RUN chown -R root:root /home/saw/rootfs

--- a/saw/Dockerfile
+++ b/saw/Dockerfile
@@ -32,7 +32,8 @@ WORKDIR /home/saw//rootfs/usr/local/bin
 # The URL here is based on the same logic used to specify BUILD_TARGET_OS and
 # BUILD_TARGET_ARCH in `.github/workflow/ci.yml`, but specialized to x86-64
 # Ubuntu.
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20241119/ubuntu-22.04-X64-bin.zip"
+# If updating the snapshot version, update ci.yml and saw-remote-api/Dockerfile too.
+RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250227/ubuntu-22.04-X64-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 USER root
 RUN chown -R root:root /home/saw/rootfs


### PR DESCRIPTION
This backports the changes from https://github.com/GaloisInc/saw-script/pull/2261 to the `release-1.3` branch.

(cherry picked from commit 9c155d4c2110d42564d9c175e43a3a608e3254d9)