### PR TITLE
`saw-core-{sbv,what4}`: Fix semantics of `int{Div,Mod}`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -99,6 +99,13 @@ The most notable changes are:
 * The `mir_isize` and `mir_usize` types now correspond to the Cryptol type
   `[64]` instead of `[32]`.
 
+* SAW's interpretation of signed integer division and modulus is now
+  self-consistent and matches Cryptol. Previously, what you got depended on how
+  and where the evaluation happened. Note however that the interpretation used
+  by Cryptol (which rounds towards negative infinity) is not the same as that
+  found in conventional CPUs and programming languages (which uses Euclidean
+  division).
+
 ## Deprecations
 
 * It was previously possible to declare monadic values of an

--- a/intTests/test2415/Test.cry
+++ b/intTests/test2415/Test.cry
@@ -1,0 +1,2 @@
+p : Integer -> Integer -> Bit
+property p x y = y != 0 ==> x / (-y) == (-x) / y

--- a/intTests/test2415/test.sh
+++ b/intTests/test2415/test.sh
@@ -1,0 +1,4 @@
+set -e
+
+$SAW test1.saw
+$SAW test2.saw

--- a/intTests/test2415/test1.saw
+++ b/intTests/test2415/test1.saw
@@ -1,0 +1,4 @@
+import "Test.cry";
+
+prove_print z3 {{ p }};
+prove_print (w4_unint_z3 []) {{ p }};

--- a/intTests/test2415/test2.saw
+++ b/intTests/test2415/test2.saw
@@ -1,0 +1,16 @@
+let prove_print_sbv = prove_print z3;
+let prove_print_w4 = prove_print w4;
+
+let props =
+      [ {{ (  5  /   4)  ==  1 }}
+      , {{ ((-5) /   4)  == -2 }}
+      , {{ (  5  / (-4)) == -2 }}
+      , {{ ((-5) / (-4)) ==  1 }}
+
+      , {{ (  5  %   4)  ==  1 }}
+      , {{ ((-5) %   4)  ==  3 }}
+      , {{ (  5  % (-4)) == -3 }}
+      , {{ ((-5) % (-4)) == -1 }}
+      ];
+for props prove_print_sbv;
+for props prove_print_w4;


### PR DESCRIPTION
These now implement integer division that rounds towards negative infinity (like in Cryptol) instead of Euclidean division. These implementations were highly inspired by what is done on the Cryptol side.

Fixes #2415.