### PR TITLE
Support `quickcheck` in the remote API and Python bindings

### DIFF
--- a/saw-remote-api/CHANGELOG.md
+++ b/saw-remote-api/CHANGELOG.md
@@ -7,6 +7,10 @@
   should be allocated. This field can only be used with LLVM, and attempting to
   use this field with JVM or MIR verification will raise an error.
 
+* Add support for the `quickcheck` tactic, which is the remote API counterpart
+  to SAWScript's `quickcheck`. This also accepts a `"number of inputs"` fields
+  containing an integer with the number of randomly sampled inputs.
+
 ## 1.3 -- 2025-03-21
 
 * No changes specifically to the remote API.

--- a/saw-remote-api/python/CHANGELOG.md
+++ b/saw-remote-api/python/CHANGELOG.md
@@ -7,6 +7,9 @@
   function can only be used with LLVM verification, and attempting to use this
   function with JVM or MIR verification will raise an error.
 
+* Add a `Quickcheck(n)` proof script, where `n` is the number of randomly
+  sampled inputs. This is the Python counterpart to SAWScript's `quickcheck`.
+
 ## 1.3 - 2025-03-21
 
 * Bump the lmdb Python bindings to 1.6.2 to gain support for Python 3.13.

--- a/saw-remote-api/python/saw_client/proofscript.py
+++ b/saw-remote-api/python/saw_client/proofscript.py
@@ -121,6 +121,14 @@ class Trivial(ProofTactic):
   def to_json(self) -> Any:
     return { "tactic": "trivial" }
 
+class Quickcheck(ProofTactic):
+  def __init__(self, num_inputs : int) -> None:
+    self.num_inputs = num_inputs
+
+  def to_json(self) -> Any:
+    return { "tactic": "quickcheck",
+             "number of inputs": self.num_inputs }
+
 class ProofScript:
   def __init__(self, tactics : List[ProofTactic]) -> None:
     self.tactics = tactics

--- a/saw-remote-api/python/tests/saw/test_provers.py
+++ b/saw-remote-api/python/tests/saw/test_provers.py
@@ -20,6 +20,7 @@ class ProverTest(unittest.TestCase):
         simple_thm = cry('\(x:[8]) -> x != x+1')
         #self.assertTrue(saw.prove(simple_thm, ProofScript([yices([])])).is_valid())
         self.assertTrue(saw.prove(simple_thm, ProofScript([z3([])])).is_valid())
+        self.assertTrue(saw.prove(simple_thm, ProofScript([Quickcheck(100)])).is_valid())
 
         self.assertTrue(saw.prove(simple_thm, ProofScript([Admit()])).is_valid())
         self.assertTrue(saw.prove(cry('True'), ProofScript([Trivial()])).is_valid())


### PR DESCRIPTION
Fixes #2292.