### PR TITLE
Remove GADTs and simplify module SAWCore.Term.CtxTerm

### DIFF
--- a/saw-core/src/SAWCore/Module.hs
+++ b/saw-core/src/SAWCore/Module.hs
@@ -126,13 +126,12 @@ instance Hashable Def -- automatically derived
 
 -- | A specification of a constructor
 data Ctor =
-  forall d params ixs.
   Ctor
   { ctorNameInfo :: !NameInfo
     -- ^ The name of this constructor
   , ctorVarIndex :: !VarIndex
     -- ^ Unique var index for this constructor
-  , ctorArgStruct :: CtorArgStruct d params ixs
+  , ctorArgStruct :: CtorArgStruct
     -- ^ Arguments to the constructor
   , ctorDataType :: !Name
     -- ^ The datatype this constructor belongs to

--- a/saw-core/src/SAWCore/Module.hs
+++ b/saw-core/src/SAWCore/Module.hs
@@ -178,12 +178,12 @@ data Ctor =
 -- | Return the number of parameters of a constructor
 ctorNumParams :: Ctor -> Int
 ctorNumParams (Ctor { ctorArgStruct = CtorArgStruct {..}}) =
-  bindingsLength ctorParams
+  length ctorParams
 
 -- | Return the number of non-parameter arguments of a constructor
 ctorNumArgs :: Ctor -> Int
 ctorNumArgs (Ctor { ctorArgStruct = CtorArgStruct {..}}) =
-  bindingsLength ctorArgs
+  length ctorArgs
 
 -- | Compute the 'Name' that uniquely references a constructor
 ctorName :: Ctor -> Name

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -820,7 +820,7 @@ scBuildCtor ::
   SharedContext ->
   Name {- ^ data type -} ->
   Ident {- ^ constructor name -} ->
-  CtorArgStruct d params ixs {- ^ constructor formal arguments -} ->
+  CtorArgStruct {- ^ constructor formal arguments -} ->
   IO Ctor
 scBuildCtor sc d c arg_struct =
   do

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -838,7 +838,7 @@ scBuildCtor sc d c arg_struct =
     -- constructor argument variables
     let num_args =
           case arg_struct of
-            CtorArgStruct {..} -> bindingsLength ctorArgs
+            CtorArgStruct {..} -> length ctorArgs
 
     vars <- reverse <$> mapM (scLocalVar sc) (take num_args [0 ..])
     elim_var <- scLocalVar sc num_args

--- a/saw-core/src/SAWCore/Term/CtxTerm.hs
+++ b/saw-core/src/SAWCore/Term/CtxTerm.hs
@@ -53,12 +53,6 @@ ctxTermsForBindings bs ts
   | length bs == length ts = Just ts
   | otherwise = Nothing
 
-splitCtxTermsCtx :: [(LocalName, tp)] ->
-                    [Term] ->
-                    ([Term], [Term])
-splitCtxTermsCtx ctx terms =
-  splitAt (length terms - length ctx) terms
-
 --
 -- * Operations on Terms-in-Context
 --
@@ -99,7 +93,8 @@ ctxVars2 :: MonadTerm m => [(LocalName, tp)] ->
             [(LocalName, tp)] ->
             m ([Term], [Term])
 ctxVars2 vars1 vars2 =
-  splitCtxTermsCtx vars2 <$> ctxVars (vars1 ++ vars2)
+  splitAt (length vars1) <$> ctxVars (vars1 ++ vars2)
+
 
 -- | Build a 'Term' for a 'Sort'
 ctxSort :: MonadTerm m => Sort -> m Term

--- a/saw-core/src/SAWCore/Term/CtxTerm.hs
+++ b/saw-core/src/SAWCore/Term/CtxTerm.hs
@@ -17,16 +17,11 @@ Portability : non-portable (language extensions)
 
 module SAWCore.Term.CtxTerm
   (
-    -- * Terms in Context
-    ctxTermsForBindings
     -- * Operations on Terms-in-Context
-  , MonadTerm(..)
+    MonadTerm(..)
   , ctxLambda, ctxPi, ctxPi1
-    -- * Generalized Lifting and Substitution
-  , CtxLiftSubst(..), ctxLiftInBindings
-  , mkLiftedClosedTerm
     -- * Constructor Argument Types
-  , CtorArg(..), CtorArgStruct(..), ctxCtorArgType, ctxCtorType
+  , CtorArg(..), CtorArgStruct(..), ctxCtorType
     -- * Computing with Eliminators
   , mkPRetTp
   , ctxCtorElimType, mkCtorElimTypeFun
@@ -303,10 +298,6 @@ instance MonadTerm m => CtxLiftSubst CtorArg m where
   ctxSubst subst ctx (RecursiveArg zs ixs) =
     RecursiveArg <$> ctxSubst subst ctx zs <*>
     ctxSubstInBindings subst ctx zs ixs
-
--- | Make a closed term and then lift it into a context
-mkLiftedClosedTerm :: MonadTerm m => [(LocalName, tp)] -> Term -> m Term
-mkLiftedClosedTerm inners t = ctxLift [] inners t
 
 
 --

--- a/saw-core/src/SAWCore/Term/CtxTerm.hs
+++ b/saw-core/src/SAWCore/Term/CtxTerm.hs
@@ -47,7 +47,7 @@ module SAWCore.Term.CtxTerm
     -- * Contexts and Bindings
   , Typ
   , CtxInvApp, CtxInv
-  , Bindings(..), bindingsLength, InvBindings(..), InBindings(..)
+  , Bindings(..), bindingsLength, InvBindings(..)
   , invAppendBindings, invertBindings
     -- * Terms in Context
   , Arrows
@@ -197,13 +197,6 @@ appendTopInvBindings ctx1 InvNoBind = ctx1
 appendTopInvBindings ctx1 (InvBind ctx2 x tp) =
   let ret = appendTopInvBindings ctx1 ctx2 in
   InvBind ret x (ctxLiftNil ret tp)
-
--- | A sequence of bindings bundled with something that is relative to those
--- bindings
-data InBindings tp (f :: Ctx Type -> k -> Type) ctx (a::k) where
-  InBindings :: Bindings tp ctx as -> f (CtxInvApp ctx as) a ->
-                InBindings tp f ctx a
-
 
 --
 -- * Terms In Context

--- a/saw-core/src/SAWCore/Term/CtxTerm.hs
+++ b/saw-core/src/SAWCore/Term/CtxTerm.hs
@@ -183,9 +183,7 @@ ctxAsDataTypeApp d params ixs t =
      guard (d == d')
      guard (length args == length params + length ixs)
      let (params', ixs') = splitAt (length params) args
-     params_ret <- ctxTermsForBindings params params'
-     ixs_ret <- ctxTermsForBindings ixs ixs'
-     pure (params_ret, ixs_ret)
+     pure (params', ixs')
 
 
 -- | Build an application of a constructor as a 'Term'

--- a/saw-core/src/SAWCore/Term/CtxTerm.hs
+++ b/saw-core/src/SAWCore/Term/CtxTerm.hs
@@ -21,7 +21,6 @@ module SAWCore.Term.CtxTerm
     bindingsLength, InvBindings(..)
   , invAppendBindings, invertBindings
     -- * Terms in Context
-  , CtxTermsCtx(..)
   , ctxTermsForBindings
     -- * Operations on Terms-in-Context
   , MonadTerm(..)
@@ -117,13 +116,6 @@ ctxTermsHeadTail (a : as) = (a, as)
 ctxTermsCtxHeadTail :: CtxTermsCtx -> (CtxTermsCtx, Term)
 ctxTermsCtxHeadTail (CtxTermsCtxCons as a) = (as, a)
 ctxTermsCtxHeadTail CtxTermsCtxNil = error "ctxTermCtxHeadTail: unexpected CtxTermsCtxNil"
-
--- | Convert a typed list of terms to a list of untyped terms; this is "unsafe"
--- because it throws away our typing information
-ctxTermsToListUnsafe :: [Term] -> [Term]
-ctxTermsToListUnsafe [] = []
-ctxTermsToListUnsafe (t : ts) =
-  t : ctxTermsToListUnsafe ts
 
 -- | Convert a typed list of terms to a list of untyped terms; this is "unsafe"
 -- because it throws away our typing information
@@ -852,7 +844,7 @@ asCtorDTApp :: Name -> [(LocalName, Term)] ->
 asCtorDTApp d params dt_ixs ctx1 ctx2 (ctxAsDataTypeApp d params dt_ixs ->
                                        Just (param_vars, ixs))
   | isVarList params ctx1 ctx2 param_vars &&
-    not (any (usesDataType d) $ ctxTermsToListUnsafe ixs)
+    not (any (usesDataType d) ixs)
   = Just ixs
   where
     -- Check that the given list of terms is a list of bound variables, one for

--- a/saw-core/src/SAWCore/Term/CtxTerm.hs
+++ b/saw-core/src/SAWCore/Term/CtxTerm.hs
@@ -102,9 +102,6 @@ appendTopInvBindings ctx1 (InvBind ctx2 x tp) =
 -- * Terms In Context
 --
 
--- | An 'Either' type relative to a context and type
-newtype CtxEither f g = CtxEither (Either f g)
-
 -- | A list of terms in a given context, stored "inside-out"
 data CtxTermsCtx where
   CtxTermsCtxNil :: CtxTermsCtx
@@ -401,15 +398,15 @@ ctxLiftInBindings :: CtxLiftSubst f m => InvBindings tp1 ->
                      [(LocalName, tp2)] ->
                      [(LocalName, tp3)] ->
                      f -> m f
-ctxLiftInBindings = helper . mapInvBindings (CtxEither . Left)
+ctxLiftInBindings = helper . mapInvBindings (Left)
   where
-    helper :: CtxLiftSubst f m => InvBindings (CtxEither tp1 tp2) ->
+    helper :: CtxLiftSubst f m => InvBindings (Either tp1 tp2) ->
               [(LocalName, tp2)] ->
               [(LocalName, tp3)] ->
               f -> m f
     helper ctx1 [] as = ctxLift ctx1 as
     helper ctx1 ((str, tp) : ctx2) as =
-      helper (InvBind ctx1 str (CtxEither $ Right tp)) ctx2 as
+      helper (InvBind ctx1 str (Right tp)) ctx2 as
 
 -- | Substitute into an @f@ that is in an extended list of 'Bindings'
 ctxSubstInBindings :: CtxLiftSubst f m => CtxTermsCtx ->
@@ -417,14 +414,14 @@ ctxSubstInBindings :: CtxLiftSubst f m => CtxTermsCtx ->
                       [(LocalName, tp2)] ->
                       f -> m f
 ctxSubstInBindings subst =
-  helper subst . mapInvBindings (CtxEither . Left) where
+  helper subst . mapInvBindings Left where
   helper :: CtxLiftSubst f m => CtxTermsCtx ->
-            InvBindings (CtxEither tp1 tp2) ->
+            InvBindings (Either tp1 tp2) ->
             [(LocalName, tp2)] ->
             f -> m f
   helper s ctx2 [] f = ctxSubst s ctx2 f
   helper s ctx2 ((x, tp) : ctx3) f =
-    helper s (InvBind ctx2 x (CtxEither $ Right tp)) ctx3 f
+    helper s (InvBind ctx2 x (Right tp)) ctx3 f
 
 instance MonadTerm m => CtxLiftSubst Term m where
   ctxLift ctx1 ctx2 t =

--- a/saw-core/src/SAWCore/Term/CtxTerm.hs
+++ b/saw-core/src/SAWCore/Term/CtxTerm.hs
@@ -231,7 +231,7 @@ class Monad m => CtxLiftSubst f m where
   -- | Substitute a list of terms into an @f@
   ctxSubst :: [Term] -> [(LocalName, tp)] -> f -> m f
 
--- | Lift an @f@ that is in an extended list of 'Bindings'
+-- | Lift an @f@ that is in an extended list of bindings
 ctxLiftInBindings :: CtxLiftSubst f m => [(LocalName, tp1)] ->
                      [(LocalName, tp2)] ->
                      [(LocalName, tp3)] ->
@@ -246,7 +246,7 @@ ctxLiftInBindings = helper . map (fmap Left)
     helper ctx1 ((str, tp) : ctx2) as =
       helper (ctx1 ++ [(str, Right tp)]) ctx2 as
 
--- | Substitute into an @f@ that is in an extended list of 'Bindings'
+-- | Substitute into an @f@ that is in an extended list of bindings
 ctxSubstInBindings :: CtxLiftSubst f m => [Term] ->
                       [(LocalName, tp1)] ->
                       [(LocalName, tp2)] ->
@@ -768,7 +768,7 @@ mkCtorArgsIxs d params dt_ixs prevs (asCtorDTApp d params dt_ixs prevs [] ->
 mkCtorArgsIxs _ _ _ _ _ = Nothing
 
 
--- | Take in a datatype and 'Bindings' lists for its parameters and indices, and
+-- | Take in a datatype and bindings lists for its parameters and indices, and
 -- also a prospective type of a constructor for that datatype, where the
 -- constructor type is allowed to have the parameters but not the indices free.
 -- Test that the constructor type is an allowed type for a constructor of this

--- a/saw-core/src/SAWCore/Term/CtxTerm.hs
+++ b/saw-core/src/SAWCore/Term/CtxTerm.hs
@@ -44,14 +44,6 @@ import SAWCore.Term.Functor
 
 
 --
--- * Contexts and Bindings
---
-
--- | Map over all types in an inverted bindings list
-mapInvBindings :: (f -> g) -> [(LocalName, f)] -> [(LocalName, g)]
-mapInvBindings f = map (fmap f)
-
---
 -- * Terms In Context
 --
 
@@ -261,7 +253,7 @@ ctxLiftInBindings :: CtxLiftSubst f m => [(LocalName, tp1)] ->
                      [(LocalName, tp2)] ->
                      [(LocalName, tp3)] ->
                      f -> m f
-ctxLiftInBindings = helper . mapInvBindings (Left)
+ctxLiftInBindings = helper . map (fmap Left)
   where
     helper :: CtxLiftSubst f m => [(LocalName, Either tp1 tp2)] ->
               [(LocalName, tp2)] ->
@@ -277,7 +269,7 @@ ctxSubstInBindings :: CtxLiftSubst f m => [Term] ->
                       [(LocalName, tp2)] ->
                       f -> m f
 ctxSubstInBindings subst =
-  helper subst . mapInvBindings Left where
+  helper subst . map (fmap Left) where
   helper :: CtxLiftSubst f m => [Term] ->
             [(LocalName, Either tp1 tp2)] ->
             [(LocalName, tp2)] ->

--- a/saw-core/src/SAWCore/Term/CtxTerm.hs
+++ b/saw-core/src/SAWCore/Term/CtxTerm.hs
@@ -88,14 +88,11 @@ ctxVar i = mkTermF (LocalVar i)
 
 -- | Build a list of all the free variables as 'Term's
 ctxVars :: MonadTerm m => [(LocalName, tp)] -> m [Term]
-ctxVars ctx_top =
-  helper ctx_top 0
-      where
-        helper :: MonadTerm m => [(LocalName, tp)] -> DeBruijnIndex -> m [Term]
-        helper [] _ = return []
-        helper vars_ctx i =
-          snoc <$> helper (init vars_ctx) (i + 1) <*> ctxVar i
-        snoc xs x = xs ++ [x]
+ctxVars = helper
+  where
+    helper :: MonadTerm m => [(LocalName, tp)] -> m [Term]
+    helper [] = pure []
+    helper (_ : ctx) = (:) <$> ctxVar (length ctx) <*> helper ctx
 
 -- | Build two lists of the free variables, split at a specific point
 ctxVars2 :: MonadTerm m => [(LocalName, tp)] ->

--- a/saw-core/src/SAWCore/Term/CtxTerm.hs
+++ b/saw-core/src/SAWCore/Term/CtxTerm.hs
@@ -4,53 +4,23 @@ Copyright   : Galois, Inc. 2018
 License     : BSD3
 Stability   : experimental
 Portability : non-portable (language extensions)
-
-The purpose of this module is to define a dependently-typed / GADT approach
-to representing SAW core terms, that reflects (to some degree) the typing
-and context information in the Haskell type of a term.
-
-Why are we doing this, when GADT programming can be so gross? The point of all
-this is to get all the deBruijn indices right. Doing deBruijn index math when
-manipulating open terms can be error prone and hard to read, and those bugs are
-really hard to track down. Although GADT programming can be a pain sometimes,
-this file is organized so at least you will always get the deBruijn indices
-right when you finally get GHC to accept your code. :)
 -}
 
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module SAWCore.Term.CtxTerm
   (
-    -- * Re-exports from "Data.Parameterized.Context"
-    -- | We use DataKinds to represent contexts of free variables at the type level.
-    -- These contexts are "inside-out", meaning that the most recently-bound
-    -- variable is listed on the outside. We reflect this by having that most
-    -- recently-bound variable to the right in '::>'.
-    Ctx(..), EmptyCtx, (::>), type (<+>)
     -- * Contexts and Bindings
-  , Typ
-  , CtxInvApp, CtxInv
-  , Bindings(..), bindingsLength, InvBindings(..)
+    Bindings(..), bindingsLength, InvBindings(..)
   , invAppendBindings, invertBindings
     -- * Terms in Context
-  , Arrows
   , CtxTerm(..), CtxTerms(..), CtxTermsCtx(..)
   , mkClosedTerm, mkClosedTyp, elimClosedTerm
   , ExistsTp(..), ctxBindingsOfTerms
@@ -71,13 +41,8 @@ module SAWCore.Term.CtxTerm
   , mkCtorArgStruct
   ) where
 
-import Data.Kind(Type)
-import Data.Proxy
-import Data.Type.Equality
 import Control.Monad
 import Control.Monad.Trans
-
-import Data.Parameterized.Context
 
 import SAWCore.Name
 import SAWCore.Recognizer
@@ -88,30 +53,11 @@ import SAWCore.Term.Functor
 -- * Contexts and Bindings
 --
 
--- | A representation of the type of SAW types as a Haskell type. This is
--- actually a singleton type, meaning that a 'CtxTerm' with type @'Typ' a@ is a
--- SAW type that is represented by Haskell type @a@. Of course, the Haskell type
--- system is not rich enough to capture SAW types in complete detail, but we do
--- our best, and capture at least the types and functions.
-data Typ (a :: Type)
-
 -- | An identifier for a datatype that is statically associated with Haskell
 -- type @d@. Again, we cannot capture all of the SAW type system in Haskell, so
 -- we simplify datatypes to arbitrary Haskell types.
-newtype DataIdent d = DataIdent Name
+newtype DataIdent = DataIdent Name
   -- Invariant, the type of datatypes is always a closed term
-
--- | Append a list of types to a context, i.e., "invert" the list of types,
--- putting the last type on the "outside", and append it. The way to think of
--- this operation is that we are already "inside" @ctx@, and we are moving
--- further "inside" of @as@, one type at a time, to yield a combined context
--- where the last type of @as@ is bound last, i.e., most recently.
-type family CtxInvApp ctx as where
-  CtxInvApp ctx '[] = ctx
-  CtxInvApp ctx (a ': as) = CtxInvApp (ctx ::> a) as
-
--- | Invert a type list to make a context
-type CtxInv as = CtxInvApp EmptyCtx as
 
 -- | A sequence of bindings of pairs of a variable name and a type of some form
 -- for that variable. These bindings are relative to ambient context @ctx@, use
@@ -122,77 +68,57 @@ type CtxInv as = CtxInvApp EmptyCtx as
 -- by a Haskell type @a@ in the 'Bind' constructor. There is no way to actually
 -- related the Haskell type @a@ to the type it "represents", so we do not try,
 -- and just write "represent" in quotes.
-data Bindings (tp :: Ctx Type -> Type -> Type) (ctx :: Ctx Type) (as :: [Type]) where
-  NoBind :: Bindings tp ctx '[]
-  Bind :: LocalName -> tp ctx (Typ a) -> Bindings tp (ctx ::> a) as ->
-          Bindings tp ctx (a ': as)
+data Bindings tp where
+  NoBind :: Bindings tp
+  Bind :: LocalName -> tp -> Bindings tp ->
+          Bindings tp
 
 -- | Compute the number of bindings in a bindings list
-bindingsLength :: Bindings tp ctx as -> Int
+bindingsLength :: Bindings tp -> Int
 bindingsLength NoBind = 0
 bindingsLength (Bind _ _ bs) = 1 + bindingsLength bs
 
 -- | An inverted list of bindings, seen from the "inside out"
-data InvBindings (tp :: Ctx Type -> Type -> Type) (ctx :: Ctx Type) (as :: Ctx Type) where
-  InvNoBind :: InvBindings tp ctx EmptyCtx
-  InvBind :: InvBindings tp ctx as -> LocalName -> tp (ctx <+> as) (Typ a) ->
-             InvBindings tp ctx (as ::> a)
+data InvBindings tp where
+  InvNoBind :: InvBindings tp
+  InvBind :: InvBindings tp -> LocalName -> tp -> InvBindings tp
 
 -- | Compute the number of bindings in an inverted bindings list
-invBindingsLength :: InvBindings tp ctx as -> Int
+invBindingsLength :: InvBindings tp -> Int
 invBindingsLength InvNoBind = 0
 invBindingsLength (InvBind bs _ _) = 1 + invBindingsLength bs
 
 -- | Map over all types in an inverted bindings list
-mapInvBindings :: (forall ctx a. f ctx a -> g ctx a) ->
-                  InvBindings f c1 c2 -> InvBindings g c1 c2
+mapInvBindings :: (f -> g) -> InvBindings f -> InvBindings g
 mapInvBindings _ InvNoBind = InvNoBind
 mapInvBindings f (InvBind ctx x tp) =
   InvBind (mapInvBindings f ctx) x (f tp)
 
--- | Typeclass for things from which we can build proofs that 'EmptyCtx' is the left
--- unit of '(<+>)', i.e., that @'EmptyCtx' '<+>' ctx ~ ctx@
-class CtxAppNilEq f where
-  ctxAppNilEq :: f ctx -> EmptyCtx <+> ctx :~: ctx
-
-instance CtxAppNilEq (InvBindings tp ctx') where
-  ctxAppNilEq InvNoBind = Refl
-  ctxAppNilEq (InvBind ctx _ _) =
-    case ctxAppNilEq ctx of
-      Refl -> Refl
-
-instance CtxAppNilEq (CtxTermsCtx ctx') where
-  ctxAppNilEq CtxTermsCtxNil = Refl
-  ctxAppNilEq (CtxTermsCtxCons ts _) =
-    case ctxAppNilEq ts of
-      Refl -> Refl
-
--- | Use 'ctxAppNilEq' to lift from @ctx@ to @'EmptyCtx' '<+>' ctx@
-ctxLiftNil :: InvBindings tp EmptyCtx ctx -> f ctx a -> f (EmptyCtx <+> ctx) a
-ctxLiftNil ctx f = case ctxAppNilEq ctx of Refl -> f
+ctxLiftNil :: InvBindings tp -> f -> f
+ctxLiftNil _ctx f = f
 
 -- | Append a 'Bindings' list to an inverted 'InvBindings' list, inverting the
 -- former as we go to yield an inverted 'InvBindings' list. Intuitively, this
 -- means we are already "inside" the inverted bindings lists, and we are moving
 -- further "inside" the regular bindings list; at the end we will be "inside"
 -- both, meaning that we will see the combination "from the inside".
-invAppendBindings :: InvBindings tp ctx as ->
-                     Bindings tp (ctx <+> as) bs ->
-                     InvBindings tp ctx (CtxInvApp as bs)
+invAppendBindings :: InvBindings tp ->
+                     Bindings tp ->
+                     InvBindings tp
 invAppendBindings as NoBind = as
 invAppendBindings as (Bind y y_tp bs) =
   (invAppendBindings (InvBind as y y_tp) bs)
 
 -- | Invert a 'Bindings' list; i.e., move "inside" those bindings
-invertBindings :: Bindings tp ctx as -> InvBindings tp ctx (CtxInv as)
+invertBindings :: Bindings tp -> InvBindings tp
 invertBindings = invAppendBindings InvNoBind
 
 -- | Append two inverted contexts, where the first one is top-level. This
 -- restriction allows us to avoid writing a proof of associativity of '(<+>)',
 -- and instead just using 'ctxAppNilEq'
-appendTopInvBindings :: InvBindings tp EmptyCtx ctx1 ->
-                        InvBindings tp ctx1 ctx2 ->
-                        InvBindings tp EmptyCtx (ctx1 <+> ctx2)
+appendTopInvBindings :: InvBindings tp ->
+                        InvBindings tp ->
+                        InvBindings tp
 appendTopInvBindings ctx1 InvNoBind = ctx1
 appendTopInvBindings ctx1 (InvBind ctx2 x tp) =
   let ret = appendTopInvBindings ctx1 ctx2 in
@@ -202,45 +128,39 @@ appendTopInvBindings ctx1 (InvBind ctx2 x tp) =
 -- * Terms In Context
 --
 
--- | Abstract a type list using Haskell arrows. This is done "outside-in", since
--- type-level lists represent bindings from the outside in.
-type family Arrows as b where
-  Arrows '[] b = b
-  Arrows (a ': as) b = a -> Arrows as b
-
 -- | A 'Term' with a given "type" relative to a given context. Since we cannot
 -- hope to represent dependent type theory in Haskell types anyway, these
 -- "types" are usually instantiated with a dummy, such as '()', but the code
 -- that consumes them cannot know that and has to be agnostic to what type it
 -- is.
-newtype CtxTerm (ctx :: Ctx Type) (a :: Type) = CtxTerm Term
+newtype CtxTerm = CtxTerm Term
 
 -- | Convert a 'CtxTerm' to an untyped term. This is "unsafe" because it throws
 -- away our typing information.
-unCtxTermUnsafe :: CtxTerm ctx a -> Term
+unCtxTermUnsafe :: CtxTerm -> Term
 unCtxTermUnsafe (CtxTerm t) = t
 
 -- | Because we cannot capture the SAW type system in Haskell, sometimes we have
 -- to cast our terms. We try not to use this very often, and we only allow
 -- casting the output type, not the context, since the latter could screw up our
 -- deBruijn indices.
-castCtxTerm :: Proxy a -> Proxy b -> CtxTerm ctx a -> CtxTerm ctx b
-castCtxTerm _ _ (CtxTerm t) = CtxTerm t
+castCtxTerm :: CtxTerm -> CtxTerm
+castCtxTerm (CtxTerm t) = CtxTerm t
 
 -- | Build a term in the empty context
-mkClosedTerm :: Term -> CtxTerm EmptyCtx a
+mkClosedTerm :: Term -> CtxTerm
 mkClosedTerm = CtxTerm
 
 -- | Build a term to represent a type in the empty context
-mkClosedTyp :: Term -> CtxTerm EmptyCtx (Typ a)
+mkClosedTyp :: Term -> CtxTerm
 mkClosedTyp = mkClosedTerm
 
 -- | Take a term out of the empty context
-elimClosedTerm :: CtxTerm EmptyCtx a -> Term
+elimClosedTerm :: CtxTerm -> Term
 elimClosedTerm (CtxTerm t) = t
 
 -- | Existentially quantify over the "type" of an object
-data ExistsTp tp ctx = forall a. ExistsTp (tp ctx a)
+data ExistsTp tp = ExistsTp tp
 
 -- | Build a 'Bindings' list from a list of variable names and types, assuming
 -- that each variable is free in the remaining types and that @ctx@ describes
@@ -250,7 +170,7 @@ data ExistsTp tp ctx = forall a. ExistsTp (tp ctx a)
 -- the Haskell type system is not powerful enough to represent all the SAW types
 -- anyway, and any code that consumes this 'Bindings' list cannot know that
 -- anyway. See also the comments for 'CtxTerm'.
-ctxBindingsOfTerms :: [(LocalName, Term)] -> ExistsTp (Bindings CtxTerm) ctx
+ctxBindingsOfTerms :: [(LocalName, Term)] -> ExistsTp (Bindings CtxTerm)
 ctxBindingsOfTerms [] = ExistsTp NoBind
 ctxBindingsOfTerms ((x,tp):ctx) =
   case ctxBindingsOfTerms ctx of
@@ -260,40 +180,39 @@ ctxBindingsOfTerms ((x,tp):ctx) =
 data CtxUnit ctx a = CtxUnit
 
 -- | An 'Either' type relative to a context and type
-newtype CtxEither f g ctx a = CtxEither (Either (f ctx a) (g ctx a))
+newtype CtxEither f g = CtxEither (Either f g)
 
 -- | A list of terms in a given context
-data CtxTerms ctx as where
-  CtxTermsNil :: CtxTerms ctx '[]
-  CtxTermsCons :: CtxTerm ctx a -> CtxTerms ctx as -> CtxTerms ctx (a ': as)
+data CtxTerms where
+  CtxTermsNil :: CtxTerms
+  CtxTermsCons :: CtxTerm -> CtxTerms -> CtxTerms
 
 -- | A list of terms in a given context, stored "inside-out"
-data CtxTermsCtx ctx term_ctx where
-  CtxTermsCtxNil :: CtxTermsCtx ctx EmptyCtx
-  CtxTermsCtxCons :: CtxTermsCtx ctx as -> CtxTerm ctx a ->
-                     CtxTermsCtx ctx (as ::> a)
+data CtxTermsCtx where
+  CtxTermsCtxNil :: CtxTermsCtx
+  CtxTermsCtxCons :: CtxTermsCtx -> CtxTerm -> CtxTermsCtx
 
 {-
 -- | Get the head and tail of a non-empty 'CtxTerms' list
-ctxTermsHeadTail :: CtxTerms ctx (a ': as) -> (CtxTerm ctx a, CtxTerms ctx as)
+ctxTermsHeadTail :: CtxTerms -> (CtxTerm, CtxTerms)
 ctxTermsHeadTail (CtxTermsCons a as) = (a, as)
 -}
 
 -- | Get the head and tail of a non-empty 'CtxTermsCtx' list
-ctxTermsCtxHeadTail :: CtxTermsCtx ctx (as ::> a) ->
-                       (CtxTermsCtx ctx as, CtxTerm ctx a)
+ctxTermsCtxHeadTail :: CtxTermsCtx -> (CtxTermsCtx, CtxTerm)
 ctxTermsCtxHeadTail (CtxTermsCtxCons as a) = (as, a)
+ctxTermsCtxHeadTail CtxTermsCtxNil = error "ctxTermCtxHeadTail: unexpected CtxTermsCtxNil"
 
 -- | Convert a typed list of terms to a list of untyped terms; this is "unsafe"
 -- because it throws away our typing information
-ctxTermsToListUnsafe :: CtxTerms ctx as -> [Term]
+ctxTermsToListUnsafe :: CtxTerms -> [Term]
 ctxTermsToListUnsafe CtxTermsNil = []
 ctxTermsToListUnsafe (CtxTermsCons (CtxTerm t) ts) =
   t : ctxTermsToListUnsafe ts
 
 -- | Convert a typed list of terms to a list of untyped terms; this is "unsafe"
 -- because it throws away our typing information
-ctxTermsCtxToListUnsafe :: CtxTermsCtx ctx as -> [Term]
+ctxTermsCtxToListUnsafe :: CtxTermsCtx -> [Term]
 ctxTermsCtxToListUnsafe CtxTermsCtxNil = []
 ctxTermsCtxToListUnsafe (CtxTermsCtxCons ts (CtxTerm t)) =
   ctxTermsCtxToListUnsafe ts ++ [t]
@@ -301,8 +220,7 @@ ctxTermsCtxToListUnsafe (CtxTermsCtxCons ts (CtxTerm t)) =
 -- | Like 'ctxTermsForBindings' but can return a 'CtxTerms' in an arbitrary
 -- context. We consider this "unsafe" because it associates an arbitrary context
 -- with these terms, and so we do not export this function.
-ctxTermsForBindingsOpen :: Bindings tp ctx_in as -> [Term] ->
-                           Maybe (CtxTerms ctx as)
+ctxTermsForBindingsOpen :: Bindings tp -> [Term] -> Maybe CtxTerms
 ctxTermsForBindingsOpen NoBind [] = Just CtxTermsNil
 ctxTermsForBindingsOpen (Bind _ _ bs) (t : ts) =
   CtxTermsCons (CtxTerm t) <$> ctxTermsForBindingsOpen bs ts
@@ -312,7 +230,7 @@ ctxTermsForBindingsOpen _ _ = Nothing
 -- returning a structured 'CtxTerms' list. Note that the bindings themselves can
 -- be in an arbitrary context, but the terms passed in are assumed to be closed,
 -- i.e., in the empty context.
-ctxTermsForBindings :: Bindings tp ctx as -> [Term] -> Maybe (CtxTerms EmptyCtx as)
+ctxTermsForBindings :: Bindings tp -> [Term] -> Maybe CtxTerms
 ctxTermsForBindings NoBind [] = Just CtxTermsNil
 ctxTermsForBindings (Bind _ _ bs) (t : ts) =
   CtxTermsCons (mkClosedTerm t) <$> ctxTermsForBindings bs ts
@@ -320,24 +238,23 @@ ctxTermsForBindings _ _ = Nothing
 
 -- | Invert a 'CtxTerms' list and append it to an already-inverted 'CtxTermsCtx'
 -- list
-invertAppendCtxTerms :: CtxTermsCtx ctx as -> CtxTerms ctx bs ->
-                        CtxTermsCtx ctx (CtxInvApp as bs)
+invertAppendCtxTerms :: CtxTermsCtx -> CtxTerms -> CtxTermsCtx
 invertAppendCtxTerms as CtxTermsNil = as
 invertAppendCtxTerms as (CtxTermsCons b bs) =
   invertAppendCtxTerms (CtxTermsCtxCons as b) bs
 
 -- | Invert a 'CtxTerms' list
-invertCtxTerms :: CtxTerms ctx as -> CtxTermsCtx ctx (CtxInv as)
+invertCtxTerms :: CtxTerms -> CtxTermsCtx
 invertCtxTerms = invertAppendCtxTerms CtxTermsCtxNil
 
-splitCtxTermsCtx :: InvBindings tp any_ctx ctx2 ->
-                    CtxTermsCtx ctx (ctx1 <+> ctx2) ->
-                    (CtxTermsCtx ctx ctx1, CtxTermsCtx ctx ctx2)
+splitCtxTermsCtx :: InvBindings tp ->
+                    CtxTermsCtx ->
+                    (CtxTermsCtx, CtxTermsCtx)
 splitCtxTermsCtx InvNoBind terms = (terms, CtxTermsCtxNil)
 splitCtxTermsCtx (InvBind ctx _ _) (CtxTermsCtxCons ts t) =
   let (ts1, ts2) = splitCtxTermsCtx ctx ts in
   (ts1, CtxTermsCtxCons ts2 t)
-
+splitCtxTermsCtx _ _ = error "splitCtxTermsCtx: impossible"
 
 --
 -- * Operations on Terms-in-Context
@@ -363,22 +280,18 @@ mkFlatTermF :: MonadTerm m => FlatTermF Term -> m Term
 mkFlatTermF = mkTermF . FTermF
 
 -- | Build a free variable as a 'CtxTerm'
-ctxVar :: MonadTerm m => Bindings tp (ctx1 ::> a) ctx2 ->
-          m (CtxTerm (CtxInvApp (ctx1 ::> a) ctx2) a)
+ctxVar :: MonadTerm m => Bindings tp -> m CtxTerm
 ctxVar ctx = CtxTerm <$> mkTermF (LocalVar $ bindingsLength ctx)
 
 -- | Build a list of all the free variables as 'CtxTerm's
 --
 -- FIXME: there should be a nicer way to do this that does not require
 -- ctxAppNilEq
-ctxVars :: MonadTerm m => InvBindings tp EmptyCtx ctx -> m (CtxTermsCtx ctx ctx)
+ctxVars :: MonadTerm m => InvBindings tp -> m CtxTermsCtx
 ctxVars ctx_top =
-  case ctxAppNilEq ctx_top of
-    Refl -> helper ctx_top NoBind
+  helper ctx_top NoBind
       where
-        helper :: MonadTerm m => InvBindings tp EmptyCtx ctx ->
-                  Bindings tp (EmptyCtx <+> ctx) as ->
-                  m (CtxTermsCtx (CtxInvApp (EmptyCtx <+> ctx) as) ctx)
+        helper :: MonadTerm m => InvBindings tp -> Bindings tp -> m CtxTermsCtx
         helper InvNoBind _ = return CtxTermsCtxNil
         helper (InvBind vars_ctx x tp) ctx =
           CtxTermsCtxCons <$> helper vars_ctx (Bind x tp ctx) <*> ctxVar ctx
@@ -388,60 +301,49 @@ ctxVars ctx_top =
 -- FIXME: there should be a nicer way to do this that does not require
 -- splitCtxTermsCtx and appendTopInvBindings (the latter of which requires
 -- ctxAppNilEq)
-ctxVars2 :: MonadTerm m => InvBindings tp EmptyCtx ctx1 ->
-            InvBindings tp ctx1 ctx2 ->
-            m (CtxTermsCtx (ctx1 <+> ctx2) ctx1,
-               CtxTermsCtx (ctx1 <+> ctx2) ctx2)
+ctxVars2 :: MonadTerm m => InvBindings tp ->
+            InvBindings tp ->
+            m (CtxTermsCtx, CtxTermsCtx)
 ctxVars2 vars1 vars2 =
   splitCtxTermsCtx vars2 <$> ctxVars (appendTopInvBindings vars1 vars2)
 
 -- | Build a 'CtxTerm' for a 'Sort'
-ctxSort :: MonadTerm m => Sort -> m (CtxTerm ctx (Typ a))
+ctxSort :: MonadTerm m => Sort -> m CtxTerm
 ctxSort s = CtxTerm <$> mkFlatTermF (Sort s noFlags)
 
 -- | Apply two 'CtxTerm's
-ctxApply :: MonadTerm m => m (CtxTerm ctx (a -> b)) -> m (CtxTerm ctx a) ->
-            m (CtxTerm ctx b)
+ctxApply :: MonadTerm m => m CtxTerm -> m CtxTerm -> m CtxTerm
 ctxApply fm argm =
   do CtxTerm f <- fm
      CtxTerm arg <- argm
      CtxTerm <$> mkTermF (App f arg)
 
--- | Apply two 'CtxTerm's, using a 'Proxy' to tell GHC the types
-ctxApplyProxy :: MonadTerm m => Proxy a -> Proxy b ->
-                 m (CtxTerm ctx (a -> b)) -> m (CtxTerm ctx a) ->
-                 m (CtxTerm ctx b)
-ctxApplyProxy _ _ = ctxApply
-
 -- | Apply a 'CtxTerm' to a list of arguments
 ctxApplyMulti :: MonadTerm m =>
-                 m (CtxTerm ctx (Arrows as b)) ->
-                 m (CtxTerms ctx as) ->
-                 m (CtxTerm ctx b)
+                 m CtxTerm ->
+                 m CtxTerms ->
+                 m CtxTerm
 ctxApplyMulti fm argsm =
   fm >>= \f -> argsm >>= \args -> helper f args
   where
-    helper :: MonadTerm m => CtxTerm ctx (Arrows as b) ->
-              CtxTerms ctx as -> m (CtxTerm ctx b)
+    helper :: MonadTerm m => CtxTerm -> CtxTerms -> m CtxTerm
     helper f CtxTermsNil = return f
     helper f (CtxTermsCons arg args) =
       do f' <- ctxApply (return f) (return arg)
          helper f' args
 
 -- | Form a lambda-abstraction as a 'CtxTerm'
-ctxLambda1 :: MonadTerm m => LocalName -> CtxTerm ctx (Typ a) ->
-              (CtxTerm (ctx ::> a) a -> m (CtxTerm (ctx ::> a) b)) ->
-              m (CtxTerm ctx (a -> b))
+ctxLambda1 :: MonadTerm m => LocalName -> CtxTerm ->
+              (CtxTerm -> m CtxTerm) ->
+              m CtxTerm
 ctxLambda1 x (CtxTerm tp) body_f =
   do var <- ctxVar NoBind
      CtxTerm body <- body_f var
      CtxTerm <$> mkTermF (Lambda x tp body)
 
 -- | Form a multi-arity lambda-abstraction as a 'CtxTerm'
-ctxLambda :: MonadTerm m => Bindings CtxTerm ctx as ->
-             (CtxTerms (CtxInvApp ctx as) as ->
-              m (CtxTerm (CtxInvApp ctx as) a)) ->
-             m (CtxTerm ctx (Arrows as a))
+ctxLambda :: MonadTerm m => Bindings CtxTerm ->
+             (CtxTerms -> m CtxTerm) -> m CtxTerm
 ctxLambda NoBind body_f = body_f CtxTermsNil
 ctxLambda (Bind x tp xs) body_f =
   ctxLambda1 x tp $ \_ ->
@@ -450,20 +352,16 @@ ctxLambda (Bind x tp xs) body_f =
      body_f (CtxTermsCons var vars)
 
 -- | Form a pi-abstraction as a 'CtxTerm'
-ctxPi1 :: MonadTerm m => LocalName -> CtxTerm ctx (Typ a) ->
-          (CtxTerm (ctx ::> a) a ->
-           m (CtxTerm (ctx ::> a) (Typ b))) ->
-          m (CtxTerm ctx (Typ (a -> b)))
+ctxPi1 :: MonadTerm m => LocalName -> CtxTerm ->
+          (CtxTerm -> m CtxTerm) -> m CtxTerm
 ctxPi1 x (CtxTerm tp) body_f =
   do var <- ctxVar NoBind
      CtxTerm body <- body_f var
      CtxTerm <$> mkTermF (Pi x tp body)
 
 -- | Form a multi-arity pi-abstraction as a 'CtxTerm'
-ctxPi :: MonadTerm m => Bindings CtxTerm ctx as ->
-         (CtxTerms (CtxInvApp ctx as) as ->
-          m (CtxTerm (CtxInvApp ctx as) (Typ b))) ->
-         m (CtxTerm ctx (Typ (Arrows as b)))
+ctxPi :: MonadTerm m => Bindings CtxTerm ->
+         (CtxTerms -> m CtxTerm) -> m CtxTerm
 ctxPi NoBind body_f = body_f CtxTermsNil
 ctxPi (Bind x tp xs) body_f =
   ctxPi1 x tp $ \_ ->
@@ -471,36 +369,26 @@ ctxPi (Bind x tp xs) body_f =
   do var <- ctxVar xs
      body_f (CtxTermsCons var vars)
 
--- | Form a multi-arity pi-abstraction as a 'CtxTerm', using a 'Proxy' to tell
--- stupid GHC what the result type should be
-ctxPiProxy :: MonadTerm m => Proxy (Typ b) -> Bindings CtxTerm ctx as ->
-              (CtxTerms (CtxInvApp ctx as) as ->
-               m (CtxTerm (CtxInvApp ctx as) (Typ b))) ->
-              m (CtxTerm ctx (Typ (Arrows as b)))
-ctxPiProxy _ = ctxPi
-
 -- | Existential return type of 'ctxAsPi'
-data CtxPi ctx =
-  forall b c.
-  CtxPi LocalName (CtxTerm ctx (Typ b)) (CtxTerm (ctx ::> b) (Typ c))
+data CtxPi =
+  CtxPi LocalName CtxTerm CtxTerm
 
 -- | Test if a 'CtxTerm' is a pi-abstraction, returning its components if so.
 -- Note that we are not returning any equality constraints on the input type,
 -- @a@; i.e., if a term is a pi-abstraction, one would expect @a@ to have the
 -- form @b -> c@, but this would require a /lot/ more work...
-ctxAsPi :: CtxTerm ctx (Typ a) -> Maybe (CtxPi ctx)
+ctxAsPi :: CtxTerm -> Maybe CtxPi
 ctxAsPi (CtxTerm (unwrapTermF -> Pi x tp body)) =
   Just (CtxPi x (CtxTerm tp) (CtxTerm body))
 ctxAsPi _ = Nothing
 
 -- | Existential return type of 'ctxAsPiMulti'
-data CtxMultiPi ctx =
-  forall as b.
-  CtxMultiPi (Bindings CtxTerm ctx as) (CtxTerm (CtxInvApp ctx as) (Typ b))
+data CtxMultiPi =
+  CtxMultiPi (Bindings CtxTerm) CtxTerm
 
 -- | Repeatedly apply 'ctxAsPi', returning the 'Bindings' list of 0 or more
 -- pi-abstraction bindings in the given term
-ctxAsPiMulti :: CtxTerm ctx (Typ a) -> CtxMultiPi ctx
+ctxAsPiMulti :: CtxTerm -> CtxMultiPi
 ctxAsPiMulti (ctxAsPi -> Just (CtxPi x tp body)) =
   case ctxAsPiMulti body of
     CtxMultiPi as body' -> CtxMultiPi (Bind x tp as) body'
@@ -508,24 +396,23 @@ ctxAsPiMulti t = CtxMultiPi NoBind t
 
 -- | Build an application of a datatype as a 'CtxTerm'
 ctxDataTypeM ::
-  forall m d ctx params ixs.
+  forall m.
   MonadTerm m =>
-  DataIdent d ->
-  m (CtxTermsCtx ctx params) ->
-  m (CtxTermsCtx ctx ixs) ->
-  m (CtxTerm ctx (Typ d))
+  DataIdent ->
+  m CtxTermsCtx ->
+  m CtxTermsCtx ->
+  m CtxTerm
 ctxDataTypeM (DataIdent d) paramsM ixsM =
   ctxApplyMultiInv (ctxApplyMultiInv t paramsM) ixsM
   where
-    t :: m (CtxTerm ctx (InvArrows params (InvArrows ixs (Typ d))))
+    t :: m CtxTerm
     t = CtxTerm <$> mkTermF (Constant d)
 
 -- | Test if a 'CtxTerm' is an application of a specific datatype with the
 -- supplied context of parameters and indices
-ctxAsDataTypeApp :: DataIdent d -> Bindings tp1 EmptyCtx params ->
-                    Bindings tp2 (CtxInv params) ixs ->
-                    CtxTerm ctx (Typ a) ->
-                    Maybe (CtxTerms ctx params, CtxTerms ctx ixs)
+ctxAsDataTypeApp :: DataIdent -> Bindings tp1 ->
+                    Bindings tp2 -> CtxTerm ->
+                    Maybe (CtxTerms, CtxTerms)
 ctxAsDataTypeApp (DataIdent d) params ixs (CtxTerm t) =
   do let (f, args) = asApplyAll t
      d' <- asConstant f
@@ -539,49 +426,40 @@ ctxAsDataTypeApp (DataIdent d) params ixs (CtxTerm t) =
 
 -- | Build an application of a constructor as a 'CtxTerm'
 ctxCtorAppM ::
-  forall m d ctx params args.
+  forall m.
   MonadTerm m =>
-  DataIdent d ->
+  DataIdent ->
   ExtCns Term ->
-  m (CtxTermsCtx ctx params) ->
-  m (CtxTermsCtx ctx args) ->
-  m (CtxTerm ctx d)
+  m CtxTermsCtx ->
+  m CtxTermsCtx ->
+  m CtxTerm
 ctxCtorAppM _d c paramsM argsM =
   ctxApplyMultiInv (ctxApplyMultiInv t paramsM) argsM
   where
-    t :: m (CtxTerm ctx (InvArrows params (InvArrows args d)))
+    t :: m CtxTerm
     t = CtxTerm <$> mkTermF (Constant (Name (ecVarIndex c) (ecName c)))
-
--- | Abstract an inside-out type list using Haskell arrows. Used only
--- to define 'ctxDataTypeM' and 'ctxCtorAppM'.
-type family InvArrows as b where
-  InvArrows EmptyCtx b = b
-  InvArrows (as ::> a) b = InvArrows as (a -> b)
 
 -- | Apply a 'CtxTerm' to an inside-out list of arguments. Used only
 -- to define 'ctxDataTypeM' and 'ctxCtorAppM`.
 ctxApplyMultiInv ::
   MonadTerm m =>
-  m (CtxTerm ctx (InvArrows as b)) ->
-  m (CtxTermsCtx ctx as) ->
-  m (CtxTerm ctx b)
+  m CtxTerm ->
+  m CtxTermsCtx ->
+  m CtxTerm
 ctxApplyMultiInv fm argsm =
   do f <- fm
      args <- argsm
      helper f args
   where
-    helper :: MonadTerm m => CtxTerm ctx (InvArrows as b) ->
-              CtxTermsCtx ctx as -> m (CtxTerm ctx b)
+    helper :: MonadTerm m => CtxTerm -> CtxTermsCtx -> m CtxTerm
     helper f CtxTermsCtxNil = pure f
     helper f (CtxTermsCtxCons args arg) = ctxApply (helper f args) (pure arg)
 
-data Rec d
-
 ctxRecursorAppM :: MonadTerm m =>
-  m (CtxTerm ctx (Rec d)) ->
-  m (CtxTermsCtx ctx ixs) ->
-  m (CtxTerm ctx d) ->
-  m (CtxTerm ctx a)
+  m CtxTerm ->
+  m CtxTermsCtx ->
+  m CtxTerm ->
+  m CtxTerm
 ctxRecursorAppM recM ixsM argM =
   do app <- RecursorApp <$>
               (unCtxTermUnsafe <$> recM) <*>
@@ -596,49 +474,40 @@ ctxRecursorAppM recM ixsM argM =
 -- | The class of "in-context" types that support lifting and substitution
 class Monad m => CtxLiftSubst f m where
   -- | Lift an @f@ into an extended context
-  ctxLift :: InvBindings tp1 ctx ctx' -> Bindings tp2 ctx as ->
-             f (ctx <+> ctx') a ->
-             m (f (CtxInvApp ctx as <+> ctx') a)
+  ctxLift :: InvBindings tp1 -> Bindings tp2 -> f -> m f
   -- | Substitute a list of terms into an @f@
-  ctxSubst :: CtxTermsCtx ctx1 subst ->
-              InvBindings tp (ctx1 <+> subst) ctx2 ->
-              f ((ctx1 <+> subst) <+> ctx2) a ->
-              m (f (ctx1 <+> ctx2) a)
+  ctxSubst :: CtxTermsCtx -> InvBindings tp -> f -> m f
 
 -- | Lift an @f@ into a context extended with one type
-ctxLift1 :: CtxLiftSubst f m => f ctx b -> m (f (ctx ::> a) b)
+ctxLift1 :: CtxLiftSubst f m => f -> m f
 ctxLift1 = ctxLift InvNoBind (Bind "_" CtxUnit NoBind)
 
 -- | Lift an @f@ that is in an extended list of 'Bindings'
-ctxLiftInBindings :: CtxLiftSubst f m => InvBindings tp1 ctx ctx1 ->
-                     Bindings tp2 (ctx <+> ctx1) ctx2 ->
-                     Bindings tp3 ctx as ->
-                     f (CtxInvApp (ctx <+> ctx1) ctx2) a ->
-                     m (f (CtxInvApp (CtxInvApp ctx as <+> ctx1) ctx2) a)
+ctxLiftInBindings :: CtxLiftSubst f m => InvBindings tp1 ->
+                     Bindings tp2 ->
+                     Bindings tp3 ->
+                     f -> m f
 ctxLiftInBindings = helper . mapInvBindings (CtxEither . Left)
   where
-    helper :: CtxLiftSubst f m => InvBindings (CtxEither tp1 tp2) ctx ctx1 ->
-              Bindings tp2 (ctx <+> ctx1) ctx2 ->
-              Bindings tp3 ctx as ->
-              f (CtxInvApp (ctx <+> ctx1) ctx2) a ->
-              m (f (CtxInvApp (CtxInvApp ctx as <+> ctx1) ctx2) a)
+    helper :: CtxLiftSubst f m => InvBindings (CtxEither tp1 tp2) ->
+              Bindings tp2 ->
+              Bindings tp3 ->
+              f -> m f
     helper ctx1 NoBind as = ctxLift ctx1 as
     helper ctx1 (Bind str tp ctx2) as =
       helper (InvBind ctx1 str (CtxEither $ Right tp)) ctx2 as
 
 -- | Substitute into an @f@ that is in an extended list of 'Bindings'
-ctxSubstInBindings :: CtxLiftSubst f m => CtxTermsCtx ctx1 subst ->
-                      InvBindings tp1 (ctx1 <+> subst) ctx2 ->
-                      Bindings tp2 ((ctx1 <+> subst) <+> ctx2) ctx3 ->
-                      f (CtxInvApp ((ctx1 <+> subst) <+> ctx2) ctx3) a ->
-                      m (f (CtxInvApp (ctx1 <+> ctx2) ctx3) a)
+ctxSubstInBindings :: CtxLiftSubst f m => CtxTermsCtx ->
+                      InvBindings tp1 ->
+                      Bindings tp2 ->
+                      f -> m f
 ctxSubstInBindings subst =
   helper subst . mapInvBindings (CtxEither . Left) where
-  helper :: CtxLiftSubst f m => CtxTermsCtx ctx1 s ->
-            InvBindings (CtxEither tp1 tp2) (ctx1 <+> s) ctx2 ->
-            Bindings tp2 ((ctx1 <+> s) <+> ctx2) ctx3 ->
-            f (CtxInvApp ((ctx1 <+> s) <+> ctx2) ctx3) a ->
-            m (f (CtxInvApp (ctx1 <+> ctx2) ctx3) a)
+  helper :: CtxLiftSubst f m => CtxTermsCtx ->
+            InvBindings (CtxEither tp1 tp2) ->
+            Bindings tp2 ->
+            f -> m f
   helper s ctx2 NoBind f = ctxSubst s ctx2 f
   helper s ctx2 (Bind x tp ctx3) f =
     helper s (InvBind ctx2 x (CtxEither $ Right tp)) ctx3 f
@@ -681,7 +550,7 @@ instance CtxLiftSubst tp m => CtxLiftSubst (Bindings tp) m where
     Bind x <$> ctxSubst subst ctx x_tp <*>
     ctxSubst subst (InvBind ctx x (error "Unused")) bs
 
-instance MonadTerm m => CtxLiftSubst (CtorArg d ixs) m where
+instance MonadTerm m => CtxLiftSubst CtorArg m where
   ctxLift ctx1 ctx2 (ConstArg tp) = ConstArg <$> ctxLift ctx1 ctx2 tp
   ctxLift ctx1 ctx2 (RecursiveArg zs ixs) =
     RecursiveArg <$> ctxLift ctx1 ctx2 zs <*>
@@ -692,8 +561,7 @@ instance MonadTerm m => CtxLiftSubst (CtorArg d ixs) m where
     ctxSubstInBindings subst ctx zs ixs
 
 -- | Make a closed term and then lift it into a context
-mkLiftedClosedTerm :: MonadTerm m => Bindings tp EmptyCtx as -> Term ->
-                      m (CtxTerm (CtxInv as) a)
+mkLiftedClosedTerm :: MonadTerm m => Bindings tp -> Term -> m CtxTerm
 mkLiftedClosedTerm inners t = ctxLift InvNoBind inners $ mkClosedTerm t
 
 
@@ -704,9 +572,9 @@ mkLiftedClosedTerm inners t = ctxLift InvNoBind inners $ mkClosedTerm t
 -- | A specification of the type of an argument for a constructor of datatype
 -- @d@, that has a specified list @ixs@ of indices, inside a context @ctx@ of
 -- parameters and earlier arguments
-data CtorArg d ixs ctx a where
+data CtorArg where
   -- | A fixed, constant type
-  ConstArg :: CtxTerm ctx (Typ a) -> CtorArg d ixs ctx (Typ a)
+  ConstArg :: CtxTerm -> CtorArg
   -- | The construct @'RecursiveArg [(z1,tp1),..,(zn,tpn)] [e1,..,ek]'@
   -- specifies a recursive argument type of the form
   --
@@ -717,30 +585,29 @@ data CtorArg d ixs ctx a where
   -- parameters of @d@ (not given here), and the @ei@ are the type indices of
   -- @d@.
   RecursiveArg ::
-    Bindings CtxTerm ctx zs ->
-    CtxTerms (CtxInvApp ctx zs) ixs ->
-    CtorArg d ixs ctx (Typ (Arrows zs d))
+    Bindings CtxTerm ->
+    CtxTerms ->
+    CtorArg
 
 -- | A structure that defines the parameters, arguments, and return type indices
 -- of a constructor, using 'CtxTerm' and friends to get the bindings right
-data CtorArgStruct d params ixs =
-  forall args.
+data CtorArgStruct =
   CtorArgStruct
   {
-    ctorParams :: Bindings CtxTerm EmptyCtx params,
-    ctorArgs :: Bindings (CtorArg d ixs) (CtxInv params) args,
-    ctorIndices :: CtxTerms (CtxInvApp (CtxInv params) args) ixs,
-    dataTypeIndices :: Bindings CtxTerm (CtxInv params) ixs
+    ctorParams :: Bindings CtxTerm,
+    ctorArgs :: Bindings CtorArg,
+    ctorIndices :: CtxTerms,
+    dataTypeIndices :: Bindings CtxTerm
   }
 
 
 -- | Convert a 'CtorArg' into the type that it represents, given a context of
 -- the parameters and of the previous arguments
-ctxCtorArgType :: MonadTerm m => DataIdent d ->
-                  InvBindings CtxTerm EmptyCtx params ->
-                  InvBindings CtxTerm params prevs ->
-                  CtorArg d ixs (params <+> prevs) a ->
-                  m (CtxTerm (params <+> prevs) a)
+ctxCtorArgType :: MonadTerm m => DataIdent ->
+                  InvBindings CtxTerm ->
+                  InvBindings CtxTerm ->
+                  CtorArg ->
+                  m CtxTerm
 ctxCtorArgType _ _ _ (ConstArg tp) = return tp
 ctxCtorArgType d params prevs (RecursiveArg zs_ctx ixs) =
   ctxPi zs_ctx $ \_ ->
@@ -748,11 +615,11 @@ ctxCtorArgType d params prevs (RecursiveArg zs_ctx ixs) =
   (return $ invertCtxTerms ixs)
 
 -- | Convert a bindings list of 'CtorArg's to a binding list of types
-ctxCtorArgBindings :: MonadTerm m => DataIdent d ->
-                      InvBindings CtxTerm EmptyCtx params ->
-                      InvBindings CtxTerm params prevs ->
-                      Bindings (CtorArg d ixs) (params <+> prevs) args ->
-                      m (Bindings CtxTerm (params <+> prevs) args)
+ctxCtorArgBindings :: MonadTerm m => DataIdent ->
+                      InvBindings CtxTerm ->
+                      InvBindings CtxTerm ->
+                      Bindings CtorArg ->
+                      m (Bindings CtxTerm)
 ctxCtorArgBindings _ _ _ NoBind = return NoBind
 ctxCtorArgBindings d params prevs (Bind x arg args) =
   do tp <- ctxCtorArgType d params prevs arg
@@ -761,7 +628,7 @@ ctxCtorArgBindings d params prevs (Bind x arg args) =
 
 -- | Compute the type of a constructor from the name of its datatype and its
 -- 'CtorArgStruct'
-ctxCtorType :: MonadTerm m => Name -> CtorArgStruct d params ixs -> m Term
+ctxCtorType :: MonadTerm m => Name -> CtorArgStruct -> m Term
 ctxCtorType d (CtorArgStruct{..}) =
   elimClosedTerm <$>
   (ctxPi ctorParams $ \params ->
@@ -785,12 +652,12 @@ ctxCtorType d (CtorArgStruct{..}) =
 --
 -- where the @pi@ are free variables for the parameters of @d@, the @ixj@
 -- are the indices of @d@, and @s@ is any sort supplied as an argument.
-ctxPRetTp :: MonadTerm m => Proxy (Typ a) -> DataIdent d ->
-             InvBindings CtxTerm EmptyCtx ps ->
-             Bindings CtxTerm ps ixs -> Sort ->
-             m (CtxTerm ps (Typ (Arrows ixs (d -> Typ a))))
-ctxPRetTp (_ :: Proxy (Typ a)) (d :: DataIdent d) params ixs s =
-  ctxPiProxy (Proxy :: Proxy (Typ (d -> Typ a))) ixs $ \ix_vars ->
+ctxPRetTp :: MonadTerm m => DataIdent ->
+             InvBindings CtxTerm ->
+             Bindings CtxTerm -> Sort ->
+             m CtxTerm
+ctxPRetTp (d :: DataIdent) params ixs s =
+  ctxPi ixs $ \ix_vars ->
   do param_vars <- ctxVars params
      dt <- ctxDataTypeM d (ctxLift InvNoBind ixs param_vars)
        (return $ invertCtxTerms ix_vars)
@@ -811,7 +678,7 @@ mkPRetTp d untyped_p_ctx untyped_ix_ctx untyped_params s =
       case (ctxBindingsOfTerms untyped_ix_ctx,
             ctxTermsForBindings p_ctx untyped_params) of
         (ExistsTp ix_ctx, Just params) ->
-          do p_ret <- (ctxPRetTp Proxy (DataIdent d)
+          do p_ret <- (ctxPRetTp (DataIdent d)
                        (invertBindings p_ctx) ix_ctx s)
              elimClosedTerm <$>
                ctxSubst (invertCtxTerms params) InvNoBind
@@ -819,11 +686,8 @@ mkPRetTp d untyped_p_ctx untyped_ix_ctx untyped_params s =
         (_, Nothing) ->
           error "mkPRetTp: incorrect number of parameters"
   where
-    castPRet :: InvBindings tp ctx1 ctx -> CtxTerm ctx a ->
-                CtxTerm (EmptyCtx <+> ctx) a
-    castPRet ctx =
-      case ctxAppNilEq ctx of
-        Refl -> id
+    castPRet :: InvBindings tp -> CtxTerm -> CtxTerm
+    castPRet _ctx = id
 
 
 -- | Compute the type of an eliminator function for a constructor from the name
@@ -850,19 +714,17 @@ mkPRetTp d untyped_p_ctx untyped_ix_ctx untyped_params s =
 -- since it depends on fields of the 'CtorArgStruct', so, instead, the result is
 -- just casted to whatever type the caller specifies.
 ctxCtorElimType :: MonadTerm m =>
-  Proxy (Typ ret) ->
-  Proxy (Typ a) ->
-  DataIdent d ->
+  DataIdent ->
   ExtCns Term ->
-  CtorArgStruct d params ixs ->
-  m (CtxTerm (CtxInv params ::>(Arrows ixs (d -> Typ a))) (Typ ret))
-ctxCtorElimType ret (a_top :: Proxy (Typ a)) (d_top :: DataIdent d) c
+  CtorArgStruct ->
+  m CtxTerm
+ctxCtorElimType (d_top :: DataIdent) c
   (CtorArgStruct{..}) =
   (do let params = invertBindings ctorParams
       -- NOTE: we use propSort for the type of p_ret just as arbitrary sort, but
       -- it doesn't matter because p_ret_tp is only actually used to form
       -- contexts, and is never actually used directly in the output
-      p_ret_tp <- ctxPRetTp a_top d_top params dataTypeIndices propSort
+      p_ret_tp <- ctxPRetTp d_top params dataTypeIndices propSort
 
       -- Lift the argument and return indices into the context of p_ret
       args <- ctxLift InvNoBind (Bind "_" p_ret_tp NoBind) ctorArgs
@@ -872,8 +734,8 @@ ctxCtorElimType ret (a_top :: Proxy (Typ a)) (d_top :: DataIdent d) c
       -- Form the context (params ::> p_ret)
       let params_pret = InvBind params "_" (ctxLiftNil params p_ret_tp)
       -- Call the helper and cast the result to (Typ ret)
-      castCtxTerm Proxy ret <$>
-        helper a_top d_top params_pret InvNoBind args ixs
+      castCtxTerm <$>
+        helper d_top params_pret InvNoBind args ixs
   ) where
 
   -- Iterate through the argument types of the constructor, building up a
@@ -882,25 +744,24 @@ ctxCtorElimType ret (a_top :: Proxy (Typ a)) (d_top :: DataIdent d) c
   -- a slightly richer type, but we are not going to try to compute this richer
   -- type in Haskell land.
   helper :: MonadTerm m =>
-    Proxy (Typ a) ->
-    DataIdent d ->
-    InvBindings CtxTerm EmptyCtx (ps ::> Arrows ixs (d -> Typ a)) ->
-    InvBindings CtxTerm (ps ::> Arrows ixs (d -> Typ a)) prevs ->
-    Bindings (CtorArg d ixs) ((ps ::> Arrows ixs (d -> Typ a)) <+> prevs) args ->
-    CtxTerms (CtxInvApp ((ps ::> Arrows ixs (d -> Typ a)) <+> prevs) args) ixs ->
-    m (CtxTerm ((ps ::> Arrows ixs (d -> Typ a)) <+> prevs) (Typ (Arrows args a)))
-  helper _a d params_pret prevs NoBind ret_ixs =
+    DataIdent ->
+    InvBindings CtxTerm ->
+    InvBindings CtxTerm ->
+    Bindings CtorArg ->
+    CtxTerms ->
+    m CtxTerm
+  helper d params_pret prevs NoBind ret_ixs =
     -- If we are finished with our arguments, construct the final result type
     -- (p_ret ret_ixs (c params prevs))
     do (vars, prev_vars) <- ctxVars2 params_pret prevs
        let (param_terms, p_ret) = ctxTermsCtxHeadTail vars
        ctxApply (ctxApplyMulti (return p_ret) (return ret_ixs)) $
          ctxCtorAppM d c (return param_terms) (return prev_vars)
-  helper a d params_pret prevs (Bind str (ConstArg tp) args) ixs =
+  helper d params_pret prevs (Bind str (ConstArg tp) args) ixs =
     -- For a constant argument type, just abstract it and continue
     (ctxPi (Bind str tp NoBind) $ \_ ->
-      helper a d params_pret (InvBind prevs str tp) args ixs)
-  helper (a :: Proxy (Typ a)) (d::DataIdent d) params_pret
+      helper d params_pret (InvBind prevs str tp) args ixs)
+  helper (d::DataIdent) params_pret
     prevs (Bind str (RecursiveArg zs ts) args) ixs =
     -- For a recursive argument type of the form
     --
@@ -928,10 +789,10 @@ ctxCtorElimType ret (a_top :: Proxy (Typ a)) (d_top :: DataIdent d) c
       -- Build the pi-abstraction for arg
       ctxPi1 str arg_tp $ \arg ->
         do rest <-
-             helper a d params_pret (InvBind prevs str arg_tp) args ixs
+             helper d params_pret (InvBind prevs str arg_tp) args ixs
            -- Build the type of ih, in the context of arg
            ih_tp <- ctxPi zs' $ \z_vars ->
-             ctxApplyProxy (Proxy :: Proxy d) (Proxy :: Proxy (Typ a))
+             ctxApply
              (ctxApplyMulti
               (ctxLift InvNoBind (Bind "_" arg_tp zs') p_ret) (return ts'))
              (ctxApplyMulti (ctxLift InvNoBind zs' arg) (return z_vars))
@@ -941,7 +802,7 @@ ctxCtorElimType ret (a_top :: Proxy (Typ a)) (d_top :: DataIdent d) c
            -- computed from the argument structure, and we cannot (well, we
            -- could, but it would be much more work to) express that computation
            -- in the Haskell type system
-           castCtxTerm Proxy Proxy <$>
+           castCtxTerm <$>
              (ctxPi1 "_" ih_tp $ \_ ->
                ctxLift InvNoBind (Bind "_" ih_tp NoBind) rest)
 
@@ -953,13 +814,11 @@ ctxCtorElimType ret (a_top :: Proxy (Typ a)) (d_top :: DataIdent d) c
 mkCtorElimTypeFun :: MonadTerm m =>
   Name {- ^ data type -} ->
   ExtCns Term {- ^ constructor type -} ->
-  CtorArgStruct d params ixs ->
+  CtorArgStruct ->
   m ([Term] -> Term -> m Term)
 mkCtorElimTypeFun d c argStruct@(CtorArgStruct {..}) =
-  do ctxElimType <- ctxCtorElimType Proxy Proxy (DataIdent d) c argStruct
-     case ctxAppNilEq (invertBindings ctorParams) of
-       Refl ->
-         return $ \params p_ret ->
+  do ctxElimType <- ctxCtorElimType (DataIdent d) c argStruct
+     return $ \params p_ret ->
          whnfTerm =<<
          case ctxTermsForBindings ctorParams params of
            Nothing -> error "ctorElimTypeFun: wrong number of parameters!"
@@ -995,15 +854,15 @@ mkCtorElimTypeFun d c argStruct@(CtorArgStruct {..}) =
 -- where @[xs/args]@ substitutes the concrete values for the earlier
 -- constructor arguments @xs@ for the remaining free variables.
 
-ctxReduceRecursor :: forall m d params ixs.
+ctxReduceRecursor :: forall m.
   MonadTerm m =>
   Term {- ^ abstracted recursor -} ->
   Term {- ^ constructor elimnator function -} ->
   [Term] {- ^ constructor arguments -} ->
-  CtorArgStruct d params ixs {- ^ constructor formal argument descriptor -} ->
+  CtorArgStruct {- ^ constructor formal argument descriptor -} ->
   m Term
 ctxReduceRecursor rec elimf c_args CtorArgStruct{..} =
-  let inctx :: Term -> CtxTerm (CtxInv params) tp
+  let inctx :: Term -> CtxTerm
       inctx = CtxTerm
    in
   case ctxTermsForBindingsOpen ctorArgs c_args of
@@ -1017,12 +876,12 @@ ctxReduceRecursor rec elimf c_args CtorArgStruct{..} =
 --   iota reduction for @ctxReduceRecursor@.  We assume
 --   the input terms we are given live in an ambient
 --   context @amb@.
-ctxReduceRecursor_ :: forall m amb d ixs elim args.
+ctxReduceRecursor_ :: forall m.
   MonadTerm m =>
-  CtxTerm  amb (Rec d) {- ^ recursor value eliminatiting data type d -}->
-  CtxTerm  amb elim    {- ^ eliminator function for the constructor -} ->
-  CtxTerms amb args    {- ^ constructor actual arguments -} ->
-  Bindings (CtorArg d ixs) amb args
+  CtxTerm     {- ^ recursor value eliminatiting data type d -}->
+  CtxTerm     {- ^ eliminator function for the constructor -} ->
+  CtxTerms    {- ^ constructor actual arguments -} ->
+  Bindings CtorArg
     {- ^ telescope describing the constructor arguments -} ->
   m Term
 ctxReduceRecursor_ rec fi args0 argCtx =
@@ -1031,13 +890,12 @@ ctxReduceRecursor_ rec fi args0 argCtx =
 
  where
    -- extract a raw term into the ambient context
-    unAmb :: forall tp. CtxTerm amb tp -> Term
+    unAmb :: CtxTerm -> Term
     unAmb (CtxTerm t) = t
 
-    mk_args :: forall ctx xs.
-               CtxTermsCtx amb ctx ->  -- already processed parameters/arguments
-               CtxTerms    amb xs ->   -- remaining actual arguments to process
-               Bindings (CtorArg d ixs) (amb<+>ctx) xs ->
+    mk_args :: CtxTermsCtx ->  -- already processed parameters/arguments
+               CtxTerms ->     -- remaining actual arguments to process
+               Bindings CtorArg ->
                  -- telescope for typing the actual arguments
                m [Term]
     -- no more arguments to process
@@ -1056,12 +914,14 @@ ctxReduceRecursor_ rec fi args0 argCtx =
          tl   <- mk_args (CtxTermsCtxCons pre_xs x) xs args
          pure (unAmb x : recx : tl)
 
+    mk_args _ _ _ = error "mk_args: impossible"
+
     -- Build an individual recursive call, given the parameters, the bindings
     -- for the RecursiveArg, and the argument we are going to recurse on
-    mk_rec_arg :: forall zs.
-      Bindings CtxTerm amb zs ->         -- telescope describing the zs
-      CtxTerms (CtxInvApp amb zs) ixs -> -- actual values for the indicies, shifted under zs
-      CtxTerm amb (Arrows zs d) ->       -- actual value in recursive position
+    mk_rec_arg ::
+      Bindings CtxTerm ->                -- telescope describing the zs
+      CtxTerms ->                        -- actual values for the indices, shifted under zs
+      CtxTerm ->                         -- actual value in recursive position
       m Term
     mk_rec_arg zs_ctx ixs x = unAmb <$>
       -- eta expand over the zs and apply the RecursorApp form
@@ -1080,7 +940,7 @@ ctxReduceRecursor_ rec fi args0 argCtx =
 
 -- | Generic method for testing whether a datatype occurs in an object
 class UsesDataType a where
-  usesDataType :: DataIdent d -> a -> Bool
+  usesDataType :: DataIdent -> a -> Bool
 
 instance UsesDataType (TermF Term) where
   usesDataType (DataIdent d) (Constant d')
@@ -1096,10 +956,10 @@ instance UsesDataType (TermF Term) where
 instance UsesDataType Term where
   usesDataType d = usesDataType d . unwrapTermF
 
-instance UsesDataType (CtxTerm ctx a) where
+instance UsesDataType CtxTerm where
   usesDataType d (CtxTerm t) = usesDataType d t
 
-instance UsesDataType (Bindings CtxTerm ctx as) where
+instance UsesDataType (Bindings CtxTerm) where
   usesDataType _ NoBind = False
   usesDataType d (Bind _ tp tps) = usesDataType d tp || usesDataType d tps
 
@@ -1113,46 +973,44 @@ instance UsesDataType (Bindings CtxTerm ctx as) where
 -- where the @pi@ are the distinct bound variables bound in the @params@
 -- context, given as argument, and that the @xj@ have no occurrences of @d@. If
 -- the given type is of this form, return the @xj@.
-asCtorDTApp :: DataIdent d -> Bindings CtxTerm EmptyCtx params ->
-               Bindings CtxTerm (CtxInv params) ixs ->
-               InvBindings tp1 (CtxInv params) ctx1 ->
-               Bindings tp2 (CtxInv params <+> ctx1) ctx2 ->
-               CtxTerm (CtxInvApp (CtxInv params <+> ctx1) ctx2) (Typ a) ->
-               Maybe (CtxTerms (CtxInvApp (CtxInv params <+> ctx1) ctx2) ixs)
+asCtorDTApp :: DataIdent -> Bindings CtxTerm ->
+               Bindings CtxTerm ->
+               InvBindings tp1 ->
+               Bindings tp2 ->
+               CtxTerm ->
+               Maybe CtxTerms
 asCtorDTApp d params dt_ixs ctx1 ctx2 (ctxAsDataTypeApp d params dt_ixs ->
                                        Just (param_vars, ixs))
-  | isVarList Proxy params ctx1 ctx2 param_vars &&
+  | isVarList params ctx1 ctx2 param_vars &&
     not (any (usesDataType d) $ ctxTermsToListUnsafe ixs)
   = Just ixs
   where
     -- Check that the given list of terms is a list of bound variables, one for
     -- each parameter, in the context extended by the given arguments
-    isVarList :: Proxy prev_params ->
-                 Bindings tp1 prev_params params ->
-                 InvBindings tp2 (CtxInvApp prev_params params) ctx1 ->
-                 Bindings tp3 (CtxInvApp prev_params params <+> ctx1) ctx2 ->
-                 CtxTerms (CtxInvApp
-                           (CtxInvApp prev_params params <+> ctx1) ctx2) params ->
+    isVarList :: Bindings tp1 ->
+                 InvBindings tp2 ->
+                 Bindings tp3 ->
+                 CtxTerms ->
                  Bool
-    isVarList _ _ _ _ CtxTermsNil = True
-    isVarList _ (Bind _ _ ps) c1 c2 (CtxTermsCons
+    isVarList _ _ _ CtxTermsNil = True
+    isVarList (Bind _ _ ps) c1 c2 (CtxTermsCons
                                      (CtxTerm (unwrapTermF -> LocalVar i)) ts) =
       i == bindingsLength ps + invBindingsLength c1 + bindingsLength c2 &&
-      isVarList Proxy ps c1 c2 ts
-    isVarList _ _ _ _ _ = False
+      isVarList ps c1 c2 ts
+    isVarList _ _ _ _ = False
 asCtorDTApp _ _ _ _ _ _ = Nothing
 
 
 -- | Existential return type for 'asCtorArg'
-data ExCtorArg d ixs ctx =
-  forall a. ExCtorArg (CtorArg d ixs ctx (Typ a))
+data ExCtorArg =
+  ExCtorArg CtorArg
 
 -- | Check that an argument for a constructor has one of the allowed forms
-asCtorArg :: DataIdent d -> Bindings CtxTerm EmptyCtx params ->
-             Bindings CtxTerm (CtxInv params) ixs ->
-             InvBindings tp (CtxInv params) prevs ->
-             CtxTerm (CtxInv params <+> prevs) (Typ a) ->
-             Maybe (ExCtorArg d ixs (CtxInv params <+> prevs))
+asCtorArg :: DataIdent -> Bindings CtxTerm ->
+             Bindings CtxTerm ->
+             InvBindings tp ->
+             CtxTerm ->
+             Maybe ExCtorArg
 asCtorArg d params dt_ixs prevs (ctxAsPiMulti ->
                                  CtxMultiPi zs
                                  (asCtorDTApp d params dt_ixs prevs zs ->
@@ -1165,40 +1023,36 @@ asCtorArg d _ _ _ tp
 asCtorArg _ _ _ _ _ = Nothing
 
 -- | Existential return type of 'asPiCtorArg'
-data CtxPiCtorArg d ixs ctx =
-  forall a b .
-  CtxPiCtorArg LocalName (CtorArg d ixs ctx (Typ a))
-  (CtxTerm (ctx ::> a) (Typ b))
+data CtxPiCtorArg =
+  CtxPiCtorArg LocalName CtorArg CtxTerm
 
 -- | Check that a constructor type is a pi-abstraction that takes as input an
 -- argument of one of the allowed forms described by 'CtorArg'
-asPiCtorArg :: DataIdent d -> Bindings CtxTerm EmptyCtx params ->
-               Bindings CtxTerm (CtxInv params) ixs ->
-               InvBindings tp (CtxInv params) prevs ->
-               CtxTerm (CtxInv params <+> prevs) (Typ a) ->
-               Maybe (CtxPiCtorArg d ixs (CtxInv params <+> prevs))
+asPiCtorArg :: DataIdent -> Bindings CtxTerm ->
+               Bindings CtxTerm ->
+               InvBindings tp ->
+               CtxTerm ->
+               Maybe CtxPiCtorArg
 asPiCtorArg d params dt_ixs prevs (ctxAsPi ->
                                    Just (CtxPi x
                                          (asCtorArg d params dt_ixs prevs ->
                                           Just (ExCtorArg arg)) rest)) =
   Just $ CtxPiCtorArg x arg (castTopCtxElem rest)
   where
-    castTopCtxElem :: CtxTerm (ctx ::> a1) b -> CtxTerm (ctx ::> a2) b
+    castTopCtxElem :: CtxTerm -> CtxTerm
     castTopCtxElem (CtxTerm t) = CtxTerm t
 asPiCtorArg _ _ _ _ _ = Nothing
 
 -- | Existential return type of 'mkCtorArgsIxs'
-data CtorArgsIxs d ixs prevs =
-  forall args.
-  CtorArgsIxs (Bindings (CtorArg d ixs) prevs args)
-  (CtxTerms (CtxInvApp prevs args) ixs)
+data CtorArgsIxs =
+  CtorArgsIxs (Bindings CtorArg) CtxTerms
 
 -- | Helper function for 'mkCtorArgStruct'
-mkCtorArgsIxs :: DataIdent d -> Bindings CtxTerm EmptyCtx params ->
-                 Bindings CtxTerm (CtxInv params) ixs ->
-                 InvBindings (CtorArg d ixs) (CtxInv params) prevs ->
-                 CtxTerm (CtxInv params <+> prevs) (Typ a) ->
-                 Maybe (CtorArgsIxs d ixs (CtxInv params <+> prevs))
+mkCtorArgsIxs :: DataIdent -> Bindings CtxTerm ->
+                 Bindings CtxTerm ->
+                 InvBindings CtorArg ->
+                 CtxTerm ->
+                 Maybe CtorArgsIxs
 mkCtorArgsIxs d params dt_ixs prevs (asPiCtorArg d params dt_ixs prevs ->
                                      Just (CtxPiCtorArg x arg rest)) =
   case mkCtorArgsIxs d params dt_ixs (InvBind prevs x arg) rest of
@@ -1217,10 +1071,10 @@ mkCtorArgsIxs _ _ _ _ _ = Nothing
 -- datatype, and, if so, build a 'CtorArgStruct' for it.
 mkCtorArgStruct ::
   Name ->
-  Bindings CtxTerm EmptyCtx params ->
-  Bindings CtxTerm (CtxInv params) ixs ->
+  Bindings CtxTerm ->
+  Bindings CtxTerm ->
   Term ->
-  Maybe (CtorArgStruct d params ixs)
+  Maybe CtorArgStruct
 mkCtorArgStruct d params dt_ixs ctor_tp =
   case mkCtorArgsIxs (DataIdent d) params dt_ixs InvNoBind (CtxTerm ctor_tp) of
     Just (CtorArgsIxs args ctor_ixs) ->

--- a/saw-core/src/SAWCore/Term/CtxTerm.hs
+++ b/saw-core/src/SAWCore/Term/CtxTerm.hs
@@ -701,12 +701,12 @@ asPiCtorArg :: Name -> [(LocalName, Term)] ->
                [(LocalName, tp)] ->
                Term ->
                Maybe (LocalName, CtorArg, Term)
-asPiCtorArg d params dt_ixs prevs (asPi ->
-                                   Just (x,
-                                         asCtorArg d params dt_ixs prevs ->
-                                          Just arg, rest)) =
-  Just (x, arg, rest)
-asPiCtorArg _ _ _ _ _ = Nothing
+asPiCtorArg d params dt_ixs prevs t =
+  case asPi t of
+    Just (x, asCtorArg d params dt_ixs prevs -> Just arg, rest) ->
+      Just (x, arg, rest)
+    _ ->
+      Nothing
 
 -- | Helper function for 'mkCtorArgStruct'
 mkCtorArgsIxs :: Name -> [(LocalName, Term)] ->

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -422,9 +422,9 @@ processDecls (Un.DataDecl (PosPair p nm) param_ctx dt_tp c_decls : rest) =
            (c,) <$> typeInferComplete (Un.Pi p' ctx body)) c_decls
   ctors <-
     case ctxBindingsOfTerms dtParams of
-      ExistsTp p_ctx ->
+      p_ctx ->
         case ctxBindingsOfTerms dtIndices of
-          ExistsTp ix_ctx ->
+          ix_ctx ->
             forM typed_ctors $ \(c, typed_tp) ->
             -- Check that the universe level of the type of each constructor
             (case asSort (typedType typed_tp) of

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -421,9 +421,9 @@ processDecls (Un.DataDecl (PosPair p nm) param_ctx dt_tp c_decls : rest) =
     mapM (\(Un.Ctor (PosPair p' c) ctx body) ->
            (c,) <$> typeInferComplete (Un.Pi p' ctx body)) c_decls
   ctors <-
-    case ctxBindingsOfTerms dtParams of
+    case dtParams of
       p_ctx ->
-        case ctxBindingsOfTerms dtIndices of
+        case dtIndices of
           ix_ctx ->
             forM typed_ctors $ \(c, typed_tp) ->
             -- Check that the universe level of the type of each constructor


### PR DESCRIPTION
This is a step toward removing the dependence of this module on de Bruijn indices (see #2438).