### PR TITLE
Cleanup mostly in and around Value.hs

### DIFF
--- a/crucible-mir-comp/src/Mir/Compositional/Override.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Override.hs
@@ -237,7 +237,7 @@ runSpec myCS mh ms = ovrWithBackend $ \bak ->
             let var = SAW.ecVarIndex $ SAW.tecExt tec
             when (not $ Map.member var termSub) $ do
                 error $ "argument matching failed to produce a binding for " ++
-                    show (MS.ppTypedExtCns tec)
+                    show (SAW.ppTypedExtCns tec)
 
         -- All pre-state allocs must be bound.
         allocSub <- use MS.setupValueSub

--- a/saw-central/src/SAWCentral/Bisimulation.hs
+++ b/saw-central/src/SAWCentral/Bisimulation.hs
@@ -88,7 +88,6 @@ import qualified Cryptol.Utils.PP as C
 
 import SAWCentral.BisimulationTheorem
 import SAWCentral.Builtins (unfold_term)
-import SAWCentral.Crucible.Common.MethodSpec (ppTypedTermType, ppTypedTerm)
 import SAWCentral.Options (Verbosity(..))
 import SAWCentral.Panic (panic)
 import SAWCentral.Proof

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -168,7 +168,7 @@ definePrim name (TypedTerm (TypedTermSchema schema) rhs) =
 definePrim _name (TypedTerm tp _) =
   fail $ unlines
     [ "Expected term with Cryptol schema type, but got"
-    , show (MS.ppTypedTermType tp)
+    , show (ppTypedTermType tp)
     ]
 
 sbvUninterpreted :: String -> Term -> TopLevel Uninterp
@@ -724,7 +724,7 @@ term_type tt =
     TypedTermSchema sch -> pure sch
     tp -> fail $ unlines
             [ "Term does not have a Cryptol type"
-            , show (MS.ppTypedTermType tp)
+            , show (ppTypedTermType tp)
             ]
 
 goal_eval :: [String] -> ProofScript ()

--- a/saw-central/src/SAWCentral/Crucible/Common/MethodSpec.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/MethodSpec.hs
@@ -28,6 +28,7 @@ Grow\", and is prevalent across the Crucible codebase.
 
 module SAWCentral.Crucible.Common.MethodSpec
   ( AllocIndex(..)
+  , ppAllocIndex
   , nextAllocIndex
 
   , PrePost(..)
@@ -58,10 +59,6 @@ module SAWCentral.Crucible.Common.MethodSpec
   , SetupValueHas
 
   , ppSetupValue
-  , ppAllocIndex
-  , ppTypedTerm
-  , ppTypedTermType
-  , ppTypedExtCns
 
   , setupToTypedTerm
   , setupToTerm
@@ -142,11 +139,8 @@ import           Mir.Intrinsics (MIR)
 import qualified Cryptol.TypeCheck.Type as Cryptol (Schema)
 import qualified Cryptol.Utils.PP as Cryptol
 
-import qualified SAWSupport.Pretty as PPS (defaultOpts)
-
 import           CryptolSAWCore.TypedTerm as SAWVerifier
 import           SAWCore.SharedTerm as SAWVerifier
-import           SAWCore.Term.Pretty (ppTerm)
 import           SAWCoreWhat4.ReturnTrip as SAWVerifier
 
 import           SAWCentral.Crucible.Common (Sym, sawCoreState)
@@ -291,29 +285,6 @@ ppSetupValue setupval = case setupval of
     ppMirSetupSlice (MirSetupSliceRange _ arr start end) =
       ppSetupValue arr <> PP.pretty "[" <> PP.pretty start <>
       PP.pretty ".." <> PP.pretty end <> PP.pretty "]"
-
-ppAllocIndex :: AllocIndex -> PP.Doc ann
-ppAllocIndex i = PP.pretty '@' <> PP.viaShow i
-
-ppTypedTerm :: TypedTerm -> PP.Doc ann
-ppTypedTerm (TypedTerm tp tm) =
-  PP.unAnnotate (ppTerm PPS.defaultOpts tm)
-  PP.<+> PP.pretty ":" PP.<+>
-  ppTypedTermType tp
-
-ppTypedTermType :: TypedTermType -> PP.Doc ann
-ppTypedTermType (TypedTermSchema sch) =
-  PP.viaShow (Cryptol.ppPrec 0 sch)
-ppTypedTermType (TypedTermKind k) =
-  PP.viaShow (Cryptol.ppPrec 0 k)
-ppTypedTermType (TypedTermOther tp) =
-  PP.unAnnotate (ppTerm PPS.defaultOpts tp)
-
-ppTypedExtCns :: TypedExtCns -> PP.Doc ann
-ppTypedExtCns (TypedExtCns tp ec) =
-  PP.unAnnotate (ppName (ecName ec))
-  PP.<+> PP.pretty ":" PP.<+>
-  PP.viaShow (Cryptol.ppPrec 0 tp)
 
 setupToTypedTerm ::
   Options {-^ Printing options -} ->

--- a/saw-central/src/SAWCentral/Crucible/Common/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/Override.hs
@@ -323,7 +323,7 @@ ppOverrideFailureReason rsn = case rsn of
   AmbiguousVars vs ->
     PP.vcat
     [ PP.pretty "Fresh variable(s) not reachable via points-tos from function inputs/outputs:"
-    , PP.indent 2 $ PP.vcat (map MS.ppTypedExtCns vs)
+    , PP.indent 2 $ PP.vcat (map ppTypedExtCns vs)
     ]
   BadTermMatch x y ->
     PP.vcat
@@ -676,7 +676,7 @@ learnGhost _sc _md _prepost _var (TypedTerm tp _)
   = fail $ unlines
       [ "Ghost variable expected value has improper type"
       , "expected Cryptol schema type, but got"
-      , show (MS.ppTypedTermType tp)
+      , show (ppTypedTermType tp)
       ]
 
 executeGhost ::
@@ -693,7 +693,7 @@ executeGhost _sc _md _var (TypedTerm tp _) =
   fail $ unlines
     [ "executeGhost: improper value type"
     , "expected Cryptol schema type, but got"
-    , show (MS.ppTypedTermType tp)
+    , show (ppTypedTermType tp)
     ]
 
 -- | NOTE: The two 'Term' arguments must have the same type.

--- a/saw-central/src/SAWCentral/Crucible/Common/Setup/Value.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/Setup/Value.hs
@@ -26,6 +26,7 @@ module, plus additional functionality) instead.
 
 module SAWCentral.Crucible.Common.Setup.Value
   ( AllocIndex(..)
+  , ppAllocIndex
   , nextAllocIndex
 
   , CrucibleContext
@@ -65,6 +66,8 @@ import           Data.Constraint (Constraint)
 import           Data.Kind (Type)
 import           Data.Set (Set)
 
+import qualified Prettyprinter as PP
+
 import           What4.ProgramLoc (ProgramLoc)
 
 import           CryptolSAWCore.TypedTerm
@@ -72,6 +75,9 @@ import           CryptolSAWCore.TypedTerm
 -- | How many allocations have we made in this method spec?
 newtype AllocIndex = AllocIndex Int
   deriving (Eq, Ord, Show)
+
+ppAllocIndex :: AllocIndex -> PP.Doc ann
+ppAllocIndex i = PP.pretty '@' <> PP.viaShow i
 
 nextAllocIndex :: AllocIndex -> AllocIndex
 nextAllocIndex (AllocIndex n) = AllocIndex (n + 1)

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -589,7 +589,7 @@ setupPrestateConditions mspec cc env = aux []
         TypedTerm tp _ ->
           fail $ unlines
             [ "Setup term for global variable expected to have Cryptol schema type, but got"
-            , show (MS.ppTypedTermType tp)
+            , show (ppTypedTermType tp)
             ]
 
 --------------------------------------------------------------------------------
@@ -1072,7 +1072,7 @@ instance Show JVMSetupError where
       JVMNonValueType tp ->
         unlines
         [ "Expected term with value type, but got"
-        , show (MS.ppTypedTermType tp)
+        , show (ppTypedTermType tp)
         ]
 
 -- | Returns Cryptol type of actual type if it is an array or

--- a/saw-central/src/SAWCentral/Crucible/JVM/MethodSpecIR.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/MethodSpecIR.hs
@@ -74,6 +74,8 @@ import qualified Lang.JVM.Codebase as CB
 -- jvm-parser
 import qualified Language.JVM.Parser as J
 
+import CryptolSAWCore.TypedTerm (ppTypedTerm)
+
 import           SAWCentral.Crucible.Common
 import qualified SAWCentral.Crucible.Common.MethodSpec as MS
 import qualified SAWCentral.Crucible.Common.Setup.Type as Setup
@@ -143,7 +145,7 @@ ppPointsTo =
     JVMPointsToArray _loc ptr val ->
       MS.ppAllocIndex ptr
       PPL.<+> PPL.pretty "points to"
-      PPL.<+> opt MS.ppTypedTerm val
+      PPL.<+> opt ppTypedTerm val
   where
     opt = maybe (PPL.pretty "<unspecified>")
 

--- a/saw-central/src/SAWCentral/Crucible/JVM/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/ResolveSetupValue.hs
@@ -107,7 +107,7 @@ instance Show JVMTypeOfError where
   show (JVMInvalidTypedTerm tp) =
     unlines
     [ "Expected typed term with Cryptol represnentable type, but got"
-    , show (MS.ppTypedTermType tp)
+    , show (ppTypedTermType tp)
     ]
 
 instance X.Exception JVMTypeOfError
@@ -207,7 +207,7 @@ resolveTypedTerm cc tm =
     tp -> fail $ unlines
             [ "resolveSetupVal: expected monomorphic term"
             , "but got a term of type"
-            , show (MS.ppTypedTermType tp)
+            , show (ppTypedTermType tp)
             ]
 
 resolveSAWPred ::

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
@@ -1146,7 +1146,7 @@ setupPrestateConditions mspec cc mem env = aux []
         TypedTerm tp _ ->
           fail $ unlines
             [ "Setup term for global variable expected to have Cryptol schema type, but got"
-            , show (MS.ppTypedTermType tp)
+            , show (ppTypedTermType tp)
             ]
 
 --------------------------------------------------------------------------------

--- a/saw-central/src/SAWCentral/Crucible/LLVM/FFI.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/FFI.hs
@@ -140,7 +140,7 @@ llvm_ffi_setup TypedTerm { ttTerm = appTerm } = do
   let (funTerm, tyArgTerms) = asApplyAll appTerm
   sc <- lll getSharedContext
   let ?ctx = FFISetupCtx {..}
-  cryEnv <- lll $ rwCryptol <$> getMergedEnv
+  cryEnv <- lll getCryptolEnv
   case asConstant funTerm of
     Just (ec, funDef)
       | Just FFIFunType {..} <- Map.lookup (Term.ecName ec) (eFFITypes cryEnv) -> do

--- a/saw-central/src/SAWCentral/Crucible/LLVM/MethodSpecIR.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/MethodSpecIR.hs
@@ -206,7 +206,7 @@ ppPointsTo (LLVMPointsTo _md cond ptr val) =
   MS.ppSetupValue ptr
   PPL.<+> PPL.pretty "points to"
   PPL.<+> PPL.pretty val
-  PPL.<+> maybe PPL.emptyDoc (\tt -> PPL.pretty "if" PPL.<+> MS.ppTypedTerm tt) cond
+  PPL.<+> maybe PPL.emptyDoc (\tt -> PPL.pretty "if" PPL.<+> ppTypedTerm tt) cond
 ppPointsTo (LLVMPointsToBitfield _md ptr fieldName val) =
   MS.ppSetupValue ptr <> PPL.pretty ("." ++ fieldName)
   PPL.<+> PPL.pretty "points to (bitfield)"
@@ -219,7 +219,7 @@ instance PPL.Pretty (LLVMPointsToValue arch) where
   pretty = \case
     ConcreteSizeValue val -> MS.ppSetupValue val
     SymbolicSizeValue arr sz ->
-      MS.ppTypedTerm arr PPL.<+> PPL.pretty "[" PPL.<+> MS.ppTypedTerm sz PPL.<+> PPL.pretty "]"
+      ppTypedTerm arr PPL.<+> PPL.pretty "[" PPL.<+> ppTypedTerm sz PPL.<+> PPL.pretty "]"
 
 --------------------------------------------------------------------------------
 -- ** SAW LLVM intrinsics

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
@@ -203,7 +203,7 @@ ppPointsToAsLLVMVal opts cc sc spec (LLVMPointsTo md cond ptr val) = do
   let pretty2 = PP.pretty val
   pure $ PP.vcat [ "Pointer:" PP.<+> pretty1
                  , "Pointee:" PP.<+> pretty2
-                 , maybe PP.emptyDoc (\tt -> "Condition:" PP.<+> MS.ppTypedTerm tt) cond
+                 , maybe PP.emptyDoc (\tt -> "Condition:" PP.<+> ppTypedTerm tt) cond
                  , "Assertion made at:" PP.<+>
                    PP.pretty (W4.plSourceLoc (MS.conditionLoc md))
                  ]
@@ -1464,7 +1464,7 @@ matchPointsToValue opts sc cc spec prepost md maybe_cond ptr val =
             let errMsg = PP.vcat $ map (PP.pretty . unwords)
                   [ [ "When reading through pointer:", show (Crucible.ppPtr ptr) ]
                   , [ "in the ", MS.stateCond prepost, "of an override" ]
-                  , [ "Tried to read an array prefix of size:", show (MS.ppTypedTerm expected_sz_tm) ]
+                  , [ "Tried to read an array prefix of size:", show (ppTypedTerm expected_sz_tm) ]
                   ]
             case maybe_allocation_array of
               Just (ok, arr, sz)

--- a/saw-central/src/SAWCentral/Crucible/LLVM/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/ResolveSetupValue.hs
@@ -82,7 +82,7 @@ import SAWCoreWhat4.ReturnTrip
 import qualified Text.LLVM.DebugUtils as L
 
 import           SAWCentral.Crucible.Common (Sym, sawCoreState, HasSymInterface(..))
-import           SAWCentral.Crucible.Common.MethodSpec (AllocIndex(..), SetupValue(..), ppTypedTermType)
+import           SAWCentral.Crucible.Common.MethodSpec (AllocIndex(..), SetupValue(..))
 import           SAWCentral.Crucible.Common.ResolveSetupValue (checkBooleanType)
 
 import SAWCentral.Crucible.LLVM.MethodSpecIR

--- a/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
@@ -1072,7 +1072,7 @@ setupPrestateConditions mspec cc env = aux []
         TypedTerm tp _ ->
           fail $ unlines
             [ "Setup term for global variable expected to have Cryptol schema type, but got"
-            , show (MS.ppTypedTermType tp)
+            , show (ppTypedTermType tp)
             ]
 
 verifyObligations ::

--- a/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
@@ -250,7 +250,7 @@ instance Show MIRTypeOfError where
   show (MIRInvalidTypedTerm tp) =
     unlines
     [ "Expected typed term with Cryptol-representable type, but got"
-    , show (MS.ppTypedTermType tp)
+    , show (ppTypedTermType tp)
     ]
   show (MIRInvalidIdentifier errMsg) =
     errMsg
@@ -849,7 +849,7 @@ resolveTypedTerm mcc tm =
     tp -> fail $ unlines
             [ "resolveTypedTerm: expected monomorphic term"
             , "but got a term of type"
-            , show (MS.ppTypedTermType tp)
+            , show (ppTypedTermType tp)
             ]
 
 resolveSAWPred ::

--- a/saw-central/src/SAWCentral/Prover/Exporter.hs
+++ b/saw-central/src/SAWCentral/Prover/Exporter.hs
@@ -94,7 +94,6 @@ import qualified SAWCoreWhat4.What4 as W -- XXX duplicate!?
 import qualified SAWCore.UntypedAST as Un
 
 import SAWCentral.Crucible.Common
-import SAWCentral.Crucible.Common.MethodSpec (ppTypedTermType)
 import SAWCentral.Proof
   (Prop, Sequent, propSize, sequentSharedSize, propToTerm, predicateToSATQuery, sequentToSATQuery)
 import SAWCentral.Prover.SolverStats

--- a/saw-central/src/SAWCentral/Prover/Util.hs
+++ b/saw-central/src/SAWCentral/Prover/Util.hs
@@ -7,7 +7,6 @@ import CryptolSAWCore.TypedTerm
 import qualified Cryptol.TypeCheck.AST as C
 import Cryptol.Utils.PP (pretty)
 
-import SAWCentral.Crucible.Common.MethodSpec (ppTypedTermType)
 
 -- | Is this a bool, or something that returns bool.
 checkBooleanType :: C.Type -> IO ()

--- a/saw-central/src/SAWCentral/TopLevel.hs
+++ b/saw-central/src/SAWCentral/TopLevel.hs
@@ -34,10 +34,6 @@ module SAWCentral.TopLevel
     -- used in SAWCentral.Crucible.LLVM.X86, SAWCentral.Crucible.LLVM.Builtins,
     --    SAWCentral.Builtins, SAWScript.Interpreter
   , putTopLevelRW
-    -- used by SAWScript.REPL.Monad
-  , makeCheckpoint
-    -- used by SAWScript.REPL.Monad
-  , restoreCheckpoint
   ) where
 
 import SAWCentral.Value

--- a/saw-central/src/SAWCentral/TopLevel.hs
+++ b/saw-central/src/SAWCentral/TopLevel.hs
@@ -6,20 +6,37 @@ Maintainer  : huffman
 Stability   : provisional
 -}
 module SAWCentral.TopLevel
+    -- used by SAWCentral.Builtins and a lot of other places
   ( TopLevel(..)
   , TopLevelRO(..)
   , TopLevelRW(..)
+    -- used by SAWCentral.Builtins, SAWScript.REPL.Monad, SAWScript.Interpreter,
+    --    SAWServer.TopLevel
   , runTopLevel
+    -- used by ... a lot of places, let's not try to make a list just yet
   , io
+    -- used by SAWCentral.Builtins and basically everywhere else
   , getSharedContext
-  , getJavaCodebase
+    -- used by SAWCentral.Builtins, various other places in SAWCentral,
+    --    SAWScript.Interpreter
   , getOptions
+    -- used in SAWCentral.Crucible.*, SAWCentral.Builtins,
+    --    SAWServer.SAWServer, SAWServer.Ghost, SAWServer.LLVMCrucibleSetup
   , getHandleAlloc
+    -- used in SAWCentral.Builtins SAWScript.REPL.Monad, SAWScript.AutoMatch
+    -- also accessible via SAWCentral.TopLevel
   , getTopLevelRO
+    -- used in SAWCentral.Crucible.*.Builtins.hs, SAWCentral.Crucible.X86,
+    --    SAWCentral.Bisimulation, SAWCentral.Builtins,
+    --    SAWScript.Interpreter, SAWScript.AutoMatch,
+    --    SAWServer.Yosys
   , getTopLevelRW
-  , localOptions
+    -- used in SAWCentral.Crucible.LLVM.X86, SAWCentral.Crucible.LLVM.Builtins,
+    --    SAWCentral.Builtins, SAWScript.Interpreter
   , putTopLevelRW
+    -- used by SAWScript.REPL.Monad
   , makeCheckpoint
+    -- used by SAWScript.REPL.Monad
   , restoreCheckpoint
   ) where
 

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -67,9 +67,10 @@ module SAWCentral.Value (
     addTypedef,
     -- used by SAWScript.REPL.Monad, and by getMergedEnv
     mergeLocalEnv,
-    -- used by SAWCentral.Crucible.LLVM.FFI (XXX: alas), SAWCentral.Builtins,
-    --   SAWScript.Interpreter
+    -- used by SAWCentral.Builtins, SAWScript.Interpreter, and by getCryptolEnv
     getMergedEnv,
+    -- used by SAWCentral.Crucible.LLVM.FFI
+    getCryptolEnv,
     -- used by SAWScript.Automatch, SAWScript.REPL.*, SAWScript.Interpreter,
     --    SAWServer.SAWServer
     TopLevelRO(..),
@@ -571,6 +572,10 @@ getMergedEnv =
      rw <- getTopLevelRW
      liftIO $ mergeLocalEnv sc env rw
 
+getCryptolEnv :: TopLevel CEnv.CryptolEnv
+getCryptolEnv = do
+  env <- getMergedEnv
+  return $ rwCryptol env
 
 -- | TopLevel Read-Only Environment.
 data TopLevelRO =

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -45,12 +45,10 @@ module SAWCentral.Value (
     -- used by SAWScript.Interpreter, SAWScript.HeapsterBuiltins,
     --    SAWServer.SAWServer, SAWServer.*CrucibleSetup
     BuiltinContext(..),
-    -- used by SAWScript.HeapsterBuiltins
-    HeapsterEnv(..), (and the Value type)
+    -- used by SAWScript.HeapsterBuiltins (and the Value type)
+    HeapsterEnv(..),
     -- used by SAWCentral.Builtins.hs, and appears in the Value type and showsSatResult
     SatResult(..),
-    -- used by SAWScript.Interpreter (and the Value type)
-    isVUnit,
     -- used by SAWCentral.Bisimulation, SAWCentral.Builtins, SAWScript.REPL.Monad
     showsProofResult,
     -- used by SAWCentral.Builtins
@@ -401,10 +399,6 @@ data SatResult
   | SatUnknown
     deriving (Show)
 
-isVUnit :: Value -> Bool
-isVUnit (VTuple []) = True
-isVUnit _ = False
-
 showsProofResult :: PPS.Opts -> ProofResult -> ShowS
 showsProofResult opts r =
   case r of
@@ -537,7 +531,7 @@ evaluateTypedTerm sc (TypedTerm (TypedTermSchema schema) trm) =
   C.runEval mempty . exportValueWithSchema schema =<< evaluateTerm sc trm
 evaluateTypedTerm _sc (TypedTerm tp _) =
   fail $ unlines [ "Could not evaluate term with type"
-                 , show (CMS.ppTypedTermType tp)
+                 , show (ppTypedTermType tp)
                  ]
 
 applyValue :: Value -> Value -> TopLevel Value

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -57,8 +57,6 @@ module SAWCentral.Value (
     showsSatResult,
     -- used by SAWCentral.Builtins, SAWScript.Interpreter
     showsPrecValue,
-    -- XXX rename to evaluateTerm
-    evaluate,
     -- used by SAWCentral.Builtins, SAWScript.Interpreter
     evaluateTypedTerm,
     -- used by SAWCentral.Builtins
@@ -529,14 +527,14 @@ showsPrecValue opts nenv p v =
 instance Show Value where
     showsPrec p v = showsPrecValue PPS.defaultOpts emptySAWNamingEnv p v
 
-evaluate :: SharedContext -> Term -> IO Concrete.CValue
-evaluate sc t =
+evaluateTerm:: SharedContext -> Term -> IO Concrete.CValue
+evaluateTerm sc t =
   (\modmap -> Concrete.evalSharedTerm modmap mempty mempty t) <$>
   scGetModuleMap sc
 
 evaluateTypedTerm :: SharedContext -> TypedTerm -> IO C.Value
 evaluateTypedTerm sc (TypedTerm (TypedTermSchema schema) trm) =
-  C.runEval mempty . exportValueWithSchema schema =<< evaluate sc trm
+  C.runEval mempty . exportValueWithSchema schema =<< evaluateTerm sc trm
 evaluateTypedTerm _sc (TypedTerm tp _) =
   fail $ unlines [ "Could not evaluate term with type"
                  , show (CMS.ppTypedTermType tp)

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -28,7 +28,217 @@ Stability   : provisional
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module SAWCentral.Value where
+module SAWCentral.Value (
+    Value(..),
+
+    -- used by SAWCentral.Builtins, SAWScript.Interpreter, SAWServer.SAWServer
+    SAWSimpset,
+    -- used by SAWCentral.Builtins, SAWScript.Interpreter
+    SAWRefnset,
+    -- used by SAWCentral.Builtins
+    AIGNetwork(..),
+    -- used by SAWCentral.Prover.Exporter, SAWCentral.Builtins,
+    --    SAWScript.Interpreter and more, SAWServer.SAWServer
+    AIGProxy(..),
+    -- used by SAWCentral.Crucible.LLVM.Builtins, SAWScript.HeapsterBuiltins
+    SAW_CFG(..),
+    -- used by SAWScript.Interpreter, SAWScript.HeapsterBuiltins,
+    --    SAWServer.SAWServer, SAWServer.*CrucibleSetup
+    BuiltinContext(..),
+    -- used by SAWScript.HeapsterBuiltins
+    HeapsterEnv(..), (and the Value type)
+    -- used by SAWCentral.Builtins.hs, and appears in the Value type and showsSatResult
+    SatResult(..),
+    -- used by SAWScript.Interpreter
+    isVUnit,
+    -- used by SAWCentral.Bisimulation, SAWCentral.Builtins, SAWScript.REPL.Monad
+    showsProofResult,
+    -- used by SAWCentral.Builtins
+    showsSatResult,
+    -- used by SAWCentral.Builtins, SAWScript.Interpreter
+    showsPrecValue,
+    -- used by SAWScript.Interpreter
+    -- XXX: name overlaps with unrelated fn from Data.Parameterized.Nonce
+    --      and should be changed
+    indexValue,
+    -- used by SAWScript.Interpreter
+    lookupValue,
+    -- used by SAWScript.Interpreter
+    tupleLookupValue,
+    -- XXX rename to evaluateTerm
+    evaluate,
+    -- used by SAWCentral.Builtins, SAWScript.Interpreter
+    evaluateTypedTerm,
+    -- used by SAWScript.Interpreter
+    toplevelCallCC,
+    -- used by SAWScript.Interpreter
+    toplevelSubshell,
+    -- used by SAWScript.Interpreter
+    proofScriptSubshell,
+    -- used by SAWCentral.Builtins
+    applyValue,
+    -- XXX apparently unused
+    thenValue,
+    -- used by SAWScript.Interpreter
+    bindValue,
+    -- used by SAWScript.Interpreter
+    forValue,
+    -- used by SAWScript.Interpreter
+    LocalBinding(..),
+    -- used by SAWScript.Interpreter
+    LocalEnv,
+    -- used by SAWScript.Interpreter
+    emptyLocal,
+    -- used by SAWScript.Interpreter
+    extendLocal,
+    -- used by SAWScript.Interpreter
+    addTypedef,
+    -- used by SAWScript.REPL.Monad
+    mergeLocalEnv,
+    -- used by SAWCentral.Crucible.LLVM.FFI (XXX: alas), SAWCentral.Builtins,
+    --   SAWScript.Interpreter
+    getMergedEnv,
+    -- used by SAWScript.Automatch, SAWScript.REPL.*, SAWScript.Interpreter,
+    --    SAWServer.SAWServer
+    TopLevelRO(..),
+    -- used by ... a lot of places, let's not try to make a list just yet
+    TopLevelRW(..),
+    -- used by ... a lot of places, let's not try to make a list just yet
+    TopLevel(..),
+    -- used by SAWCentral.Builtins, SAWScript.REPL.Monad, SAWScript.Interpreter,
+    --    SAWServer.TopLevel
+    runTopLevel,
+    -- used by SAWScript.Interpreter
+    bracketTopLevel,
+    -- used by ... a lot of places, let's not try to make a list just yet
+    io,
+    -- unused but that probably won't stay that way
+    TopLevelCheckpoint(..),
+    -- used by SAWScript.REPL.Monad
+    makeCheckpoint,
+    -- used by SAWScript.REPL.Monad
+    restoreCheckpoint,
+    -- used by SAWScript.Interpreter
+    checkpoint,
+    -- used by SAWScript.Interpreter
+    proof_checkpoint,
+    -- used in various places in SAWCentral
+    throwTopLevel,
+    -- used by SAWScript.Interpreter plus locally
+    withPosition,
+    -- used by SAWScript.Interpreter and locally in topLevelSubshell
+    withLocalEnv,
+    -- used locally in proofScriptSubshell
+    withLocalEnvProof,
+    -- used by SAWScript.Interpreter plus locally
+    getLocalEnv,
+    -- used in various places in SAWCentral
+    getPosition,
+    -- used all over the place
+    getSharedContext,
+    -- used in SAWCentral.Crucible.JVM.Builtins{,JVM} and SAWScript.AutoMatch
+    getJavaCodebase,
+    -- used in SAWCentral.Builtins
+    getTheoremDB,
+    -- used in SAWCentral.Builtins
+    putTheoremDB,
+    -- used in various places in SAWCentral, plus SAWScript.Interpreter
+    getOptions,
+    -- used in SAWCentral.Prover.Exporter, SAWCentral.Builtins
+    getProxy,
+    -- used in SAWCentral.Crucible.LLVM.{X86,Builtins}
+    getBasicSS,
+    -- used in SAWScript.Interpreter
+    localOptions,
+    -- used in various places in SAWCentral, plus SAWScript.Interpreter
+    printOutLnTop,
+    -- used in SAWCentral.Crucible.*, SAWCentral.Builtins,
+    --    SAWServer.SAWServer, SAWServer.Ghost, SAWServer.LLVMCrucibleSetup
+    getHandleAlloc,
+    -- used in SAWCentral.Builtins SAWScript.REPL.Monad, SAWScript.AutoMatch
+    -- also accessible via SAWCentral.TopLevel
+    getTopLevelRO,
+    -- used in SAWCentral.Crucible.*.Builtins.hs, SAWCentral.Crucible.X86,
+    --    SAWCentral.Bisimulation, SAWCentral.Builtins,
+    --    SAWScript.Interpreter, SAWScript.AutoMatch,
+    --    SAWServer.Yosys
+    getTopLevelRW,
+    -- used in SAWCentral.Crucible.LLVM.X86, SAWCentral.Crucible.LLVM.Builtins,
+    --    SAWCentral.Builtins, SAWScript.Interpreter
+    putTopLevelRW,
+    -- used in various places in SAWCentral
+    returnProof,
+    -- used in various places in SAWCentral
+    recordProof,
+    -- used in SAWCentral.Builtins, SAWScript.Interpreter
+    onSolverCache,
+    -- used by SAWCentral.Crucible.JVM.Builtins*
+    getJVMTrans,
+    -- used by SAWCentral.Crucible.JVM.Builtins*
+    putJVMTrans,
+    -- XXX: apparently unused
+    addJVMTrans,
+    -- used by SAWCentral.Crucible.LLVM.Builtins, SAWScript.Interpreter
+    --    ... the use in LLVM is the abusive insertion done by llvm_compositional_extract
+    --    XXX: we're going to need to clean that up
+    extendEnv,
+    -- used by various places in SAWCentral.Crucible, SAWCentral.Builtins
+    --    XXX: it wraps TopLevel rather than being part of it; is that necessary?
+    CrucibleSetup,
+    -- used in SAWCentral.Crucible.LLVM.*,
+    --    SAWServer.SAWServer, SAWServer.LLVMCrucibleSetup
+    LLVMCrucibleSetupM(..),
+    -- used in SAWCentral.Crucible.*.Builtins
+    throwCrucibleSetup,
+    -- used in SAWCentral.Crucible.LLVM.Skeleton.Builtins,
+    --    SAWCentral.Crucible.LLVM.FFI
+    throwLLVMFun,
+    -- used in SAWCentral.Crucible.*.Builtins, SAWCentral.Builtins
+    getW4Position,
+    -- used by SAWServer.SAWServer, SAWServer.JVMVerify, SAWScript.Interpreter
+    JVMSetup,
+    -- used by SAWCentral.Crucible.JVM.Builtins,
+    --    SAWServer.SAWServer, SAWServer.JVMCrucibleSetup
+    JVMSetupM(..),
+    -- used by SAWCentral.Crucible.MIR.ResolveSetupValue,
+    --    SAWServer.SAWServer, SAWServer.MIRVerify, SAWScript.Interpreter
+    MIRSetup,
+    -- used by SAWCentral.Crucible.MIR.Builtins, SAWServer.MIRCrucibleSetup
+    MIRSetupM(..),
+    -- used in SAWCentral.Crucible.LLVM.X86, SAWCentral.Crucible.*.Builtins,
+    --    SAWCentral.Crucible.Common.Vacuity,
+    --    SAWCentral.Bisimulation, SAWCentral.Yosys, SAWCentral.Builtins
+    --    SAWScript.REPL.Monad, SAWScript.Typechecker, SAWScript.Interpreter,
+    --    SAWServer.SAWServer, SAWServer.ProofScript, SAWServer.*Verify,
+    --    SAWServer.VerifyCommon, SAWServer.Yosys, saw-remote-api Main
+    ProofScript(..),
+    -- used by SAWCentral.Crucible.LLVM.X86, SAWCentral.Crucible.*.Builtins,
+    --    SAWCentral.Crucible.Common.Vacuity,
+    --    SAWCentral.Bisimulation, SAWCentral.Builtins
+    runProofScript,
+    -- used by SAWCentral.Builtins, SAWScript.Interpreter
+    scriptTopLevel,
+    -- used by SAWScript.REPL.Monad, SAWScript.Interpreter,
+    --    SAWServer.TopLevel, SAWServer.Eval
+    IsValue(..),
+    -- used by SAWCentral.Builtins,
+    --    SAWScript.Interpreter,
+    --    SAWServer.TopLevel, SAWServer.Eval
+    FromValue(..),
+    -- used in SAWScript.Interpreter
+    -- XXX: probably belongs in SAWSupport
+    underStateT,
+    -- used only locally
+    -- XXX: probably belongs in SAWSupport
+    --underReaderT,
+    -- used in SAWScript.Interpreter
+    -- XXX: probably belongs in SAWSupport
+    underExceptT,
+    -- used in SAWScript.Interpreter
+    addTrace,
+    -- used by SAWCentral.Crucible.LLVM.Skeleton.Builtins
+    SkeletonState(..), skelArgs
+ ) where
 
 import Prelude hiding (fail)
 

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -918,11 +918,10 @@ throwLLVMFun nm msg = do
   loc <- LLVMCrucibleSetupM $ getW4Position nm
   throwLLVM loc msg
 
--- | This gets more accurate locations than @lift (lift getPosition)@ because
---   of the @local@ in the @fromValue@ instance for @CrucibleSetup@
+-- | Get the current interpreter position and convert to a What4 position.
 getW4Position :: Text -> CrucibleSetup arch ProgramLoc
 getW4Position s = do
-  pos <- lift $ lift $ gets rwPosition
+  pos <- lift $ lift $ getPosition
   return $ SS.toW4Loc s pos
 
 --

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -563,7 +563,7 @@ interpretFile file runMain =
                                              map (\l -> "\t"  ++ l) (lines str)
                          showLoc <- printShowPos <$> getOptions
                          if showLoc
-                           then localOptions (\o -> o { printOutFn = \lvl str ->
+                           then withOptions (\o -> o { printOutFn = \lvl str ->
                                                           printOutFn o lvl (withPos str) })
                                   (interpretStmt False s)
                            else interpretStmt False s

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -74,6 +74,7 @@ import SAWScript.Panic (panic)
 import SAWCentral.TopLevel
 import SAWCentral.Utils
 import SAWCentral.Value
+import SAWScript.ValueOps
 import SAWCentral.SolverCache
 import SAWCentral.SolverVersions
 import SAWCentral.Proof (emptyTheoremDB)

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -5295,6 +5295,18 @@ primitives = Map.fromList
     pureVal :: forall t. IsValue t => t -> Options -> BuiltinContext -> Value
     pureVal x _ _ = toValue x
 
+    -- pureVal can be used for anything with a ToValue instance,
+    -- including functions. However, functions in TopLevel need to use
+    -- funVal* instead; the IsValue instances capture incorrectly and
+    -- you get a function that returns a VTopLevel instead of executing
+    -- in TopLevel. (There isn't a special-case IsValue instance for
+    -- a -> TopLevel t, because that would require overlapping instances;
+    -- but there is an IsValue instance for TopLevel t by itself (that
+    -- produces VTopLevel) so use of pureVal matches that and the
+    -- generic IsValue instance for a -> t.)
+    --
+    -- XXX: rename these to e.g. monadVal1/2/3 so this is clearer?
+
     funVal1 :: forall a t. (FromValue a, IsValue t) => (a -> TopLevel t)
                -> Options -> BuiltinContext -> Value
     funVal1 f _ _ = VLambda $ \a -> fmap toValue (f (fromValue a))

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -297,7 +297,7 @@ interpret expr =
                                        Nothing -> fail $ Text.unpack $ "unknown variable: " <> SS.getVal x
                                        Just (lc, _ty, v)
                                          | Set.member lc (rwPrimsAvail rw) ->
-                                              return (addTrace (show x) v)
+                                              return (withStackTraceFrame (show x) v)
                                          | otherwise ->
                                               fail $ Text.unpack $ "inaccessible variable: " <> SS.getVal x
       SS.Function _ pat e      -> do env <- getLocalEnv

--- a/saw-script/src/SAWScript/REPL/Monad.hs
+++ b/saw-script/src/SAWScript/REPL/Monad.hs
@@ -488,9 +488,8 @@ getEnvironment = readRef environment
 
 getValueEnvironment :: REPL TopLevelRW
 getValueEnvironment =
-  do ro <- getTopLevelRO
-     rw <- getEnvironment
-     io (mergeLocalEnv (rwSharedContext rw) (roLocalEnv ro) rw)
+  do rw <- getEnvironment
+     io (mergeLocalEnv (rwSharedContext rw) (rwLocalEnv rw) rw)
 
 putEnvironment :: TopLevelRW -> REPL ()
 putEnvironment = modifyEnvironment . const

--- a/saw-script/src/SAWScript/REPL/Monad.hs
+++ b/saw-script/src/SAWScript/REPL/Monad.hs
@@ -94,19 +94,23 @@ import qualified Data.AIG.CompactGraph as AIG
 
 --------------------
 
+import SAWCore.SAWCore (SharedContext)
+
 import SAWCentral.AST (Located(getVal))
-import SAWScript.Interpreter (buildTopLevelEnv)
 import SAWCentral.Options (Options)
 import SAWCentral.Proof (ProofState, ProofResult(..), psGoals)
-import SAWCentral.TopLevel (TopLevelRO(..), TopLevelRW(..), TopLevel(..), runTopLevel,
-                            makeCheckpoint, restoreCheckpoint)
+import SAWCentral.TopLevel (TopLevelRO(..), TopLevelRW(..), TopLevel(..), runTopLevel)
 import SAWCentral.Value
   ( AIGProxy(..), mergeLocalEnv, IsValue, Value
   , ProofScript(..), showsProofResult, toValue
   )
-import SAWCore.SAWCore (SharedContext)
+
+import SAWScript.Interpreter (buildTopLevelEnv)
+import SAWScript.ValueOps (makeCheckpoint, restoreCheckpoint)
+
 
 deriving instance Typeable AIG.Proxy
+
 
 -- REPL Environment ------------------------------------------------------------
 

--- a/saw-script/src/SAWScript/ValueOps.hs
+++ b/saw-script/src/SAWScript/ValueOps.hs
@@ -1,0 +1,235 @@
+{- |
+Module      : SAWScript.ValueOps
+Description : Operations on the SAWScript Value datatype, plus other code from Value.hs
+License     : BSD3
+Maintainer  : saw@galois.com
+Stability   : provisional
+-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module SAWScript.ValueOps (
+    -- used by SAWScript.Interpreter
+    -- XXX: name overlaps with unrelated fn from Data.Parameterized.Nonce
+    --      and should be changed
+    indexValue,
+    -- used by SAWScript.Interpreter
+    lookupValue,
+    -- used by SAWScript.Interpreter
+    tupleLookupValue,
+    -- used by SAWScript.Interpreter
+    toplevelCallCC,
+    -- used by SAWScript.Interpreter
+    toplevelSubshell,
+    -- used by SAWScript.Interpreter
+    proofScriptSubshell,
+    -- XXX apparently unused
+    thenValue,
+    -- used by SAWScript.Interpreter
+    bindValue,
+    -- used by SAWScript.Interpreter
+    forValue,
+    -- used by SAWScript.Interpreter
+    emptyLocal,
+    -- used by SAWScript.Interpreter
+    extendLocal,
+    -- used by SAWScript.Interpreter
+    bracketTopLevel,
+    -- unused but that probably won't stay that way
+    TopLevelCheckpoint(..),
+    -- used by SAWScript.REPL.Monad
+    makeCheckpoint,
+    -- used by SAWScript.REPL.Monad
+    restoreCheckpoint,
+    -- used by SAWScript.Interpreter
+    checkpoint,
+    -- used by SAWScript.Interpreter
+    proof_checkpoint,
+    -- used by SAWScript.Interpreter and locally in topLevelSubshell
+    withLocalEnv,
+    -- used locally in proofScriptSubshell
+    withLocalEnvProof,
+    -- used in SAWScript.Interpreter
+    localOptions,
+    -- used in SAWScript.Interpreter
+    addTrace,
+ ) where
+
+import Prelude hiding (fail)
+
+import Control.Monad.Catch (MonadThrow(..), try)
+import qualified Control.Exception as X
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (ask, local)
+
+import Data.Text (Text, unpack)
+--import Data.Map ( Map )
+import qualified Data.Map as M
+--import Data.Set ( Set )
+
+import Lang.Crucible.Utils.StateContT (get, put, callCC)
+
+import SAWCore.SharedTerm
+
+import CryptolSAWCore.CryptolEnv as CEnv
+
+import qualified SAWCentral.AST as SS
+import qualified SAWCentral.Position as SS
+--import qualified SAWCentral.Crucible.JVM.MethodSpecIR ()
+--import qualified SAWCentral.Crucible.MIR.MethodSpecIR ()
+import SAWCentral.Options (Options, Verbosity(..))
+import SAWCentral.Value
+
+
+
+
+indexValue :: Value -> Value -> Value
+indexValue (VArray vs) (VInteger x)
+    | i < length vs = vs !! i
+    | otherwise = error "array index out of bounds"
+    where i = fromInteger x
+indexValue _ _ = error "indexValue"
+
+lookupValue :: Value -> Text -> Value
+lookupValue (VRecord vm) name =
+    case M.lookup name vm of
+      Nothing -> error $ "no such record field: " ++ unpack name
+      Just x -> x
+lookupValue _ _ = error "lookupValue"
+
+tupleLookupValue :: Value -> Integer -> Value
+tupleLookupValue (VTuple vs) i
+  | 0 <= i && fromIntegral i < length vs = vs !! fromIntegral i
+  | otherwise = error $ "no such tuple index: " ++ show i
+tupleLookupValue _ _ = error "tupleLookupValue"
+
+-- NB, the precise locations of VTopLevel constructors in this
+--  operator are rather delicate, which is why we write it out
+--  here explicitly.
+toplevelCallCC :: Value
+toplevelCallCC = VLambda body
+  where
+   body (VLambda m) =
+     callCC $ \(k :: Value -> TopLevel Value) ->
+           m (VLambda (\v -> return (VTopLevel (k ((VTopLevel (return v)))))))
+   body _ = error "toplevelCallCC : expected lambda"
+
+toplevelSubshell :: Value
+toplevelSubshell = VLambda $ \_ ->
+  do m <- roSubshell <$> ask
+     env <- getLocalEnv
+     return (VTopLevel (toValue <$> withLocalEnv env m))
+
+proofScriptSubshell :: Value
+proofScriptSubshell = VLambda $ \_ ->
+  do m <- roProofSubshell <$> ask
+     env <- getLocalEnv
+     return (VProofScript (toValue <$> withLocalEnvProof env m))
+
+thenValue :: SS.Pos -> Value -> Value -> Value
+thenValue pos v1 v2 = VBind pos v1 (VLambda (const (return v2)))
+
+bindValue :: SS.Pos -> Value -> Value -> TopLevel Value
+bindValue pos v1 v2 = return (VBind pos v1 v2)
+
+forValue :: [Value] -> Value -> TopLevel Value
+forValue [] _ = return $ VReturn (VArray [])
+forValue (x : xs) f =
+  do m1 <- applyValue f x
+     m2 <- forValue xs f
+     bindValue (SS.PosInternal "<for>") m1 (VLambda $ \v1 ->
+       bindValue (SS.PosInternal "<for>") m2 (VLambda $ \v2 ->
+         return $ VReturn (VArray (v1 : fromValue v2))))
+
+emptyLocal :: LocalEnv
+emptyLocal = []
+
+extendLocal :: SS.LName -> SS.Schema -> Maybe String -> Value -> LocalEnv -> LocalEnv
+extendLocal x ty md v env = LocalLet x ty md v : env
+
+-- | A version of 'Control.Exception.bracket' specialized to 'TopLevel'. We
+-- can't use 'Control.Monad.Catch.bracket' because it requires 'TopLevel' to
+-- implement 'Control.Monad.Catch.MonadMask', which it can't do.
+bracketTopLevel :: TopLevel a -> (a -> TopLevel b) -> (a -> TopLevel c) -> TopLevel c
+bracketTopLevel acquire release action =
+  do  resource <- acquire
+      try (action resource) >>= \case
+        Left (bad :: X.SomeException) -> release resource >> throwM bad
+        Right good -> release resource >> pure good
+
+combineRW :: TopLevelCheckpoint -> TopLevelRW -> IO TopLevelRW
+combineRW (TopLevelCheckpoint chk scc) rw =
+  do cenv' <- CEnv.combineCryptolEnv (rwCryptol chk) (rwCryptol rw)
+     sc' <- restoreSharedContext scc (rwSharedContext rw)
+     return chk{ rwCryptol = cenv'
+               , rwSharedContext = sc'
+               }
+
+-- | Represents the mutable state of the TopLevel monad
+--   that can later be restored.
+data TopLevelCheckpoint =
+  TopLevelCheckpoint
+    TopLevelRW
+    SharedContextCheckpoint
+
+makeCheckpoint :: TopLevelRW -> IO TopLevelCheckpoint
+makeCheckpoint rw =
+  do scc <- checkpointSharedContext (rwSharedContext rw)
+     return (TopLevelCheckpoint rw scc)
+
+restoreCheckpoint :: TopLevelCheckpoint -> TopLevel ()
+restoreCheckpoint chk =
+  do rw <- getTopLevelRW
+     rw' <- io (combineRW chk rw)
+     putTopLevelRW rw'
+
+-- | Capture the current state of the TopLevel monad
+--   and return an action that, if invoked, resets
+--   the state back to that point.
+checkpoint :: TopLevel (() -> TopLevel ())
+checkpoint = TopLevel_ $
+  do chk <- liftIO . makeCheckpoint =<< get
+     return $ \_ ->
+       do printOutLnTop Info "Restoring state from checkpoint"
+          restoreCheckpoint chk
+
+-- | Capture the current proof state and return an
+--   action that, if invoked, resets the state back to that point.
+proof_checkpoint :: ProofScript (() -> ProofScript ())
+proof_checkpoint =
+  do ps <- get
+     return $ \_ ->
+       do scriptTopLevel (printOutLnTop Info "Restoring proof state from checkpoint")
+          put ps
+
+withLocalEnv :: LocalEnv -> TopLevel a -> TopLevel a
+withLocalEnv env (TopLevel_ m) = TopLevel_ (local (\ro -> ro{ roLocalEnv = env }) m)
+
+withLocalEnvProof :: LocalEnv -> ProofScript a -> ProofScript a
+withLocalEnvProof env (ProofScript m) =
+  ProofScript (underExceptT (underStateT (withLocalEnv env)) m)
+
+localOptions :: (Options -> Options) -> TopLevel a -> TopLevel a
+localOptions f (TopLevel_ m) = TopLevel_ (local (\x -> x {roOptions = f (roOptions x)}) m)
+
+-- | Implement stack tracing by adding error handlers that rethrow
+-- user errors, prepended with the given string.
+addTrace :: String -> Value -> Value
+addTrace str val =
+  case val of
+    VLambda        f -> VLambda        (\x -> addTrace str `fmap` addTraceTopLevel str (f x))
+    VTopLevel      m -> VTopLevel      (addTrace str `fmap` addTraceTopLevel str m)
+    VProofScript   m -> VProofScript   (addTrace str `fmap` addTraceProofScript str m)
+    VBind pos v1 v2  -> VBind pos      (addTrace str v1) (addTrace str v2)
+    VLLVMCrucibleSetup (LLVMCrucibleSetupM m) -> VLLVMCrucibleSetup $ LLVMCrucibleSetupM $
+        addTrace str `fmap` underReaderT (underStateT (addTraceTopLevel str)) m
+  -- TODO? JVM setup blocks too?
+    _                -> val
+
+addTraceProofScript :: String -> ProofScript a -> ProofScript a
+addTraceProofScript str (ProofScript m) = ProofScript (underExceptT (underStateT (addTraceTopLevel str)) m)
+
+addTraceTopLevel :: String -> TopLevel a -> TopLevel a
+addTraceTopLevel str (TopLevel_ action) =
+  TopLevel_ (local (\ro -> ro{ roStackTrace = str : roStackTrace ro }) action)

--- a/saw-script/src/SAWScript/ValueOps.hs
+++ b/saw-script/src/SAWScript/ValueOps.hs
@@ -11,6 +11,8 @@ Stability   : provisional
 
 module SAWScript.ValueOps (
     -- used by SAWScript.Interpreter
+    isVUnit,
+    -- used by SAWScript.Interpreter
     -- XXX: name overlaps with unrelated fn from Data.Parameterized.Nonce
     --      and should be changed
     indexValue,
@@ -83,6 +85,9 @@ import SAWCentral.Value
 
 
 
+isVUnit :: Value -> Bool
+isVUnit (VTuple []) = True
+isVUnit _ = False
 
 indexValue :: Value -> Value -> Value
 indexValue (VArray vs) (VInteger x)

--- a/saw-script/src/SAWScript/ValueOps.hs
+++ b/saw-script/src/SAWScript/ValueOps.hs
@@ -53,7 +53,7 @@ module SAWScript.ValueOps (
     -- used locally in proofScriptSubshell
     withLocalEnvProof,
     -- used in SAWScript.Interpreter
-    localOptions,
+    withOptions,
     -- used in SAWScript.Interpreter
     withStackTraceFrame,
  ) where
@@ -221,8 +221,8 @@ withLocalEnvProof :: LocalEnv -> ProofScript a -> ProofScript a
 withLocalEnvProof env (ProofScript m) = do
   ProofScript (underExceptT (underStateT (withLocalEnv env)) m)
 
-localOptions :: (Options -> Options) -> TopLevel a -> TopLevel a
-localOptions f (TopLevel_ m) =
+withOptions :: (Options -> Options) -> TopLevel a -> TopLevel a
+withOptions f (TopLevel_ m) =
   TopLevel_ (local (\x -> x {roOptions = f (roOptions x)}) m)
 
 -- | Implement stack tracing by adding error handlers that rethrow

--- a/saw-script/src/SAWScript/ValueOps.hs
+++ b/saw-script/src/SAWScript/ValueOps.hs
@@ -245,6 +245,12 @@ withStackTraceFrame str val =
       doLLVM :: LLVMCrucibleSetupM a -> LLVMCrucibleSetupM a
       doLLVM (LLVMCrucibleSetupM m) =
         LLVMCrucibleSetupM (underReaderT (underStateT doTopLevel) m)
+      doJVM :: JVMSetupM a -> JVMSetupM a
+      doJVM (JVMSetupM m) =
+        JVMSetupM (underReaderT (underStateT doTopLevel) m)
+      doMIR :: MIRSetupM a -> MIRSetupM a
+      doMIR (MIRSetupM m) =
+        MIRSetupM (underReaderT (underStateT doTopLevel) m)
   in
   case val of
     VLambda f ->
@@ -272,7 +278,16 @@ withStackTraceFrame str val =
             withStackTraceFrame str `fmap` doLLVM m
       in
       VLLVMCrucibleSetup m'
-    -- TODO: JVM and MIR setup blocks too
+    VJVMSetup m ->
+      let m' =
+            withStackTraceFrame str `fmap` doJVM m
+      in
+      VJVMSetup m'
+    VMIRSetup m ->
+      let m' =
+            withStackTraceFrame str `fmap` doMIR m
+      in
+      VMIRSetup m'
     _ ->
       val
 

--- a/saw-server/src/SAWServer/SAWServer.hs
+++ b/saw-server/src/SAWServer/SAWServer.hs
@@ -233,7 +233,6 @@ initialState readFileFn =
                 { roJavaCodebase = jcb
                 , roOptions = opts
                 , roHandleAlloc = halloc
-                , roPosition = PosInternal "SAWServer"
 #if USE_BUILTIN_ABC
                 , roProxy = AIGProxy GIA.proxy
 #else
@@ -241,16 +240,17 @@ initialState readFileFn =
 #endif
                 , roInitWorkDir = cwd
                 , roBasicSS = ss
-                , roStackTrace = []
                 , roSubshell = fail "SAW server does not support subshells."
                 , roProofSubshell = fail "SAW server does not support subshells."
-                , roLocalEnv = []
                 }
          rw = TopLevelRW
                 { rwValueInfo = mempty
                 , rwTypeInfo = mempty
                 , rwDocs = mempty
                 , rwCryptol = cenv
+                , rwPosition = PosInternal "SAWServer"
+                , rwStackTrace = []
+                , rwLocalEnv = []
                 , rwMonadify = defaultMonEnv
                 , rwMRSolverEnv = emptyMREnv
                 , rwPPOpts = PPS.defaultOpts

--- a/saw.cabal
+++ b/saw.cabal
@@ -772,6 +772,7 @@ library saw-script
     SAWScript.Search
     SAWScript.Token
     SAWScript.Typechecker
+    SAWScript.ValueOps
 
     SAWScript.HeapsterBuiltins
 

--- a/saw.cabal
+++ b/saw.cabal
@@ -225,6 +225,7 @@ library cryptol-saw-core
     integer-gmp,
     modern-uri,
     mtl,
+    prettyprinter >= 1.7.0,
     sbv,
     template-haskell,
     text,


### PR DESCRIPTION
See individual commits for details. This changeset is a somewhat mixed bag in that it's several not-terribly-related things motivated by working on the deps tangle that passes through Value.hs, which is in turn motivated by wanting to simplify the material surrounding the interpreter's naming environments (and get unrelated stuff out of the way) so it's easier to work on them.

This much seems like a good batch to merge before/while continuing, though.