### PR TITLE
saw-core: Don't let-bind unapplied constants when pretty-printing.

### DIFF
--- a/intTests/test_sawscript_builtins/run.log.good
+++ b/intTests/test_sawscript_builtins/run.log.good
@@ -8,9 +8,7 @@
 
 * Theorem:
 ~~~~
-  let { x@1 = True
-      }
-   in EqTrue (ecEq Bool PEqBit x@1 x@1)
+  EqTrue (ecEq Bool PEqBit True True)
 ~~~~
 
 # Solvers Used
@@ -24,9 +22,7 @@
 
 * Theorem:
 ~~~~
-  let { x@1 = True
-      }
-   in EqTrue (ecEq Bool PEqBit x@1 x@1)
+  EqTrue (ecEq Bool PEqBit True True)
 ~~~~
 
 # Solvers Used

--- a/saw-core/src/SAWCore/Term/Pretty.hs
+++ b/saw-core/src/SAWCore/Term/Pretty.hs
@@ -561,6 +561,7 @@ shouldMemoizeTerm t =
     FTermF (ArrayValue _ v) | V.length v == 0 -> False
     FTermF StringLit{} -> False
     FTermF ExtCns{} -> False
+    Constant{} -> False
     LocalVar{} -> False
     _ -> True
 


### PR DESCRIPTION
Function `shouldMemoizeTerm` now returns False for any Constant. This was always a problem, but it became more noticeable after PRs #2419 and #2422, when primitives, data constructors, and data types switched to Constant; previously `shouldMemoizeTerm` had special cases that marked all those special forms as False.