### PR TITLE
Speed up Yosys import

### DIFF
--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -64,10 +64,13 @@ moduleNetgraph m =
       , b <- concat (Map.elems (cellOutputConnections c)) ]
 
     cellDeps :: Cell [Bitrep] -> [Text]
-    cellDeps c =
-      Set.toAscList $ Set.fromList $
-      Maybe.mapMaybe (flip Map.lookup sources) $
-      concat $ Map.elems $ cellInputConnections c
+    cellDeps c
+      | c ^. cellType == CellTypeDff = []
+      | c ^. cellType == CellTypeFf = []
+      | otherwise =
+        Set.toAscList $ Set.fromList $
+        Maybe.mapMaybe (flip Map.lookup sources) $
+        concat $ Map.elems $ cellInputConnections c
 
     nodes :: [(Cell [Bitrep], Text, [Text])]
     nodes = [ (c, cname, cellDeps c) | (cname, c) <- Map.assocs (m ^. moduleCells) ]

--- a/saw-central/src/SAWCentral/Yosys/State.hs
+++ b/saw-central/src/SAWCentral/Yosys/State.hs
@@ -44,12 +44,12 @@ import SAWCentral.Yosys.Netgraph
 
 -- | Find all of the flip-flop cells in a network graph.
 findDffs ::
-  Netgraph Bitrep ->
+  Netgraph ->
   Map Text (Cell [Bitrep])
 findDffs ng =
   Map.fromList
   . filter (\(_, c) -> c ^. cellType `elem` [CellTypeDff, CellTypeFf])
-  . fmap (\v -> let ((nm, n), _, _) = ng ^. netgraphNodeFromVertex $ v in (cellIdentifier nm, n))
+  . fmap (\v -> let (n, nm, _) = ng ^. netgraphNodeFromVertex $ v in (cellIdentifier nm, n))
   . Graph.vertices
   $ ng ^. netgraphGraph
 


### PR DESCRIPTION
We make two changes to `yosys_import` to speed it up:

* The big one is to avoid translating every `n`-bit cell `n` times
* A smaller speedup (~3x) comes from skipping a redundant type checking pass