### PR TITLE
Remove unsafe Module-related operations from SharedTerm API.

### DIFF
--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -87,8 +87,6 @@ module SAWCore.SharedTerm
     -- ** Modules
   , scLoadModule
   , scImportModule
-  , scUnloadModule
-  , scModifyModule
   , scDeclarePrim
   , scInsertDef
   , scModuleIsLoaded
@@ -586,12 +584,6 @@ scImportModule sc p mn1 mn2 =
   do i_exists <- scModuleIsLoaded sc mn1
      i <- if i_exists then scFindModule sc mn1 else pure (emptyModule mn1)
      scModifyModule sc mn2 (insImport (p . resolvedNameIdent) i)
-
--- | Remove a module from the current shared context, or do nothing if it does
--- not exist
-scUnloadModule :: SharedContext -> ModuleName -> IO ()
-scUnloadModule sc mnm =
-  modifyIORef' (scModuleMap sc) $ HMap.delete mnm
 
 -- | Modify an already loaded module, raising an error if it is not loaded
 scModifyModule :: SharedContext -> ModuleName -> (Module -> Module) -> IO ()

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -94,6 +94,7 @@ module SAWCore.SharedTerm
   , scFindModule
   , scFindDef
   , scBeginDataType
+  , scCompleteDataType
   , scFindDataType
   , scFindCtor
   , scRequireDef
@@ -321,7 +322,7 @@ import Text.URI
 import SAWCore.Panic (panic)
 import SAWCore.Cache
 import SAWCore.Change
-import SAWCore.Module (insInjectCode, beginDataType)
+import SAWCore.Module (insInjectCode, beginDataType, completeDataType)
 import SAWCore.Name
 import SAWCore.Prelude.Constants
 import SAWCore.Recognizer
@@ -634,7 +635,8 @@ scRequireDef sc i =
     Nothing -> fail ("Could not find definition: " ++ show i)
 
 -- | Insert an "incomplete" datatype, used as part of building up a
--- 'DataType' to typecheck its constructors.
+-- 'DataType' to typecheck its constructors. The constructors must be
+-- registered separately with @scCompleteDataType@.
 scBeginDataType ::
   SharedContext ->
   Ident {- ^ The name of this datatype -} ->
@@ -649,6 +651,12 @@ scBeginDataType sc dtName dtParams dtIndices dtSort =
      let mnm = identModule dtName
      scModifyModule sc mnm (\m -> beginDataType m dt)
      pure $ PrimName dtVarIndex dtName dtType
+
+-- | Complete a datatype, by adding its constructors. See also @scBeginDataType@.
+scCompleteDataType :: SharedContext -> Ident -> [Ctor] -> IO ()
+scCompleteDataType sc dtName ctors =
+  do let mnm = identModule dtName
+     scModifyModule sc mnm (\m -> completeDataType m dtName ctors)
 
 -- | Look up a datatype by its identifier
 scFindDataType :: SharedContext -> Ident -> IO (Maybe DataType)

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -641,13 +641,14 @@ scBeginDataType ::
   [(LocalName, Term)] {- ^ The context of parameters of this datatype -} ->
   [(LocalName, Term)] {- ^ The context of indices of this datatype -} ->
   Sort {- ^ The universe of this datatype -} ->
-  IO ()
+  IO (PrimName Term)
 scBeginDataType sc dtName dtParams dtIndices dtSort =
   do dtVarIndex <- scFreshGlobalVar sc
      dtType <- scPiList sc (dtParams ++ dtIndices) =<< scSort sc dtSort
      let dt = DataType { dtCtors = [], .. }
      let mnm = identModule dtName
      scModifyModule sc mnm (\m -> beginDataType m dt)
+     pure $ PrimName dtVarIndex dtName dtType
 
 -- | Look up a datatype by its identifier
 scFindDataType :: SharedContext -> Ident -> IO (Maybe DataType)

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -690,7 +690,7 @@ scRequireCtor sc i =
     Just ctor -> return ctor
     Nothing -> fail ("Could not find constructor: " ++ show i)
 
--- | Insert an "injectCode" declaration to the given SAWCore module.
+-- | Insert an \"injectCode\" declaration to the given SAWCore module.
 -- This declaration has no logical effect within SAW; it is used to
 -- add extra code (like class instance declarations, for example) to
 -- exported SAWCore modules in certain translation backends.

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -698,7 +698,8 @@ scInjectCode ::
   SharedContext ->
   ModuleName ->
   Text {- ^ Code namespace -} ->
-  Text {- ^ Code to inject -} -> IO ()
+  Text {- ^ Code to inject -} ->
+  IO ()
 scInjectCode sc mnm ns txt =
   scModifyModule sc mnm $ \m -> insInjectCode m ns txt
 

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -596,6 +596,7 @@ scModifyModule sc mnm f =
 scDeclarePrim :: SharedContext -> ModuleName -> Ident -> DefQualifier -> Term -> IO ()
 scDeclarePrim sc mnm ident q def_tp =
   do i <- scFreshGlobalVar sc
+     scRegisterName sc i (ModuleIdentifier ident)
      let pn = PrimName i ident def_tp
      t <- scFlatTermF sc (Primitive pn)
      scRegisterGlobal sc ident t
@@ -650,6 +651,7 @@ scBeginDataType ::
   IO (PrimName Term)
 scBeginDataType sc dtName dtParams dtIndices dtSort =
   do dtVarIndex <- scFreshGlobalVar sc
+     scRegisterName sc dtVarIndex (ModuleIdentifier dtName)
      dtType <- scPiList sc (dtParams ++ dtIndices) =<< scSort sc dtSort
      let dt = DataType { dtCtors = [], .. }
      let mnm = identModule dtName

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -639,7 +639,7 @@ scRequireDef sc i =
     Just d -> return d
     Nothing -> fail ("Could not find definition: " ++ show i)
 
--- | Insert an "incomplete" datatype, used as part of building up a
+-- | Insert an \"incomplete\" datatype, used as part of building up a
 -- 'DataType' to typecheck its constructors. The constructors must be
 -- registered separately with @scCompleteDataType@.
 scBeginDataType ::

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -86,6 +86,7 @@ module SAWCore.SharedTerm
   , scBuildCtor
     -- ** Modules
   , scLoadModule
+  , scImportModule
   , scUnloadModule
   , scModifyModule
   , scDeclarePrim
@@ -322,7 +323,7 @@ import Text.URI
 import SAWCore.Panic (panic)
 import SAWCore.Cache
 import SAWCore.Change
-import SAWCore.Module (insInjectCode, beginDataType, completeDataType)
+import SAWCore.Module (insInjectCode, beginDataType, completeDataType, resolvedNameIdent)
 import SAWCore.Name
 import SAWCore.Prelude.Constants
 import SAWCore.Recognizer
@@ -574,6 +575,17 @@ scLoadModule sc m =
   HMap.insertWith (error $ "scLoadModule: module "
                    ++ show (moduleName m) ++ " already loaded!")
   (moduleName m) m
+
+scImportModule ::
+  SharedContext ->
+  (Ident -> Bool) {- ^ which names to import -} ->
+  ModuleName {- ^ from this module -} ->
+  ModuleName {- ^ into this module -} ->
+  IO ()
+scImportModule sc p mn1 mn2 =
+  do i_exists <- scModuleIsLoaded sc mn1
+     i <- if i_exists then scFindModule sc mn1 else pure (emptyModule mn1)
+     scModifyModule sc mn2 (insImport (p . resolvedNameIdent) i)
 
 -- | Remove a module from the current shared context, or do nothing if it does
 -- not exist

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -97,6 +97,7 @@ module SAWCore.SharedTerm
   , scRequireDef
   , scRequireDataType
   , scRequireCtor
+  , scInjectCode
     -- ** Term construction
     -- *** Datatypes and constructors
   , scDataTypeAppParams
@@ -318,6 +319,7 @@ import Text.URI
 import SAWCore.Panic (panic)
 import SAWCore.Cache
 import SAWCore.Change
+import SAWCore.Module (insInjectCode)
 import SAWCore.Name
 import SAWCore.Prelude.Constants
 import SAWCore.Recognizer
@@ -641,6 +643,18 @@ scRequireCtor sc i =
   case maybe_ctor of
     Just ctor -> return ctor
     Nothing -> fail ("Could not find constructor: " ++ show i)
+
+-- | Insert an "injectCode" declaration to the given SAWCore module.
+-- This declaration has no logical effect within SAW; it is used to
+-- add extra code (like class instance declarations, for example) to
+-- exported SAWCore modules in certain translation backends.
+scInjectCode ::
+  SharedContext ->
+  ModuleName ->
+  Text {- ^ Code namespace -} ->
+  Text {- ^ Code to inject -} -> IO ()
+scInjectCode sc mnm ns txt =
+  scModifyModule sc mnm $ \m -> insInjectCode m ns txt
 
 -- SharedContext implementation.
 

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -574,6 +574,7 @@ scLoadModule sc m =
                    ++ show (moduleName m) ++ " already loaded!")
   (moduleName m) m
 
+-- | Bring a subset of names from one module into scope in a second module.
 scImportModule ::
   SharedContext ->
   (Ident -> Bool) {- ^ which names to import -} ->

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -441,7 +441,7 @@ processDecls (Un.DataDecl (PosPair p nm) param_ctx dt_tp c_decls : rest) =
               Nothing -> err ("Malformed type form constructor: " ++ show c)
 
   -- Step 6: complete the datatype with the given ctors
-  liftTCM scModifyModule mnm (\m -> completeDataType m dtName ctors)
+  liftTCM scCompleteDataType dtName ctors
 
 
 -- | Typecheck a module and, on success, insert it into the current context

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -447,8 +447,6 @@ processDecls (Un.DataDecl (PosPair p nm) param_ctx dt_tp c_decls : rest) =
 -- | Typecheck a module and, on success, insert it into the current context
 tcInsertModule :: SharedContext -> Un.Module -> IO ()
 tcInsertModule sc (Un.Module (PosPair _ mnm) imports decls) = do
-  let myfail :: String -> IO a
-      myfail msg = scUnloadModule sc mnm >> fail msg
   -- First, insert an empty module for mnm
   scLoadModule sc $ emptyModule mnm
   -- Next, process all the imports
@@ -460,7 +458,7 @@ tcInsertModule sc (Un.Module (PosPair _ mnm) imports decls) = do
   -- Finally, process all the decls
   decls_res <- runTCM (processDecls decls) sc (Just mnm) []
   case decls_res of
-    Left err -> myfail $ unlines $ prettyTCError err
+    Left err -> fail $ unlines $ prettyTCError err
     Right _ -> return ()
 
 

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -309,7 +309,7 @@ processDecls [] = return ()
 
 processDecls (Un.InjectCodeDecl ns txt : rest) =
   do mnm <- getModuleName
-     liftTCM scModifyModule mnm $ \m -> insInjectCode m ns txt
+     liftTCM scInjectCode mnm ns txt
      processDecls rest
 
 processDecls (Un.TypedDef nm params rty body : rest) =

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -366,17 +366,8 @@ processDecls (Un.TypeDecl q (PosPair p nm) tp : rest) =
       void $ ensureSort $ typedType typed_tp
       mnm <- getModuleName
       let ident = mkIdent mnm nm
-      i <- liftTCM scFreshGlobalVar
-      liftTCM scRegisterName i (ModuleIdentifier ident)
       let def_tp = typedVal typed_tp
-      let pn = PrimName i ident def_tp
-      t <- liftTCM scFlatTermF (Primitive pn)
-      liftTCM scRegisterGlobal ident t
-      liftTCM scModifyModule mnm $ \m ->
-        insDef m $ Def { defIdent = ident,
-                         defQualifier = q,
-                         defType = typedVal typed_tp,
-                         defBody = Nothing }) >>
+      liftTCM scDeclarePrim mnm ident q def_tp) >>
   processDecls rest
 
 processDecls (Un.TermDef (PosPair p nm) _ _ : _) =

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -350,13 +350,7 @@ processDecls (Un.TypeDecl NoQualifier (PosPair p nm) tp :
      -- Step 4: add the definition to the current module
      mnm <- getModuleName
      let ident = mkIdent mnm nm
-     t <- liftTCM scConstant' (ModuleIdentifier ident) def_tm def_tp
-     liftTCM scRegisterGlobal ident t
-     liftTCM scModifyModule mnm $ \m ->
-       insDef m $ Def { defIdent = ident,
-                        defQualifier = NoQualifier,
-                        defType = def_tp,
-                        defBody = Just def_tm }) >>
+     liftTCM scInsertDef mnm ident def_tp def_tm) >>
   processDecls rest
 
 processDecls (Un.TypeDecl NoQualifier (PosPair p nm) _ : _) =

--- a/saw-script/src/SAWScript/HeapsterBuiltins.hs
+++ b/saw-script/src/SAWScript/HeapsterBuiltins.hs
@@ -984,14 +984,7 @@ insPrimitive henv nm tp =
      let ident = mkSafeIdent mnm nm
      i <- liftIO $ scFreshGlobalVar sc
      liftIO $ scRegisterName sc i (ModuleIdentifier ident)
-     let pn = PrimName i ident tp
-     t <- liftIO $ scFlatTermF sc (Primitive pn)
-     liftIO $ scRegisterGlobal sc ident t
-     liftIO $ scModifyModule sc mnm $ \m ->
-        insDef m $ Def { defIdent = ident,
-                         defQualifier = PrimQualifier,
-                         defType = tp,
-                         defBody = Nothing }
+     liftIO $ scDeclarePrim sc mnm ident PrimQualifier tp
      return ident
 
 -- | Assume that the given named function has the supplied type and translates

--- a/saw-script/src/SAWScript/HeapsterBuiltins.hs
+++ b/saw-script/src/SAWScript/HeapsterBuiltins.hs
@@ -982,8 +982,6 @@ insPrimitive henv nm tp =
   do sc <- getSharedContext
      let mnm = heapsterEnvSAWModule henv
      let ident = mkSafeIdent mnm nm
-     i <- liftIO $ scFreshGlobalVar sc
-     liftIO $ scRegisterName sc i (ModuleIdentifier ident)
      liftIO $ scDeclarePrim sc mnm ident PrimQualifier tp
      return ident
 


### PR DESCRIPTION
The following functions have been removed from `SAWCore.SharedTerm`:
* `scUnloadModule :: SharedContext -> ModuleName -> IO ()`
* `scModifyModule :: SharedContext -> ModuleName -> (Module -> Module) -> IO ()`

We also have several new operations to provide functionality for things that used to require `scModifyModule`.
* `scInjectCode :: SharedContext -> ModuleName -> Text -> Text -> IO ()`
* `scDeclarePrim :: SharedContext -> ModuleName -> Ident -> DefQualifier -> Term -> IO ()`
* `scBeginDataType :: SharedContext -> Ident -> [(LocalName, Term)] -> [(LocalName, Term)] -> Sort -> IO (PrimName Term)`
* `scCompleteDataType :: SharedContext -> Ident -> [Ctor] -> IO ()`
* `scImportModule :: SharedContext -> (Ident -> Bool) -> ModuleName -> ModuleName -> IO ()`

Fixes #2333.

This PR also serves to hide more implementation details of `SharedContext` and `ModuleMap`, facilitating further changes and simplifications to that code.