### PR TITLE
SAWScript: remove unused AST elements CryptolSetup and CrucibleSetup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,10 @@ The most notable changes are:
 
 ## Deprecations
 
+* It was previously possible to declare monadic values of an
+  undocumented type `CryptolSetup t` but not do anything with them.
+  This name is no longer magic.
+
 * `llvm_struct` has been marked deprecated.
 It is the same as `llvm_alias` and you should use this instead.
 (If you were looking for a function to create a struct type from its

--- a/saw-central/src/SAWCentral/AST.hs
+++ b/saw-central/src/SAWCentral/AST.hs
@@ -227,13 +227,11 @@ instance Positioned Decl where
 -- Type Level {{{
 
 data Context
-  = CryptolSetup
-  | JavaSetup
+  = JavaSetup
   | LLVMSetup
   | MIRSetup
   | ProofScript
   | TopLevel
-  | CrucibleSetup
   deriving (Eq, Ord, Show)
 
 -- The position information in a type should be thought of as its
@@ -477,13 +475,11 @@ instance PPS.PrettyPrec TyCon where
 
 instance PPS.PrettyPrec Context where
   prettyPrec _ c = case c of
-    CryptolSetup -> "CryptolSetup"
     JavaSetup    -> "JavaSetup"
     LLVMSetup    -> "LLVMSetup"
     MIRSetup     -> "MIRSetup"
     ProofScript  -> "ProofScript"
     TopLevel     -> "TopLevel"
-    CrucibleSetup-> "CrucibleSetup"
 
 instance PPS.PrettyPrec NamedType where
   prettyPrec par ty = case ty of

--- a/saw-script/src/SAWScript/Lexer.x
+++ b/saw-script/src/SAWScript/Lexer.x
@@ -48,7 +48,7 @@ $idchar    = [$alpha $digit $unidigit $unitick \' \_]
 $codechar  = [$graphic $whitechar \n]
 
 @reservedid  = import|and|let|rec|in|do|if|then|else|as|hiding|typedef
-             |CryptolSetup|JavaSetup|LLVMSetup|MIRSetup|ProofScript|TopLevel|CrucibleSetup
+             |JavaSetup|LLVMSetup|MIRSetup|ProofScript|TopLevel|CrucibleSetup
              |Int|String|Term|Type|Bool|AIG|CFG
              |CrucibleMethodSpec|LLVMSpec|JVMMethodSpec|JVMSpec|MIRSpec
 

--- a/saw-script/src/SAWScript/Parser.y
+++ b/saw-script/src/SAWScript/Parser.y
@@ -260,8 +260,7 @@ BaseType :: { Type }
  | '{' commas(FieldType) '}'            { tRecord (maxSpan [$1, $3]) $2 }
 
 Context :: { Type }
- : 'CryptolSetup'                       { tContext (getPos $1) CryptolSetup   }
- | 'JavaSetup'                          { tContext (getPos $1) JavaSetup      }
+ : 'JavaSetup'                          { tContext (getPos $1) JavaSetup      }
  | 'LLVMSetup'                          { tContext (getPos $1) LLVMSetup      }
  | 'MIRSetup'                           { tContext (getPos $1) MIRSetup       }
  | 'ProofScript'                        { tContext (getPos $1) ProofScript    }


### PR DESCRIPTION
CryptolSetup existed as its own monad type (like LLVMSetup) but there were no available actions in this monad. So you could write vacuous declarations like "let three : CryptolSetup Int = return 3;" but not do anything with them.

CrucibleSetup did too, but any reference in the input was (and still is) intercepted in the parser and turned into LLVMSetup, so it wasn't accessible at all.

G/C the lot.

The result of this is that if anyone actually has that declaration "three" it will still be accepted: it'll treat "CryptolSetup" as a free type variable and produce an object of polymorphic monad type "{m} m Int". This is not entirely ideal, but the existence of any such declarations in the field is unlikely and they still don't do anything particularly useful.