### PR TITLE
Fix `saw-core-{sbv,what4}` buglets involving `Vec`-related model values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,6 +111,9 @@ support compositional verification using techniques similar to SAW.
   found in conventional CPUs and programming languages (which uses Euclidean
   division).
 
+* Fix SAW errors that could arise when producing models for sequence values
+  (e.g., values of type `[2][8]`) when using the `sat` or `sat_print` commands.
+
 ## Deprecations
 
 * The "highly experimental" SAWScript `callcc` builtin (an

--- a/intTests/test1094_2464/test.saw
+++ b/intTests/test1094_2464/test.saw
@@ -1,0 +1,21 @@
+// A regression test for #1094 and #2464. This ensures that we can successfully
+// use sat-related commands to produce models for Vec values in SAWCore, in both
+// the SBV and What4 backends.
+
+let test_prop (prover : ProofScript ()) (prop : Term) = do {
+    // Test both sat_print...
+    sat_print prover prop;
+
+    // ...and sat/caseSatResult, as these commands exercise slightly different
+    // code paths.
+    r_sbv <- sat prover prop;
+    caseSatResult r_sbv (print "Unsat") print;
+};
+
+let prop1 = {{ \(x : [2][8]) -> x == reverse x }};
+test_prop (sbv_unint_z3 []) prop1;
+test_prop (w4_unint_z3 []) prop1;
+
+let prop2 = {{ \(x : [0][8]) -> x == reverse x }};
+test_prop (sbv_unint_z3 []) prop2;
+test_prop (w4_unint_z3 []) prop2;

--- a/intTests/test1094_2464/test.sh
+++ b/intTests/test1094_2464/test.sh
@@ -1,0 +1,3 @@
+set -e
+
+$SAW test.saw


### PR DESCRIPTION
Neither the SBV nor What4 backends of SAWCore were particularly robust when tasked with producing models for `Vec`-related values (e.g., values corresponding to the Cryptol types `[2][8]` or `[0][8]`) when using commands such as `sat` or `sat_print`. In particular, the SBV backend would crash when producing an empty `Vec`, and the What4 backend would be liable to crash when trying to produce any `Vec` values at all. This led to the issues seen in #1094 (for the SBV backend) and #2464 (for the What4 backend).

Fortunately, both issues can be fixed in a relatively simple fashion: simply store the element type (as a `FirstOrderType`) in the `VecLabel` case of each backend's `Labeler` data type.

Fixes #1094. Fixes #2464.