### PR TITLE
CI: Migrate from `windows-2019` to `windows-2022` runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ env:
   # Solver package snapshot date - also update in the following locations:
   # ./saw/Dockerfile
   # ./saw-remote-api/Dockerfile
-  SOLVER_PKG_VERSION: "snapshot-20250326"
+  SOLVER_PKG_VERSION: "snapshot-20250606"
 
 jobs:
   config:
@@ -101,7 +101,7 @@ jobs:
           # so we only build one particular GHC version to test them on. We
           # include both an x86-64 macOS runner (macos-13) as well as an AArch64
           # macOS runner (macos-14).
-          - os: windows-2019
+          - os: windows-2022
             ghc: 9.4.8
             haddock: false
             run-tests: true
@@ -593,7 +593,7 @@ jobs:
             os: macos-14
             continue-on-error: true  # https://github.com/GaloisInc/saw-script/issues/1135
           - suite: integration-tests
-            os: windows-2019
+            os: windows-2022
             timeout-minutes: 60
             continue-on-error: true  # https://github.com/GaloisInc/saw-script/issues/1135
         exclude:
@@ -601,7 +601,7 @@ jobs:
             os: macos-14
             continue-on-error: false
           - suite: integration-tests
-            os: windows-2019
+            os: windows-2022
             continue-on-error: false
     steps:
       - uses: actions/checkout@v4

--- a/saw-remote-api/Dockerfile
+++ b/saw-remote-api/Dockerfile
@@ -68,7 +68,7 @@ RUN case ${TARGETPLATFORM} in \
         printf "Unsupported architecture: %s\n" "${TARGETPLATFORM}" >&2 \
         exit 1 ;; \
     esac && \
-    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
+    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250606/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 USER root
 RUN chown -R root:root /home/saw/rootfs

--- a/saw/Dockerfile
+++ b/saw/Dockerfile
@@ -69,7 +69,7 @@ RUN case ${TARGETPLATFORM} in \
         printf "Unsupported architecture: %s\n" "${TARGETPLATFORM}" >&2 \
         exit 1 ;; \
     esac && \
-    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
+    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250606/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 USER root
 RUN chown -R root:root /home/saw/rootfs


### PR DESCRIPTION
Per https://github.com/actions/runner-images/issues/12045, GitHub Actions will be dropping support for its `windows-2019` runners soon. This migrates the CI to use `windows-2022` instead.