### PR TITLE
Add mir_ref_of for convenience in MIR specs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,10 @@ Note that build.sh is in any case the recommended way to build.
 
 * Support verifying Rust code up to version 1.86.
 
+* Added `mir_ref_of` to SAWScript's MIR support. This helper combines mir_alloc
+  and mir_points_to, simplifying the common pattern of allocating a reference
+  and immediately initializing it.
+
 ## Bug fixes
 
 * The `head` and `tail` primitives are now implemented in the SAW-Core

--- a/doc/rust-verification-with-saw/reference-types.md
+++ b/doc/rust-verification-with-saw/reference-types.md
@@ -124,4 +124,34 @@ There are two interesting things worth calling out in this spec:
    to after calling the function. The two uses to `mir_points_to` after the
    function has been called swap the order of `a_val` and `b_val`, reflecting
    the fact that the `swap` function itself swaps the values that the references
-   point to.
+   point to. Sandberg
+
+### Convenience: `mir_ref_of`
+
+Because this pattern of allocating a reference and initializing it with `mir_points_to`
+is so common, SAW provides a helper: `mir_ref_of`.
+
+:::{code-block} console
+sawscript> :type mir_ref_of
+MIRValue -> MIRSetup MIRValue
+:::
+
+`mir_ref_of` combines `mir_alloc` and `mir_points_to` into a single operation, returning 
+a reference to the specified value. This portion of a spec:
+
+:::{code-block} console
+s <- mir_alloc (mir_adt s_adt);
+s_val <- mir_fresh_expanded_value "s_val" (mir_adt s_adt);
+mir_points_to s s_val;
+:::
+
+can be rewritten more concisely as:
+
+:::{code-block} console
+s_val <- mir_fresh_expanded_value "s_val" (mir_adt s_adt);
+s <- mir_ref_of s_val;
+:::
+
+This version mirrors how one would write the function in Rust, where a `&T`
+points to an already-initialized value. Using `mir_ref_of` encourages that 
+style and avoids the risk of forgetting to initialize allocated memory.

--- a/doc/saw-user-manual/specification-based-verification.md
+++ b/doc/saw-user-manual/specification-based-verification.md
@@ -853,6 +853,12 @@ and states that the memory specified by that reference should contain the
 value given in the second argument (which may be any type of
 `SetupValue`).
 
+As a convenience, SAW also provides:
+
+- `mir_ref_of : SetupValue -> MIRSetup SetupValue`
+
+which combines `mir_alloc` and `mir_points_to` into a single operation.
+
 ## Working with Compound Types
 
 The commands mentioned so far give us no way to specify the values of

--- a/intTests/test1999/README
+++ b/intTests/test1999/README
@@ -1,0 +1,11 @@
+This test verifies that `mir_ref_of` behaves equivalently to the more verbose
+pattern using `mir_alloc` followed by `mir_points_to`. It corresponds to
+
+https://github.com/GaloisInc/saw-script/issues/1999.
+
+The Rust function under test takes an immutable reference to a struct and
+returns it.  The SAW specification uses `mir_ref_of` to allocate and initialize
+the reference in one step.
+
+This test reuses the same MIR module as test1973 and should verify
+successfully.

--- a/intTests/test1999/test.saw
+++ b/intTests/test1999/test.saw
@@ -1,0 +1,17 @@
+enable_experimental;
+
+m <- mir_load_module "../test1973/test.linked-mir.json";
+
+let s_adt = mir_find_adt m "test::S" [];
+
+let f_spec = do {
+  let ty = mir_adt s_adt;
+  s <- mir_fresh_expanded_value "s" ty;
+  s_ref <- mir_ref_of s;
+
+  mir_execute_func [s_ref];
+
+  mir_return s_ref;
+};
+
+mir_verify m "test::f" [] false f_spec z3;

--- a/intTests/test1999/test.sh
+++ b/intTests/test1999/test.sh
@@ -1,0 +1,3 @@
+set -e
+
+$SAW test.saw

--- a/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Use camelCase" #-}
 
 -- | Implementations of Crucible-related SAWScript primitives for MIR.
 module SAWCentral.Crucible.MIR.Builtins
@@ -12,6 +14,7 @@ module SAWCentral.Crucible.MIR.Builtins
     -- ** Setup
     mir_alloc
   , mir_alloc_mut
+  , mir_ref_of
   , mir_assert
   , mir_execute_func
   , mir_equal
@@ -212,6 +215,32 @@ mir_alloc_internal mut mty =
                           , _maLen = 1
                           })
      return (MS.SetupVar n)
+
+-- | Allocate a MIR reference and initialize it to point to a given SetupValue.
+-- This is a convenience function that avoids requiring the caller to manually
+-- pair `mir_alloc` and `mir_points_to`.
+mir_ref_of :: SetupValue -> MIRSetupM SetupValue
+mir_ref_of val = do
+  cc  <- MIRSetupM getMIRCrucibleContext
+  loc <- MIRSetupM $ getW4Position "mir_ref_of"
+  st  <- MIRSetupM get
+
+  let env     = MS.csAllocations (st ^. Setup.csMethodSpec)
+      nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
+
+  ty  <- MIRSetupM $ typeOfSetupValue cc env nameEnv val
+  ptr <- mir_alloc_internal Mir.Immut ty
+
+  tags <- MIRSetupM $ view Setup.croTags
+  let md = MS.ConditionMetadata
+            { MS.conditionLoc     = loc
+            , MS.conditionTags    = tags
+            , MS.conditionType    = "MIR ref-of"
+            , MS.conditionContext = ""
+            }
+
+  MIRSetupM $ Setup.addPointsTo (MirPointsTo md ptr [val])
+  return ptr
 
 mir_execute_func :: [SetupValue] -> MIRSetupM ()
 mir_execute_func args =

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -4467,6 +4467,11 @@ primitives = Map.fromList
     , "method being verified."
     ]
 
+  , prim "mir_ref_of" "MIRValue -> MIRSetup MIRValue"
+    (pureVal mir_ref_of)
+    Experimental
+    [ "Allocates a reference and initializes it to point to the given MIRValue." ]
+
   , prim "mir_return" "MIRValue -> MIRSetup ()"
     (pureVal mir_return)
     Experimental


### PR DESCRIPTION
- Introduced `mir_ref_of`, a helper that combines `mir_alloc` and `mir_points_to`.
- Simplifies common spec patterns and reduces the chance of forgetting to initialize memory.
- Added user documentation for `mir_ref_of` in the reference-types and heap-layout sections of the SAW manual.
- Added regression test in test1999 to ensure it behaves equivalently to the explicit pattern using `mir_alloc` and `mir_points_to` in test 1973.

Fixes #1999