### PR TITLE
Change handling of endianness in Yosys import.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,12 @@ Note that build.sh is in any case the recommended way to build.
 
 ## Bug fixes
 
+* Functions imported with `yosys_import` now use a non-reversed bit
+  ordering. All bit indices in Yosys JSON files are now treated as
+  indexing from the right. Arithmetic operations treat the right-most
+  bit (Yosys index 0) as the least significant, and are translated
+  without using `reverse`.
+
 * Invoking the Cryptol `error` function in SAW now preserves the error message
   instead of throwing it away.
 

--- a/intTests/test_yosys_adder/test.json
+++ b/intTests/test_yosys_adder/test.json
@@ -34,11 +34,11 @@
             "s": "output"
           },
           "connections": {
-            "a": [ 5 ],
-            "b": [ 9 ],
+            "a": [ 2 ],
+            "b": [ 6 ],
             "cin": [ "0" ],
             "cout": [ 14 ],
-            "s": [ 13 ]
+            "s": [ 10 ]
           }
         },
         "full1": {
@@ -56,11 +56,11 @@
             "s": "output"
           },
           "connections": {
-            "a": [ 4 ],
-            "b": [ 8 ],
+            "a": [ 3 ],
+            "b": [ 7 ],
             "cin": [ 14 ],
             "cout": [ 15 ],
-            "s": [ 12 ]
+            "s": [ 11 ]
           }
         },
         "full2": {
@@ -78,11 +78,11 @@
             "s": "output"
           },
           "connections": {
-            "a": [ 3 ],
-            "b": [ 7 ],
+            "a": [ 4 ],
+            "b": [ 8 ],
             "cin": [ 15 ],
             "cout": [ 16 ],
-            "s": [ 11 ]
+            "s": [ 12 ]
           }
         },
         "full3": {
@@ -100,24 +100,24 @@
             "s": "output"
           },
           "connections": {
-            "a": [ 2 ],
-            "b": [ 6 ],
+            "a": [ 5 ],
+            "b": [ 9 ],
             "cin": [ 16 ],
             "cout": [ 17 ],
-            "s": [ 10 ]
+            "s": [ 13 ]
           }
         }
       },
       "netnames": {
         "$auto$ghdl.cc:764:import_module$2": {
           "hide_name": 1,
-          "bits": [ 13 ],
+          "bits": [ 10 ],
           "attributes": {
           }
         },
         "$auto$ghdl.cc:764:import_module$4": {
           "hide_name": 1,
-          "bits": [ 12 ],
+          "bits": [ 11 ],
           "attributes": {
           }
         },
@@ -135,7 +135,7 @@
         },
         "$auto$ghdl.cc:764:import_module$8": {
           "hide_name": 1,
-          "bits": [ 10 ],
+          "bits": [ 13 ],
           "attributes": {
           }
         },

--- a/intTests/test_yosys_compositional/test.json
+++ b/intTests/test_yosys_compositional/test.json
@@ -34,11 +34,11 @@
             "s": "output"
           },
           "connections": {
-            "a": [ 5 ],
-            "b": [ 9 ],
+            "a": [ 2 ],
+            "b": [ 6 ],
             "cin": [ "0" ],
             "cout": [ 14 ],
-            "s": [ 13 ]
+            "s": [ 10 ]
           }
         },
         "full1": {
@@ -56,11 +56,11 @@
             "s": "output"
           },
           "connections": {
-            "a": [ 4 ],
-            "b": [ 8 ],
+            "a": [ 3 ],
+            "b": [ 7 ],
             "cin": [ 14 ],
             "cout": [ 15 ],
-            "s": [ 12 ]
+            "s": [ 11 ]
           }
         },
         "full2": {
@@ -78,11 +78,11 @@
             "s": "output"
           },
           "connections": {
-            "a": [ 3 ],
-            "b": [ 7 ],
+            "a": [ 4 ],
+            "b": [ 8 ],
             "cin": [ 15 ],
             "cout": [ 16 ],
-            "s": [ 11 ]
+            "s": [ 12 ]
           }
         },
         "full3": {
@@ -100,24 +100,24 @@
             "s": "output"
           },
           "connections": {
-            "a": [ 2 ],
-            "b": [ 6 ],
+            "a": [ 5 ],
+            "b": [ 9 ],
             "cin": [ 16 ],
             "cout": [ 17 ],
-            "s": [ 10 ]
+            "s": [ 13 ]
           }
         }
       },
       "netnames": {
         "$auto$ghdl.cc:764:import_module$2": {
           "hide_name": 1,
-          "bits": [ 13 ],
+          "bits": [ 10 ],
           "attributes": {
           }
         },
         "$auto$ghdl.cc:764:import_module$4": {
           "hide_name": 1,
-          "bits": [ 12 ],
+          "bits": [ 11 ],
           "attributes": {
           }
         },
@@ -135,7 +135,7 @@
         },
         "$auto$ghdl.cc:764:import_module$8": {
           "hide_name": 1,
-          "bits": [ 10 ],
+          "bits": [ 13 ],
           "attributes": {
           }
         },

--- a/intTests/test_yosys_verilog/test.saw
+++ b/intTests/test_yosys_verilog/test.saw
@@ -3,8 +3,8 @@ m <- yosys_import "test.json";
 
 let {{
   cryfull :  {a : [4], b : [4], c_in : [1]} -> {c_out : [1], sum : [4]}
-  cryfull inp = { c_out = cout, sum = reverse s }
-    where (cout, s) = splitAt (zext (reverse inp.a) + zext (reverse inp.b) + zext inp.c_in)
+  cryfull inp = { c_out = cout, sum = s }
+    where (cout, s) = splitAt (zext inp.a + zext inp.b + zext inp.c_in)
 }};
 
 prove_print w4 {{ m.fulladd === cryfull }};

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -141,7 +141,8 @@ lookupPatternTerm sc loc pat ts =
         case Map.lookup [b] ts of
           Just t -> pure t
           Nothing -> throw $ YosysErrorNoSuchOutputBitvec (Text.pack $ show b) loc
-      vecBits <- liftIO $ SC.scVector sc onety bits
+      -- Yosys lists bits in little-endian order, while scVector expects big-endian, so reverse
+      vecBits <- liftIO $ SC.scVector sc onety (reverse bits)
       liftIO $ SC.scJoin sc many one boolty vecBits
 
 -- | Given a netgraph and an initial map from bit patterns to terms, populate that map with terms

--- a/saw-central/src/SAWCentral/Yosys/Utils.hs
+++ b/saw-central/src/SAWCentral/Yosys/Utils.hs
@@ -290,7 +290,8 @@ fieldsToCryptolType fields = pure . C.tRec . C.recordFromFields $ bimap C.mkIden
 deriveTermsByIndices :: (MonadIO m, Ord b) => SC.SharedContext -> [b] -> SC.Term -> m (Map [b] SC.Term)
 deriveTermsByIndices sc rep t = do
   boolty <- liftIO $ SC.scBoolType sc
-  telems <- forM [0..length rep - 1] $ \index -> do
+  -- Yosys uses little-endian order while saw uses big-endian (msb at index 0), so reverse indices
+  telems <- forM (reverse [0..length rep - 1]) $ \index -> do
     tlen <- liftIO . SC.scNat sc . fromIntegral $ length rep
     idx <- liftIO . SC.scNat sc $ fromIntegral index
     bit <- liftIO $ SC.scAt sc tlen boolty t idx


### PR DESCRIPTION
Extra reversing of inputs and outputs on Cryptol specs should no longer be necessary.