### PR TITLE
saw-core: Hash ExtCns values by name instead of VarIndex.

### DIFF
--- a/saw-core/src/SAWCore/Name.hs
+++ b/saw-core/src/SAWCore/Name.hs
@@ -252,7 +252,7 @@ instance Ord (ExtCns e) where
   compare x y = compare (ecVarIndex x) (ecVarIndex y)
 
 instance Hashable (ExtCns e) where
-  hashWithSalt x ec = hashWithSalt x (ecVarIndex ec)
+  hashWithSalt x ec = hashWithSalt x (ecName ec)
 
 
 scFreshNameURI :: Text -> VarIndex -> URI


### PR DESCRIPTION
This ensures that hashes of identical subterms will be stable across executions, and not depend on the particular VarIndexes that come from the hash-consing tables.

Fixes #2386.