### PR TITLE
Change various integration tests to use prove_print instead of prove.

### DIFF
--- a/intTests/README.md
+++ b/intTests/README.md
@@ -50,6 +50,12 @@ variable "SAW", pointing to the corresponding executable, and with appropriate
 Java classpaths included. It's a good idea to include a README in each test
 directory.
 
+Test script success or failure is typically determined by the SAW exit
+code. Note that the SAW `prove` command does *not* produce an error
+upon finding a counterexample; to abort with an error code when a
+proof fails, use `prove_print`. The SAW `exit` command is also useful.
+Use `fails` to write tests involving expected failure.
+
 For tests that need binary artefacts (Java bytecode, LLVM bitcode) or
 things that might as well be (linked-mir.json from mir-json), include
 the corresponding source and a (gmake) Makefile that builds the

--- a/intTests/test0054/test.saw
+++ b/intTests/test0054/test.saw
@@ -16,6 +16,6 @@ let thm1 = {{ \z w -> f1 z w == f2 z w}};
 let thm2 = {{ \z w -> f2 z w == f3 z w}};
 let thm3 = {{ t == f4 }};
 
-prove z3 thm1;
-prove z3 thm2;
-prove z3 thm3;
+prove_print z3 thm1;
+prove_print z3 thm2;
+prove_print z3 thm3;

--- a/intTests/test0055/test.saw
+++ b/intTests/test0055/test.saw
@@ -1,18 +1,18 @@
 // read an empty file into byte list
 empty <- read_bytes "empty";
 let actually_empty = {{ empty == [] }};
-prove z3 actually_empty;
+prove_print z3 actually_empty;
 
 // non-empty file; should be ASCII rep. of "Hello, world!" (13 bytes)
 nonempty <- read_bytes "nonempty";
 let correct_seq = {{ nonempty == "Hello, world!" }};
-prove z3 correct_seq;
+prove_print z3 correct_seq;
 
 // non-empty, but full of 255 bytes of random noise
 // random data generated at https://random.org/bytes/
 noise <- read_bytes "noise";
 let length_correct = {{ length noise == 255 }};
-prove z3 length_correct;
+prove_print z3 length_correct;
 
 // pathological case: empty file name
 fails (read_bytes "");

--- a/intTests/test0057/test.saw
+++ b/intTests/test0057/test.saw
@@ -13,17 +13,17 @@ let t5 = {{ [1 .. 10] : [10][32] }};
 write_core "c.out" c;
 c_in <- read_core "c.out";
 let thm_c = {{ c_in == c }};
-prove z3 thm_c;
+prove_print z3 thm_c;
 
 write_core "x.out" x;
 x_in <- read_core "x.out";
 let thm_x = {{ x_in == x }};
-prove z3 thm_x;
+prove_print z3 thm_x;
 
 write_core "t1.out" t1;
 t1_in<- read_core "t1.out";
 let thm_t1 = {{ t1_in == t1 }};
-prove z3 thm_t1;
+prove_print z3 thm_t1;
 
 // N.B. This test currently crashes SAW due to bug #780
 // write_core "t2.out" t2;
@@ -34,15 +34,15 @@ prove z3 thm_t1;
 write_core "t3.out" t3;
 t3_in <- read_core "t3.out";
 let thm_t3 = {{ \x -> t3_in x == t3 x }};
-prove z3 thm_t3;
+prove_print z3 thm_t3;
 
 // N.B. This test currently crashes SAW due to bug #780
 // write_core "t4.out" t4;
 // t4_in <- read_core "t4.out";
 // let thm_t4 = {{ t4_in == t4 }};
-// prove z3 thm_t4;
+// prove_print z3 thm_t4;
 
 write_core "t5.out" t5;
 t5_in <- read_core "t5.out";
 let thm_t5 = {{ t5_in == t5 }};
-prove z3 thm_t5;
+prove_print z3 thm_t5;

--- a/intTests/test0058/test.saw
+++ b/intTests/test0058/test.saw
@@ -37,8 +37,8 @@ print l2'; // [..] ... List of Cryptol terms representing "the", "and", "for", "
 // eval_list and list_term should be inverses
 let l1'' = list_term l1';
 let thm1 = {{ l1 == l1'' }};
-prove z3 thm1;
+prove_print z3 thm1;
 
 let l2'' = list_term l2';
 let thm2 = {{ l2 == l2'' }};
-prove z3 thm2;
+prove_print z3 thm2;

--- a/intTests/test1788/test.saw
+++ b/intTests/test1788/test.saw
@@ -10,4 +10,4 @@ cryptol_mult x = x * 0x85EBCA77
 
 m <- llvm_load_module "test.bc";
 llvm_mult <- llvm_extract m "mult";
-prove abc {{ \x -> llvm_mult x == cryptol_mult x }};
+prove_print abc {{ \x -> llvm_mult x == cryptol_mult x }};

--- a/intTests/test669/test1.saw
+++ b/intTests/test669/test1.saw
@@ -1,5 +1,5 @@
 let {{ f (x : Integer, y : Integer) = (x + 1, y + 1) }};
 let {{ g (a : Integer, b : Integer) (c, d) = (a < c) && (b < d) }};
 
-prove (quickcheck 100) {{ \x -> g x (f x) }};
-prove (quickcheck 100) {{ \(a, b) -> g (a, b) (a + 2, b + 2) }};
+prove_print (quickcheck 100) {{ \x -> g x (f x) }};
+prove_print (quickcheck 100) {{ \(a, b) -> g (a, b) (a + 2, b + 2) }};

--- a/intTests/test669/test2.saw
+++ b/intTests/test669/test2.saw
@@ -5,5 +5,5 @@ let {{
    g (a : t) (b : t) = (a.x < b.x) && (a.y < b.y)
 }};
 
-prove (quickcheck 100) {{ \x -> g x (f x) }};
+prove_print (quickcheck 100) {{ \x -> g x (f x) }};
 

--- a/intTests/test_bitwuzla/test.saw
+++ b/intTests/test_bitwuzla/test.saw
@@ -5,6 +5,6 @@ add_mul_lemma m n p =
   m * (n + p) == (m * n) + (m * p)
 }};
 
-prove bitwuzla               {{ add_mul_lemma }};
-prove sbv_bitwuzla           {{ add_mul_lemma }};
-prove (w4_unint_bitwuzla []) {{ add_mul_lemma }};
+prove_print bitwuzla               {{ add_mul_lemma }};
+prove_print sbv_bitwuzla           {{ add_mul_lemma }};
+prove_print (w4_unint_bitwuzla []) {{ add_mul_lemma }};

--- a/intTests/test_cvc5/test.saw
+++ b/intTests/test_cvc5/test.saw
@@ -6,4 +6,4 @@ add_mul_lemma m n p q =
   (m * n + p < m * q)
 }};
 
-prove (w4_unint_cvc5 []) {{ add_mul_lemma }};
+prove_print (w4_unint_cvc5 []) {{ add_mul_lemma }};

--- a/intTests/test_goal_eval/test.saw
+++ b/intTests/test_goal_eval/test.saw
@@ -7,14 +7,14 @@ enable_experimental;
 
 let prop = {{ \(xs:[4][8]) (ys:([8],[8])) -> sum xs == ys.0 * ys.1 }};
 
-prove
+prove_print
   do {
     goal_intro "z";
     assume_unsat;
   }
   prop;
 
-prove
+prove_print
   do {
     goal_eval;
     goal_intro "z";

--- a/intTests/test_hoist_ifs_in_goal/test.saw
+++ b/intTests/test_hoist_ifs_in_goal/test.saw
@@ -11,7 +11,7 @@ let prop = {{ \c x y -> f (if c then g x else g y) == if c then x else y }};
 
 l1 <- prove_print assume_unsat {{ \x -> f (g x) == x }};
 
-prove
+prove_print
   (do {
     hoist_ifs_in_goal;
     simplify (addsimps [l1] empty_ss);

--- a/intTests/test_univ_assert/test.saw
+++ b/intTests/test_univ_assert/test.saw
@@ -21,7 +21,7 @@ lemmas <- for
   ]
   (prove_print assume_unsat);
 
-// Use those axioms to prove a nonmtrivial equality
+// Use those axioms to prove a nontrivial equality
 thm <- prove_print
   (do {
     unfolding ["term1","term2"];

--- a/intTests/test_yosys_bmux/test.saw
+++ b/intTests/test_yosys_bmux/test.saw
@@ -3,5 +3,4 @@ m <- yosys_import_sequential "PrimeSelector" "mux.json";
 f <- yosys_extract_sequential_raw m;
 b <- yosys_import_sequential "PrimeSelector" "bmux.json";
 g <- yosys_extract_sequential_raw b;
-r <- prove z3 {{ f === g }};
-print r;
+prove_print z3 {{ f === g }};


### PR DESCRIPTION
This ensures that they will exit with an error code if a proof fails. Fixes #2388.