### PR TITLE
Remove non-working SAWCore parsing code related to qualified recursor names.

### DIFF
--- a/saw-core/src/SAWCore/Grammar.y
+++ b/saw-core/src/SAWCore/Grammar.y
@@ -191,7 +191,7 @@ AtomTerm :: { UTerm } :
   | bvlit                                       { BVLit (pos $1) (tokBits (val $1)) }
   | string                                      { mkString $1 }
   | Ident                                       { Name $1 }
-  | IdentRec                                    { Recursor Nothing $1 }
+  | IdentRec                                    { Recursor $1 }
   | 'Prop'                                      { Sort (pos $1) propSort noFlags }
   | Sort nat                                   { Sort (pos $1) (mkSort (tokNat (val $2))) (val $1) }
   | AtomTerm '.' Ident                          { RecordProj $1 (val $3) }

--- a/saw-core/src/SAWCore/Grammar.y
+++ b/saw-core/src/SAWCore/Grammar.y
@@ -195,7 +195,6 @@ AtomTerm :: { UTerm } :
   | 'Prop'                                      { Sort (pos $1) propSort noFlags }
   | Sort nat                                   { Sort (pos $1) (mkSort (tokNat (val $2))) (val $1) }
   | AtomTerm '.' Ident                          { RecordProj $1 (val $3) }
-  | AtomTerm '.' IdentRec                       {% parseRecursorProj $1 $3 }
   | AtomTerm '.' nat                            {% parseTupleSelector $1 (fmap tokNat $3) }
   | '(' sepBy(Term, ',') ')'                    { mkTupleValue (pos $1) $2 }
   | '#' '(' sepBy(Term, ',') ')'                { mkTupleType (pos $1) $3 }
@@ -346,19 +345,6 @@ mkTupleProj t 1 = return $ PairLeft t
 mkTupleProj t 2 = return $ PairRight t
 mkTupleProj t _ =
   do addParseError (pos t) "Projections must be either .(1) or .(2)"
-     return (badTerm (pos t))
-
--- | Parse a term as a dotted list of strings
-parseModuleName :: UTerm -> Maybe [Text]
-parseModuleName (RecordProj t fname) = (++ [fname]) <$> parseModuleName t
-parseModuleName _ = Nothing
-
--- | Parse a qualified recursor @M1.M2...Mn.d#rec@
-parseRecursorProj :: UTerm -> PosPair Text -> Parser UTerm
-parseRecursorProj (parseModuleName -> Just mnm) i =
-  return $ Recursor (Just $ mkModuleName mnm) i
-parseRecursorProj t _ =
-  do addParseError (pos t) "Malformed recursor projection"
      return (badTerm (pos t))
 
 parseTupleSelector :: UTerm -> PosPair Natural -> Parser UTerm

--- a/saw-core/src/SAWCore/UntypedAST.hs
+++ b/saw-core/src/SAWCore/UntypedAST.hs
@@ -69,7 +69,7 @@ data UTerm
   | App UTerm UTerm
   | Lambda Pos UTermCtx UTerm
   | Pi Pos UTermCtx UTerm
-  | Recursor (Maybe ModuleName) (PosPair Text)
+  | Recursor (PosPair Text)
   | UnitValue Pos
   | UnitType Pos
     -- | New-style records
@@ -119,7 +119,7 @@ instance Positioned UTerm where
       Lambda p _ _         -> p
       App x _              -> pos x
       Pi p _ _             -> p
-      Recursor _ i         -> pos i
+      Recursor i           -> pos i
       UnitValue p          -> p
       UnitType p           -> p
       RecordValue p _      -> p


### PR DESCRIPTION
Fixes #2408.