### PR TITLE
Vacuity checking added to JVM and MIR Backends

### DIFF
--- a/saw-central/src/SAWCentral/Crucible/Common/Vacuity.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/Vacuity.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module SAWCentral.Crucible.Common.Vacuity (
+  GenericCrucibleContext(..),
+  checkAssumptionsForContradictions
+) where
+
+import Prelude hiding (fail)
+import           Control.Lens
+import           Control.Monad (forM_)
+import           Control.Monad.Extra (findM, whenM)
+import           Data.Function
+import           Data.List
+import qualified What4.ProgramLoc as W4
+import qualified What4.Interface as W4
+import qualified Lang.Crucible.Backend as Crucible
+import SAWCore.SharedTerm
+import SAWCoreWhat4.ReturnTrip
+import SAWCentral.Proof
+import SAWCentral.TopLevel
+import SAWCentral.Value
+import SAWCentral.Options
+import qualified SAWCentral.Crucible.Common as Common
+import           SAWCentral.Crucible.Common.MethodSpec (CrucibleMethodSpecIR)
+import qualified SAWCentral.Crucible.Common.MethodSpec as MS
+
+type AssumptionReason = (MS.ConditionMetadata, String)
+
+-- | Minimal backend-independent context
+data GenericCrucibleContext sym = GenericCrucibleContext
+  { gccSym :: sym  -- What4 symbolic backend
+  }
+
+-- | Top-level check and minimal core reporter
+checkAssumptionsForContradictions ::
+  GenericCrucibleContext Common.Sym ->
+  CrucibleMethodSpecIR ext ->
+  ProofScript () ->
+  [Crucible.LabeledPred Term AssumptionReason] ->
+  TopLevel ()
+checkAssumptionsForContradictions gcc methodSpec tactic assumptions =
+  whenM
+    (assumptionsContainContradiction gcc methodSpec tactic assumptions)
+    (computeMinimalContradictingCore gcc methodSpec tactic assumptions)
+
+-- | Check if the assumptions are contradictory
+assumptionsContainContradiction ::
+  GenericCrucibleContext Common.Sym ->
+  CrucibleMethodSpecIR ext ->
+  ProofScript () ->
+  [Crucible.LabeledPred Term AssumptionReason] ->
+  TopLevel Bool
+assumptionsContainContradiction gcc methodSpec tactic assumptions = do
+  let sym = gccSym gcc
+  st <- io $ Common.sawCoreState sym
+  let sc = saw_ctx st
+  let ploc = methodSpec ^. MS.csLoc
+
+  (goal', pgl) <- io $
+   do
+    -- conjunction of all assumptions
+    assume <- scAndList sc (toListOf (folded . Crucible.labeledPred) assumptions)
+    -- implies falsehood
+    goal   <- scImplies sc assume =<< toSC sym st (W4.falsePred sym)
+    goal'  <- boolToProp sc [] goal
+    return (goal',
+            ProofGoal
+              { goalNum     = 0
+              , goalType    = "vacuousness check"
+              , goalName    = "vacuousness_check"
+              , goalLoc     = show (W4.plSourceLoc ploc) ++ " in " ++ show (W4.plFunction ploc)
+              , goalDesc    = "vacuousness check"
+              , goalSequent = propToSequent goal'
+              , goalTags    = mempty
+              })
+
+  res <- runProofScript tactic goal' pgl Nothing
+           "vacuousness check" False False
+  case res of
+    ValidProof _ _     -> return True
+    InvalidProof _ _ _ -> return False
+    UnfinishedProof _  ->
+      -- TODO? is this the right behavior?
+      do printOutLnTop Warn "Could not determine if preconditions are vacuous"
+         return True
+
+-- | Try to find the smallest contradictory subset
+computeMinimalContradictingCore ::
+  GenericCrucibleContext Common.Sym ->
+  CrucibleMethodSpecIR ext ->
+  ProofScript () ->
+  [Crucible.LabeledPred Term AssumptionReason] ->
+  TopLevel ()
+computeMinimalContradictingCore gcc methodSpec tactic assumes = do
+  printOutLnTop Warn "Contradiction detected! Computing minimal core of contradictory assumptions:"
+  let cores = sortBy (compare `on` length) (subsequences assumes)
+  findM (assumptionsContainContradiction gcc methodSpec tactic) cores >>= \case
+    Nothing ->
+      printOutLnTop Warn "No minimal core: the assumptions did not contain a contradiction."
+    Just core -> do
+      forM_ core $ \assume ->
+        case assume ^. Crucible.labeledPredMsg of
+          (loc, reason) ->
+            printOutLnTop Warn (show loc ++ ": " ++ reason)
+      printOutLnTop Warn "Because of the contradiction, the following proofs may be vacuous."

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -133,6 +133,7 @@ import qualified SAWCentral.Crucible.Common as Common
 import           SAWCentral.Crucible.Common
 import           SAWCentral.Crucible.Common.Override (MetadataMap)
 import           SAWCentral.Crucible.Common.MethodSpec (AllocIndex(..), nextAllocIndex, PrePost(..))
+import qualified SAWCentral.Crucible.Common.Vacuity as Vacuity
 
 import qualified SAWCentral.Crucible.Common.MethodSpec as MS
 import qualified SAWCentral.Crucible.Common.Setup.Type as Setup
@@ -246,6 +247,14 @@ jvm_verify cls nm lemmas checkSat setup tactic =
 
      -- construct the initial state for verifications
      (args, assumes, env, globals2) <- io $ verifyPrestate cc methodSpec globals1
+
+     -- check for contradictory preconditions
+     when (detectVacuity opts) $
+       Vacuity.checkAssumptionsForContradictions
+         (Vacuity.GenericCrucibleContext sym)
+         methodSpec
+         tactic
+         assumes
 
      -- save initial path conditions
      frameIdent <- io $ Crucible.pushAssumptionFrame bak

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
@@ -94,8 +94,7 @@ import Prelude hiding (fail)
 import qualified Control.Exception as X
 import           Control.Lens
 
-import           Control.Monad (foldM, forM, forM_, replicateM, unless, when)
-import           Control.Monad.Extra (findM, whenM)
+import           Control.Monad (foldM, forM, replicateM, unless, when)
 import           Control.Monad.Fail (MonadFail(..))
 import           Control.Monad.IO.Class (MonadIO(..))
 import           Control.Monad.Reader (runReaderT)
@@ -104,7 +103,6 @@ import           Control.Monad.Trans.Class (MonadTrans(..))
 import qualified Data.Bimap as Bimap
 import           Data.Char (isDigit)
 import           Data.Foldable (for_, toList, fold)
-import           Data.Function
 import           Data.Functor (void)
 import           Data.IORef
 import           Data.List

--- a/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
@@ -132,6 +132,7 @@ import qualified SAWCentral.Crucible.Common.MethodSpec as MS
 import SAWCentral.Crucible.Common.Override
 import qualified SAWCentral.Crucible.Common.Setup.Builtins as Setup
 import qualified SAWCentral.Crucible.Common.Setup.Type as Setup
+import qualified SAWCentral.Crucible.Common.Vacuity as Vacuity
 import SAWCentral.Crucible.MIR.MethodSpecIR
 import SAWCentral.Crucible.MIR.Override
 import SAWCentral.Crucible.MIR.ResolveSetupValue
@@ -709,6 +710,14 @@ mir_verify rm nm lemmas checkSat setup tactic =
 
      -- save initial path conditions
      frameIdent <- io $ Crucible.pushAssumptionFrame bak
+
+     -- check for contradictory preconditions
+     when (detectVacuity opts) $
+       Vacuity.checkAssumptionsForContradictions
+         (Vacuity.GenericCrucibleContext sym)
+         methodSpec
+         tactic
+         assumes
 
      -- run the symbolic execution
      printOutLnTop Info $

--- a/saw.cabal
+++ b/saw.cabal
@@ -641,6 +641,7 @@ library saw-central
     SAWCentral.Crucible.Common.Setup.Builtins
     SAWCentral.Crucible.Common.Setup.Type
     SAWCentral.Crucible.Common.Setup.Value
+    SAWCentral.Crucible.Common.Vacuity
 
     SAWCentral.Crucible.LLVM.Builtins
     SAWCentral.Crucible.LLVM.Boilerplate


### PR DESCRIPTION
Changes

* Extracted vacuity logic (checkAssumptionsForContradictions, etc.) into a new backend independent module: SAWCentral.Crucible.Common.Vacuity.
* Introduced GenericCrucibleContext to pass symbolic backend context uniformly across backends.
* Hooked vacuity checks into:
  * mir_verify in SAWCentral.Crucible.MIR.Builtins
  * jvm_verify in SAWCentral.Crucible.JVM.Builtins
  * verifyMethodSpec and refineMethodSpec in SAWCentral.Crucible.LLVM.Builtins
  
I verified the with test cases demonstrating vacuous and non-vacuous proofs across all three backends.