### PR TITLE
saw-core: Remove 'Primitive' term constructor in favor of 'Constant'.

### DIFF
--- a/cryptol-saw-core/src/CryptolSAWCore/Monadify.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Monadify.hs
@@ -169,8 +169,6 @@ globalDefOpenTerm = closedOpenTerm . globalDefTerm
 asTypedGlobalDef :: Recognizer Term GlobalDef
 asTypedGlobalDef t =
   case unwrapTermF t of
-    FTermF (Primitive ec) ->
-      Just $ GlobalDef (ecName ec) (ecVarIndex ec) (ecType ec) t
     Constant ec ->
       Just $ GlobalDef (ecName ec) (ecVarIndex ec) (ecType ec) t
     FTermF (ExtCns ec) ->

--- a/saw-core-coq/src/SAWCoreCoq/Term.hs
+++ b/saw-core-coq/src/SAWCoreCoq/Term.hs
@@ -387,7 +387,6 @@ flatTermFToExpr ::
   m Coq.Term
 flatTermFToExpr tf = -- traceFTermF "flatTermFToExpr" tf $
   case tf of
-    Primitive ec  -> translateConstant ec
     UnitValue     -> pure (Coq.Var "tt")
     UnitType      ->
       -- We need to explicitly tell Coq that we want unit to be a Type, since

--- a/saw-core/src/SAWCore/ExternalFormat.hs
+++ b/saw-core/src/SAWCore/ExternalFormat.hs
@@ -141,9 +141,6 @@ scWriteExternal t0 =
                pure $ unwords ["Constant", show (ecVarIndex ec), show (ecType ec)]
         FTermF ftf     ->
           case ftf of
-            Primitive ec ->
-               do stashName ec
-                  pure $ unwords ["Primitive", show (ecVarIndex ec), show (ecType ec)]
             UnitValue           -> pure $ unwords ["Unit"]
             UnitType            -> pure $ unwords ["UnitT"]
             PairValue x y       -> pure $ unwords ["Pair", show x, show y]
@@ -302,7 +299,6 @@ scReadExternal sc input =
         ["Var", i]          -> pure $ LocalVar (read i)
         ["Constant",i,t]    -> Constant <$> readEC i t
         ["ConstantOpaque",i,t]  -> Constant <$> readEC i t
-        ["Primitive", i, t] -> FTermF <$> (Primitive <$> readEC i t)
         ["Unit"]            -> pure $ FTermF UnitValue
         ["UnitT"]           -> pure $ FTermF UnitType
         ["Pair", x, y]      -> FTermF <$> (PairValue <$> readIdx x <*> readIdx y)

--- a/saw-core/src/SAWCore/Recognizer.hs
+++ b/saw-core/src/SAWCore/Recognizer.hs
@@ -133,7 +133,6 @@ asModuleIdentifier (EC _ nmi _) =
 asGlobalDef :: Recognizer Term Ident
 asGlobalDef t =
   case unwrapTermF t of
-    FTermF (Primitive ec) -> asModuleIdentifier ec
     Constant ec -> asModuleIdentifier ec
     _ -> Nothing
 

--- a/saw-core/src/SAWCore/Rewriter.hs
+++ b/saw-core/src/SAWCore/Rewriter.hs
@@ -834,7 +834,6 @@ rewriteSharedTermTypeSafe sc ss t0 =
           Sort{}           -> return ftf -- doesn't matter
           NatLit{}         -> return ftf -- doesn't matter
           ArrayValue t es  -> ArrayValue t <$> traverse rewriteAll es
-          Primitive{}      -> return ftf
           StringLit{}      -> return ftf
           ExtCns{}         -> return ftf
 

--- a/saw-core/src/SAWCore/SCTypeCheck.hs
+++ b/saw-core/src/SAWCore/SCTypeCheck.hs
@@ -444,7 +444,6 @@ instance TypeInfer (TermF Term) where
 -- with special cases for primitives and constants to avoid re-type-checking
 -- their types as we are assuming they were type-checked when they were created
 instance TypeInfer (FlatTermF Term) where
-  typeInfer (Primitive ec) = pure $ ecType ec
   typeInfer (ExtCns ec) = return $ ecType ec
   typeInfer t = typeInfer =<< mapM typeInferComplete t
   typeInferComplete ftf =
@@ -491,8 +490,6 @@ instance TypeInfer (TermF SCTypedTerm) where
 -- terms. Intuitively, this represents the case where each immediate subterm of
 -- a term has already been labeled with its (most general) type.
 instance TypeInfer (FlatTermF SCTypedTerm) where
-  typeInfer (Primitive ec) =
-    typeCheckWHNF $ typedVal $ ecType ec
   typeInfer UnitValue = liftTCM scUnitType
   typeInfer UnitType = liftTCM scSort (mkSort 0)
   typeInfer (PairValue (SCTypedTerm _ tx) (SCTypedTerm _ ty)) =

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -616,7 +616,7 @@ scDeclarePrim sc ident q def_tp =
   do let nmi = ModuleIdentifier ident
      i <- scRegisterName sc nmi
      let ec = EC i nmi def_tp
-     t <- scFlatTermF sc (Primitive ec)
+     t <- scTermF sc (Constant ec)
      scRegisterGlobal sc ident t
      scInsDefInMap sc $
                   Def { defNameInfo = nmi,
@@ -1186,7 +1186,6 @@ scTypeOf' sc env t0 = State.evalStateT (memo t0) Map.empty
            -> State.StateT (Map TermIndex Term) IO Term
     ftermf tf =
       case tf of
-        Primitive ec -> return (ecType ec)
         UnitValue -> lift $ scUnitType sc
         UnitType -> lift $ scSort sc (mkSort 0)
         PairValue x y -> do
@@ -1471,10 +1470,7 @@ scLookupDef :: SharedContext -> Ident -> IO Term
 scLookupDef sc ident = scGlobalDef sc ident --FIXME: implement module check.
 
 scDefTerm :: SharedContext -> Def -> IO Term
-scDefTerm sc Def{..} =
-  case defBody of
-    Just _ -> scTermF sc (Constant (EC defVarIndex defNameInfo defType))
-    Nothing -> scFlatTermF sc (Primitive (EC defVarIndex defNameInfo defType))
+scDefTerm sc Def{..} = scTermF sc (Constant (EC defVarIndex defNameInfo defType))
 
 -- TODO: implement version of scCtorApp that looks up the arity of the
 -- constructor identifier in the module.

--- a/saw-core/src/SAWCore/Simulator/TermModel.hs
+++ b/saw-core/src/SAWCore/Simulator/TermModel.hs
@@ -100,10 +100,10 @@ extractUninterp sc m addlPrims ecVals unintSet opaqueSet t =
          tyv  <- evalType cfg =<< scTypeOf sc tm
          reflectTerm sc cfg tyv tm
 
-    primHandler cfg pn _msg env tp =
-      do pn'  <- traverse (readBackTValue sc cfg) pn
+    primHandler cfg ec _msg env tp =
+      do ec'  <- traverse (readBackTValue sc cfg) ec
          args <- reverse <$> traverse (\(x,ty) -> readBackValue sc cfg ty =<< force x) env
-         prim <- scFlatTermF sc (Primitive pn')
+         prim <- scTermF sc (Constant ec')
          f    <- foldM (scApply sc) prim args
          reflectTerm sc cfg tp f
 
@@ -182,11 +182,11 @@ normalizeSharedTerm' sc m primsFn ecVals opaqueSet t =
          tyv  <- evalType cfg =<< scTypeOf sc tm
          reflectTerm sc cfg tyv tm
 
-    primHandler cfg pn _msg env tp =
+    primHandler cfg ec _msg env tp =
       do let ?recordEC = \_ec -> return ()
-         pn'  <- traverse (readBackTValue sc cfg) pn
+         ec'  <- traverse (readBackTValue sc cfg) ec
          args <- reverse <$> traverse (\(x,ty) -> readBackValue sc cfg ty =<< force x) env
-         prim <- scFlatTermF sc (Primitive pn')
+         prim <- scTermF sc (Constant ec')
          f    <- foldM (scApply sc) prim args
          reflectTerm sc cfg tp f
 

--- a/saw-core/src/SAWCore/Term/Pretty.hs
+++ b/saw-core/src/SAWCore/Term/Pretty.hs
@@ -394,7 +394,6 @@ ppPi tp (name, body) = vsep [lhs, "->" <+> body]
 ppFlatTermF :: Prec -> FlatTermF Term -> PPM PPS.Doc
 ppFlatTermF prec tf =
   case tf of
-    Primitive ec  -> annotate PPS.PrimitiveStyle <$> ppExtCns ec
     UnitValue     -> return "(-empty-)"
     UnitType      -> return "#(-empty-)"
     PairValue x y -> ppPair prec <$> ppTerm' PrecTerm x <*> ppTerm' PrecCommas y
@@ -560,7 +559,6 @@ scTermCountAux doBinders = go
             Lambda _ t1 _ | not doBinders  -> [t1]
             Pi _ t1 _     | not doBinders  -> [t1]
             Constant{}                     -> []
-            FTermF (Primitive _)           -> []
             FTermF (DataTypeApp _ ps xs)   -> ps ++ xs
             FTermF (CtorApp _ ps xs)       -> ps ++ xs
             FTermF (RecursorType _ ps m _) -> ps ++ [m]
@@ -575,7 +573,6 @@ scTermCountAux doBinders = go
 shouldMemoizeTerm :: Term -> Bool
 shouldMemoizeTerm t =
   case unwrapTermF t of
-    FTermF Primitive{} -> False
     FTermF UnitValue -> False
     FTermF UnitType -> False
     FTermF (CtorApp _ [] []) -> False


### PR DESCRIPTION
Since #2414 we can tell whether a global constant has a definition and whether it is a primitive when we look up its name in the `ModuleMap`; we don't need to encode that same fact again in the term AST itself. This PR is in the same spirit as #2358.