### PR TITLE
Implement head and tail saw-core primitives.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,9 @@ Note that build.sh is in any case the recommended way to build.
 
 ## Bug fixes
 
+* The `head` and `tail` primitives are now implemented in the SAW-Core
+  evaluator (#2312).
+
 * Functions imported with `yosys_import` now use a non-reversed bit
   ordering. All bit indices in Yosys JSON files are now treated as
   indexing from the right. Arithmetic operations treat the right-most

--- a/intTests/test2312/test.saw
+++ b/intTests/test2312/test.saw
@@ -1,0 +1,4 @@
+prove_core z3 "EqTrue (equalNat (head 2 Nat (gen 3 Nat (\\(n : Nat) -> n))) 0)";
+prove_core z3 "EqTrue (vecEq 2 Nat equalNat (tail 2 Nat (gen 3 Nat (\\(n : Nat) -> n))) (gen 2 Nat (\\(n : Nat) -> Succ n)))";
+prove_core z3 "EqTrue (boolEq (head 2 Bool (bvNat 3 6)) True)";
+prove_core z3 "EqTrue (vecEq 2 Bool boolEq (tail 2 Bool (bvNat 3 6)) (bvNat 2 2))";

--- a/intTests/test2312/test.sh
+++ b/intTests/test2312/test.sh
@@ -1,0 +1,3 @@
+set -e
+
+$SAW test.saw


### PR DESCRIPTION
Fixes #2312.

It would probably be a good idea to add the proof commands from the #2312 thread as a regression test.