### PR TITLE
Fix the saw-core-coq Makefile

### DIFF
--- a/saw-core-coq/coq/Makefile
+++ b/saw-core-coq/coq/Makefile
@@ -12,14 +12,14 @@ include Makefile.coq
 SAW=$(shell which saw)
 ifeq ($(SAW),)
   ifeq ($(CI),)
-	    SAW=cabal run saw
+	    SAW=cabal run exe:saw
   else
     $(error Could not find SAW executable; PATH = $(PATH))
   endif
 endif
 
 generated/CryptolToCoq/SAWCorePrelude.v: ../../saw-core/prelude/Prelude.sawcore
-	(mkdir -p generated/CryptolToCoq; cd ../../; $(SAW) saw-core-coq/saw/generate_scaffolding.saw)
+	(mkdir -p generated/CryptolToCoq; cd ../saw; $(SAW) generate_scaffolding.saw)
 
 generated/CryptolToCoq/CryptolPrimitivesForSAWCore.v: ../../cryptol-saw-core/saw/Cryptol.sawcore
 	(mkdir -p generated/CryptolToCoq; cd ../saw; $(SAW) generate_scaffolding.saw)


### PR DESCRIPTION
This fixes the path to the saw file generating the coq support libraries as well as the path to the saw cabal file.