### PR TITLE
Dockerfiles: Support both amd64 and arm64 builds

### DIFF
--- a/saw-remote-api/Dockerfile
+++ b/saw-remote-api/Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p /home/saw/.ghcup && \
     ghcup set ghc 9.4.8
 RUN cabal v2-update && cabal v2-build -j exe:saw-remote-api
 RUN mkdir -p /home/saw/rootfs/usr/local/bin
-RUN cp $(cabal v2-exec which saw-remote-api) /home/saw/rootfs/usr/local/bin/saw-remote-api
+RUN cp $(cabal -v0 list-bin exe:saw-remote-api) /home/saw/rootfs/usr/local/bin/saw-remote-api
 WORKDIR /home/saw//rootfs/usr/local/bin
 # The URL here is based on the same logic used to specify BUILD_TARGET_OS and
 # BUILD_TARGET_ARCH in `.github/workflow/ci.yml`, but specialized to x86-64

--- a/saw-remote-api/Dockerfile
+++ b/saw-remote-api/Dockerfile
@@ -4,6 +4,10 @@ RUN apt-get update && \
     apt-get install -y \
       # ghcup requirements
       build-essential curl libffi-dev libffi8 libgmp-dev libgmp10 libncurses-dev libncurses6 libtinfo6 \
+      # Although ghcup's version of GHC shouldn't require libnuma, the aarch64 \
+      # version does impose this requirement for unknown reasons. \
+      # (See https://gitlab.haskell.org/ghc/ghc/-/issues/20876#note_399802) \
+      libnuma1 \
       # SAW dependencies
       pkg-config zlib1g-dev \
       # Miscellaneous
@@ -16,8 +20,18 @@ ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 COPY cabal.GHC-9.4.8.config cabal.project.freeze
 ENV PATH=/home/saw/ghcup-download/bin:/home/saw/.ghcup/bin:$PATH
-RUN mkdir -p /home/saw/ghcup-download/bin && \
-    curl -L https://downloads.haskell.org/~ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 -o /home/saw/ghcup-download/bin/ghcup && \
+ARG TARGETPLATFORM
+RUN case ${TARGETPLATFORM} in \
+      "linux/amd64") \
+        GHCUP_ARCH=x86_64 ;; \
+      "linux/arm64" | "linux/arm64/v8") \
+        GHCUP_ARCH=aarch64 ;; \
+      *) \
+        printf "Unsupported architecture: %s\n" "${TARGETPLATFORM}" >&2 \
+        exit 1 ;; \
+    esac && \
+    mkdir -p /home/saw/ghcup-download/bin && \
+    curl -L https://downloads.haskell.org/~ghcup/0.1.19.5/${GHCUP_ARCH}-linux-ghcup-0.1.19.5 -o /home/saw/ghcup-download/bin/ghcup && \
     chmod +x /home/saw/ghcup-download/bin/ghcup
 RUN mkdir -p /home/saw/.ghcup && \
     ghcup --version && \
@@ -29,10 +43,18 @@ RUN mkdir -p /home/saw/rootfs/usr/local/bin
 RUN cp $(cabal -v0 list-bin exe:saw-remote-api) /home/saw/rootfs/usr/local/bin/saw-remote-api
 WORKDIR /home/saw//rootfs/usr/local/bin
 # The URL here is based on the same logic used to specify BUILD_TARGET_OS and
-# BUILD_TARGET_ARCH in `.github/workflow/ci.yml`, but specialized to x86-64
-# Ubuntu.
+# BUILD_TARGET_ARCH in `.github/workflow/ci.yml`, but specialized to Ubuntu.
 # If updating the snapshot version, update ci.yml and saw/Dockerfile too.
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-24.04-X64-bin.zip"
+RUN case ${TARGETPLATFORM} in \
+      "linux/amd64") \
+        WHAT4_SOLVERS_ARCH=X64 ;; \
+      "linux/arm64" | "linux/arm64/v8") \
+        WHAT4_SOLVERS_ARCH=ARM64 ;; \
+      *) \
+        printf "Unsupported architecture: %s\n" "${TARGETPLATFORM}" >&2 \
+        exit 1 ;; \
+    esac && \
+    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-24.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 USER root
 RUN chown -R root:root /home/saw/rootfs

--- a/saw/Dockerfile
+++ b/saw/Dockerfile
@@ -27,7 +27,7 @@ RUN mkdir -p /home/saw/.ghcup && \
 RUN cabal v2-update
 RUN cabal v2-build
 RUN mkdir -p /home/saw/rootfs/usr/local/bin
-RUN cp $(cabal v2-exec which saw) /home/saw/rootfs/usr/local/bin/saw
+RUN cp $(cabal -v0 list-bin exe:saw) /home/saw/rootfs/usr/local/bin/saw
 WORKDIR /home/saw//rootfs/usr/local/bin
 # The URL here is based on the same logic used to specify BUILD_TARGET_OS and
 # BUILD_TARGET_ARCH in `.github/workflow/ci.yml`, but specialized to x86-64

--- a/saw/Dockerfile
+++ b/saw/Dockerfile
@@ -4,6 +4,10 @@ RUN apt-get update && \
     apt-get install -y \
       # ghcup requirements
       build-essential curl libffi-dev libffi8 libgmp-dev libgmp10 libncurses-dev libncurses6 libtinfo6 \
+      # Although ghcup's version of GHC shouldn't require libnuma, the aarch64 \
+      # version does impose this requirement for unknown reasons. \
+      # (See https://gitlab.haskell.org/ghc/ghc/-/issues/20876#note_399802) \
+      libnuma1 \
       # SAW dependencies
       pkg-config zlib1g-dev \
       # Miscellaneous
@@ -16,8 +20,18 @@ ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 COPY cabal.GHC-9.4.8.config cabal.project.freeze
 ENV PATH=/home/saw/ghcup-download/bin:/home/saw/.ghcup/bin:$PATH
-RUN mkdir -p /home/saw/ghcup-download/bin && \
-    curl -L https://downloads.haskell.org/~ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 -o /home/saw/ghcup-download/bin/ghcup && \
+ARG TARGETPLATFORM
+RUN case ${TARGETPLATFORM} in \
+      "linux/amd64") \
+        GHCUP_ARCH=x86_64 ;; \
+      "linux/arm64" | "linux/arm64/v8") \
+        GHCUP_ARCH=aarch64 ;; \
+      *) \
+        printf "Unsupported architecture: %s\n" "${TARGETPLATFORM}" >&2 \
+        exit 1 ;; \
+    esac && \
+    mkdir -p /home/saw/ghcup-download/bin && \
+    curl -L https://downloads.haskell.org/~ghcup/0.1.19.5/${GHCUP_ARCH}-linux-ghcup-0.1.19.5 -o /home/saw/ghcup-download/bin/ghcup && \
     chmod +x /home/saw/ghcup-download/bin/ghcup
 RUN mkdir -p /home/saw/.ghcup && \
     ghcup --version && \
@@ -30,10 +44,18 @@ RUN mkdir -p /home/saw/rootfs/usr/local/bin
 RUN cp $(cabal -v0 list-bin exe:saw) /home/saw/rootfs/usr/local/bin/saw
 WORKDIR /home/saw//rootfs/usr/local/bin
 # The URL here is based on the same logic used to specify BUILD_TARGET_OS and
-# BUILD_TARGET_ARCH in `.github/workflow/ci.yml`, but specialized to x86-64
-# Ubuntu.
+# BUILD_TARGET_ARCH in `.github/workflow/ci.yml`, but specialized to Ubuntu.
 # If updating the snapshot version, update ci.yml and saw-remote-api/Dockerfile too.
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-24.04-X64-bin.zip"
+RUN case ${TARGETPLATFORM} in \
+      "linux/amd64") \
+        WHAT4_SOLVERS_ARCH=X64 ;; \
+      "linux/arm64" | "linux/arm64/v8") \
+        WHAT4_SOLVERS_ARCH=ARM64 ;; \
+      *) \
+        printf "Unsupported architecture: %s\n" "${TARGETPLATFORM}" >&2 \
+        exit 1 ;; \
+    esac && \
+    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-24.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 USER root
 RUN chown -R root:root /home/saw/rootfs


### PR DESCRIPTION
Ensure that the `what4-solvers` and `ghcup` binaries correspond to the appropriate architecture when downloading them.

Addresses one half of https://github.com/GaloisInc/saw-script/issues/2279.