### PR TITLE
cabal: Group build-deps by how we get them

### DIFF
--- a/crucible-mir-comp/crucible-mir-comp.cabal
+++ b/crucible-mir-comp/crucible-mir-comp.cabal
@@ -19,22 +19,30 @@ extra-source-files:  README.md
 
 library
   default-language: Haskell2010
-  build-depends: base >= 4.9 && < 5,
-                 text,
-                 prettyprinter >= 1.7.0,
-                 crucible,
-                 parameterized-utils >= 1.0.8,
+  build-depends:
+                 -- upstream packages from hackage
+                 base >= 4.9 && < 5,
+                 bytestring,
                  containers,
                  lens,
-                 vector,
                  mtl,
-                 what4,
+                 prettyprinter >= 1.7.0,
+                 text,
+                 vector,
+
+                 -- galois packages from hackage
                  bv-sized,
-                 bytestring,
+
+                 -- packages in git submodules
+                 crucible,
                  crucible-mir,
+                 parameterized-utils >= 1.0.8,
+                 what4,
+
+                 -- internal subpackages in the saw tree
+                 cryptol-saw-core,
                  saw-core,
                  saw-core-what4,
-                 cryptol-saw-core,
                  saw-script
 
   hs-source-dirs: src

--- a/crux-mir-comp/crux-mir-comp.cabal
+++ b/crux-mir-comp/crux-mir-comp.cabal
@@ -19,24 +19,30 @@ extra-source-files:  README.md
 
 library
   default-language: Haskell2010
-  build-depends: base >= 4.9 && < 5,
-                 text,
-                 extra,
-                 crucible,
-                 parameterized-utils >= 1.0.8,
-                 containers,
-                 lens,
-                 what4,
+  build-depends:
+                 -- upstream packages from hackage
+                 base >= 4.9 && < 5,
                  bytestring,
-                 crux,
+                 containers,
+                 extra,
+                 lens,
+                 text,
+
+                 -- packages in git submodules
+                 crucible,
                  crucible-mir,
-                 crucible-mir-comp,
+                 crux,
                  crux-mir,
+                 cryptol,
+                 parameterized-utils >= 1.0.8,
+                 what4,
+
+                 -- internal subpackages in the saw tree
+                 cryptol-saw-core,
+                 crucible-mir-comp,
                  saw-core,
                  saw-core-what4,
-                 saw-script,
-                 cryptol,
-                 cryptol-saw-core
+                 saw-script
 
   hs-source-dirs: src
   exposed-modules: Mir.Compositional
@@ -51,24 +57,29 @@ executable crux-mir-comp
   main-is: Main.hs
 
   build-depends:
+                -- upstream packages from hackage
                 base >= 4.7 && < 5,
-                crux-mir-comp,
-                text,
-                crucible,
-                parameterized-utils >= 1.0.8,
                 containers,
                 lens,
-                vector,
                 mtl,
-                transformers,
-                what4,
                 tasty            >= 0.10,
                 tasty-hunit      >= 0.10,
                 tasty-quickcheck >= 0.8,
                 tasty-golden     >= 2.3,
+                template-haskell,
+                text,
+                transformers,
+                vector,
+
+                -- packages in git submodules
+                crucible,
                 crux,
                 crux-mir,
-                template-haskell
+                parameterized-utils >= 1.0.8,
+                what4,
+
+                -- this package's own library
+                crux-mir-comp
 
   ghc-options: -Wall -threaded
   ghc-prof-options: -O2 -fprof-auto-top
@@ -85,30 +96,35 @@ test-suite test
   main-is: Test.hs
 
   build-depends:
+                -- upstream packages from hackage
                 base             >= 4.7,
+                bytestring,
+                config-schema,
+                config-value,
                 containers,
                 deepseq,
                 directory,
                 filepath,
                 parsec,
                 process,
-                crux-mir,
-                crux-mir-comp,
                 QuickCheck,
+                regex-base,
+                regex-posix,
                 tasty            >= 0.10,
                 tasty-hunit      >= 0.10,
                 tasty-quickcheck >= 0.8,
                 tasty-golden     >= 2.3,
                 tasty-expected-failure >= 0.11,
                 temporary        >= 1.3,
+                utf8-string,
+
+                -- packages in git submodules
                 aig,
-                crux,
                 crucible,
-                config-schema,
-                config-value,
-                bytestring,
-                regex-base,
-                regex-posix,
-                utf8-string
+                crux,
+                crux-mir,
+
+                -- this package's own library
+                crux-mir-comp
 
   default-language: Haskell2010

--- a/cryptol-saw-core/cryptol-saw-core.cabal
+++ b/cryptol-saw-core/cryptol-saw-core.cabal
@@ -20,29 +20,36 @@ extra-source-files:
 
 library
   build-depends:
-    aig,
-    array,
+
+    -- upstream packages from hackage
     base,
     base-compat,
+    array,
     bytestring,
     containers,
-    cryptol >= 2.3.0,
     data-inttrie >= 0.1.4,
+    executable-path,
+    filepath,
     integer-gmp,
     modern-uri,
     mtl,
     panic,
+    sbv,
+    template-haskell,
+    text,
+    vector,
+
+    -- packages in git submodules
+    aig,
+    cryptol >= 2.3.0,
+    what4,
+
+    -- internal subpackages in the saw tree
     saw-core,
     saw-core-aig,
     saw-core-sbv,
-    saw-core-what4,
-    what4,
-    sbv,
-    vector,
-    text,
-    template-haskell,
-    executable-path,
-    filepath
+    saw-core-what4
+
   hs-source-dirs: src
   exposed-modules:
      Verifier.SAW.Cryptol
@@ -61,16 +68,22 @@ executable css
     Paths_cryptol_saw_core
 
   build-depends:
-    aig,
-    array,
+
+    -- upstream packages from hackage
     base >= 4.5,
+    array,
     bytestring,
     containers,
-    cryptol,
-    saw-core,
-    saw-core-aig,
     text,
-    cryptol-saw-core
+
+    -- packages in git submodules
+    aig,
+    cryptol,
+
+    -- internal subpackages in the saw tree
+    cryptol-saw-core,
+    saw-core,
+    saw-core-aig
 
   hs-source-dirs : css
   main-is : Main.hs
@@ -85,13 +98,19 @@ test-suite cryptol-saw-core-tc-test
   main-is: CryptolVerifierTC.hs
 
   build-depends:
+
+    -- upstream packages from hackage
     base,
     bytestring,
     containers,
-    cryptol,
-    cryptol-saw-core,
     heredoc >= 0.2,
-    saw-core,
-    text
+    text,
+
+    -- packages in git submodules
+    cryptol,
+
+    -- internal subpackages in the saw tree
+    cryptol-saw-core,
+    saw-core
 
   GHC-options: -threaded

--- a/heapster-saw/heapster-saw.cabal
+++ b/heapster-saw/heapster-saw.cabal
@@ -15,33 +15,42 @@ Description:
 
 library
   build-depends:
+
+    -- upstream packages from hackage
     base == 4.*,
+    aeson >= 1.5 && < 2.3,
     array ^>= 0.5.3,
-    saw-core,
+    bytestring,
+    containers,
+    extra,
+    filepath,
+    lens,
+    mtl,
+    pretty,
+    prettyprinter >= 1.7.0,
+    reflection,
+    text,
+    template-haskell,
+    th-abstraction,
+    transformers,
+    vector,
+
+    -- galois packages from hackage
+    bv-sized,
+
+    -- packages in git submodules
+    -- (hobbits is for now actually a source-repository-package)
     crucible,
     crucible-llvm,
-    what4,
-    parameterized-utils,
-    lens,
-    text,
-    llvm-pretty >= 0.8,
-    reflection,
-    -- ansi-wl-pprint,
-    prettyprinter >= 1.7.0,
-    pretty,
-    transformers,
-    mtl,
-    containers,
-    bv-sized,
-    bytestring,
-    vector,
-    filepath,
-    language-rust,
     hobbits ^>= 1.4,
-    aeson >= 1.5 && < 2.3,
-    th-abstraction,
-    template-haskell,
-    extra
+    language-rust,
+    llvm-pretty >= 0.8,
+    parameterized-utils,
+    what4,
+
+    -- internal subpackages in the saw tree
+    saw-core
+
   hs-source-dirs: src
   build-tool-depends:
     alex:alex,
@@ -83,7 +92,9 @@ test-suite prover_tests
 
   main-is: Main.hs
 
-  build-depends: base
+  build-depends:
+                 -- upstream packages from hackage
+                 base
                , directory
                , filemanip
                , filepath
@@ -91,7 +102,12 @@ test-suite prover_tests
                , tasty
                , tasty-hunit
                , tasty-expected-failure
-               , heapster-saw
-               , hobbits ^>= 1.4
+
+                 -- packages in git submodules
+                 -- (hobbits is for now actually a source-repository-package)
                , crucible
                , crucible-llvm
+               , hobbits ^>= 1.4
+
+                 -- this package's own library
+               , heapster-saw

--- a/rme/rme.cabal
+++ b/rme/rme.cabal
@@ -15,9 +15,12 @@ Description:
 
 library
   build-depends:
+
+    -- upstream packages from hackage
     base == 4.*,
     containers,
     vector
+
   hs-source-dirs: src
   exposed-modules:
     Data.RME

--- a/saw-core-aig/saw-core-aig.cabal
+++ b/saw-core-aig/saw-core-aig.cabal
@@ -16,12 +16,19 @@ Description:
 
 library
   build-depends:
-    aig,
+
+    -- upstream packages from hackage
     base == 4.*,
     containers,
-    saw-core,
     text,
-    vector
+    vector,
+
+    -- packages in git submodules
+    aig,
+
+    -- internal subpackages in the saw tree
+    saw-core
+
   hs-source-dirs: src
   exposed-modules:
      Verifier.SAW.Simulator.BitBlast

--- a/saw-core-coq/saw-core-coq.cabal
+++ b/saw-core-coq/saw-core-coq.cabal
@@ -15,20 +15,29 @@ description:
 
 library
   build-depends:
+
+    -- upstream packages from hackage
     base == 4.*,
-    cryptol,
-    cryptol-saw-core,
     containers,
     interpolate,
     lens,
     mtl,
     prettyprinter,
-    saw-core,
     text,
-    parameterized-utils,
-    bv-sized,
     vector,
-    zenc
+    zenc,
+
+    -- galois packages from hackage
+    bv-sized,
+
+    -- packages in git submodules
+    cryptol,
+    parameterized-utils,
+
+    -- internal subpackages in the saw tree
+    cryptol-saw-core,
+    saw-core
+
   hs-source-dirs: src
   exposed-modules:
      Language.Coq.AST

--- a/saw-core-sbv/saw-core-sbv.cabal
+++ b/saw-core-sbv/saw-core-sbv.cabal
@@ -15,15 +15,20 @@ Description:
 
 library
   build-depends:
+
+    -- upstream packages from hackage
     base == 4.*,
     containers,
     lens,
     mtl,
-    saw-core,
     sbv >= 9.1 && < 10.11,
     text,
     transformers,
-    vector
+    vector,
+
+    -- internal subpackages in the saw tree
+    saw-core
+
   hs-source-dirs: src
   exposed-modules:
      Verifier.SAW.Simulator.SBV

--- a/saw-core-what4/saw-core-what4.cabal
+++ b/saw-core-what4/saw-core-what4.cabal
@@ -15,20 +15,27 @@ Description:
 
 library
   build-depends:
+
+    -- upstream packages from hackage
     base >= 4.9,
     bv-sized >= 1.0.0,
     containers,
     indexed-traversable,
     lens,
     mtl,
-    saw-core,
-    what4,
     panic,
     text,
     transformers,
     vector,
+    reflection,
+
+    -- packages in git submodules
     parameterized-utils >= 1.0.8 && < 2.2,
-    reflection
+    what4,
+
+    -- internal subpackages in the saw tree
+    saw-core
+
   hs-source-dirs: src
   exposed-modules:
      Verifier.SAW.Simulator.What4

--- a/saw-core/saw-core.cabal
+++ b/saw-core/saw-core.cabal
@@ -24,6 +24,8 @@ library
     happy >= 1.9.6
 
   build-depends:
+
+    -- upstream packages from hackage
     base >= 4.8,
     aeson >= 2.0 && < 2.3,
     array,
@@ -41,12 +43,10 @@ library
     MonadRandom,
     mtl,
     panic,
-    parameterized-utils,
     pretty,
     prettyprinter >= 1.7.0,
     prettyprinter-ansi-terminal >= 1.1.2,
     random,
-    rme,
     template-haskell,
     text,
     th-lift-instances,
@@ -55,7 +55,14 @@ library
     transformers-compat,
     unordered-containers,
     utf8-string,
-    vector
+    vector,
+
+    -- packages in git submodules
+    parameterized-utils,
+
+    -- internal subpackages in the saw tree
+    rme
+
   hs-source-dirs: src
   exposed-modules:
      Verifier.SAW
@@ -116,22 +123,26 @@ test-suite test-sawcore
   main-is: Tests.hs
   hs-source-dirs: tests/src
   build-depends:
+
+      -- upstream packages from hackage
       base >= 4
     , containers
     , data-ref
     , hashable
     , lens
     , mtl
-    , saw-core
-    , time
-    , unordered-containers
-    , vector
     , QuickCheck >= 2.7
+    , tagged
     , tasty
     , tasty-ant-xml >= 1.1.0
     , tasty-hunit
     , tasty-quickcheck
-    , tagged
+    , time
+    , unordered-containers
+    , vector
+
+      -- this package's own library
+    , saw-core
 
   other-modules:
     Tests.CacheTests
@@ -144,5 +155,9 @@ executable extcore-info
   main-is: extcore-info.hs
   hs-source-dirs: tools
   build-depends:
+
+      -- upstream packages from hackage
       base >= 4
+
+      -- this package's own library
     , saw-core

--- a/saw-remote-api/saw-remote-api.cabal
+++ b/saw-remote-api/saw-remote-api.cabal
@@ -34,34 +34,41 @@ common errors
     -Werror=overlapping-patterns
 
 common deps
-  build-depends: base >=4.11.1.0 && <4.20,
+  build-depends:
+                 -- upstream packages from hackage
+                 base >=4.11.1.0 && <4.20,
                  aeson >= 1.4.2 && < 2.3,
-                 aig,
-                 argo,
                  base64-bytestring,
                  bytestring,
                  containers >= 0.6 && < 0.7,
-                 cryptol >= 2.8.1,
-                 cryptol-saw-core,
-                 crucible,
-                 crucible-jvm,
-                 crucible-mir,
                  cryptonite,
                  cryptonite-conduit,
                  directory,
-                 jvm-parser,
                  lens,
-                 llvm-pretty,
-                 llvm-pretty-bc-parser,
                  mtl,
-                 parameterized-utils,
-                 saw-core,
-                 saw-script,
                  silently,
                  text,
                  unordered-containers,
                  vector >= 0.12 && < 0.14,
-                 cryptol-remote-api
+
+                 -- packages in git submodules
+                 aig,
+                 argo,
+                 cryptol >= 2.8.1,
+                 cryptol-remote-api,
+                 crucible,
+                 crucible-jvm,
+                 crucible-mir,
+                 jvm-parser,
+                 llvm-pretty,
+                 llvm-pretty-bc-parser,
+                 parameterized-utils,
+
+                 -- internal subpackages in the saw tree
+                 cryptol-saw-core,
+                 saw-core,
+                 saw-script
+
   default-language: Haskell2010
 
 library

--- a/saw-script.cabal
+++ b/saw-script.cabal
@@ -22,69 +22,42 @@ custom-setup
 library
   default-language: Haskell2010
   build-depends:
+
+      -- upstream packages from hackage
       base >= 4.9
     , aeson >= 2.0 && < 2.3
-    , aig
     , array
     , binary
     , bimap
     , bytestring
-    , bv-sized >= 1.0 && < 1.1
     , cborg-json
     , containers
     , constraints >= 0.6
     , cryptohash-sha256 >= 0.11.102.1
-    , cryptol
-    , cryptol-saw-core
-    , crucible >= 0.4
-    , crucible-jvm
-    , crucible-llvm >= 0.2
-    , crucible-mir
     , deepseq
+    , directory >= 1.2.4.0
     , either
-    , elf-edit
     , exceptions
     , executable-path
     , extra
-    , directory >= 1.2.4.0
     , fgl
     , filepath
-    , flexdis86
     , free
     , haskeline
-    , heapster-saw
-    , hobbits >= 1.3.1
     , indexed-traversable
-    , galois-dwarf >= 0.2.2
     , IfElse
-    , jvm-parser
-    , language-sally
     , lens
-    , llvm-pretty >= 0.8
-    , llvm-pretty-bc-parser >= 0.1.3.1
-    , lmdb-simple
-    , macaw-base
-    , macaw-x86
-    , macaw-symbolic
-    , macaw-x86-symbolic
     , modern-uri >= 0.3.2 && < 0.4
     , mtl >= 2.1
     , old-locale
     , old-time
     , panic
-    , parameterized-utils
     , parsec
     , pretty
     , prettyprinter
     , pretty-show
     , process
     , reflection
-    , rme
-    , saw-core
-    , saw-core-aig
-    , saw-core-coq
-    , saw-core-sbv
-    , saw-core-what4
     , sbv >= 9.1 && < 10.11
     , serialise
     , split
@@ -98,9 +71,45 @@ library
     , unordered-containers
     , utf8-string
     , vector
+    , zenc
+
+      -- galois packages from hackage
+    , bv-sized >= 1.0 && < 1.1
+
+      -- packages in git submodules
+      -- (hobbits is for now actually a source-repository-package)
+    , aig
+    , crucible >= 0.4
+    , crucible-jvm
+    , crucible-llvm >= 0.2
+    , crucible-mir
+    , cryptol
+    , elf-edit
+    , flexdis86
+    , galois-dwarf >= 0.2.2
+    , hobbits >= 1.3.1
+    , jvm-parser
+    , language-sally
+    , llvm-pretty >= 0.8
+    , llvm-pretty-bc-parser >= 0.1.3.1
+    , lmdb-simple
+    , macaw-base
+    , macaw-x86
+    , macaw-symbolic
+    , macaw-x86-symbolic
+    , parameterized-utils
     , what4 >= 0.4
     , what4-transition-system
-    , zenc
+
+      -- internal subpackages in the saw tree
+    , cryptol-saw-core
+    , heapster-saw
+    , rme
+    , saw-core
+    , saw-core-aig
+    , saw-core-coq
+    , saw-core-sbv
+    , saw-core-what4
 
   hs-source-dirs: src
 
@@ -245,10 +254,11 @@ executable saw
     GitRev
 
   build-depends:
+
+      -- upstream packages from hackage
       base >= 4.5
     , ansi-terminal
     , containers >= 0.5.8
-    , cryptol
     , directory
     , either
     , exceptions
@@ -258,11 +268,16 @@ executable saw
     , QuickCheck
     , text
     , transformers
-    , saw-script
-    , saw-core
-    , heapster-saw
-    , cryptol-saw-core
+
+      -- packages in git submodules
     , aig
+    , cryptol
+
+      -- internal subpackages in the saw tree
+    , cryptol-saw-core
+    , heapster-saw
+    , saw-core
+    , saw-script
 
   GHC-options: -O2 -Wall -Werror -threaded -fno-ignore-asserts -fno-spec-constr-count -rtsopts
 
@@ -275,7 +290,9 @@ test-suite integration_tests
 
   main-is: IntegrationTest.hs
 
-  build-depends: base
+  build-depends:
+                 -- upstream packages from hackage
+                 base
                , directory
                , filemanip
                , filepath

--- a/verif-viewer/verif-viewer.cabal
+++ b/verif-viewer/verif-viewer.cabal
@@ -19,12 +19,15 @@ library
     happy >= 1.9.6
 
   build-depends:
+
+    -- upstream packages from hackage
     base == 4.*,
     aeson,
     attoparsec,
     fgl,
     graphviz,
     text
+
   hs-source-dirs: src
   exposed-modules:
 
@@ -43,13 +46,17 @@ executable verif-viewer
   main-is: VerifViewer.hs
   hs-source-dirs: tools
   build-depends:
+
+      -- upstream packages from hackage
       base >= 4.5
     , aeson
     , attoparsec
     , attoparsec-aeson
-    , containers
-    , text
-    , verif-viewer
     , bytestring
-    , time
+    , containers
     , graphviz
+    , text
+    , time
+
+      -- this package's own library
+    , verif-viewer


### PR DESCRIPTION
This should considerably reduce the chances of missing something when syncing versions and making releases.