### PR TITLE
Two improvements to build.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
   # older .so files are cached, which can have various effects
   # (e.g. cabal complains it can't find a valid version of the "happy"
   # tool).
-  CABAL_CACHE_VERSION: 9
+  CABAL_CACHE_VERSION: 10
   SOLVER_CACHE_VERSION: 1
 
   DISABLED_TESTS: "test0000 test_FNV_a1_rev test0010_jss_cnf_exp test0039_rust test_boilerplate test_external_abc"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,8 @@ Once the git data has been updated you can run `cabal build` or other
 cabal commands as needed.
 However, running `cabal` by hand is not the recommended or supported
 build interface and additional manual steps may appear in the future.
+For example, be aware that while `build.sh` compiles the test code as
+part of the default build, `cabal build` does not.
 
 You can also set the environment variable SAW_SUPPRESS_GITREV to
 something nonempty to prevent updating the git checkout state.
@@ -107,11 +109,6 @@ This is a hack and will hopefully be replaced by some other better
 solution when we can find one.
 
 As a contributor there are a few additional quirks to be aware of.
-
-One is that test infrastructure is not compiled by default and will
-only be built when you go to run the test that requires it or if you
-explicitly build it with `cabal`.
-This can occasionally bite you.
 
 A second is that `build.sh` runs `git submodule update --init` and
 this will silently reset any uncommitted submodule changes you are

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,18 @@ cabal commands as needed.
 However, running `cabal` by hand is not the recommended or supported
 build interface and additional manual steps may appear in the future.
 
+You can also set the environment variable SAW_SUPPRESS_GITREV to
+something nonempty to prevent updating the git checkout state.
+
+This is not recommended except when actively developing; however, when
+actively developing it avoids recompiling certain slow things (that do
+not actually need to be rebuilt) over and over again every time the
+git state changes.
+If you use this method be sure to include the correct git hash when
+reporting issues, particularly when pasting panic messages.
+This is a hack and will hopefully be replaced by some other better
+solution when we can find one.
+
 As a contributor there are a few additional quirks to be aware of.
 
 One is that test infrastructure is not compiled by default and will

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,9 @@
 #    gitrev (included in build, needed before building)
 #    submodules (included in build, at least for now)
 #    clean
+#
+# Setting environment variable SAW_SUPPRESS_GITREV suppresses updating
+# GitRev.hs. See savegitinfo.sh.
 
 set -e
 

--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,11 @@ tgt_build() {
 
     echo "cabal build ..."
     cabal build exe:cryptol exe:saw exe:saw-remote-api \
-                exe:crux-mir-comp exe:extcore-info exe:verif-viewer
+                exe:crux-mir-comp exe:extcore-info exe:verif-viewer \
+                test-suite:integration-tests test-suite:saw-core-tests \
+                test-suite:cryptol-saw-core-tests \
+                test-suite:saw-core-coq-tests \
+                test-suite:heapster-prover-tests
 
     echo "rm -rf bin && mkdir bin"
     rm -rf bin && mkdir bin


### PR DESCRIPTION
Two improvements to build.sh:
- Add a way to circumvent updating GitRev.hs, for reasons explained therein
- Build the test suite code by default

Also include a cabal cache version bump in light of [this build failure](https://github.com/GaloisInc/saw-script/actions/runs/15282738373/job/42985517200) which doesn't really have any clear explanation other than cache corruption.