### PR TITLE
Fix an endianness problem with $bmux in yosys import.

### DIFF
--- a/intTests/test_yosys_bmux/test.saw
+++ b/intTests/test_yosys_bmux/test.saw
@@ -3,5 +3,4 @@ m <- yosys_import_sequential "PrimeSelector" "mux.json";
 f <- yosys_extract_sequential_raw m;
 b <- yosys_import_sequential "PrimeSelector" "bmux.json";
 g <- yosys_extract_sequential_raw b;
-r <- prove z3 {{ f === g }};
-print r;
+prove_print z3 {{ f === g }};

--- a/saw-central/src/SAWCentral/Yosys/Cell.hs
+++ b/saw-central/src/SAWCentral/Yosys/Cell.hs
@@ -283,10 +283,12 @@ primCellToMap sc c args = case c ^. cellType of
     ywidth' <- liftIO (SC.scNat sc ywidth)
     bool <- liftIO (SC.scBoolType sc)
     splitA <- liftIO (SC.scSplit sc chunks ywidth' bool (cellTermTerm ia))
-    -- Select chunk from output
+    -- reverse to put index 0 on the left
     outputType <- liftIO (SC.scBitvector sc ywidth)
+    revA <- liftIO (SC.scGlobalApply sc "Prelude.reverse" [chunks, outputType, splitA])
+    -- Select chunk from output
     ixWidth <- liftIO (SC.scNat sc swidth)
-    elt <- liftIO (SC.scBvAt sc chunks outputType ixWidth splitA (cellTermTerm is))
+    elt <- liftIO (SC.scBvAt sc chunks outputType ixWidth revA (cellTermTerm is))
     output (CellTerm elt ywidth (connSigned "Y"))
   -- "$demux" -> _
   -- "$lut" -> _


### PR DESCRIPTION
The test_yosys_bmux test should be working again now.

It had been broken since #2316 was merged. For some reason the CI didn't notice the broken test case; we should make sure that the test is properly running in CI.