### PR TITLE
 Remove definition bodies from `Constant` terms

### DIFF
--- a/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
@@ -473,7 +473,7 @@ updateFFITypes m env = env { eFFITypes = eFFITypes' }
     case Map.lookup nm (eTermEnv env) of
       Just tm ->
         case asConstant tm of
-          Just (ec, _) -> ecName ec
+          Just ec -> ecName ec
           Nothing ->
             panic "updateFFITypes" [
                 "SAWCore term of Cryptol name is not Constant",

--- a/cryptol-saw-core/src/CryptolSAWCore/Monadify.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Monadify.hs
@@ -169,9 +169,8 @@ globalDefOpenTerm = closedOpenTerm . globalDefTerm
 asTypedGlobalDef :: Recognizer Term GlobalDef
 asTypedGlobalDef t =
   case unwrapTermF t of
-    FTermF (Primitive pn) ->
-      Just $ GlobalDef (ModuleIdentifier $
-                        primName pn) (primVarIndex pn) (primType pn) t
+    FTermF (Primitive ec) ->
+      Just $ GlobalDef (ecName ec) (ecVarIndex ec) (ecType ec) t
     Constant ec ->
       Just $ GlobalDef (ecName ec) (ecVarIndex ec) (ecType ec) t
     FTermF (ExtCns ec) ->

--- a/cryptol-saw-core/src/CryptolSAWCore/Monadify.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Monadify.hs
@@ -106,7 +106,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IntMap
-import Control.Monad (forM_)
+import Control.Monad (forM_, unless)
 import Control.Monad.Cont (Cont, cont, runCont)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Reader (MonadReader(..), ReaderT(..))
@@ -120,6 +120,7 @@ import Data.Type.Equality
 
 import qualified SAWSupport.Pretty as PPS (defaultOpts)
 
+import SAWCore.Module (Def(..), ResolvedName(..), lookupVarIndexInMap)
 import SAWCore.Name
 import SAWCore.Term.Functor
 import SAWCore.SharedTerm
@@ -145,8 +146,7 @@ import GHC.Stack
 data GlobalDef = GlobalDef { globalDefName :: NameInfo,
                              globalDefIndex :: VarIndex,
                              globalDefType :: Term,
-                             globalDefTerm :: Term,
-                             globalDefBody :: Maybe Term }
+                             globalDefTerm :: Term }
 
 instance Eq GlobalDef where
   gd1 == gd2 = globalDefIndex gd1 == globalDefIndex gd2
@@ -171,11 +171,11 @@ asTypedGlobalDef t =
   case unwrapTermF t of
     FTermF (Primitive pn) ->
       Just $ GlobalDef (ModuleIdentifier $
-                        primName pn) (primVarIndex pn) (primType pn) t Nothing
-    Constant ec body ->
-      Just $ GlobalDef (ecName ec) (ecVarIndex ec) (ecType ec) t body
+                        primName pn) (primVarIndex pn) (primType pn) t
+    Constant ec ->
+      Just $ GlobalDef (ecName ec) (ecVarIndex ec) (ecType ec) t
     FTermF (ExtCns ec) ->
-      Just $ GlobalDef (ecName ec) (ecVarIndex ec) (ecType ec) t Nothing
+      Just $ GlobalDef (ecName ec) (ecVarIndex ec) (ecType ec) t
     _ -> Nothing
 
 
@@ -1678,14 +1678,17 @@ monadifyTermInEnvH :: SharedContext -> Term -> Term ->
                       StateT MonadifyEnv IO Term
 monadifyTermInEnvH sc top_trm top_tp =
   do lift $ ensureCryptolMLoaded sc
-     let const_infos =
-           map snd $ Map.toAscList $ getConstantSet top_trm
-     forM_ const_infos $ \(nmi,tp,maybe_body) ->
-       get >>= \env ->
-       if isPreludeName nmi ||
-          Map.member nmi (monEnvMonTable env) then return () else
-         do mtrm <- monadifyNamedTermH sc nmi maybe_body tp
-            modify $ monEnvAdd nmi (monMacro0 mtrm)
+     mm <- lift $ scGetModuleMap sc
+     let const_infos = Map.toAscList $ getConstantSet top_trm
+     forM_ const_infos $ \(vi, (nmi, tp)) ->
+       do let maybe_body =
+                case lookupVarIndexInMap vi mm of
+                  Just (ResolvedDef d) -> defBody d
+                  _ -> Nothing
+          env <- get
+          unless (isPreludeName nmi || Map.member nmi (monEnvMonTable env)) $
+            do mtrm <- monadifyNamedTermH sc nmi maybe_body tp
+               modify $ monEnvAdd nmi (monMacro0 mtrm)
      env <- get
      lift $ monadifyCompleteTerm sc env top_trm top_tp
   where preludeModules = mkModuleName <$> [["Prelude"], ["Cryptol"]]

--- a/cryptol-saw-core/src/CryptolSAWCore/Simpset.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Simpset.hs
@@ -27,7 +27,7 @@ mkCryptolSimpset sc =
     excluded d =
       case defNameInfo d of
         ModuleIdentifier ident -> ident `elem` excludedNames
-        _ -> True
+        ImportedName{} -> True
 
 cryptolModuleName :: ModuleName
 cryptolModuleName = mkModuleName ["Cryptol"]

--- a/cryptol-saw-core/src/CryptolSAWCore/Simpset.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Simpset.hs
@@ -24,7 +24,10 @@ mkCryptolSimpset sc =
      scSimpset sc (cryptolDefs m) [] []
   where
     cryptolDefs m = filter (not . excluded) $ moduleDefs m
-    excluded d = defIdent d `elem` excludedNames
+    excluded d =
+      case defNameInfo d of
+        ModuleIdentifier ident -> ident `elem` excludedNames
+        _ -> True
 
 cryptolModuleName :: ModuleName
 cryptolModuleName = mkModuleName ["Cryptol"]

--- a/otherTests/saw-core-coq/Test.hs
+++ b/otherTests/saw-core-coq/Test.hs
@@ -68,9 +68,9 @@ aRecordType = do
   unitType <- scUnitType sc
   scRecordType sc [("natField", natType), ("unitField", unitType)]
 
-translate :: Monad m => Term -> Term -> m (Doc ann)
-translate term ty = do
-  let result = translateTermAsDeclImports configuration "MyDefinition" term ty
+translate :: Monad m => ModuleMap -> Term -> Term -> m (Doc ann)
+translate mm term ty = do
+  let result = translateTermAsDeclImports configuration mm "MyDefinition" term ty
   case result of
     Left  e -> error $ show e
     Right r -> return r
@@ -116,6 +116,7 @@ translateSAWCorePrelude = do
   sc <- mkSharedContext
   -- In order to get test data types, we load the Prelude
   tcInsertModule sc preludeModule
+  mm <- scGetModuleMap sc
   flip runReaderT sc $ do
 
     prelude <- getPreludeModule
@@ -125,7 +126,7 @@ translateSAWCorePrelude = do
       putStrLn "From CryptolToCoq Require Import SAWCoreScaffolding."
       putStrLn ""
 
-    let doc = translateSAWModule configuration prelude
+    let doc = translateSAWModule configuration mm prelude
 
     liftIO $ putStrLn $ show doc
 

--- a/otherTests/saw-core/Tests/Functor.hs
+++ b/otherTests/saw-core/Tests/Functor.hs
@@ -187,7 +187,7 @@ instance TestIt Term where
         testOne depth' $ Pi lnBar t localvar
         testTwo depth' EQ (Lambda lnFoo t t) (Lambda lnBar t t)
         testTwo depth' EQ (Pi lnFoo t t) (Pi lnBar t t)
-        testTwo depth' GT (Constant ecFoo (Just t)) (Constant ecFoo Nothing)
+        testTwo depth' EQ (Constant ecFoo) (Constant ecFoo)
 
   testTwo depth comp t1 t2 = do
       -- check that they compare as expected

--- a/otherTests/saw-core/Tests/Parser.hs
+++ b/otherTests/saw-core/Tests/Parser.hs
@@ -16,12 +16,12 @@ import SAWCore.SharedTerm
 import SAWCore.Term.Functor
 
 
-namedMsg :: Ident -> String -> String
-namedMsg sym msg = "In " ++ show sym ++ ": " ++ msg
+namedMsg :: NameInfo -> String -> String
+namedMsg sym msg = "In " ++ show (toAbsoluteName sym) ++ ": " ++ msg
 
 checkDef :: Def -> Assertion
 checkDef d = do
-  let sym = defIdent d
+  let sym = defNameInfo d
   let tp = defType d
   assertBool (namedMsg sym "Type is not ground.") (termIsClosed tp)
   case defBody d of

--- a/saw-central/src/SAWCentral/Bisimulation.hs
+++ b/saw-central/src/SAWCentral/Bisimulation.hs
@@ -81,6 +81,7 @@ import Control.Monad.Trans.Class (MonadTrans(..))
 import Data.Foldable (foldl')
 import qualified Data.IntSet as IntSet
 import qualified Data.Map.Strict as Map
+import Data.Maybe (mapMaybe)
 import qualified Data.Text as Text
 
 import qualified Cryptol.TypeCheck.Type as C
@@ -425,15 +426,19 @@ buildOutputRelationTheorem bthms bc = do
   rhsState <- io $ scLocalVar sc 1        -- s2
   input <- io $ scLocalVar sc 2           -- in
 
+  -- LHS/RHS constants
+  let lhs = ttTerm (bisimTheoremLhs outerBt)
+  let rhs = ttTerm (bisimTheoremRhs outerBt)
+
   -- LHS/RHS inputs
   lhsTuple <- io $ scTuple sc [lhsState, input]  -- (s1, in)
   rhsTuple <- io $ scTuple sc [rhsState, input]  -- (s2, in)
 
   -- LHS/RHS outputs
   -- lhs (s1, in)
-  lhsOutput <- io $ scApply sc (ttTerm (bisimTheoremLhs outerBt)) lhsTuple
+  lhsOutput <- io $ scApply sc lhs lhsTuple
   -- rhs (s2, in)
-  rhsOutput <- io $ scApply sc (ttTerm (bisimTheoremRhs outerBt)) rhsTuple
+  rhsOutput <- io $ scApply sc rhs rhsTuple
 
   -- Initial relation result
   -- srel s1 s2
@@ -449,8 +454,13 @@ buildOutputRelationTheorem bthms bc = do
   -- srel s1 s2 -> orel (lhs (s1, in)) (rhs (s2, in))
   implication <- io $ scImplies sc initRelation relationRes
 
+  -- Unfold LHS/RHS constants to reveal opportunities for simplification
+  let vs = map ecVarIndex $ mapMaybe asConstant [lhs, rhs]
+  implication_unfolded <-
+    io $ scUnfoldConstants sc vs implication >>= betaNormalize sc
+
   -- Simplify Term with any theorems that apply
-  (implication', sideConditions) <- applyAllTheorems bthms bc implication
+  (implication', sideConditions) <- applyAllTheorems bthms bc implication_unfolded
 
   -- Function to prove
   -- forall s1 s2 in out1 out2.

--- a/saw-central/src/SAWCentral/Bisimulation.hs
+++ b/saw-central/src/SAWCentral/Bisimulation.hs
@@ -750,7 +750,7 @@ replaceConstantTerm constant constantRetType term = do
 
 -- Extract the name from a 'Constant'. Fails if provided another kind of 'TermF'
 constantName :: TermF Term -> TopLevel Text.Text
-constantName (Constant e _) = return $ toShortName $ ecName e
+constantName (Constant e) = return $ toShortName $ ecName e
 constantName tf = do
   sc <- getSharedContext
   term <- io $ scTermF sc tf

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -543,7 +543,7 @@ printGoalConsts =
   execTactic $ tacticId $ \goal ->
   do let cs = sequentConstantSet (goalSequent goal)
      mapM_ (printOutLnTop Info) $
-       [ show nm | (_,(nm,_,_)) <- Map.toList cs ]
+       [ show nm | (_,(nm,_)) <- Map.toList cs ]
 
 printGoalSize :: ProofScript ()
 printGoalSize =

--- a/saw-central/src/SAWCentral/Crucible/LLVM/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/ResolveSetupValue.hs
@@ -767,7 +767,7 @@ resolveSAWPred cc tm = do
            do cryptol_ss <- Cryptol.mkCryptolSimpset @SP.TheoremNonce sc
               (_,tm'') <- rewriteSharedTerm sc cryptol_ss tm'
               (_,tm''') <- rewriteSharedTerm sc ss tm''
-              if not (any (\(name, _, _) -> not (isPreludeName name)) (Map.elems $ getConstantSet tm''')) then
+              if not (any (\(name, _) -> not (isPreludeName name)) (Map.elems $ getConstantSet tm''')) then
                 do (_names, (_mlabels, p)) <- w4Eval sym st sc mempty Set.empty tm'''
                    return p
               else bindSAWTerm sym st W4.BaseBoolRepr tm'
@@ -799,7 +799,7 @@ resolveSAWSymBV cc w tm =
               cryptol_ss <- Cryptol.mkCryptolSimpset @SP.TheoremNonce sc
               (_,tm'') <- rewriteSharedTerm sc cryptol_ss tm'
               (_,tm''') <- rewriteSharedTerm sc ss tm''
-              if not (any (\(name, _, _) -> not (isPreludeName name)) (Map.elems $ getConstantSet tm''')) then
+              if not (any (\(name, _) -> not (isPreludeName name)) (Map.elems $ getConstantSet tm''')) then
                 do (_names, _, _, x) <- w4EvalAny sym st sc mempty Set.empty tm'''
                    case valueToSymExpr x of
                      Just (Some y)

--- a/saw-central/src/SAWCentral/MRSolver/Evidence.hs
+++ b/saw-central/src/SAWCentral/MRSolver/Evidence.hs
@@ -144,13 +144,13 @@ emptyRefnset = HashMap.empty
 -- | Given a 'FunName' and a 'Refnset', return the 'FunAssump' which has
 -- the given 'FunName' as its LHS function, if possible
 lookupFunAssump :: FunName -> Refnset t -> Maybe (FunAssump t)
-lookupFunAssump (GlobalName (GlobalDef _ ix _ _ _) projs) refSet =
+lookupFunAssump (GlobalName (GlobalDef _ ix _ _) projs) refSet =
     HashMap.lookup ix refSet >>= Map.lookup projs
 lookupFunAssump _ _ = Nothing
 
 -- | Add a 'FunAssump' to a 'Refnset'
 addFunAssump :: FunAssump t -> Refnset t -> Refnset t
-addFunAssump fa@(fassumpFun -> GlobalName (GlobalDef _ ix _ _ _) projs) =
+addFunAssump fa@(fassumpFun -> GlobalName (GlobalDef _ ix _ _) projs) =
     HashMap.insertWith (\_ -> Map.insert projs fa) ix
                        (Map.singleton projs fa)
 addFunAssump _ = error "Cannot insert a non-global name into a Refnset"

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -621,7 +621,7 @@ focusOnHyp i sqt =
       (hs1,h:hs2) -> Just (HypFocusedSequent (FB hs1 h hs2) gs)
       (_  , [])   -> Nothing
 
-sequentConstantSet :: Sequent -> Map VarIndex (NameInfo, Term, Maybe Term)
+sequentConstantSet :: Sequent -> Map VarIndex (NameInfo, Term)
 sequentConstantSet sqt = foldr (\p m -> Map.union (getConstantSet (unProp p)) m) mempty (hs++gs)
   where
     RawSequent hs gs = sequentToRawSequent sqt

--- a/saw-central/src/SAWCentral/Yosys/Theorem.hs
+++ b/saw-central/src/SAWCentral/Yosys/Theorem.hs
@@ -120,7 +120,7 @@ buildTheorem sc ymod newmod precond body = do
   inpTy <- liftIO $ CSC.importType sc CSC.emptyEnv cinpTy
   outTy <- liftIO $ CSC.importType sc CSC.emptyEnv coutTy
   nmi <- case SC.ttTerm ymod of
-    (R.asConstant -> Just (SC.EC _ nmi _, _)) -> pure nmi
+    (R.asConstant -> Just (SC.EC _ nmi _)) -> pure nmi
     _ -> throw YosysErrorInvalidOverrideTarget
   uri <- case nmi of
     SC.ImportedName uri _ -> pure uri
@@ -158,12 +158,12 @@ applyOverride sc thm t = do
   let
     go :: SC.Term -> IO SC.Term
     go s@(SC.Unshared tf) = case tf of
-      SC.Constant (SC.EC idx _ _) _
+      SC.Constant (SC.EC idx _ _)
         | idx == tidx -> theoremReplacement sc thm
         | otherwise -> pure s
       _ -> SC.Unshared <$> traverse go tf
     go s@SC.STApp { SC.stAppIndex = aidx, SC.stAppTermF = tf } = SC.useCache cache aidx $ case tf of
-      SC.Constant (SC.EC idx _ _) _
+      SC.Constant (SC.EC idx _ _)
         | idx == tidx -> theoremReplacement sc thm
         | otherwise -> pure s
       _ -> SC.scTermF sc =<< traverse go tf

--- a/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
+++ b/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
@@ -466,12 +466,7 @@ bitBlastBasic :: AIG.IsAIG l g
               -> IO (BValue (l s))
 bitBlastBasic be m addlPrims ecMap t = do
   let neutral _env nt = fail ("bitBlastBasic: could not evaluate neutral term: " ++ show nt)
-  let primHandler pn msg env _tv =
-         fail $ unlines
-           [ "Could not evaluate primitive " ++ show (primName pn)
-           , "On argument " ++ show (length env)
-           , Text.unpack msg
-           ]
+  let primHandler = Sim.defaultPrimHandler
   cfg <- Sim.evalGlobal m (Map.union (beConstMap be) (addlPrims be))
          (bitBlastExtCns ecMap)
          (const Nothing)

--- a/saw-core-coq/src/SAWCoreCoq/Coq.hs
+++ b/saw-core-coq/src/SAWCoreCoq/Coq.hs
@@ -22,6 +22,7 @@ module SAWCoreCoq.Coq (
   ) where
 
 import           Data.String.Interpolate                       (i)
+import qualified Data.Text                                     as Text
 import           Prelude                                       hiding (fail)
 import           Prettyprinter
 
@@ -105,5 +106,5 @@ translateCryptolModule sc env nm configuration globalDecls m = do
 -- | Extract out the 'String' name of a declaration in a SAW core module
 moduleDeclName :: ModuleDecl -> Maybe String
 moduleDeclName (TypeDecl (DataType { dtName })) = Just (identName dtName)
-moduleDeclName (DefDecl  (Def      { defIdent })) = Just (identName defIdent)
+moduleDeclName (DefDecl  (Def      { defNameInfo })) = Just (Text.unpack (toShortName defNameInfo))
 moduleDeclName InjectCodeDecl{} = Nothing

--- a/saw-core-coq/src/SAWCoreCoq/Coq.hs
+++ b/saw-core-coq/src/SAWCoreCoq/Coq.hs
@@ -65,26 +65,27 @@ Import VectorNotations.
 |]
 
 translateTermAsDeclImports ::
-  TranslationConfiguration -> Coq.Ident -> Term -> Term ->
+  TranslationConfiguration -> ModuleMap -> Coq.Ident -> Term -> Term ->
   Either (TranslationError Term) (Doc ann)
-translateTermAsDeclImports configuration name t tp = do
+translateTermAsDeclImports configuration mm name t tp = do
   doc <-
     TermTranslation.translateDefDoc
       configuration
       Nothing
+      mm
       [] name t tp
   return $ vcat [preamble configuration, hardline <> doc]
 
 -- | Translate a SAW core module to a Coq module
-translateSAWModule :: TranslationConfiguration -> Module -> Doc ann
-translateSAWModule configuration m =
+translateSAWModule :: TranslationConfiguration -> ModuleMap -> Module -> Doc ann
+translateSAWModule configuration mm m =
   let name = show $ translateModuleName (moduleName m)
   in
   vcat $ []
   ++ [ text $ "Module " ++ name ++ "."
      , ""
      ]
-  ++ [ SAWModuleTranslation.translateDecl configuration (Just $ moduleName m) decl
+  ++ [ SAWModuleTranslation.translateDecl configuration (Just $ moduleName m) mm decl
      | decl <- moduleDecls m ]
   ++ [ text $ "End " ++ name ++ "."
      , ""

--- a/saw-core-coq/src/SAWCoreCoq/CryptolModule.hs
+++ b/saw-core-coq/src/SAWCoreCoq/CryptolModule.hs
@@ -12,7 +12,7 @@ import           Cryptol.ModuleSystem.Name          (Name, nameIdent)
 import           Cryptol.Utils.Ident                (unpackIdent)
 import qualified Language.Coq.AST                   as Coq
 import           SAWCore.Term.Functor          (Term)
-import           SAWCore.SharedTerm            (SharedContext)
+import           SAWCore.SharedTerm            (SharedContext, scGetModuleMap)
 import           SAWCoreCoq.Monad
 import qualified SAWCoreCoq.Term  as TermTranslation
 import           CryptolSAWCore.TypedTerm
@@ -49,11 +49,13 @@ translateCryptolModule sc env configuration globalDecls (CryptolModule _ tm) =
        forM (Map.assocs tm) $ \(nm, t) ->
        do tp <- ttTypeAsTerm sc env t
           return (nm, ttTerm t, tp)
+     mm <- scGetModuleMap sc
      return
        (reverse . view TermTranslation.topLevelDeclarations . snd <$>
         TermTranslation.runTermTranslationMonad
         configuration
         Nothing -- TODO: this should be Just no?
+        mm
         globalDecls
         []
         (translateTypedTermMap defs))

--- a/saw-core-coq/src/SAWCoreCoq/SpecialTreatment.hs
+++ b/saw-core-coq/src/SAWCoreCoq/SpecialTreatment.hs
@@ -93,7 +93,7 @@ findSpecialTreatment' ::
 findSpecialTreatment' nmi =
   case nmi of
     ModuleIdentifier ident -> findSpecialTreatment ident
-    _ -> pure $ IdentSpecialTreatment DefPreserve UsePreserve
+    ImportedName{} -> pure $ IdentSpecialTreatment DefPreserve UsePreserve
 
 findSpecialTreatment ::
   TranslationConfigurationMonad r m =>

--- a/saw-core-coq/src/SAWCoreCoq/SpecialTreatment.hs
+++ b/saw-core-coq/src/SAWCoreCoq/SpecialTreatment.hs
@@ -87,6 +87,14 @@ translateModuleName :: ModuleName -> ModuleName
 translateModuleName mn =
   Map.findWithDefault mn mn moduleRenamingMap
 
+findSpecialTreatment' ::
+  TranslationConfigurationMonad r m =>
+  NameInfo -> m IdentSpecialTreatment
+findSpecialTreatment' nmi =
+  case nmi of
+    ModuleIdentifier ident -> findSpecialTreatment ident
+    _ -> pure $ IdentSpecialTreatment DefPreserve UsePreserve
+
 findSpecialTreatment ::
   TranslationConfigurationMonad r m =>
   Ident -> m IdentSpecialTreatment

--- a/saw-core-coq/src/SAWCoreCoq/Term.hs
+++ b/saw-core-coq/src/SAWCoreCoq/Term.hs
@@ -387,7 +387,7 @@ flatTermFToExpr ::
   m Coq.Term
 flatTermFToExpr tf = -- traceFTermF "flatTermFToExpr" tf $
   case tf of
-    Primitive pn  -> translateIdent (primName pn)
+    Primitive ec  -> translateConstant ec
     UnitValue     -> pure (Coq.Var "tt")
     UnitType      ->
       -- We need to explicitly tell Coq that we want unit to be a Type, since

--- a/saw-core-sbv/src/SAWCoreSBV/SBV.hs
+++ b/saw-core-sbv/src/SAWCoreSBV/SBV.hs
@@ -617,12 +617,7 @@ sbvSolveBasic sc addlPrims unintSet t = do
         | Set.member (ecVarIndex ec) unintSet = Just (extcns ec)
         | otherwise                           = Nothing
   let neutral _env nt = fail ("sbvSolveBasic: could not evaluate neutral term: " ++ show nt)
-  let primHandler pn msg env _tv =
-         fail $ unlines
-           [ "Could not evaluate primitive " ++ show (primName pn)
-           , "On argument " ++ show (length env)
-           , Text.unpack msg
-           ]
+  let primHandler = Sim.defaultPrimHandler
   cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted neutral primHandler
   Sim.evalSharedTerm cfg t
 
@@ -710,12 +705,7 @@ sbvSATQuery sc addlPrims query =
                 | Set.member (ecVarIndex ec) unintSet = Just (mkUninterp ec)
                 | otherwise                           = Nothing
           let neutral _env nt = fail ("sbvSATQuery: could not evaluate neutral term: " ++ show nt)
-          let primHandler pn msg env _tv =
-                 fail $ unlines
-                   [ "Could not evaluate primitive " ++ show (primName pn)
-                   , "On argument " ++ show (length env)
-                   , Text.unpack msg
-                   ]
+          let primHandler = Sim.defaultPrimHandler
 
           cfg  <- liftIO (Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted neutral primHandler)
           bval <- liftIO (Sim.evalSharedTerm cfg t)

--- a/saw-core-what4/src/SAWCoreWhat4/What4.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/What4.hs
@@ -842,12 +842,7 @@ w4SolveBasic sym sc addlPrims ecMap ref unintSet t =
            | Set.member (ecVarIndex ec) unintSet = Just (extcns ec)
            | otherwise                           = Nothing
      let neutral _ nt = fail ("w4SolveBasic: could not evaluate neutral term: " ++ show nt)
-     let primHandler pn msg env _tv =
-            fail $ unlines
-              [ "Could not evaluate primitive " ++ show (primName pn)
-              , "On argument " ++ show (length env)
-              , Text.unpack msg
-              ]
+     let primHandler = Sim.defaultPrimHandler
      cfg <- Sim.evalGlobal m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral primHandler
      Sim.evalSharedTerm cfg t
 
@@ -1510,12 +1505,7 @@ w4EvalBasic sym st sc m addlPrims ref unintSet t =
            | Set.member (ecVarIndex ec) unintSet = Just (extcns tf ec)
            | otherwise                           = Nothing
      let neutral _env nt = fail ("w4EvalBasic: could not evaluate neutral term: " ++ show nt)
-     let primHandler pn msg env _tv =
-            fail $ unlines
-              [ "Could not evaluate primitive " ++ show (primName pn)
-              , "On argument " ++ show (length env)
-              , Text.unpack msg
-              ]
+     let primHandler = Sim.defaultPrimHandler
      cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral primHandler
      Sim.evalSharedTerm cfg t
 
@@ -1543,12 +1533,7 @@ w4SimulatorEval sym st sc m addlPrims ref constantFilter t =
      let uninterpreted _tf ec =
           if constantFilter ec then Nothing else Just (X.throwIO (NeutralTermEx (ecName ec)))
      let neutral _env nt = fail ("w4SimulatorEval: could not evaluate neutral term: " ++ show nt)
-     let primHandler pn msg env _tv =
-            fail $ unlines
-              [ "Could not evaluate primitive " ++ show (primName pn)
-              , "On argument " ++ show (length env)
-              , Text.unpack msg
-              ]
+     let primHandler = Sim.defaultPrimHandler
      res <- X.try $ do
               cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral primHandler
               Sim.evalSharedTerm cfg t

--- a/saw-core/src/SAWCore/ExternalFormat.hs
+++ b/saw-core/src/SAWCore/ExternalFormat.hs
@@ -142,8 +142,8 @@ scWriteExternal t0 =
         FTermF ftf     ->
           case ftf of
             Primitive ec ->
-               do stashPrimName ec
-                  pure $ unwords ["Primitive", show (primVarIndex ec), show (primType ec)]
+               do stashName ec
+                  pure $ unwords ["Primitive", show (ecVarIndex ec), show (ecType ec)]
             UnitValue           -> pure $ unwords ["Unit"]
             UnitType            -> pure $ unwords ["UnitT"]
             PairValue x y       -> pure $ unwords ["Pair", show x, show y]
@@ -302,7 +302,7 @@ scReadExternal sc input =
         ["Var", i]          -> pure $ LocalVar (read i)
         ["Constant",i,t]    -> Constant <$> readEC i t
         ["ConstantOpaque",i,t]  -> Constant <$> readEC i t
-        ["Primitive", i, t] -> FTermF <$> (Primitive <$> readPrimName i t)
+        ["Primitive", i, t] -> FTermF <$> (Primitive <$> readEC i t)
         ["Unit"]            -> pure $ FTermF UnitValue
         ["UnitT"]           -> pure $ FTermF UnitType
         ["Pair", x, y]      -> FTermF <$> (PairValue <$> readIdx x <*> readIdx y)

--- a/saw-core/src/SAWCore/ExternalFormat.hs
+++ b/saw-core/src/SAWCore/ExternalFormat.hs
@@ -136,12 +136,9 @@ scWriteExternal t0 =
         Lambda s t e   -> pure $ unwords ["Lam", Text.unpack s, show t, show e]
         Pi s t e       -> pure $ unwords ["Pi", Text.unpack s, show t, show e]
         LocalVar i     -> pure $ unwords ["Var", show i]
-        Constant ec (Just e)  ->
+        Constant ec    ->
             do stashName ec
-               pure $ unwords ["Constant", show (ecVarIndex ec), show (ecType ec), show e]
-        Constant ec Nothing ->
-            do stashName ec
-               pure $ unwords ["ConstantOpaque", show (ecVarIndex ec), show (ecType ec)]
+               pure $ unwords ["Constant", show (ecVarIndex ec), show (ecType ec)]
         FTermF ftf     ->
           case ftf of
             Primitive ec ->
@@ -303,8 +300,8 @@ scReadExternal sc input =
         ["Lam", x, t, e]    -> Lambda (Text.pack x) <$> readIdx t <*> readIdx e
         ["Pi", s, t, e]     -> Pi (Text.pack s) <$> readIdx t <*> readIdx e
         ["Var", i]          -> pure $ LocalVar (read i)
-        ["Constant",i,t,e]  -> Constant <$> readEC i t <*> (Just <$> readIdx e)
-        ["ConstantOpaque",i,t]  -> Constant <$> readEC i t <*> pure Nothing
+        ["Constant",i,t]    -> Constant <$> readEC i t
+        ["ConstantOpaque",i,t]  -> Constant <$> readEC i t
         ["Primitive", i, t] -> FTermF <$> (Primitive <$> readPrimName i t)
         ["Unit"]            -> pure $ FTermF UnitValue
         ["UnitT"]           -> pure $ FTermF UnitType

--- a/saw-core/src/SAWCore/Module.hs
+++ b/saw-core/src/SAWCore/Module.hs
@@ -401,7 +401,7 @@ localResolvedNames m =
     isLocal r =
       case resolvedNameInfo r of
         ModuleIdentifier i -> identModule i == moduleName m
-        _ -> False
+        ImportedName{} -> False
 
 -- | Get all definitions defined in a module
 moduleDefs :: Module -> [Def]
@@ -549,7 +549,7 @@ insResolvedNameInMap r mm =
         base = identBaseName ident
         env = fromMaybe emptyDisplayNameEnv $ Map.lookup mname (mmNameEnv mm)
         env' = extendDisplayNameEnv vi [base] env
-    _ -> Right mm'
+    ImportedName{} -> Right mm'
 
 insDeclInMap :: ModuleName -> ModuleDecl -> ModuleMap -> ModuleMap
 insDeclInMap mname decl mm =
@@ -562,7 +562,7 @@ insDefInMap d mm =
   case defNameInfo d of
     ModuleIdentifier i ->
       insDeclInMap (identModule i) (DefDecl d) mm
-    _ -> mm
+    ImportedName{} -> mm
 
 -- | Insert an injectCode declaration into a 'ModuleMap'.
 insInjectCodeInMap :: ModuleName -> Text -> Text -> ModuleMap -> ModuleMap

--- a/saw-core/src/SAWCore/Name.hs
+++ b/saw-core/src/SAWCore/Name.hs
@@ -193,6 +193,12 @@ data NameInfo
 
  deriving (Eq,Ord,Show)
 
+instance Hashable NameInfo where
+  hashWithSalt x nmi =
+    case nmi of
+      ModuleIdentifier ident -> hashWithSalt x ident
+      ImportedName uri _ -> hashWithSalt x uri
+
 nameURI :: NameInfo -> URI
 nameURI =
   \case

--- a/saw-core/src/SAWCore/OpenTerm.hs
+++ b/saw-core/src/SAWCore/OpenTerm.hs
@@ -1216,7 +1216,7 @@ sawLetMinimize sc t_top =
        liftIO $ scTermF sc (Pi x tp' body')
   slMinTermF' tf@(LocalVar i) =
     tell (varOccs1 i) >> liftIO (scTermF sc tf)
-  slMinTermF' tf@(Constant _ _) = liftIO (scTermF sc tf)
+  slMinTermF' tf@(Constant _) = liftIO (scTermF sc tf)
 
   slMinFTermF :: FlatTermF Term -> SLMinM Term
   slMinFTermF ftf@(ExtCns _) = liftIO $ scFlatTermF sc ftf

--- a/saw-core/src/SAWCore/Recognizer.hs
+++ b/saw-core/src/SAWCore/Recognizer.hs
@@ -134,7 +134,7 @@ asGlobalDef :: Recognizer Term Ident
 asGlobalDef t =
   case unwrapTermF t of
     FTermF (Primitive pn) -> Just (primName pn)
-    Constant ec _ -> asModuleIdentifier ec
+    Constant ec -> asModuleIdentifier ec
     _ -> Nothing
 
 isGlobalDef :: Ident -> Recognizer Term ()
@@ -362,8 +362,8 @@ asLocalVar :: Recognizer Term DeBruijnIndex
 asLocalVar (unwrapTermF -> LocalVar i) = return i
 asLocalVar _ = Nothing
 
-asConstant :: Recognizer Term (ExtCns Term, Maybe Term)
-asConstant (unwrapTermF -> Constant ec mt) = return (ec, mt)
+asConstant :: Recognizer Term (ExtCns Term)
+asConstant (unwrapTermF -> Constant ec) = pure ec
 asConstant _ = Nothing
 
 asExtCns :: Recognizer Term (ExtCns Term)

--- a/saw-core/src/SAWCore/Recognizer.hs
+++ b/saw-core/src/SAWCore/Recognizer.hs
@@ -133,7 +133,7 @@ asModuleIdentifier (EC _ nmi _) =
 asGlobalDef :: Recognizer Term Ident
 asGlobalDef t =
   case unwrapTermF t of
-    FTermF (Primitive pn) -> Just (primName pn)
+    FTermF (Primitive ec) -> asModuleIdentifier ec
     Constant ec -> asModuleIdentifier ec
     _ -> Nothing
 

--- a/saw-core/src/SAWCore/Rewriter.hs
+++ b/saw-core/src/SAWCore/Rewriter.hs
@@ -533,12 +533,14 @@ scExpandRewriteRules sc rs =
 -- | Create a rewrite rule for a definition that expands the definition, if it
 -- has a body to expand to, otherwise return the empty list
 scDefRewriteRules :: SharedContext -> Def -> IO [RewriteRule a]
-scDefRewriteRules _ (Def { defBody = Nothing }) = return []
-scDefRewriteRules sc (Def { defIdent = ident, defBody = Just body }) =
-  do lhs <- scGlobalDef sc ident
-     rhs <- scSharedTerm sc body
-     scExpandRewriteRules sc [mkRewriteRule [] lhs rhs False Nothing]
-
+scDefRewriteRules sc d =
+  case defBody d of
+    Just body ->
+      do lhs <- scDefTerm sc d
+         rhs <- scSharedTerm sc body
+         scExpandRewriteRules sc [mkRewriteRule [] lhs rhs False Nothing]
+    Nothing ->
+      pure []
 
 -- | A "shallow" rule is one where further
 --   rewrites are not applied to the result

--- a/saw-core/src/SAWCore/Rewriter.hs
+++ b/saw-core/src/SAWCore/Rewriter.hs
@@ -411,12 +411,20 @@ ruleOfProp sc term ann =
     (R.asApplyAll -> (R.isGlobalDef arrayEqIdent -> Just (), [_, _, x, y])) -> eqRule x y
     (R.asApplyAll -> (R.isGlobalDef intEqIdent -> Just (), [x, y])) -> eqRule x y
     (R.asApplyAll -> (R.isGlobalDef intModEqIdent -> Just (), [_, x, y])) -> eqRule x y
-    (unwrapTermF -> Constant _ (Just body)) -> ruleOfProp sc body ann
+    (unwrapTermF -> Constant ec) ->
+      do mres <- lookupVarIndexInMap (ecVarIndex ec) <$> scGetModuleMap sc
+         case mres of
+           Just (ResolvedDef (defBody -> Just body)) -> ruleOfProp sc body ann
+           _ -> pure Nothing
     (R.asEq -> Just (_, x, y)) -> eqRule x y
     (R.asEqTrue -> Just body) -> ruleOfProp sc body ann
-    (R.asApplyAll -> (R.asConstant -> Just (_, Just body), args)) ->
-      do  app <- scApplyAllBeta sc body args
-          ruleOfProp sc app ann
+    (R.asApplyAll -> (R.asConstant -> Just ec, args)) ->
+      do mres <- lookupVarIndexInMap (ecVarIndex ec) <$> scGetModuleMap sc
+         case mres of
+           Just (ResolvedDef (defBody -> Just body)) ->
+             do app <- scApplyAllBeta sc body args
+                ruleOfProp sc app ann
+           _ -> pure Nothing
     _ -> pure Nothing
 
   where

--- a/saw-core/src/SAWCore/SCTypeCheck.hs
+++ b/saw-core/src/SAWCore/SCTypeCheck.hs
@@ -444,7 +444,7 @@ instance TypeInfer (TermF Term) where
 -- with special cases for primitives and constants to avoid re-type-checking
 -- their types as we are assuming they were type-checked when they were created
 instance TypeInfer (FlatTermF Term) where
-  typeInfer (Primitive pn) = return $ primType pn
+  typeInfer (Primitive ec) = pure $ ecType ec
   typeInfer (ExtCns ec) = return $ ecType ec
   typeInfer t = typeInfer =<< mapM typeInferComplete t
   typeInferComplete ftf =
@@ -492,7 +492,7 @@ instance TypeInfer (TermF SCTypedTerm) where
 -- a term has already been labeled with its (most general) type.
 instance TypeInfer (FlatTermF SCTypedTerm) where
   typeInfer (Primitive ec) =
-    typeCheckWHNF $ typedVal $ primType ec
+    typeCheckWHNF $ typedVal $ ecType ec
   typeInfer UnitValue = liftTCM scUnitType
   typeInfer UnitType = liftTCM scSort (mkSort 0)
   typeInfer (PairValue (SCTypedTerm _ tx) (SCTypedTerm _ ty)) =

--- a/saw-core/src/SAWCore/SCTypeCheck.hs
+++ b/saw-core/src/SAWCore/SCTypeCheck.hs
@@ -431,7 +431,7 @@ instance TypeInfer (TermF Term) where
        rhs_tptrm <- withVar x (typedVal a_whnf) $ typeInferComplete rhs
        let a_tptrm = SCTypedTerm a (typedType a_whnf)
        typeInfer (Pi x a_tptrm rhs_tptrm)
-  typeInfer (Constant ec _) =
+  typeInfer (Constant ec) =
     -- NOTE: this special case is to prevent us from re-type-checking the
     -- definition of each constant, as we assume it was type-checked when it was
     -- created
@@ -478,18 +478,9 @@ instance TypeInfer (TermF SCTypedTerm) where
          else
          error ("Context = " ++ show ctx)
          -- throwTCError (DanglingVar (i - length ctx))
-  typeInfer (Constant (EC _ n (SCTypedTerm req_tp req_tp_sort)) (Just (SCTypedTerm _ tp))) =
+  typeInfer (Constant (EC _ _ (SCTypedTerm req_tp req_tp_sort))) =
     do void (ensureSort req_tp_sort)
-       -- NOTE: we do the subtype check here, rather than call checkSubtype, so
-       -- that we can throw the custom BadConstType error on failure
-       ok <- isSubtype tp req_tp
-       if ok then return tp else
-         throwTCError $ BadConstType n tp req_tp
-
-  typeInfer (Constant (EC _ _ (SCTypedTerm req_tp req_tp_sort)) Nothing) =
-    -- Constant with no body, just return the EC type
-    do void (ensureSort req_tp_sort)
-       return req_tp
+       pure req_tp
 
   typeInferComplete tf =
     SCTypedTerm <$> liftTCM scTermF (fmap typedVal tf)

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -613,12 +613,13 @@ scInsDefInMap sc d =
 -- | Declare a SAW core primitive of the specified type.
 scDeclarePrim :: SharedContext -> Ident -> DefQualifier -> Term -> IO ()
 scDeclarePrim sc ident q def_tp =
-  do i <- scRegisterName sc (ModuleIdentifier ident)
-     let pn = PrimName i ident def_tp
-     t <- scFlatTermF sc (Primitive pn)
+  do let nmi = ModuleIdentifier ident
+     i <- scRegisterName sc nmi
+     let ec = EC i nmi def_tp
+     t <- scFlatTermF sc (Primitive ec)
      scRegisterGlobal sc ident t
      scInsDefInMap sc $
-                  Def { defNameInfo = ModuleIdentifier ident,
+                  Def { defNameInfo = nmi,
                         defVarIndex = i,
                         defQualifier = q,
                         defType = def_tp,
@@ -1185,7 +1186,7 @@ scTypeOf' sc env t0 = State.evalStateT (memo t0) Map.empty
            -> State.StateT (Map TermIndex Term) IO Term
     ftermf tf =
       case tf of
-        Primitive ec -> return (primType ec)
+        Primitive ec -> return (ecType ec)
         UnitValue -> lift $ scUnitType sc
         UnitType -> lift $ scSort sc (mkSort 0)
         PairValue x y -> do

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -1471,7 +1471,10 @@ scLookupDef :: SharedContext -> Ident -> IO Term
 scLookupDef sc ident = scGlobalDef sc ident --FIXME: implement module check.
 
 scDefTerm :: SharedContext -> Def -> IO Term
-scDefTerm sc Def{..} = scTermF sc (Constant (EC defVarIndex defNameInfo defType))
+scDefTerm sc Def{..} =
+  case defBody of
+    Just _ -> scTermF sc (Constant (EC defVarIndex defNameInfo defType))
+    Nothing -> scFlatTermF sc (Primitive (EC defVarIndex defNameInfo defType))
 
 -- TODO: implement version of scCtorApp that looks up the arity of the
 -- constructor identifier in the module.

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -629,14 +629,6 @@ scInsertDef :: SharedContext -> Ident -> Term -> Term -> IO ()
 scInsertDef sc ident def_tp def_tm =
   do t <- scConstant' sc (ModuleIdentifier ident) def_tm def_tp
      scRegisterGlobal sc ident t
-     mi <- scResolveNameByURI sc (moduleIdentToURI ident)
-     let i = fromMaybe (panic "scInsertDef" ["name not found"]) mi
-     scInsDefInMap sc $
-                  Def { defNameInfo = ModuleIdentifier ident,
-                        defVarIndex = i,
-                        defQualifier = NoQualifier,
-                        defType = def_tp,
-                        defBody = Just def_tm }
 
 -- | Look up a module by name, raising an error if it is not loaded
 scFindModule :: SharedContext -> ModuleName -> IO Module
@@ -650,6 +642,14 @@ scFindModule sc name =
 -- | Look up a definition by its identifier
 scFindDef :: SharedContext -> Ident -> IO (Maybe Def)
 scFindDef sc i = findDefInMap i <$> scGetModuleMap sc
+
+-- Internal function
+scFindDefBody :: SharedContext -> VarIndex -> IO (Maybe Term)
+scFindDefBody sc vi =
+  do mm <- scGetModuleMap sc
+     case lookupVarIndexInMap vi mm of
+       Just (ResolvedDef d) -> pure (defBody d)
+       _ -> pure Nothing
 
 -- | Look up a 'Def' by its identifier, throwing an error if it is not found
 scRequireDef :: SharedContext -> Ident -> IO Def
@@ -1015,7 +1015,10 @@ scWhnf sc t0 =
                                                                      args' <- mapM memo args
                                                                      t' <- scDataTypeAppParams sc d ps' args'
                                                                      foldM reapply t' xs
-    go xs                     (asConstant -> Just (_,Just body)) = go xs body
+    go xs                     t@(asConstant -> Just ec)         = do mbody <- scFindDefBody sc (ecVarIndex ec)
+                                                                     case mbody of
+                                                                       Just body -> go xs body
+                                                                       Nothing -> foldM reapply t xs
     go xs                     t                                 = foldM reapply t xs
 
     betaReduce :: (?cache :: Cache IO TermIndex Term) =>
@@ -1063,9 +1066,19 @@ scConvertibleEval sc eval unfoldConst tm1 tm2 = do
 
        goF :: Cache IO TermIndex Term -> TermF Term -> TermF Term -> IO Bool
 
-       goF _c (Constant ecx _) (Constant ecy _) | ecVarIndex ecx == ecVarIndex ecy = pure True
-       goF c (Constant _ (Just x)) y | unfoldConst = join (goF c <$> whnf c x <*> return y)
-       goF c x (Constant _ (Just y)) | unfoldConst = join (goF c <$> return x <*> whnf c y)
+       goF _c (Constant ecx) (Constant ecy) | ecVarIndex ecx == ecVarIndex ecy = pure True
+       goF c (Constant ecx) y
+           | unfoldConst =
+             do mx <- scFindDefBody sc (ecVarIndex ecx)
+                case mx of
+                  Just x -> join (goF c <$> whnf c x <*> return y)
+                  Nothing -> pure False
+       goF c x (Constant ecy)
+           | unfoldConst =
+             do my <- scFindDefBody sc (ecVarIndex ecy)
+                case my of
+                  Just y -> join (goF c <$> return x <*> whnf c y)
+                  Nothing -> pure False
 
        goF c (FTermF ftf1) (FTermF ftf2) =
                case zipWithFlatTermF (go c) ftf1 ftf2 of
@@ -1167,7 +1180,7 @@ scTypeOf' sc env t0 = State.evalStateT (memo t0) Map.empty
         LocalVar i
           | i < length env -> lift $ incVars sc 0 (i + 1) (env !! i)
           | otherwise      -> fail $ "Dangling bound variable: " ++ show (i - length env)
-        Constant ec _ -> return (ecType ec)
+        Constant ec -> return (ecType ec)
     ftermf :: FlatTermF Term
            -> State.StateT (Map TermIndex Term) IO Term
     ftermf tf =
@@ -1457,7 +1470,7 @@ scLookupDef :: SharedContext -> Ident -> IO Term
 scLookupDef sc ident = scGlobalDef sc ident --FIXME: implement module check.
 
 scDefTerm :: SharedContext -> Def -> IO Term
-scDefTerm sc Def{..} = scTermF sc (Constant (EC defVarIndex defNameInfo defType) defBody)
+scDefTerm sc Def{..} = scTermF sc (Constant (EC defVarIndex defNameInfo defType))
 
 -- TODO: implement version of scCtorApp that looks up the arity of the
 -- constructor identifier in the module.
@@ -1658,7 +1671,13 @@ scConstant sc name rhs ty =
      rhs' <- scAbstractExts sc ecs rhs
      ty' <- scFunAll sc (map ecType ecs) ty
      ec <- scFreshEC sc name ty'
-     t <- scTermF sc (Constant ec (Just rhs'))
+     scInsDefInMap sc $
+       Def { defNameInfo = ecName ec,
+             defVarIndex = ecVarIndex ec,
+             defQualifier = NoQualifier,
+             defType = ty',
+             defBody = Just rhs' }
+     t <- scTermF sc (Constant ec)
      args <- mapM (scFlatTermF sc . ExtCns) ecs
      scApplyAll sc t args
 
@@ -1685,7 +1704,13 @@ scConstant' sc nmi rhs ty =
      ty' <- scFunAll sc (map ecType ecs) ty
      i <- scRegisterName sc nmi
      let ec = EC i nmi ty'
-     t <- scTermF sc (Constant ec (Just rhs'))
+     scInsDefInMap sc $
+       Def { defNameInfo = ecName ec,
+             defVarIndex = ecVarIndex ec,
+             defQualifier = NoQualifier,
+             defType = ty',
+             defBody = Just rhs' }
+     t <- scTermF sc (Constant ec)
      args <- mapM (scFlatTermF sc . ExtCns) ecs
      scApplyAll sc t args
 
@@ -1701,7 +1726,7 @@ scOpaqueConstant ::
 scOpaqueConstant sc nmi ty =
   do i <- scRegisterName sc nmi
      let ec = EC i nmi ty
-     scTermF sc (Constant ec Nothing)
+     scTermF sc (Constant ec)
 
 -- | Create a function application term from a global identifier and a list of
 -- arguments (as 'Term's).
@@ -2540,7 +2565,7 @@ getAllExtSet t = snd $ getExtCns (IntSet.empty, Set.empty) t
           getExtCns acc (Unshared tf') =
             foldl' getExtCns acc tf'
 
-getConstantSet :: Term -> Map VarIndex (NameInfo, Term, Maybe Term)
+getConstantSet :: Term -> Map VarIndex (NameInfo, Term)
 getConstantSet t = snd $ go (IntSet.empty, Map.empty) t
   where
     go acc@(idxs, names) (STApp{ stAppIndex = i, stAppTermF = tf})
@@ -2550,7 +2575,7 @@ getConstantSet t = snd $ go (IntSet.empty, Map.empty) t
 
     termf acc@(idxs, names) tf =
       case tf of
-        Constant (EC vidx n ty) body -> (idxs, Map.insert vidx (n, ty, body) names)
+        Constant (EC vidx n ty) -> (idxs, Map.insert vidx (n, ty) names)
         _ -> foldl' go acc tf
 
 -- | Instantiate some of the external constants.
@@ -2735,17 +2760,24 @@ scUnfoldConstantSet :: SharedContext
                     -> IO Term
 scUnfoldConstantSet sc b names t0 = do
   cache <- newCache
+  mm <- scGetModuleMap sc
+  let getRhs v =
+        case lookupVarIndexInMap v mm of
+          Just (ResolvedDef d) -> defBody d
+          _ -> Nothing
   let go :: Term -> IO Term
       go t@(Unshared tf) =
         case tf of
-          Constant (EC idx _ _) (Just rhs)
-            | Set.member idx names == b -> go rhs
+          Constant (EC idx _ _)
+            | Set.member idx names == b
+            , Just rhs <- getRhs idx    -> go rhs
             | otherwise                 -> return t
           _ -> Unshared <$> traverse go tf
       go t@(STApp{ stAppIndex = idx, stAppTermF = tf }) = useCache cache idx $
         case tf of
-          Constant (EC ecidx _ _) (Just rhs)
-            | Set.member ecidx names == b -> go rhs
+          Constant (EC ecidx _ _)
+            | Set.member ecidx names == b
+            , Just rhs <- getRhs ecidx    -> go rhs
             | otherwise                   -> return t
           _ -> scTermF sc =<< traverse go tf
   go t0
@@ -2762,6 +2794,11 @@ scUnfoldOnceFixConstantSet :: SharedContext
                            -> IO Term
 scUnfoldOnceFixConstantSet sc b names t0 = do
   cache <- newCache
+  mm <- scGetModuleMap sc
+  let getRhs v =
+        case lookupVarIndexInMap v mm of
+          Just (ResolvedDef d) -> defBody d
+          _ -> Nothing
   let unfold t idx rhs
         | Set.member idx names == b
         , (isGlobalDef "Prelude.fix" -> Just (), [_, f]) <- asApplyAll rhs =
@@ -2771,11 +2808,11 @@ scUnfoldOnceFixConstantSet sc b names t0 = do
   let go :: Term -> IO Term
       go t@(Unshared tf) =
         case tf of
-          Constant (EC idx _ _) (Just rhs) -> unfold t idx rhs
+          Constant (EC idx _ _) | Just rhs <- getRhs idx -> unfold t idx rhs
           _ -> Unshared <$> traverse go tf
       go t@(STApp{ stAppIndex = idx, stAppTermF = tf }) = useCache cache idx $
         case tf of
-          Constant (EC ecidx _ _) (Just rhs) -> unfold t ecidx rhs
+          Constant (EC ecidx _ _) | Just rhs <- getRhs ecidx -> unfold t ecidx rhs
           _ -> scTermF sc =<< traverse go tf
   go t0
 
@@ -2787,22 +2824,28 @@ scUnfoldConstantSet' :: SharedContext
                     -> IO Term
 scUnfoldConstantSet' sc b names t0 = do
   tcache <- newCacheMap' Map.empty
+  mm <- scGetModuleMap sc
+  let getRhs v =
+        case lookupVarIndexInMap v mm of
+          Just (ResolvedDef d) -> defBody d
+          _ -> Nothing
   let go :: Term -> ChangeT IO Term
       go t@(Unshared tf) =
         case tf of
-          Constant (EC idx _ _) (Just rhs)
-            | Set.member idx names == b -> taint (go rhs)
+          Constant (EC idx _ _)
+            | Set.member idx names == b
+            , Just rhs <- getRhs idx    -> taint (go rhs)
             | otherwise                 -> pure t
           _ -> whenModified t (return . Unshared) (traverse go tf)
       go t@(STApp{ stAppIndex = idx, stAppTermF = tf }) =
         case tf of
-          Constant (EC ecidx _ _) (Just rhs)
-            | Set.member ecidx names == b -> taint (go rhs)
+          Constant (EC ecidx _ _)
+            | Set.member ecidx names == b
+            , Just rhs <- getRhs ecidx    -> taint (go rhs)
             | otherwise                   -> pure t
           _ -> useChangeCache tcache idx $
                  whenModified t (scTermF sc) (traverse go tf)
   commitChangeT (go t0)
-
 
 -- | Return the number of DAG nodes used by the given @Term@.
 scSharedSize :: Term -> Integer

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -618,7 +618,7 @@ scDeclarePrim sc ident q def_tp =
      t <- scFlatTermF sc (Primitive pn)
      scRegisterGlobal sc ident t
      scInsDefInMap sc $
-                  Def { defIdent = ident,
+                  Def { defNameInfo = ModuleIdentifier ident,
                         defVarIndex = i,
                         defQualifier = q,
                         defType = def_tp,
@@ -632,7 +632,7 @@ scInsertDef sc ident def_tp def_tm =
      mi <- scResolveNameByURI sc (moduleIdentToURI ident)
      let i = fromMaybe (panic "scInsertDef" ["name not found"]) mi
      scInsDefInMap sc $
-                  Def { defIdent = ident,
+                  Def { defNameInfo = ModuleIdentifier ident,
                         defVarIndex = i,
                         defQualifier = NoQualifier,
                         defType = def_tp,
@@ -1456,9 +1456,8 @@ scApplyAllBeta sc = foldlM (scApplyBeta sc)
 scLookupDef :: SharedContext -> Ident -> IO Term
 scLookupDef sc ident = scGlobalDef sc ident --FIXME: implement module check.
 
--- | Deprecated. Use scGlobalDef or scLookupDef instead.
 scDefTerm :: SharedContext -> Def -> IO Term
-scDefTerm sc d = scGlobalDef sc (defIdent d)
+scDefTerm sc Def{..} = scTermF sc (Constant (EC defVarIndex defNameInfo defType) defBody)
 
 -- TODO: implement version of scCtorApp that looks up the arity of the
 -- constructor identifier in the module.

--- a/saw-core/src/SAWCore/Simulator.hs
+++ b/saw-core/src/SAWCore/Simulator.hs
@@ -534,9 +534,8 @@ mkMemoLocal cfg memoClosed t env = go mempty t
                               go memo' t2
         Lambda _ t1 _   -> go memo t1
         Pi _ t1 _       -> go memo t1
-        LocalVar _      -> return memo
-        Constant _ Nothing -> return memo -- TODO? is this right?
-        Constant _ (Just t1) -> go memo t1
+        LocalVar _      -> pure memo
+        Constant{}      -> pure memo
 
 {-# SPECIALIZE evalLocalTermF ::
   Show (Extra l) =>

--- a/saw-core/src/SAWCore/Simulator.hs
+++ b/saw-core/src/SAWCore/Simulator.hs
@@ -56,9 +56,11 @@ import SAWCore.Module
   , allModulePrimitives
   , defNameInfo
   , findCtorInMap
+  , lookupVarIndexInMap
   , Ctor(..)
   , Def(..)
   , ModuleMap
+  , ResolvedName(..)
   )
 import SAWCore.Name
 import SAWCore.SharedTerm
@@ -155,7 +157,10 @@ evalTermF cfg lam recEval tf env =
                                   return $ TValue $ VPiType nm v body
 
     LocalVar i              -> force (fst (env !! i))
-    Constant ec t           -> do ec' <- traverse evalType ec
+    Constant ec             -> do ec' <- traverse evalType ec
+                                  let t = case lookupVarIndexInMap (ecVarIndex ec) (simModMap cfg) of
+                                            Just (ResolvedDef d) -> defBody d
+                                            _ -> Nothing
                                   fromMaybe
                                     (simNeutral cfg env (NeutralConstant ec))
                                     (simConstant cfg tf ec' <|> (recEval <$> t))

--- a/saw-core/src/SAWCore/Simulator.hs
+++ b/saw-core/src/SAWCore/Simulator.hs
@@ -385,7 +385,7 @@ evalGlobal' modmap prims extcns constant neutral primHandler =
             ModuleIdentifier ident ->
               let pn = PrimName (ecVarIndex ec) ident (ecType ec)
                in evalPrim (primHandler ec) pn <$> Map.lookup ident prims
-            _ -> Nothing
+            ImportedName{} -> Nothing
 
     ctors :: PrimName (TValue l) -> Maybe (MValue l)
     ctors pn = evalPrim (primHandler (primNameToExtCns pn)) pn <$> Map.lookup (primName pn) prims
@@ -431,7 +431,7 @@ defIdent :: Def -> Maybe Ident
 defIdent d =
   case defNameInfo d of
     ModuleIdentifier ident -> Just ident
-    _ -> Nothing
+    ImportedName{} -> Nothing
 
 ----------------------------------------------------------------------
 -- The evaluation strategy for SharedTerms involves two memo tables:

--- a/saw-core/src/SAWCore/Simulator/Concrete.hs
+++ b/saw-core/src/SAWCore/Simulator/Concrete.hs
@@ -31,6 +31,7 @@ import qualified Data.Map as Map
 import qualified Data.Text as Text
 
 import SAWCore.Module (ModuleMap)
+import SAWCore.Name
 import SAWCore.Panic (panic)
 import SAWCore.Prim (BitVector(..), signed, bv, bvNeg)
 import qualified SAWCore.Prim as Prim
@@ -53,9 +54,9 @@ evalSharedTerm m addlPrims ecVals t =
       case Map.lookup (ecVarIndex ec) ecVals of
         Just v  -> return v
         Nothing -> return $ Prim.userError $ "Unimplemented: external constant " ++ show (ecName ec)
-    primHandler pn msg env _tv =
+    primHandler ec msg env _tv =
       return $ Prim.userError $ unlines
-        [ "Could not evaluate primitive " ++ show (primName pn)
+        [ "Could not evaluate primitive " ++ Text.unpack (toAbsoluteName (ecName ec))
         , "On argument " ++ show (length env)
         , Text.unpack msg
         ]

--- a/saw-core/src/SAWCore/Simulator/RME.hs
+++ b/saw-core/src/SAWCore/Simulator/RME.hs
@@ -42,6 +42,7 @@ import qualified Data.RME as RME
 import qualified Data.RME.Vector as RMEV
 
 import SAWCore.Module (ModuleMap)
+import SAWCore.Name
 import SAWCore.Panic (panic)
 import qualified SAWCore.Prim as Prim
 import qualified SAWCore.Simulator as Sim
@@ -68,9 +69,9 @@ evalSharedTerm m addlPrims t =
   where
     extcns ec = return $ Prim.userError $ "Unimplemented: external constant " ++ show (ecName ec)
     neutral _env nt = return $ Prim.userError $ "Could not evaluate neutral term\n:" ++ show nt
-    primHandler pn msg env _tv =
+    primHandler ec msg env _tv =
       return $ Prim.userError $ unlines
-        [ "Could not evaluate primitive " ++ show (primName pn)
+        [ "Could not evaluate primitive " ++ Text.unpack (toAbsoluteName (ecName ec))
         , "On argument " ++ show (length env)
         , Text.unpack msg
         ]
@@ -406,9 +407,9 @@ bitBlastBasic :: ModuleMap
               -> RValue
 bitBlastBasic m addlPrims ecMap t = runIdentity $ do
   let neutral _env nt = return $ Prim.userError $ "Could not evaluate neutral term\n:" ++ show nt
-  let primHandler pn msg env _tv =
+  let primHandler ec msg env _tv =
          return $ Prim.userError $ unlines
-           [ "Could not evaluate primitive " ++ show (primName pn)
+           [ "Could not evaluate primitive " ++ Text.unpack (toAbsoluteName (ecName ec))
            , "On argument " ++ show (length env)
            , Text.unpack msg
            ]

--- a/saw-core/src/SAWCore/Simulator/Value.hs
+++ b/saw-core/src/SAWCore/Simulator/Value.hs
@@ -385,7 +385,7 @@ neutralToTerm = loop
   loop (NeutralRecursor r ixs x) =
     Unshared (FTermF (RecursorApp (loop r) ixs x))
   loop (NeutralConstant ec) =
-    Unshared (Constant ec Nothing)
+    Unshared (Constant ec)
 
 neutralToSharedTerm :: SharedContext -> NeutralTerm -> IO Term
 neutralToSharedTerm sc = loop
@@ -408,7 +408,7 @@ neutralToSharedTerm sc = loop
     do tm <- loop nt
        scFlatTermF sc (RecursorApp r ixs tm)
   loop (NeutralConstant ec) =
-    do scTermF sc (Constant ec Nothing)
+    do scTermF sc (Constant ec)
 
 ppNeutral :: PPS.Opts -> NeutralTerm -> PPS.Doc
 ppNeutral opts = ppTerm opts . neutralToTerm

--- a/saw-core/src/SAWCore/Term/Pretty.hs
+++ b/saw-core/src/SAWCore/Term/Pretty.hs
@@ -506,7 +506,7 @@ ppTermF prec (Pi x tp body) =
   (ppPi <$> ppTerm' PrecApp tp <*>
    ppTermInBinder PrecLambda x body)
 ppTermF _ (LocalVar x) = annotate PPS.LocalVarStyle <$> pretty <$> varLookupM x
-ppTermF _ (Constant ec _) = annotate PPS.ConstantStyle <$> ppExtCns ec
+ppTermF _ (Constant ec) = annotate PPS.ConstantStyle <$> ppExtCns ec
 
 
 -- | Internal function to recursively pretty-print a term

--- a/saw-core/src/SAWCore/Term/Pretty.hs
+++ b/saw-core/src/SAWCore/Term/Pretty.hs
@@ -394,7 +394,7 @@ ppPi tp (name, body) = vsep [lhs, "->" <+> body]
 ppFlatTermF :: Prec -> FlatTermF Term -> PPM PPS.Doc
 ppFlatTermF prec tf =
   case tf of
-    Primitive ec  -> annotate PPS.PrimitiveStyle <$> ppPrimName ec
+    Primitive ec  -> annotate PPS.PrimitiveStyle <$> ppExtCns ec
     UnitValue     -> return "(-empty-)"
     UnitType      -> return "#(-empty-)"
     PairValue x y -> ppPair prec <$> ppTerm' PrecTerm x <*> ppTerm' PrecCommas y

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -55,7 +55,6 @@ import SAWCore.Module
   , findDataTypeInMap
   , resolveNameInMap
   , DataType(..)
-  , Def(..)
   , DefQualifier(..)
   , ResolvedName(..)
   )
@@ -128,7 +127,7 @@ inferResolveNameApp n args =
             -- of indices
             typeInferComplete (DataTypeApp d params ixs)
        (_, Just (ResolvedDef d)) ->
-         do t <- liftTCM scGlobalDef (defIdent d)
+         do t <- liftTCM scDefTerm d
             f <- SCTypedTerm t <$> liftTCM scTypeOf t
             inferApplyAll f args
        (Nothing, Nothing) ->

--- a/saw-script/src/SAWScript/HeapsterBuiltins.hs
+++ b/saw-script/src/SAWScript/HeapsterBuiltins.hs
@@ -330,7 +330,7 @@ parseAndInsDef henv nm term_tp term_string =
      typed_term <- liftIO $ scTypeCheckCompleteError sc (Just mnm) un_term
      liftIO $ scCheckSubtype sc (Just mnm) typed_term term_tp
      case typedVal typed_term of
-       STApp _ _ _ (Constant (EC _ (ModuleIdentifier term_ident) _) _) ->
+       STApp _ _ _ (Constant (EC _ (ModuleIdentifier term_ident) _)) ->
          return term_ident
        term -> do
          m <- liftIO $ scFindModule sc mnm
@@ -1215,13 +1215,14 @@ heapster_export_coq :: BuiltinContext -> Options -> HeapsterEnv ->
 heapster_export_coq _bic _opts henv filename =
   do let coq_trans_conf = coqTranslationConfiguration [] []
      sc <- getSharedContext
+     mm <- liftIO $ scGetModuleMap sc
      saw_mod <- liftIO $ scFindModule sc $ heapsterEnvSAWModule henv
      let coq_doc =
            vcat [preamble coq_trans_conf {
                    postPreamble =
                        "From CryptolToCoq Require Import " ++
                        "SAWCorePrelude SpecMPrimitivesForSAWCore SAWCoreBitvectors.\n" },
-                 translateSAWModule coq_trans_conf saw_mod]
+                 translateSAWModule coq_trans_conf mm saw_mod]
      liftIO $ writeFile filename (show coq_doc)
 
 -- | Set the Hepaster debug level

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -607,7 +607,7 @@ buildTopLevelEnv proxy opts =
            defPred d =
              case defNameInfo d of
                ModuleIdentifier ident -> ident `Set.member` includedDefs
-               _ -> False
+               ImportedName{} -> False
            includedDefs = Set.fromList
                           [ "Cryptol.ecDemote"
                           , "Cryptol.seq"

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -604,7 +604,10 @@ buildTopLevelEnv proxy opts =
                       , remove_ident_unsafeCoerce
                       ]
            cryptolDefs = filter defPred $ moduleDefs cryptol_mod
-           defPred d = defIdent d `Set.member` includedDefs
+           defPred d =
+             case defNameInfo d of
+               ModuleIdentifier ident -> ident `Set.member` includedDefs
+               _ -> False
            includedDefs = Set.fromList
                           [ "Cryptol.ecDemote"
                           , "Cryptol.seq"


### PR DESCRIPTION
This is a big step toward addressing #2357.

We now look up constant definitions by VarIndex in the ModuleMap; this is a single fast IntMap lookup. Accordingly a ModuleMap needed to be piped into some backends (such as Coq export).