### PR TITLE
Use IntMap instead of Map VarIndex for term substitution maps.

### DIFF
--- a/saw-central/src/SAWCentral/Bisimulation.hs
+++ b/saw-central/src/SAWCentral/Bisimulation.hs
@@ -79,6 +79,7 @@ import Control.Monad.IO.Class (MonadIO(..))
 import qualified Control.Monad.State.Strict as State
 import Control.Monad.Trans.Class (MonadTrans(..))
 import Data.Foldable (foldl')
+import qualified Data.IntMap as IntMap
 import qualified Data.IntSet as IntSet
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
@@ -222,8 +223,8 @@ buildCompositionSideCondition bc innerBt = do
   rhsTuple <- io $ scTuple sc [rhsOuterState, input]  -- (f_rhs_s, in)
   innerRel' <- io $
     scInstantiateExt sc
-                     (Map.fromList [ (ecVarIndex lhsInnerEc, lhsTuple)
-                                   , (ecVarIndex rhsInnerEc, rhsTuple)])
+                     (IntMap.fromList [ (ecVarIndex lhsInnerEc, lhsTuple)
+                                      , (ecVarIndex rhsInnerEc, rhsTuple)])
                      innerRel
 
   -- outer state relation implies inner state relation

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -1752,7 +1752,7 @@ cexEvalFn sc args tm = do
   let exts = map fst args
   args' <- mapM (scFirstOrderValue sc . snd) args
   let is = map ecVarIndex exts
-      argMap = Map.fromList (zip is args')
+      argMap = IntMap.fromList (zip is args')
 
   -- TODO, instead of instantiating and then evaluating, we should
   -- evaluate in the context of an EC map instead.  argMap is almost

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -61,6 +61,7 @@ import           Control.Monad.Trans.Except (runExceptT)
 import qualified Data.BitVector.Sized as BV
 import           Data.Foldable (for_)
 import           Data.Function
+import qualified Data.IntMap as IntMap
 import           Data.IORef
 import           Data.List (isPrefixOf, sortBy)
 import           Data.List.NonEmpty (NonEmpty)
@@ -785,7 +786,7 @@ verifyPoststate cc mspec env0 globals ret mdMap =
      skipSafetyProofs <- gets rwSkipSafetyProofs
      when skipSafetyProofs (io (Crucible.clearProofObligations bak))
 
-     let ecs0 = Map.fromList
+     let ecs0 = IntMap.fromList
            [ (ecVarIndex ec, ec)
            | tt <- mspec ^. MS.csPreState . MS.csFreshVars
            , let ec = tecExt tt ]

--- a/saw-central/src/SAWCentral/Crucible/JVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Override.hs
@@ -58,11 +58,12 @@ import           Control.Monad.IO.Class (liftIO)
 import           Control.Monad
 import           Data.Either (partitionEithers)
 import           Data.Foldable (for_, traverse_)
+import           Data.IntMap (IntMap)
+import qualified Data.IntMap as IntMap
 import           Data.IORef
 import           Data.List (tails)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import           Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
@@ -204,7 +205,7 @@ methodSpecHandler opts sc cc top_loc _mdMap css h =
        forM css $ \cs -> liftIO $
          let initialFree =
                Set.fromList (cs ^.. MS.csPreState. MS.csFreshVars . each . to tecExt . to ecVarIndex)
-          in runOverrideMatcher sym g0 Map.empty Map.empty initialFree (view MS.csLoc cs)
+          in runOverrideMatcher sym g0 Map.empty IntMap.empty initialFree (view MS.csLoc cs)
                       (do methodSpecHandler_prestate opts sc cc args cs
                           return cs)
 
@@ -925,9 +926,9 @@ executePred sc cc md tt =
 -- | Map the given substitution over all 'SetupTerm' constructors in
 -- the given 'SetupValue'.
 instantiateSetupValue ::
-  SharedContext     ->
-  Map VarIndex Term ->
-  SetupValue        ->
+  SharedContext ->
+  IntMap Term ->
+  SetupValue ->
   IO SetupValue
 instantiateSetupValue sc s v =
   case v of

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
@@ -104,6 +104,7 @@ import qualified Data.Bimap as Bimap
 import           Data.Char (isDigit)
 import           Data.Foldable (for_, toList, fold)
 import           Data.Functor (void)
+import qualified Data.IntMap as IntMap
 import           Data.IORef
 import           Data.List (find, nub, partition)
 import           Data.List.Extra (nubOrd)
@@ -444,7 +445,7 @@ llvm_compositional_extract (Some lm) nm func_name lemmas checkSat setup tactic =
           shared_context <- getSharedContext
 
           let output_values =
-                map (((Map.!) $ post_override_state ^. termSub) . ecVarIndex) output_parameters
+                map (((IntMap.!) $ post_override_state ^. termSub) . ecVarIndex) output_parameters
 
           extracted_func <-
             io $ scAbstractExts shared_context input_parameters
@@ -464,7 +465,7 @@ llvm_compositional_extract (Some lm) nm func_name lemmas checkSat setup tactic =
             mkTypedTerm shared_context
               =<< scTupleSelector shared_context applied_extracted_func i (length output_parameters)
           let output_parameter_substitution =
-                Map.fromList $
+                IntMap.fromList $
                 zip (map ecVarIndex output_parameters) (map ttTerm applied_extracted_func_selectors)
           let substitute_output_parameters =
                 ttTermLens $ scInstantiateExt shared_context output_parameter_substitution
@@ -1594,7 +1595,7 @@ verifyPoststate cc mspec env0 globals ret mdMap invSubst =
      skipSafetyProofs <- gets rwSkipSafetyProofs
      when skipSafetyProofs (io (Crucible.clearProofObligations bak))
 
-     let ecs0 = Map.fromList
+     let ecs0 = IntMap.fromList
            [ (ecVarIndex ec, ec)
            | tt <- mspec ^. MS.csPreState . MS.csFreshVars
            , let ec = tecExt tt ]

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
@@ -71,6 +71,8 @@ import           Control.Monad.IO.Class (MonadIO(..))
 import qualified Data.ByteString as BS
 import           Data.Either (partitionEithers)
 import           Data.Foldable (for_, traverse_, toList)
+import           Data.IntMap (IntMap)
+import qualified Data.IntMap as IntMap
 import           Data.List (partition, tails)
 import qualified Data.List.NonEmpty as NE
 import           Data.IORef (IORef, modifyIORef)
@@ -334,7 +336,7 @@ methodSpecHandler opts sc cc mdMap css h =
        forM css $ \cs -> liftIO $
          let initialFree = Set.fromList (map (ecVarIndex . tecExt)
                                            (view (MS.csPreState . MS.csFreshVars) cs))
-          in runOverrideMatcher sym g0 Map.empty Map.empty initialFree (view MS.csLoc cs)
+          in runOverrideMatcher sym g0 Map.empty IntMap.empty initialFree (view MS.csLoc cs)
                       (do methodSpecHandler_prestate opts sc cc args cs
                           return cs)
 
@@ -2306,9 +2308,9 @@ executeFreshPointer cc (AllocIndex i) =
 -- | Map the given substitution over all 'SetupTerm' constructors in
 -- the given 'SetupValue'.
 instantiateSetupValue ::
-  SharedContext     ->
-  Map VarIndex Term ->
-  SetupValue (LLVM arch)        ->
+  SharedContext ->
+  IntMap Term ->
+  SetupValue (LLVM arch) ->
   IO (SetupValue (LLVM arch))
 instantiateSetupValue sc s v =
   case v of

--- a/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
@@ -46,6 +46,7 @@ import Control.Monad.State (MonadState, StateT(..), execStateT, gets)
 import qualified Data.BitVector.Sized as BV
 import Data.Foldable (foldlM)
 import Data.Functor (void)
+import qualified Data.IntMap as IntMap
 import           Data.IORef
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Vector as Vector
@@ -1493,7 +1494,7 @@ assertPost path func env premem preregs mdMap = do
         $ ms ^. MS.csPostState . MS.csConditions
 
   let
-    initialECs = Map.fromList
+    initialECs = IntMap.fromList
       [ (ecVarIndex ec, ec)
       | tt <- ms ^. MS.csPreState . MS.csFreshVars
       , let ec = tecExt tt

--- a/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
@@ -80,6 +80,7 @@ import Control.Monad.Trans.Class (MonadTrans(..))
 import qualified Data.ByteString.Lazy as BSL
 import Data.Foldable (for_)
 import qualified Data.Foldable.WithIndex as FWI
+import qualified Data.IntMap as IntMap
 import Data.IORef
 import qualified Data.List.Extra as List (find, unsnoc)
 import qualified Data.List.NonEmpty as NE
@@ -1163,7 +1164,7 @@ verifyPoststate cc mspec env0 globals ret mdMap =
      skipSafetyProofs <- gets rwSkipSafetyProofs
      when skipSafetyProofs (io (Crucible.clearProofObligations bak))
 
-     let ecs0 = Map.fromList
+     let ecs0 = IntMap.fromList
            [ (ecVarIndex ec, ec)
            | tt <- mspec ^. MS.csPreState . MS.csFreshVars
            , let ec = tecExt tt ]

--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -36,11 +36,12 @@ import Data.Either (partitionEithers)
 import qualified Data.Text as Text
 import qualified Data.Foldable as F
 import qualified Data.Functor.Product as Functor
+import qualified Data.IntMap as IntMap
+import Data.IntMap (IntMap)
 import Data.IORef (IORef, modifyIORef)
 import Data.List (tails)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
-import Data.Map (Map)
 import Data.Maybe (catMaybes)
 import qualified Data.Parameterized.Classes as PC
 import qualified Data.Parameterized.Context as Ctx
@@ -864,7 +865,7 @@ instantiateExtResolveSAWPred sc cc cond = do
 -- the given 'MirPointsTo' value.
 instantiateMirPointsTo ::
   SharedContext     ->
-  Map VarIndex Term ->
+  IntMap Term       ->
   MirPointsTo       ->
   IO MirPointsTo
 instantiateMirPointsTo sc s (MirPointsTo md reference referents) =
@@ -875,7 +876,7 @@ instantiateMirPointsTo sc s (MirPointsTo md reference referents) =
 -- the given 'SetupValue'.
 instantiateSetupValue ::
   SharedContext     ->
-  Map VarIndex Term ->
+  IntMap Term       ->
   SetupValue        ->
   IO SetupValue
 instantiateSetupValue sc s v =
@@ -1545,7 +1546,7 @@ methodSpecHandler opts sc cc mdMap css h =
        forM css $ \cs -> liftIO $
          let initialFree = Set.fromList (map (ecVarIndex . tecExt)
                                            (view (MS.csPreState . MS.csFreshVars) cs))
-          in runOverrideMatcher sym g0 Map.empty Map.empty initialFree (view MS.csLoc cs)
+          in runOverrideMatcher sym g0 Map.empty IntMap.empty initialFree (view MS.csLoc cs)
                       (do methodSpecHandler_prestate opts sc cc args cs
                           return cs)
 

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -136,6 +136,7 @@ import           Control.Monad.IO.Class (MonadIO(..))
 import           Control.Monad.Except (ExceptT, MonadError(..), runExceptT)
 import           Control.Monad.Trans.Class (MonadTrans(..))
 import qualified Data.Foldable as Fold
+import qualified Data.IntMap as IntMap
 import           Data.List (genericDrop, genericLength, genericSplitAt)
 import           Data.Map (Map)
 import qualified Data.Map as Map
@@ -1765,7 +1766,7 @@ checkEvidence sc what4PushMuxOps = \e p -> do
                      , showTerm ty
                      ]
                    x' <- scExtCns sc x
-                   body' <- scInstantiateExt sc (Map.singleton (ecVarIndex ec) x') body
+                   body' <- scInstantiateExt sc (IntMap.singleton (ecVarIndex ec) x') body
                    check nenv e' (mkSqt (Prop body'))
 
 passthroughEvidence :: [Evidence] -> IO Evidence
@@ -2040,7 +2041,7 @@ propApply sc rule goal = applyFirst =<< asPiLists (unProp rule)
            Just inst ->
              do let mkNewGoal :: ExtCns Term -> IO (Either Term Prop)
                     mkNewGoal ec =
-                      case Map.lookup (ecVarIndex ec) inst of
+                      case IntMap.lookup (ecVarIndex ec) inst of
                         Nothing ->
                           -- this argument not solved by unification, so make it a goal
                           do c0 <- scInstantiateExt sc inst (ecType ec)
@@ -2080,7 +2081,7 @@ tacticIntro sc usernm = Tactic \goal ->
              xv <- liftIO $ scFreshEC sc name tp
              x  <- liftIO $ scExtCns sc xv
              tt <- liftIO $ mkTypedTerm sc x
-             body' <- liftIO $ scInstantiateExt sc (Map.singleton (ecVarIndex ec) x) body
+             body' <- liftIO $ scInstantiateExt sc (IntMap.singleton (ecVarIndex ec) x) body
              let goal' = goal { goalSequent = mkSqt (Prop body') }
              return (tt, mempty, [goal'], introEvidence xv)
 

--- a/saw-core/src/SAWCore/Testing/Random.hs
+++ b/saw-core/src/SAWCore/Testing/Random.hs
@@ -30,6 +30,7 @@ import SAWCore.Simulator.Value (Value(..)) -- , TValue(..))
 import qualified Control.Monad.Fail as F
 import Control.Monad.Random
 import Data.Functor.Compose (Compose(..))
+import qualified Data.IntMap as IntMap
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import System.Random.TF (newTFGen, TFGen)
@@ -72,7 +73,7 @@ execTest sc mmap vars tm =
   do testVec <- sequence vars
      tm' <- liftIO $
              do argMap0 <- traverse (scFirstOrderValue sc) testVec
-                let argMap = Map.fromList [ (ecVarIndex ec, v) | (ec,v) <- Map.toList argMap0 ]
+                let argMap = IntMap.fromList [ (ecVarIndex ec, v) | (ec,v) <- Map.toList argMap0 ]
                 scInstantiateExt sc argMap tm
      case evalSharedTerm mmap Map.empty Map.empty tm' of
        -- satisfaible, return counterexample


### PR DESCRIPTION
The type of scInstantiateExt changes, along with everything else that maintains substitution maps that are passed to it.