### PR TITLE
Refactoring and simplification related to naming environments.

### DIFF
--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -565,7 +565,7 @@ resolveNames nms =
 resolveName :: SharedContext -> String -> TopLevel [VarIndex]
 resolveName sc nm =
   do cenv <- rwCryptol <$> getTopLevelRW
-     scnms <- fmap fst <$> io (scResolveName sc tnm)
+     scnms <- io (scResolveName sc tnm)
      let ?fileReader = StrictBS.readFile
      res <- io $ CEnv.resolveIdentifier cenv tnm
      case res of

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -157,7 +157,7 @@ import SAWCore.Recognizer
 import SAWCore.Rewriter
 import SAWCore.SATQuery
 import SAWCore.Module (ModuleMap)
-import SAWCore.Name (SAWNamingEnv)
+import SAWCore.Name (DisplayNameEnv)
 import SAWCore.SharedTerm
 import SAWCore.Term.Functor
 import CryptolSAWCore.TypedTerm
@@ -524,11 +524,11 @@ normalizeProp sc modmap opaqueSet (Prop tm) =
      termToProp sc tm'
 
 -- | Pretty print the given proposition as a string.
-prettyProp :: PPS.Opts -> SAWNamingEnv -> Prop -> String
+prettyProp :: PPS.Opts -> DisplayNameEnv -> Prop -> String
 prettyProp opts nenv p = PPS.render opts (ppProp opts nenv p)
 
 -- | Pretty print the given proposition as a @PPS.Doc@.
-ppProp :: PPS.Opts -> SAWNamingEnv -> Prop -> PPS.Doc
+ppProp :: PPS.Opts -> DisplayNameEnv -> Prop -> PPS.Doc
 ppProp opts nenv (Prop tm) = ppTermWithNames opts nenv tm
 
 -- TODO, I'd like to add metadata here
@@ -696,11 +696,11 @@ sequentToProp sc sqt =
         Prop <$> scFun sc (unProp h) (unProp g')
 
 -- | Pretty print the given proposition as a string.
-prettySequent :: PPS.Opts -> SAWNamingEnv -> Sequent -> String
+prettySequent :: PPS.Opts -> DisplayNameEnv -> Sequent -> String
 prettySequent opts nenv sqt = PPS.render opts (ppSequent opts nenv sqt)
 
 -- | Pretty print the given proposition as a @PPS.Doc@.
-ppSequent :: PPS.Opts -> SAWNamingEnv -> Sequent -> PPS.Doc
+ppSequent :: PPS.Opts -> DisplayNameEnv -> Sequent -> PPS.Doc
 ppSequent opts nenv sqt =
   ppTermContainerWithNames
     (ppRawSequent sqt)
@@ -1574,7 +1574,7 @@ checkEvidence sc what4PushMuxOps = \e p -> do
            Right p' -> checkApply nenv mkSqt (Prop p') es
 
     check ::
-      SAWNamingEnv ->
+      DisplayNameEnv ->
       Evidence ->
       Sequent ->
       IO (Set TheoremNonce, TheoremSummary)

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -255,7 +255,7 @@ import SAWCentral.Yosys.IR
 import SAWCentral.Yosys.Theorem (YosysImport, YosysTheorem)
 import SAWCentral.Yosys.State (YosysSequential)
 
-import SAWCore.Name (toShortName, SAWNamingEnv, emptySAWNamingEnv)
+import SAWCore.Name (toShortName, DisplayNameEnv, emptyDisplayNameEnv)
 import CryptolSAWCore.CryptolEnv as CEnv
 import CryptolSAWCore.Monadify as Monadify
 import SAWCore.FiniteValue (FirstOrderValue, ppFirstOrderValue)
@@ -454,7 +454,7 @@ showRefnset opts ss =
     ppFunAssumpRHS ctx (RewriteFunAssump rhs) =
       SAWCorePP.ppTermInCtx opts (map fst $ mrVarCtxInnerToOuter ctx) rhs
 
-showsPrecValue :: PPS.Opts -> SAWNamingEnv -> Int -> Value -> ShowS
+showsPrecValue :: PPS.Opts -> DisplayNameEnv -> Int -> Value -> ShowS
 showsPrecValue opts nenv p v =
   case v of
     VBool True -> showString "true"
@@ -520,7 +520,7 @@ showsPrecValue opts nenv p v =
     VMIRSetupValue x -> shows x
 
 instance Show Value where
-    showsPrec p v = showsPrecValue PPS.defaultOpts emptySAWNamingEnv p v
+    showsPrec p v = showsPrecValue PPS.defaultOpts emptyDisplayNameEnv p v
 
 evaluateTerm:: SharedContext -> Term -> IO Concrete.CValue
 evaluateTerm sc t =

--- a/saw-central/src/SAWCentral/VerificationSummary.hs
+++ b/saw-central/src/SAWCentral/VerificationSummary.hs
@@ -35,7 +35,7 @@ import qualified SAWCentral.Crucible.LLVM.MethodSpecIR as CMSLLVM
 import qualified SAWCentral.Crucible.JVM.MethodSpecIR as CMSJVM
 import SAWCentral.Proof
 import SAWCentral.Prover.SolverStats
-import SAWCore.Name (SAWNamingEnv)
+import SAWCore.Name (DisplayNameEnv)
 import What4.ProgramLoc (ProgramLoc(..))
 import What4.FunctionName
 
@@ -145,7 +145,7 @@ jsonVerificationSummary (VerificationSummary jspecs lspecs thms) =
     lvals = (\(CMSLLVM.SomeLLVM ls) -> msToJSON ls) <$> lspecs -- TODO: why is the type annotation required here?
     thmvals = thmToJSON <$> thms
 
-prettyVerificationSummary :: PPS.Opts -> SAWNamingEnv -> VerificationSummary -> String
+prettyVerificationSummary :: PPS.Opts -> DisplayNameEnv -> VerificationSummary -> String
 prettyVerificationSummary ppOpts nenv vs@(VerificationSummary jspecs lspecs thms) =
   show $ vsep
   [ prettyJVMSpecs jspecs

--- a/saw-central/src/SAWCentral/Yosys/Theorem.hs
+++ b/saw-central/src/SAWCentral/Yosys/Theorem.hs
@@ -119,11 +119,11 @@ buildTheorem sc ymod newmod precond body = do
     _ -> throw YosysErrorInvalidOverrideTarget
   inpTy <- liftIO $ CSC.importType sc CSC.emptyEnv cinpTy
   outTy <- liftIO $ CSC.importType sc CSC.emptyEnv coutTy
-  idx <- case SC.ttTerm ymod of
-    (R.asConstant -> Just (SC.EC idx _ _, _)) -> pure idx
+  nmi <- case SC.ttTerm ymod of
+    (R.asConstant -> Just (SC.EC _ nmi _, _)) -> pure nmi
     _ -> throw YosysErrorInvalidOverrideTarget
-  uri <- liftIO (SC.scLookupNameInfo sc idx) >>= \case
-    Just (SC.ImportedName uri _) -> pure uri
+  uri <- case nmi of
+    SC.ImportedName uri _ -> pure uri
     _ -> throw YosysErrorInvalidOverrideTarget
   pure YosysTheorem
     { _theoremURI = uri

--- a/saw-core/src/SAWCore/Module.hs
+++ b/saw-core/src/SAWCore/Module.hs
@@ -446,9 +446,6 @@ findModule :: ModuleName -> ModuleMap -> Maybe Module
 findModule mnm mm =
   do decls <- Map.lookup mnm (mmRDecls mm)
      env <- Map.lookup mnm (mmNameEnv mm)
-     -- moduleResolveMap :: !(Map Text ResolvedName)
-     -- { displayNames :: !(IntMap [Text]) -- Keyed by VarIndex; preferred names come first.
-     -- , displayIndexes :: !(Map Text IntSet)
      let rmap =
            Map.mapMaybe (\vi -> IntMap.lookup vi (mmIndexMap mm)) $
            Map.fromList [ (x, i) | (x, s) <- Map.assocs (displayIndexes env), i <- IntSet.elems s ]

--- a/saw-core/src/SAWCore/Module.hs
+++ b/saw-core/src/SAWCore/Module.hs
@@ -93,7 +93,7 @@ import qualified Language.Haskell.TH.Syntax as TH
 
 import Prelude hiding (all, foldr, sum)
 
-import SAWCore.Name hiding (resolveName)
+import SAWCore.Name
 import SAWCore.Panic (panic)
 import SAWCore.Term.Functor
 import SAWCore.Term.CtxTerm

--- a/saw-core/src/SAWCore/Name.hs
+++ b/saw-core/src/SAWCore/Name.hs
@@ -359,7 +359,7 @@ bestDisplayName env i =
     go [] = Nothing
     go (x : xs) =
       case Map.lookup x (displayIndexes env) of
-        Nothing -> go xs -- should never happen
+        Nothing -> panic "bestDisplayName" ["Invariant violated: Missing key " <> x]
         Just vs
           | IntSet.size vs == 1 -> Just x
           | otherwise -> go xs

--- a/saw-core/src/SAWCore/Name.hs
+++ b/saw-core/src/SAWCore/Name.hs
@@ -57,6 +57,7 @@ module SAWCore.Name
   , resolveURI
   , resolveName
   , bestAlias
+  , toDisplayNameEnv
   ) where
 
 import           Numeric (showHex)
@@ -440,3 +441,11 @@ bestAlias env nmi = go (nameAliases nmi)
         Just vs
           | Set.size vs == 1 -> Right x
           | otherwise -> go xs
+
+-- | Convert from a 'SAWNamingEnv' to a 'DisplayNameEnv'.
+toDisplayNameEnv :: SAWNamingEnv -> DisplayNameEnv
+toDisplayNameEnv env =
+  DisplayNameEnv
+  { displayNames = IntMap.fromList [ (vi, nameAliases nmi) | (vi, nmi) <- Map.assocs (resolvedNames env) ]
+  , displayIndexes = fmap (IntSet.fromList . Set.toList) (aliasNames env)
+  }

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -472,10 +472,10 @@ scResolveNameByURI sc uri =
   do env <- readIORef (scNamingEnv sc)
      pure $! resolveURI env uri
 
-scResolveName :: SharedContext -> Text -> IO [(VarIndex, NameInfo)]
+scResolveName :: SharedContext -> Text -> IO [VarIndex]
 scResolveName sc nm =
   do env <- readIORef (scNamingEnv sc)
-     pure (resolveName env nm)
+     pure (map fst (resolveName env nm))
 
 scShowTerm :: SharedContext -> PPS.Opts -> Term -> IO String
 scShowTerm sc opts t =

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -42,7 +42,6 @@ module SAWCore.SharedTerm
   , alphaEquiv
   , alistAllFields
   , scRegisterName
-  , scLookupNameInfo
   , scResolveName
   , scResolveNameByURI
   , scShowTerm
@@ -461,11 +460,6 @@ scRegisterName sc nmi =
   do i <- scFreshVarIndex sc
      scRegisterNameWithIndex sc i nmi
      pure i
-
-scLookupNameInfo :: SharedContext -> VarIndex -> IO (Maybe NameInfo)
-scLookupNameInfo sc i = do
-  env <- readIORef $ scNamingEnv sc
-  pure . Map.lookup i $ resolvedNames env
 
 scResolveNameByURI :: SharedContext -> URI -> IO (Maybe VarIndex)
 scResolveNameByURI sc uri =

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -391,7 +391,8 @@ insertTFM tf x tfm =
 data SharedContext = SharedContext
   { scModuleMap      :: IORef ModuleMap
   , scTermF          :: TermF Term -> IO Term
-  , scNamingEnv      :: IORef SAWNamingEnv
+  , scDisplayNameEnv :: IORef DisplayNameEnv
+  , scURIEnv         :: IORef (Map URI VarIndex)
   , scGlobalEnv      :: IORef (HashMap Ident Term)
   , scNextVarIndex   :: IORef VarIndex
   }
@@ -399,25 +400,29 @@ data SharedContext = SharedContext
 data SharedContextCheckpoint =
   SCC
   { sccModuleMap :: ModuleMap
-  , sccNamingEnv :: SAWNamingEnv
+  , sccNamingEnv :: DisplayNameEnv
+  , sccURIEnv    :: Map URI VarIndex
   , sccGlobalEnv :: HashMap Ident Term
   }
 
 checkpointSharedContext :: SharedContext -> IO SharedContextCheckpoint
 checkpointSharedContext sc =
   do mmap <- readIORef (scModuleMap sc)
-     nenv <- readIORef (scNamingEnv sc)
+     nenv <- readIORef (scDisplayNameEnv sc)
+     uenv <- readIORef (scURIEnv sc)
      genv <- readIORef (scGlobalEnv sc)
      return SCC
             { sccModuleMap = mmap
             , sccNamingEnv = nenv
+            , sccURIEnv = uenv
             , sccGlobalEnv = genv
             }
 
 restoreSharedContext :: SharedContextCheckpoint -> SharedContext -> IO SharedContext
 restoreSharedContext scc sc =
   do writeIORef (scModuleMap sc) (sccModuleMap scc)
-     writeIORef (scNamingEnv sc) (sccNamingEnv scc)
+     writeIORef (scDisplayNameEnv sc) (sccNamingEnv scc)
+     writeIORef (scURIEnv sc) (sccURIEnv scc)
      writeIORef (scGlobalEnv sc) (sccGlobalEnv scc)
      return sc
 
@@ -443,18 +448,17 @@ scFreshVarIndex sc = atomicModifyIORef' (scNextVarIndex sc) (\i -> (i + 1, i))
 -- 'VarIndex'. Not exported.
 scRegisterNameWithIndex :: SharedContext -> VarIndex -> NameInfo -> IO ()
 scRegisterNameWithIndex sc i nmi =
-  do let f env =
-           case registerName i nmi env of
-             Left uri -> (env, Just (DuplicateNameException uri))
-             Right env' -> (env', Nothing)
-     e <- atomicModifyIORef' (scNamingEnv sc) f
-     maybe (pure ()) throwIO e
+  do uris <- readIORef (scURIEnv sc)
+     let uri = nameURI nmi
+     when (Map.member uri uris) $ throwIO (DuplicateNameException uri)
+     writeIORef (scURIEnv sc) (Map.insert uri i uris)
+     modifyIORef' (scDisplayNameEnv sc) $ extendDisplayNameEnv i (nameAliases nmi)
 
 
 -- | Generate a fresh 'VarIndex' for the given 'NameInfo' and register
--- them together in the 'SAWNamingEnv' of the 'SharedContext'. Throws
--- 'DuplicateNameException' if the URI in the 'NameInfo' is already
--- registered.
+-- them together in the naming environment of the 'SharedContext'.
+-- Throws 'DuplicateNameException' if the URI in the 'NameInfo' is
+-- already registered.
 scRegisterName :: SharedContext -> NameInfo -> IO VarIndex
 scRegisterName sc nmi =
   do i <- scFreshVarIndex sc
@@ -463,18 +467,18 @@ scRegisterName sc nmi =
 
 scResolveNameByURI :: SharedContext -> URI -> IO (Maybe VarIndex)
 scResolveNameByURI sc uri =
-  do env <- readIORef (scNamingEnv sc)
-     pure $! resolveURI env uri
+  do env <- readIORef (scURIEnv sc)
+     pure $! Map.lookup uri env
 
 scResolveName :: SharedContext -> Text -> IO [VarIndex]
 scResolveName sc nm =
-  do env <- readIORef (scNamingEnv sc)
-     pure (map fst (resolveName env nm))
+  do env <- readIORef (scDisplayNameEnv sc)
+     pure (resolveDisplayName env nm)
 
 scShowTerm :: SharedContext -> PPS.Opts -> Term -> IO String
 scShowTerm sc opts t =
-  do env <- readIORef (scNamingEnv sc)
-     pure (showTermWithNames opts (toDisplayNameEnv env) t)
+  do env <- readIORef (scDisplayNameEnv sc)
+     pure (showTermWithNames opts env t)
 
 -- | Create a global variable with the given identifier (which may be "_") and type.
 scFreshEC :: SharedContext -> Text -> a -> IO (ExtCns a)
@@ -563,7 +567,7 @@ scCtorApp sc c_id args =
 
 -- | Get the current naming environment
 scGetNamingEnv :: SharedContext -> IO DisplayNameEnv
-scGetNamingEnv sc = toDisplayNameEnv <$> readIORef (scNamingEnv sc)
+scGetNamingEnv sc = readIORef (scDisplayNameEnv sc)
 
 -- | Get the current 'ModuleMap'
 scGetModuleMap :: SharedContext -> IO ModuleMap
@@ -2483,12 +2487,14 @@ mkSharedContext = do
   cr <- newMVar emptyAppCache
   gr <- newIORef HMap.empty
   mod_map_ref <- newIORef emptyModuleMap
-  envRef <- newIORef emptySAWNamingEnv
+  dr <- newIORef emptyDisplayNameEnv
+  ur <- newIORef Map.empty
   return SharedContext {
              scModuleMap = mod_map_ref
            , scTermF = getTerm cr
            , scNextVarIndex = vr
-           , scNamingEnv = envRef
+           , scDisplayNameEnv = dr
+           , scURIEnv = ur
            , scGlobalEnv = gr
            }
 

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -45,8 +45,6 @@ module SAWCore.SharedTerm
   , scLookupNameInfo
   , scResolveName
   , scResolveNameByURI
-  , scResolveUnambiguous
-  , scFindBestName
   , scShowTerm
   , DuplicateNameException(..)
     -- * SharedContext interface for building shared terms
@@ -468,22 +466,6 @@ scLookupNameInfo :: SharedContext -> VarIndex -> IO (Maybe NameInfo)
 scLookupNameInfo sc i = do
   env <- readIORef $ scNamingEnv sc
   pure . Map.lookup i $ resolvedNames env
-
-scResolveUnambiguous :: SharedContext -> Text -> IO (VarIndex, NameInfo)
-scResolveUnambiguous sc nm =
-  scResolveName sc nm >>= \case
-     []  -> fail ("Could not resolve name: " ++ show nm)
-     [x] -> pure x
-     xs  ->
-       do nms <- mapM (scFindBestName sc . snd) xs
-          fail $ unlines (("Ambiguous name " ++ show nm ++ " might refer to any of the following:") : map show nms)
-
-scFindBestName :: SharedContext -> NameInfo -> IO Text
-scFindBestName sc nmi =
-  do env <- readIORef (scNamingEnv sc)
-     case bestAlias env nmi of
-       Left uri -> pure (render uri)
-       Right nm -> pure nm
 
 scResolveNameByURI :: SharedContext -> URI -> IO (Maybe VarIndex)
 scResolveNameByURI sc uri =

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -498,7 +498,7 @@ scResolveName sc nm =
 scShowTerm :: SharedContext -> PPS.Opts -> Term -> IO String
 scShowTerm sc opts t =
   do env <- readIORef (scNamingEnv sc)
-     pure (showTermWithNames opts env t)
+     pure (showTermWithNames opts (toDisplayNameEnv env) t)
 
 -- | Create a global variable with the given identifier (which may be "_") and type.
 scFreshEC :: SharedContext -> Text -> a -> IO (ExtCns a)
@@ -586,8 +586,8 @@ scCtorApp sc c_id args =
      scCtorAppParams sc (ctorPrimName ctor) params args'
 
 -- | Get the current naming environment
-scGetNamingEnv :: SharedContext -> IO SAWNamingEnv
-scGetNamingEnv sc = readIORef (scNamingEnv sc)
+scGetNamingEnv :: SharedContext -> IO DisplayNameEnv
+scGetNamingEnv sc = toDisplayNameEnv <$> readIORef (scNamingEnv sc)
 
 -- | Get the current 'ModuleMap'
 scGetModuleMap :: SharedContext -> IO ModuleMap

--- a/saw-script/src/SAWScript/HeapsterBuiltins.hs
+++ b/saw-script/src/SAWScript/HeapsterBuiltins.hs
@@ -1196,7 +1196,6 @@ heapsterFunTrans henv fn_name =
        fmap (fromJust . defBody) $
        liftIO $ scRequireDef sc $ mkSafeIdent saw_modname fn_name
      bodies <-
-       fmap (fmap fst) $
        liftIO $ scResolveName sc $ T.pack $ fn_name ++ "__bodies"
      liftIO $ scUnfoldConstants sc bodies fun_term >>=
               sawLetMinimize sc >>= betaNormalize sc


### PR DESCRIPTION
This PR introduces a new type `DisplayNameEnv`, which is a stripped-down replacement for the old `SAWNamingEnv`. It only provides mappings between `Text` display names and `VarIndex` unique IDs, which is precisely what is required for parsing or pretty printing. The mapping from `URI` to `VarIndex` is now managed separately.