### PR TITLE
Adapt to MIR opaque references (GaloisInc/crucible#1391)

### DIFF
--- a/crucible-mir-comp/src/Mir/Compositional/Convert.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Convert.hs
@@ -83,7 +83,7 @@ visitRegValueExprs _sym tpr_ v_ f = go tpr_ v_
     -- write a spec for e.g. `f(arr, &arr[i], i)`, where the second reference
     -- is offset from the first by a symbolic integer value, then we'd need to
     -- visit exprs from some suffix of each MirReference.
-    go (MirReferenceRepr _) _ = return ()
+    go MirReferenceRepr _ = return ()
     go tpr _ = error $ "visitRegValueExprs: unsupported: " ++ show tpr
 
     forMWithRepr_ :: forall ctx m f. Monad m =>

--- a/crux-mir-comp/crux-mir-comp.cabal
+++ b/crux-mir-comp/crux-mir-comp.cabal
@@ -26,6 +26,7 @@ library
                  containers,
                  extra,
                  lens,
+                 prettyprinter,
                  text,
 
                  -- packages in git submodules

--- a/crux-mir-comp/src/Mir/Cryptol.hs
+++ b/crux-mir-comp/src/Mir/Cryptol.hs
@@ -78,9 +78,7 @@ cryptolOverrides ::
 cryptolOverrides _symOnline cs name cfg
 
   | hasInstPrefix ["crucible", "cryptol", "load"] explodedName
-  , Empty
-      :> MirSliceRepr (BVRepr (testEquality (knownNat @8) -> Just Refl))
-      :> MirSliceRepr (BVRepr (testEquality (knownNat @8) -> Just Refl))
+  , Empty :> MirSliceRepr :> MirSliceRepr
       <- cfgArgTypes cfg
   = Just $ bindFnHandle (cfgHandle cfg) $ UseOverride $
     mkOverride' "cryptol_load" (cfgReturnType cfg) $ do
@@ -94,11 +92,7 @@ cryptolOverrides _symOnline cs name cfg
         cryptolLoad (cs ^. collection) sig (cfgReturnType cfg) modulePathStr nameStr
 
   | hasInstPrefix ["crucible", "cryptol", "override_"] explodedName
-  , Empty
-      :> UnitRepr
-      :> MirSliceRepr (BVRepr (testEquality (knownNat @8) -> Just Refl))
-      :> MirSliceRepr (BVRepr (testEquality (knownNat @8) -> Just Refl))
-      <- cfgArgTypes cfg
+  , Empty :> UnitRepr :> MirSliceRepr :> MirSliceRepr <- cfgArgTypes cfg
   , UnitRepr <- cfgReturnType cfg
   = Just $ bindFnHandle (cfgHandle cfg) $ UseOverride $
     mkOverride' "cryptol_override_" UnitRepr $ do
@@ -143,8 +137,8 @@ cryptolLoad ::
     M.Collection ->
     M.FnSig ->
     TypeRepr tp ->
-    RegValue sym (MirSlice (BVType 8)) ->
-    RegValue sym (MirSlice (BVType 8)) ->
+    RegValue sym MirSlice ->
+    RegValue sym MirSlice ->
     OverrideSim (p sym) sym MIR rtp a r (RegValue sym tp)
 cryptolLoad col sig (FunctionHandleRepr argsCtx retTpr) modulePathStr nameStr = do
     modulePath <- loadString modulePathStr "cryptol::load module path"
@@ -170,7 +164,7 @@ cryptolLoad _ _ tpr _ _ = fail $ "cryptol::load: bad function type " ++ show tpr
 
 loadString ::
     (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs) =>
-    RegValue sym (MirSlice (BVType 8)) ->
+    RegValue sym MirSlice ->
     String ->
     OverrideSim (p sym) sym MIR rtp a r Text
 loadString str desc = getString str >>= \x -> case x of
@@ -183,8 +177,8 @@ cryptolOverride ::
     (IsSymInterface sym, sym ~ W4.ExprBuilder t st fs) =>
     M.Collection ->
     MirHandle ->
-    RegValue sym (MirSlice (BVType 8)) ->
-    RegValue sym (MirSlice (BVType 8)) ->
+    RegValue sym MirSlice ->
+    RegValue sym MirSlice ->
     OverrideSim (p sym) sym MIR rtp a r ()
 cryptolOverride col (MirHandle _ sig fh) modulePathStr nameStr = do
     modulePath <- loadString modulePathStr "cryptol::load module path"

--- a/crux-mir-comp/test/symb_eval/comp/alias_array_bad.good
+++ b/crux-mir-comp/test/symb_eval/comp/alias_array_bad.good
@@ -5,14 +5,14 @@ failures:
 
 ---- alias_array_bad/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/comp/alias_array_bad.rs:45:14: 45:16: error: in alias_array_bad/<DISAMB>::use_f[0]
+[Crux]   test/symb_eval/comp/alias_array_bad.rs:45:5: 45:17: error: in alias_array_bad/<DISAMB>::use_f[0]
 [Crux]   references AllocIndex 0 and AllocIndex 1 must not overlap
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/alias_array_bad.rs:46:5: 46:37: error: in alias_array_bad/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/alias_array_bad.rs:46:5: 46:37: error: in alias_array_bad/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/alias_array_bad.rs:46:5:
 [Crux]   	0 < b[0].get()
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/alias_array_bad.rs:47:5: 47:38: error: in alias_array_bad/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/alias_array_bad.rs:47:5: 47:38: error: in alias_array_bad/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/alias_array_bad.rs:47:5:
 [Crux]   	b[0].get() < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/alias_array_bad2.good
+++ b/crux-mir-comp/test/symb_eval/comp/alias_array_bad2.good
@@ -5,10 +5,10 @@ failures:
 
 ---- alias_array_bad2/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/comp/alias_array_bad2.rs:45:14: 45:16: error: in alias_array_bad2/<DISAMB>::use_f[0]
+[Crux]   test/symb_eval/comp/alias_array_bad2.rs:45:5: 45:17: error: in alias_array_bad2/<DISAMB>::use_f[0]
 [Crux]   references AllocIndex 0 and AllocIndex 1 must not overlap
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/alias_array_bad2.rs:47:5: 47:38: error: in alias_array_bad2/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/alias_array_bad2.rs:47:5: 47:38: error: in alias_array_bad2/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/alias_array_bad2.rs:47:5:
 [Crux]   	b[0].get() < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/alias_array_ok.good
+++ b/crux-mir-comp/test/symb_eval/comp/alias_array_ok.good
@@ -5,7 +5,7 @@ failures:
 
 ---- alias_array_ok/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/alias_array_ok.rs:48:5: 48:38: error: in alias_array_ok/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/alias_array_ok.rs:48:5: 48:38: error: in alias_array_ok/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/alias_array_ok.rs:48:5:
 [Crux]   	b[0].get() < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/alias_bad.good
+++ b/crux-mir-comp/test/symb_eval/comp/alias_bad.good
@@ -5,14 +5,14 @@ failures:
 
 ---- alias_bad/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/comp/alias_bad.rs:45:11: 45:13: error: in alias_bad/<DISAMB>::use_f[0]
+[Crux]   test/symb_eval/comp/alias_bad.rs:45:5: 45:14: error: in alias_bad/<DISAMB>::use_f[0]
 [Crux]   references AllocIndex 0 and AllocIndex 1 must not overlap
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/alias_bad.rs:46:5: 46:34: error: in alias_bad/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/alias_bad.rs:46:5: 46:34: error: in alias_bad/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/alias_bad.rs:46:5:
 [Crux]   	0 < b.get()
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/alias_bad.rs:47:5: 47:35: error: in alias_bad/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/alias_bad.rs:47:5: 47:35: error: in alias_bad/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/alias_bad.rs:47:5:
 [Crux]   	b.get() < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/alias_ok.good
+++ b/crux-mir-comp/test/symb_eval/comp/alias_ok.good
@@ -5,7 +5,7 @@ failures:
 
 ---- alias_ok/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/alias_ok.rs:49:5: 49:35: error: in alias_ok/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/alias_ok.rs:49:5: 49:35: error: in alias_ok/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/alias_ok.rs:49:5:
 [Crux]   	b.get() < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/clobber_globals.good
+++ b/crux-mir-comp/test/symb_eval/comp/clobber_globals.good
@@ -5,13 +5,13 @@ failures:
 
 ---- clobber_globals/<DISAMB>::f_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/comp/clobber_globals.rs:16:9: 16:70: error: in clobber_globals/<DISAMB>::f_test[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/clobber_globals.rs:15:5: 16:71: error: in clobber_globals/<DISAMB>::f_test[0]
 [Crux]   MIR assertion at test/symb_eval/comp/clobber_globals.rs:15:5:
 [Crux]   	expected failure; ATOMIC was clobbered by clobber_globals()
 
 ---- clobber_globals/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/comp/clobber_globals.rs:38:9: 38:61: error: in clobber_globals/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/clobber_globals.rs:37:5: 38:62: error: in clobber_globals/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/clobber_globals.rs:37:5:
 [Crux]   	expected failure; ATOMIC was clobbered by f's spec
 

--- a/crux-mir-comp/test/symb_eval/comp/override_test_indep.good
+++ b/crux-mir-comp/test/symb_eval/comp/override_test_indep.good
@@ -7,7 +7,7 @@ failures:
 
 ---- override_test_indep/<DISAMB>::use_f2[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/override_test_indep.rs:57:5: 57:29: error: in override_test_indep/<DISAMB>::use_f2[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/override_test_indep.rs:57:5: 57:29: error: in override_test_indep/<DISAMB>::use_f2[0]
 [Crux]   MIR assertion at test/symb_eval/comp/override_test_indep.rs:57:5:
 [Crux]   	d < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/ptr_offset.good
+++ b/crux-mir-comp/test/symb_eval/comp/ptr_offset.good
@@ -5,7 +5,7 @@ failures:
 
 ---- ptr_offset/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/ptr_offset.rs:64:5: 64:30: error: in ptr_offset/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/ptr_offset.rs:64:5: 64:30: error: in ptr_offset/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/ptr_offset.rs:64:5:
 [Crux]   	b2 < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/ptr_offset_rev.good
+++ b/crux-mir-comp/test/symb_eval/comp/ptr_offset_rev.good
@@ -5,7 +5,7 @@ failures:
 
 ---- ptr_offset_rev/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/ptr_offset_rev.rs:64:5: 64:30: error: in ptr_offset_rev/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/ptr_offset_rev.rs:64:5: 64:30: error: in ptr_offset_rev/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/ptr_offset_rev.rs:64:5:
 [Crux]   	b2 < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/spec_array.good
+++ b/crux-mir-comp/test/symb_eval/comp/spec_array.good
@@ -5,7 +5,7 @@ failures:
 
 ---- spec_array/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/spec_array.rs:43:5: 43:29: error: in spec_array/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/spec_array.rs:43:5: 43:29: error: in spec_array/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/spec_array.rs:43:5:
 [Crux]   	d < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/spec_box.good
+++ b/crux-mir-comp/test/symb_eval/comp/spec_box.good
@@ -5,7 +5,7 @@ failures:
 
 ---- spec_box/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/spec_box.rs:58:5: 58:29: error: in spec_box/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/spec_box.rs:58:5: 58:29: error: in spec_box/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/spec_box.rs:58:5:
 [Crux]   	d < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/spec_immut_cell.good
+++ b/crux-mir-comp/test/symb_eval/comp/spec_immut_cell.good
@@ -5,7 +5,7 @@ failures:
 
 ---- spec_immut_cell/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/spec_immut_cell.rs:68:5: 68:35: error: in spec_immut_cell/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/spec_immut_cell.rs:68:5: 68:35: error: in spec_immut_cell/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/spec_immut_cell.rs:68:5:
 [Crux]   	d.get() < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/spec_mut.good
+++ b/crux-mir-comp/test/symb_eval/comp/spec_mut.good
@@ -5,7 +5,7 @@ failures:
 
 ---- spec_mut/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/spec_mut.rs:61:5: 61:29: error: in spec_mut/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/spec_mut.rs:61:5: 61:29: error: in spec_mut/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/spec_mut.rs:61:5:
 [Crux]   	d < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/spec_mut_slice.good
+++ b/crux-mir-comp/test/symb_eval/comp/spec_mut_slice.good
@@ -5,7 +5,7 @@ failures:
 
 ---- spec_mut_slice/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/spec_mut_slice.rs:48:5: 48:29: error: in spec_mut_slice/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/spec_mut_slice.rs:48:5: 48:29: error: in spec_mut_slice/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/spec_mut_slice.rs:48:5:
 [Crux]   	d < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/spec_struct.good
+++ b/crux-mir-comp/test/symb_eval/comp/spec_struct.good
@@ -5,7 +5,7 @@ failures:
 
 ---- spec_struct/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/spec_struct.rs:51:5: 51:29: error: in spec_struct/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/spec_struct.rs:51:5: 51:29: error: in spec_struct/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/spec_struct.rs:51:5:
 [Crux]   	d < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/spec_tuple.good
+++ b/crux-mir-comp/test/symb_eval/comp/spec_tuple.good
@@ -5,7 +5,7 @@ failures:
 
 ---- spec_tuple/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/spec_tuple.rs:55:5: 55:29: error: in spec_tuple/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/spec_tuple.rs:55:5: 55:29: error: in spec_tuple/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/spec_tuple.rs:55:5:
 [Crux]   	d < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/subst_output.good
+++ b/crux-mir-comp/test/symb_eval/comp/subst_output.good
@@ -4,7 +4,7 @@ failures:
 
 ---- subst_output/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/comp/subst_output.rs:32:5: 32:30: error: in subst_output/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/comp/subst_output.rs:32:5: 32:30: error: in subst_output/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/subst_output.rs:32:5:
 [Crux]   	b0 == a
 

--- a/crux-mir-comp/test/symb_eval/cryptol/basic_err_array_size.good
+++ b/crux-mir-comp/test/symb_eval/cryptol/basic_err_array_size.good
@@ -4,7 +4,7 @@ failures:
 
 ---- basic_err_array_size/<DISAMB>::test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/cryptol/basic_err_array_size.rs:8:52: 8:62: error: in basic_err_array_size/<DISAMB>::test[0]
+[Crux]   test/symb_eval/cryptol/basic_err_array_size.rs:8:32: 8:63: error: in basic_err_array_size/<DISAMB>::test[0]
 [Crux]   error loading "arrayArg": type mismatch in argument 0: Cryptol type [2][8] does not match Rust type u8: array length 2 does not match 3
 
 [Crux] Overall status: Invalid.

--- a/crux-mir-comp/test/symb_eval/cryptol/basic_err_bv_size.good
+++ b/crux-mir-comp/test/symb_eval/cryptol/basic_err_bv_size.good
@@ -4,7 +4,7 @@ failures:
 
 ---- basic_err_bv_size/<DISAMB>::test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/cryptol/basic_err_bv_size.rs:8:52: 8:61: error: in basic_err_bv_size/<DISAMB>::test[0]
+[Crux]   test/symb_eval/cryptol/basic_err_bv_size.rs:8:32: 8:62: error: in basic_err_bv_size/<DISAMB>::test[0]
 [Crux]   error loading "addByte": type mismatch in argument 1: Cryptol type [8] does not match Rust type u16: bitvector width 8 does not match 16
 
 [Crux] Overall status: Invalid.

--- a/crux-mir-comp/test/symb_eval/cryptol/basic_err_fewer_args.good
+++ b/crux-mir-comp/test/symb_eval/cryptol/basic_err_fewer_args.good
@@ -4,7 +4,7 @@ failures:
 
 ---- basic_err_fewer_args/<DISAMB>::test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/cryptol/basic_err_fewer_args.rs:8:55: 8:64: error: in basic_err_fewer_args/<DISAMB>::test[0]
+[Crux]   test/symb_eval/cryptol/basic_err_fewer_args.rs:8:35: 8:65: error: in basic_err_fewer_args/<DISAMB>::test[0]
 [Crux]   error loading "addByte": not enough arguments: Cryptol function signature [8] -> [8] -> [8] has 2 arguments, but Rust signature (u8, u8, u8) -> u8 [RustAbi]  requires 3
 
 [Crux] Overall status: Invalid.

--- a/crux-mir-comp/test/symb_eval/cryptol/basic_err_mismatch.good
+++ b/crux-mir-comp/test/symb_eval/cryptol/basic_err_mismatch.good
@@ -4,7 +4,7 @@ failures:
 
 ---- basic_err_mismatch/<DISAMB>::test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/cryptol/basic_err_mismatch.rs:8:51: 8:60: error: in basic_err_mismatch/<DISAMB>::test[0]
+[Crux]   test/symb_eval/cryptol/basic_err_mismatch.rs:8:31: 8:61: error: in basic_err_mismatch/<DISAMB>::test[0]
 [Crux]   error loading "addByte": type mismatch in argument 1: Cryptol type [8] does not match Rust type ()
 
 [Crux] Overall status: Invalid.

--- a/crux-mir-comp/test/symb_eval/cryptol/basic_err_more_args.good
+++ b/crux-mir-comp/test/symb_eval/cryptol/basic_err_more_args.good
@@ -4,7 +4,7 @@ failures:
 
 ---- basic_err_more_args/<DISAMB>::test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/cryptol/basic_err_more_args.rs:8:47: 8:56: error: in basic_err_more_args/<DISAMB>::test[0]
+[Crux]   test/symb_eval/cryptol/basic_err_more_args.rs:8:27: 8:57: error: in basic_err_more_args/<DISAMB>::test[0]
 [Crux]   error loading "addByte": type mismatch in return value: Cryptol type [8] -> [8] does not match Rust type u8
 
 [Crux] Overall status: Invalid.

--- a/crux-mir-comp/test/symb_eval/cryptol/basic_err_tuple_size.good
+++ b/crux-mir-comp/test/symb_eval/cryptol/basic_err_tuple_size.good
@@ -4,7 +4,7 @@ failures:
 
 ---- basic_err_tuple_size/<DISAMB>::test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/cryptol/basic_err_tuple_size.rs:8:57: 8:67: error: in basic_err_tuple_size/<DISAMB>::test[0]
+[Crux]   test/symb_eval/cryptol/basic_err_tuple_size.rs:8:37: 8:68: error: in basic_err_tuple_size/<DISAMB>::test[0]
 [Crux]   error loading "tupleArg": type mismatch in argument 0: Cryptol type ([8], [8]) does not match Rust type (u8, u8, u8): tuple size 2 does not match 3
 
 [Crux] Overall status: Invalid.

--- a/saw-central/src/SAWCentral/Crucible/MIR/Setup/Value.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Setup/Value.hs
@@ -145,7 +145,7 @@ data MirPointer sym tp = MirPointer
     { _mpType :: TypeRepr tp
     , _mpMutbl :: M.Mutability
     , _mpMirType :: M.Ty
-    , _mpRef :: MirReferenceMux sym tp
+    , _mpRef :: MirReferenceMux sym
     }
 
 -- | A enum-related MIR 'SetupValue'.

--- a/saw-central/src/SAWCentral/Crucible/MIR/TypeShape.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/TypeShape.hs
@@ -79,7 +79,7 @@ data TypeShape (tp :: CrucibleType) where
              -- ^ Is the reference mutable or immutable?
              -> TypeRepr tp
              -- ^ The Crucible representation of the pointee type
-             -> TypeShape (MirReferenceType tp)
+             -> TypeShape MirReferenceType
     -- | A shape for a slice reference of type @&[T]@ or @&str@, which is
     -- represented in @crucible-mir@ as a 'MirSlice', i.e., a 'StructType'
     -- where:
@@ -105,7 +105,7 @@ data TypeShape (tp :: CrucibleType) where
                -- ^ Is the reference mutable or immutable?
                -> TypeRepr tp
                -- ^ The Crucible representation of the element type.
-               -> TypeShape (MirSlice tp)
+               -> TypeShape MirSlice
     -- | A shape for an enum type. Like 'StructShape', this is indexed by
     -- 'AnyType', so code that matches on 'EnumShape' may need to further match
     -- on the 'VariantShape's in order to bring additional type information into
@@ -306,8 +306,8 @@ shapeType = go
     go (StructShape _ _ _flds) = AnyRepr
     go (EnumShape _ _ _ _ _variants) = AnyRepr
     go (TransparentShape _ shp) = go shp
-    go (RefShape _ _ _ tpr) = MirReferenceRepr tpr
-    go (SliceShape _ _ _ tpr) = MirSliceRepr tpr
+    go (RefShape _ _ _ _) = MirReferenceRepr
+    go (SliceShape _ _ _ _) = MirSliceRepr
     go (FnPtrShape _ args ret) = FunctionHandleRepr args ret
 
 fieldShapeType :: FieldShape tp -> TypeRepr tp
@@ -386,7 +386,7 @@ data IsRefShape (tp :: CrucibleType) where
              -- ^ Is the reference mutable or immutable?
              -> TypeRepr tp
              -- ^ The Crucible representation of the pointee type
-             -> IsRefShape (MirReferenceType tp)
+             -> IsRefShape MirReferenceType
 
 -- | Check that a 'TypeShape' is equal to a 'RefShape'. If so, return 'Just' a
 -- witness of that equality. Otherwise, return 'Nothing'.
@@ -402,7 +402,7 @@ sliceShapeParts ::
     M.Ty ->
     M.Mutability ->
     TypeRepr tp ->
-    (TypeShape (MirReferenceType tp), TypeShape UsizeType)
+    (TypeShape MirReferenceType, TypeShape UsizeType)
 sliceShapeParts referentTy refMutbl referentTpr =
     ( RefShape refTy referentTy refMutbl referentTpr
     , PrimShape usizeTy BaseUsizeRepr


### PR DESCRIPTION
This bumps the `crucible` submodule to bring in the changes from https://github.com/GaloisInc/crucible/pull/1391. This requires some changes to SAW's handling of MIR references in order to accommodate the API changes in `crucible-mir`.