### PR TITLE
Refactoring of the SAWCore SharedTerm API

### DIFF
--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -249,7 +249,7 @@ importKind :: SharedContext -> C.Kind -> IO Term
 importKind sc kind =
   case kind of
     C.KType       -> scISort sc (mkSort 0)
-    C.KNum        -> scDataTypeApp sc "Cryptol.Num" []
+    C.KNum        -> scGlobalApply sc "Cryptol.Num" []
     C.KProp       -> scSort sc (mkSort 0)
     (C.:->) k1 k2 -> join $ scFun sc <$> importKind sc k1 <*> importKind sc k2
 
@@ -1699,7 +1699,7 @@ proveEq sc env t1 t2
            n2' <- importType sc env n2
            a1' <- importType sc env a1
            a2' <- importType sc env a2
-           num <- scDataTypeApp sc "Cryptol.Num" []
+           num <- scGlobalApply sc "Cryptol.Num" []
            nEq <- if n1 == n2
                   then scCtorApp sc "Prelude.Refl" [num, n1']
                   else scGlobalApply sc "Prelude.unsafeAssert" [num, n1', n2']
@@ -1710,7 +1710,7 @@ proveEq sc env t1 t2
       (C.tIsIntMod -> Just n1, C.tIsIntMod -> Just n2) ->
         do n1' <- importType sc env n1
            n2' <- importType sc env n2
-           num <- scDataTypeApp sc "Cryptol.Num" []
+           num <- scGlobalApply sc "Cryptol.Num" []
            nEq <- if n1 == n2
                   then scCtorApp sc "Prelude.Refl" [num, n1']
                   else scGlobalApply sc "Prelude.unsafeAssert" [num, n1', n2']
@@ -2273,7 +2273,7 @@ genCodeForEnum sc env nt ctors =
   -------------------------------------------------------------
   -- Definitions to access needed SAWCore Prelude types & definitions:
   sort0          <- scSort sc (mkSort 0)
-  scListSort     <- scDataTypeApp sc "Prelude.ListSort" []
+  scListSort     <- scGlobalApply sc "Prelude.ListSort" []
   scLS_Nil       <- scCtorApp sc "Prelude.LS_Nil"  []
 
   let scLS_Cons s ls   = scCtorApp     sc "Prelude.LS_Cons" [s,ls]

--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -337,8 +337,8 @@ importType sc env ty =
       case tcon of
         C.TC tc ->
           case tc of
-            C.TCNum n    -> scCtorApp sc "Cryptol.TCNum" =<< sequence [scNat sc (fromInteger n)]
-            C.TCInf      -> scCtorApp sc "Cryptol.TCInf" []
+            C.TCNum n    -> scGlobalApply sc "Cryptol.TCNum" =<< sequence [scNat sc (fromInteger n)]
+            C.TCInf      -> scGlobalApply sc "Cryptol.TCInf" []
             C.TCBit      -> scBoolType sc
             C.TCInteger  -> scIntegerType sc
             C.TCIntMod   -> scGlobalApply sc "Cryptol.IntModNum" =<< traverse go tyargs
@@ -1691,7 +1691,7 @@ proveEq sc env t1 t2
   | t1 == t2 =
     do s <- scSort sc (mkSort 0)
        t' <- importType sc env t1
-       scCtorApp sc "Prelude.Refl" [s, t']
+       scGlobalApply sc "Prelude.Refl" [s, t']
   | otherwise =
     case (tNoUser t1, tNoUser t2) of
       (C.tIsSeq -> Just (n1, a1), C.tIsSeq -> Just (n2, a2)) ->
@@ -1701,7 +1701,7 @@ proveEq sc env t1 t2
            a2' <- importType sc env a2
            num <- scGlobalApply sc "Cryptol.Num" []
            nEq <- if n1 == n2
-                  then scCtorApp sc "Prelude.Refl" [num, n1']
+                  then scGlobalApply sc "Prelude.Refl" [num, n1']
                   else scGlobalApply sc "Prelude.unsafeAssert" [num, n1', n2']
            aEq <- proveEq sc env a1 a2
            if a1 == a2
@@ -1712,7 +1712,7 @@ proveEq sc env t1 t2
            n2' <- importType sc env n2
            num <- scGlobalApply sc "Cryptol.Num" []
            nEq <- if n1 == n2
-                  then scCtorApp sc "Prelude.Refl" [num, n1']
+                  then scGlobalApply sc "Prelude.Refl" [num, n1']
                   else scGlobalApply sc "Prelude.unsafeAssert" [num, n1', n2']
            scGlobalApply sc "Cryptol.IntModNum_cong" [n1', n2', nEq]
       (C.tIsFun -> Just (a1, b1), C.tIsFun -> Just (a2, b2)) ->
@@ -2274,16 +2274,16 @@ genCodeForEnum sc env nt ctors =
   -- Definitions to access needed SAWCore Prelude types & definitions:
   sort0          <- scSort sc (mkSort 0)
   scListSort     <- scGlobalApply sc "Prelude.ListSort" []
-  scLS_Nil       <- scCtorApp sc "Prelude.LS_Nil"  []
+  scLS_Nil       <- scGlobalApply sc "Prelude.LS_Nil"  []
 
-  let scLS_Cons s ls   = scCtorApp     sc "Prelude.LS_Cons" [s,ls]
+  let scLS_Cons s ls   = scGlobalApply sc "Prelude.LS_Cons" [s,ls]
 
       scEithersV ls    = scGlobalApply sc "Prelude.EithersV" [ls]
       sc_eithersV b ls = scGlobalApply sc "Prelude.eithersV" [b,ls]
 
      -- to create values of the Either type:
-      scLeft  a b x    = scCtorApp     sc "Prelude.Left"  [a,b,x]
-      scRight a b x    = scCtorApp     sc "Prelude.Right" [a,b,x]
+      scLeft  a b x    = scGlobalApply sc "Prelude.Left"  [a,b,x]
+      scRight a b x    = scGlobalApply sc "Prelude.Right" [a,b,x]
 
       scMakeListSort :: [Term] -> IO Term
       scMakeListSort = Fold.foldrM scLS_Cons scLS_Nil
@@ -2293,9 +2293,9 @@ genCodeForEnum sc env nt ctors =
       scMakeFunsTo :: Term -> [(Term,Term)] -> IO Term
       scMakeFunsTo b tvs =
         do
-        scFunsTo_Nil <- scCtorApp sc "Prelude.FunsTo_Nil"  [b]
+        scFunsTo_Nil <- scGlobalApply sc "Prelude.FunsTo_Nil"  [b]
         let scFunsTo_Cons (t,v) r =
-              scCtorApp sc "Prelude.FunsTo_Cons" [b,t,v,r]
+              scGlobalApply sc "Prelude.FunsTo_Cons" [b,t,v,r]
         Fold.foldrM scFunsTo_Cons scFunsTo_Nil tvs
 
   -------------------------------------------------------------

--- a/otherTests/saw-core/Tests/Simulator.hs
+++ b/otherTests/saw-core/Tests/Simulator.hs
@@ -54,11 +54,11 @@ normalizeSharedTermTests = [
 
   -- Succ 2 ~> 3
   ("Succ_nat",
-   \sc -> scCtorApp sc "Prelude.Succ" . (:[]) =<< scNat sc 2,
+   \sc -> scGlobalApply sc "Prelude.Succ" . (:[]) =<< scNat sc 2,
    \sc -> scNat sc 3),
   -- Succ (bvToNat 8 2) ~> bvToNat 9 (bvNat 9 3) 
   ("Succ_bvToNat",
-   \sc -> scCtorApp sc "Prelude.Succ" . (:[]) =<<
+   \sc -> scGlobalApply sc "Prelude.Succ" . (:[]) =<<
             scBvToNat sc 8 =<< scBvLit sc 8 2,
    \sc -> scBvToNat sc 9 =<< scBvConst sc 9 3),
 

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -1390,7 +1390,7 @@ proveByBVInduction script t =
             indMotive <- io $
                 do indVar <- scFreshGlobal sc "inductionVar" natty
                    tsz'   <- scApplyAll sc toNat [wt, tsz]
-                   teq    <- scDataTypeApp sc "Prelude.IsLeNat" [tsz', indVar]
+                   teq    <- scGlobalApply sc "Prelude.IsLeNat" [tsz', indVar]
                    t2     <- scFun sc teq tbody
                    t3     <- scGeneralizeTerms sc vars t2
                    scAbstractTerms sc [indVar] t3
@@ -1429,7 +1429,7 @@ proveByBVInduction script t =
                    bvltVar <- scFreshGlobal sc "Hult" =<< scEqTrue sc =<< scBvULt sc wt innersz outersz
 
                    leVar   <- scFreshGlobal sc "Hle" =<<
-                                 scDataTypeApp sc "Prelude.IsLeNat" [natoutersz, nVar]
+                                 scGlobalApply sc "Prelude.IsLeNat" [natoutersz, nVar]
 
                    refl_inner <- scCtorApp sc "Prelude.IsLeNat_base" [natinnersz]
 

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -1424,14 +1424,14 @@ proveByBVInduction script t =
 
                    natinnersz <- scApplyAll sc toNat [wt, innersz]
 
-                   succinnersz <- scCtorApp sc "Prelude.Succ" [natinnersz]
+                   succinnersz <- scGlobalApply sc "Prelude.Succ" [natinnersz]
 
                    bvltVar <- scFreshGlobal sc "Hult" =<< scEqTrue sc =<< scBvULt sc wt innersz outersz
 
                    leVar   <- scFreshGlobal sc "Hle" =<<
                                  scGlobalApply sc "Prelude.IsLeNat" [natoutersz, nVar]
 
-                   refl_inner <- scCtorApp sc "Prelude.IsLeNat_base" [natinnersz]
+                   refl_inner <- scGlobalApply sc "Prelude.IsLeNat_base" [natinnersz]
 
                    prf     <- do hyx <- scGlobalApply sc "Prelude.bvultToIsLtNat" [wt,innersz,outersz,bvltVar]
                                  scGlobalApply sc "Prelude.IsLeNat_transitive" [succinnersz, natoutersz, nVar, hyx, leVar]
@@ -1450,7 +1450,7 @@ proveByBVInduction script t =
             indApp <- io $
                 do varH   <- scFreshGlobal sc "Hind" thmHyp
                    tsz'   <- scApplyAll sc toNat [wt, tsz]
-                   trefl  <- scCtorApp sc "Prelude.IsLeNat_base" [tsz']
+                   trefl  <- scGlobalApply sc "Prelude.IsLeNat_base" [tsz']
                    indHypArg <- scApplyBeta sc indHypProof varH
                    ind    <- scGlobalApply sc "Prelude.Nat_complete_induction" ([indMotive,indHypArg,tsz'] ++ vars ++ [trefl])
                    ind''  <- scAbstractTerms sc (varH : vars) ind
@@ -1988,8 +1988,8 @@ size_to_term s =
                   C.Forall [] [] t ->
                     case C.evalType mempty t of
                       Left (C.Nat x) | x >= 0 ->
-                        scCtorApp sc "Cryptol.TCNum" =<< sequence [scNat sc (fromInteger x)]
-                      Left C.Inf -> scCtorApp sc "Cryptol.TCInf" []
+                        scGlobalApply sc "Cryptol.TCNum" =<< sequence [scNat sc (fromInteger x)]
+                      Left C.Inf -> scGlobalApply sc "Cryptol.TCInf" []
                       _ -> fail "size_to_term: not a numeric type"
                   _ -> fail "size_to_term: unsupported polymorphic type"
 

--- a/saw-central/src/SAWCentral/MRSolver/Monad.hs
+++ b/saw-central/src/SAWCentral/MRSolver/Monad.hs
@@ -763,7 +763,7 @@ mrBvType n =
 
 -- | Build the equality proposition @Eq a t1 t2@
 mrEqProp :: Term -> Term -> Term -> MRM t Term
-mrEqProp tp t1 t2 = liftSC2 scDataTypeApp "Prelude.Eq" [tp,t1,t2]
+mrEqProp tp t1 t2 = liftSC2 scGlobalApply "Prelude.Eq" [tp,t1,t2]
 
 -- | Like 'scBvConst', but if given a bitvector literal it is converted to a
 -- natural number literal

--- a/saw-central/src/SAWCentral/MRSolver/Monad.hs
+++ b/saw-central/src/SAWCentral/MRSolver/Monad.hs
@@ -731,7 +731,7 @@ mrUnitType = Type <$> liftSC0 scUnitType
 
 -- | Build a constructor application in Mr. Monad
 mrCtorApp :: Ident -> [Term] -> MRM t Term
-mrCtorApp = liftSC2 scCtorApp
+mrCtorApp = liftSC2 scGlobalApply
 
 -- | Build a 'Term' for a global in Mr. Monad
 mrGlobalTerm :: Ident -> MRM t Term

--- a/saw-central/src/SAWCentral/MRSolver/SMT.hs
+++ b/saw-central/src/SAWCentral/MRSolver/SMT.hs
@@ -150,7 +150,7 @@ mkReflProof :: SharedContext -> Bool -> IO TmValue
 mkReflProof sc b =
   do b_trm <- scBool sc b
      bool_tp <- scBoolType sc
-     refl_trm <- scCtorApp sc "Prelude.Refl" [bool_tp, b_trm]
+     refl_trm <- scGlobalApply sc "Prelude.Refl" [bool_tp, b_trm]
      eq_tp <- scGlobalApply sc "Prelude.Eq" [bool_tp, b_trm, b_trm]
      return $ VExtra $ VExtraTerm (VTyTerm propSort eq_tp) refl_trm
 
@@ -540,7 +540,7 @@ injReprComp r1 r2 =
 mrApplyRepr :: InjectiveRepr -> Term -> MRM t Term
 mrApplyRepr InjReprId t = return t
 mrApplyRepr (InjReprNum steps) t_top = foldM applyStep t_top steps where
-  applyStep t InjNatToNum = liftSC2 scCtorApp "Cryptol.TCNum" [t]
+  applyStep t InjNatToNum = liftSC2 scGlobalApply "Cryptol.TCNum" [t]
   applyStep t (InjBVToNat n) = liftSC2 scBvToNat n t
 mrApplyRepr (InjReprPair repr1 repr2) t =
   do t1 <- mrApplyRepr repr1 =<< doTermProj t TermProjLeft

--- a/saw-central/src/SAWCentral/MRSolver/SMT.hs
+++ b/saw-central/src/SAWCentral/MRSolver/SMT.hs
@@ -151,7 +151,7 @@ mkReflProof sc b =
   do b_trm <- scBool sc b
      bool_tp <- scBoolType sc
      refl_trm <- scCtorApp sc "Prelude.Refl" [bool_tp, b_trm]
-     eq_tp <- scDataTypeApp sc "Prelude.Eq" [bool_tp, b_trm, b_trm]
+     eq_tp <- scGlobalApply sc "Prelude.Eq" [bool_tp, b_trm, b_trm]
      return $ VExtra $ VExtraTerm (VTyTerm propSort eq_tp) refl_trm
 
 mkDummyProofValue :: Text -> IO (Thunk TermModel)

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -500,7 +500,7 @@ trivialProofTerm sc (Prop p) = runExceptT (loop =<< lift (scWhnf sc p))
             Just (tp, x, _y) ->
               -- NB, we don't check if x is convertable to y here, as that will
               -- be done later in @tacticTrivial@ during the type-checking step
-              lift $ scCtorApp sc "Prelude.Refl" [tp, x]
+              lift $ scGlobalApply sc "Prelude.Refl" [tp, x]
             Nothing ->
               throwError $ unlines
                 [ "The trivial tactic can only prove quantified equalities, but"

--- a/saw-core/src/SAWCore/ParserUtils.hs
+++ b/saw-core/src/SAWCore/ParserUtils.hs
@@ -173,7 +173,7 @@ declareDataTypeFun mnm d tp =
 -- for constructor @c@ with type (including parameters) @tp@ in module @MMM@
 declareCtorFun :: ModuleName -> Text -> Un.UTerm -> DecWriter ()
 declareCtorFun mnm c tp =
-  declareTypedNameFun [| scCtorApp |] mnm c True tp
+  declareTypedNameFun [| scGlobalApply |] mnm c True tp
 
 
 -- | Declare Haskell functions, via 'declareTermApplyFun', that build shared

--- a/saw-core/src/SAWCore/ParserUtils.hs
+++ b/saw-core/src/SAWCore/ParserUtils.hs
@@ -164,7 +164,7 @@ declareDefFun mnm d tp =
 -- for datatype @d@ with parameters @p_ctx@ and type @tp@ in module @MMM@
 declareDataTypeFun :: ModuleName -> Text -> Un.UTerm -> DecWriter ()
 declareDataTypeFun mnm d tp =
-  declareTypedNameFun [| scDataTypeApp |] mnm d False tp
+  declareTypedNameFun [| scGlobalApply |] mnm d False tp
 
 -- | Declare a Haskell function
 --

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -92,7 +92,6 @@ module SAWCore.SharedTerm
     -- ** Term construction
     -- *** Datatypes and constructors
   , scCtorAppParams
-  , scCtorApp
   , scApplyCtor
   , scSort
   , scISort
@@ -567,11 +566,6 @@ scCtorAppParams :: SharedContext
 scCtorAppParams sc c params args =
   do t <- scTermF sc (Constant c)
      scApplyAll sc t (params ++ args)
-
--- | Applies the constructor with the given name to the list of
--- arguments. This version does no checking against the module.
-scCtorApp :: SharedContext -> Ident -> [Term] -> IO Term
-scCtorApp sc c_id args = scGlobalApply sc c_id args
 
 -- | Get the current naming environment
 scGetNamingEnv :: SharedContext -> IO DisplayNameEnv

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -67,7 +67,6 @@ module SAWCore.SharedTerm
   , scFreshenGlobalIdent
     -- ** Recursors and datatypes
   , scDataTypeAppParams
-  , scDataTypeApp
   , scRecursorElimTypes
   , scRecursorRetTypeType
   , scReduceRecursor
@@ -557,11 +556,6 @@ scDataTypeAppParams :: SharedContext
 scDataTypeAppParams sc d params args =
   do t <- scTermF sc (Constant d)
      scApplyAll sc t (params ++ args)
-
--- | Applies the constructor with the given name to the list of
--- arguments. This version does no checking against the module.
-scDataTypeApp :: SharedContext -> Ident -> [Term] -> IO Term
-scDataTypeApp sc d_id args = scGlobalApply sc d_id args
 
 -- | Applies the constructor with the given name to the list of parameters and
 -- arguments. This version does no checking against the module.

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -75,19 +75,23 @@ module SAWCore.SharedTerm
     -- ** Modules
   , scLoadModule
   , scImportModule
-  , scDeclarePrim
-  , scInsertDef
   , scModuleIsLoaded
   , scFindModule
   , scFindDef
-  , scBeginDataType
-  , scCompleteDataType
   , scFindDataType
   , scFindCtor
   , scRequireDef
   , scRequireDataType
   , scRequireCtor
   , scInjectCode
+    -- ** Declaring global constants
+  , scDeclarePrim
+  , scInsertDef
+  , scConstant
+  , scConstant'
+  , scOpaqueConstant
+  , scBeginDataType
+  , scCompleteDataType
     -- ** Term construction
     -- *** Datatypes and constructors
   , scCtorAppParams
@@ -97,9 +101,6 @@ module SAWCore.SharedTerm
   , scSortWithFlags
     -- *** Variables and constants
   , scLocalVar
-  , scConstant
-  , scConstant'
-  , scOpaqueConstant
   , scLookupDef
     -- *** Functions and function application
   , scApply

--- a/saw-core/src/SAWCore/Simulator/TermModel.hs
+++ b/saw-core/src/SAWCore/Simulator/TermModel.hs
@@ -1210,7 +1210,7 @@ mkStreamOp sc cfg =
                      natPN <- traverse (evalType cfg) (dtExtCns natDT)
                      ty' <- readBackTValue sc cfg ty
                      ftm <- readBackValue sc cfg (VPiType nm (VDataType natPN [] []) (VNondependentPi ty)) f
-                     scCtorApp sc (mkIdent preludeModuleName "MkStream") [ty',ftm]
+                     scGlobalApply sc (mkIdent preludeModuleName "MkStream") [ty',ftm]
            return (VExtra (VExtraStream ty fn ref stm))
 
       _ -> throwE "expected function value"


### PR DESCRIPTION
This is a collection of changes to the functions exported by the `SAWCore.SharedTerm` module. A few are removed, and a couple are modified slightly to help to maintain some now-documented SharedContext invariants.