### PR TITLE
saw-core: Rename 'ExtCns' term constructor to 'Variable'.

### DIFF
--- a/crucible-mir-comp/src/Mir/Compositional/Builder.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Builder.hs
@@ -46,7 +46,7 @@ import Lang.Crucible.Simulator
 import Lang.Crucible.Types
 
 import qualified SAWCore.Prelude as SAW
-import qualified SAWCore.Recognizer as SAW (asExtCns)
+import qualified SAWCore.Recognizer as SAW (asVariable)
 import qualified SAWCore.SharedTerm as SAW
 import qualified SAWCoreWhat4.ReturnTrip as SAW
 import qualified CryptolSAWCore.TypedTerm as SAW
@@ -399,7 +399,7 @@ gatherAsserts msb =
         gatherSubsts postOnlyVars vars [] [] asserts'
     substTerms <- forM substs $ \(Pair var expr) -> do
         varTerm <- liftIO $ eval $ W4.BoundVarExpr var
-        varEc <- case SAW.asExtCns varTerm of
+        varEc <- case SAW.asVariable varTerm of
             Just ec -> return ec
             Nothing -> error $ "eval of BoundVarExpr produced non-ExtCns ?" ++ show varTerm
         exprTerm <- liftIO $ eval expr

--- a/crucible-mir-comp/src/Mir/Compositional/Convert.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Convert.hs
@@ -330,7 +330,7 @@ exprToTerm sym sc w4VarMapRef val = liftIO $ do
     ty <- SAW.baseSCType sym sc (W4.exprType val)
     ec <- SAW.scFreshEC sc "w4expr" ty
     modifyIORef w4VarMapRef $ Map.insert (SAW.ecVarIndex ec) (Some val)
-    term <- SAW.scExtCns sc ec
+    term <- SAW.scVariable sc ec
     return term
 
 regToTerm :: forall sym t st fs tp0 m.

--- a/crucible-mir-comp/src/Mir/Compositional/Override.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Override.hs
@@ -365,7 +365,7 @@ matchArg sym sc eval allocSpecs md shp0 rv0 sv0 = go shp0 rv0 sv0
     go (PrimShape _ _btpr) expr (MS.SetupTerm tt) = do
         loc <- use MS.osLocation
         exprTerm <- liftIO $ eval expr
-        case SAW.asExtCns $ SAW.ttTerm tt of
+        case SAW.asVariable $ SAW.ttTerm tt of
             Just ec -> do
                 let var = SAW.ecVarIndex ec
                 sub <- use MS.termSub

--- a/crux-mir-comp/src/Mir/Cryptol.hs
+++ b/crux-mir-comp/src/Mir/Cryptol.hs
@@ -58,7 +58,7 @@ import qualified CryptolSAWCore.Prelude as SAW
 import qualified CryptolSAWCore.CryptolEnv as SAW
 import qualified SAWCore.SharedTerm as SAW
 import qualified SAWCoreWhat4.ReturnTrip as SAW
-import qualified SAWCore.Recognizer as SAW (asExtCns)
+import qualified SAWCore.Recognizer as SAW (asVariable)
 import qualified CryptolSAWCore.TypedTerm as SAW
 
 import SAWCentral.Crucible.MIR.TypeShape
@@ -303,7 +303,7 @@ munge sym shp0 rv0 = do
             visitExprVars visitCache x $ \var -> do
                 let expr = W4.BoundVarExpr var
                 term <- eval' expr
-                ec <- case SAW.asExtCns term of
+                ec <- case SAW.asVariable term of
                     Just ec -> return ec
                     Nothing -> error "eval on BoundVarExpr produced non-ExtCns?"
                 modifyIORef w4VarMapRef $ Map.insert (SAW.ecVarIndex ec) (Some expr)

--- a/cryptol-saw-core/src/CryptolSAWCore/Monadify.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Monadify.hs
@@ -173,7 +173,7 @@ asTypedGlobalDef t =
     Constant nm ->
       let ty = resolvedNameType (requireNameInMap nm ?mm)
       in Just $ GlobalDef (nameInfo nm) (nameIndex nm) ty t
-    FTermF (ExtCns ec) ->
+    FTermF (Variable ec) ->
       Just $ GlobalDef (ecName ec) (ecVarIndex ec) (ecType ec) t
     _ -> Nothing
 

--- a/cryptol-saw-core/src/CryptolSAWCore/TypedTerm.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/TypedTerm.hs
@@ -29,7 +29,7 @@ import qualified SAWSupport.Pretty as PPS (defaultOpts)
 
 import CryptolSAWCore.Cryptol (scCryptolType, Env, importKind, importSchema)
 import SAWCore.FiniteValue
-import SAWCore.Recognizer (asExtCns)
+import SAWCore.Recognizer (asVariable)
 import SAWCore.SharedTerm
 import SAWCore.SCTypeCheck (scTypeCheckError)
 import SAWCore.Term.Pretty (ppTerm)
@@ -189,7 +189,7 @@ typedTermOfFirstOrderValue sc fov =
      t <- scFirstOrderValue sc fov
      pure $ TypedTerm (TypedTermSchema (C.tMono cty)) t
 
--- Typed external constants ----------------------------------------------------
+-- Typed named variables -------------------------------------------------------
 
 data TypedExtCns =
   TypedExtCns
@@ -198,17 +198,17 @@ data TypedExtCns =
   }
   deriving Show
 
--- | Recognize 'TypedTerm's that are external constants.
+-- | Recognize 'TypedTerm's that are named variables.
 asTypedExtCns :: TypedTerm -> Maybe TypedExtCns
 asTypedExtCns (TypedTerm tp t) =
   do cty <- ttIsMono tp
-     ec <- asExtCns t
+     ec <- asVariable t
      pure $ TypedExtCns cty ec
 
 -- | Make a 'TypedTerm' from a 'TypedExtCns'.
 typedTermOfExtCns :: SharedContext -> TypedExtCns -> IO TypedTerm
 typedTermOfExtCns sc (TypedExtCns cty ec) =
-  TypedTerm (TypedTermSchema (C.tMono cty)) <$> scExtCns sc ec
+  TypedTerm (TypedTermSchema (C.tMono cty)) <$> scVariable sc ec
 
 abstractTypedExts :: SharedContext -> [TypedExtCns] -> TypedTerm -> IO TypedTerm
 abstractTypedExts sc tecs (TypedTerm (TypedTermSchema (C.Forall params props ty)) trm) =

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -758,7 +758,7 @@ extract_uninterp unints opaques tt =
      let tt' = tt{ ttTerm = tm }
 
      let f = traverse $ \(ec,vs) ->
-               do ectm <- scExtCns sc ec
+               do ectm <- scVariable sc ec
                   vs'  <- filterCryTerms sc vs
                   pure (ectm, vs')
      repls' <- io (traverse f repls)
@@ -779,7 +779,7 @@ extract_uninterp unints opaques tt =
      unless (Set.null boundAndUsed)
        (do ppOpts <- getTopLevelPPOpts
            vs <- io $ forM (Set.toList boundAndUsed) $ \ec ->
-                              do pptm <- scPrettyTerm ppOpts <$> scExtCns sc ec
+                              do pptm <- scPrettyTerm ppOpts <$> scVariable sc ec
                                  let ppty = scPrettyTerm ppOpts (ecType ec)
                                  return (pptm <> " : " <> ppty)
            printOutLnTop Warn $ unlines $
@@ -827,8 +827,8 @@ build_congruence sc tm =
        fail "congruence_for: cannot build congruence for dependent functions"
 
   loop [] vars =
-    do lvars <- mapM (scExtCns sc . fst) (reverse vars)
-       rvars <- mapM (scExtCns sc . snd) (reverse vars)
+    do lvars <- mapM (scVariable sc . fst) (reverse vars)
+       rvars <- mapM (scVariable sc . snd) (reverse vars)
        let allVars = concat [ [l,r] | (l,r) <- reverse vars ]
 
        basel <- scApplyAll sc tm lvars
@@ -836,8 +836,8 @@ build_congruence sc tm =
        baseeq <- scEqTrue sc =<< scEq sc basel baser
 
        let f x (l,r) =
-             do l' <- scExtCns sc l
-                r' <- scExtCns sc r
+             do l' <- scVariable sc l
+                r' <- scVariable sc r
                 eq <- scEqTrue sc =<< scEq sc l' r'
                 scFun sc eq x
        finalEq <- foldM f baseeq vars
@@ -1345,7 +1345,7 @@ proveByBVInduction script t =
          do wt  <- io $ scNat sc w
             natty <- io $ scNatType sc
             toNat <- io $ scGlobalDef sc "Prelude.bvToNat"
-            vars  <- io $ mapM (scExtCns sc) pis
+            vars  <- io $ mapM (scVariable sc) pis
             innerVars <-
               io $ sequence $
               [ scFreshGlobal sc ("i_" <> toShortName (ecName ec)) (ecType ec) | ec <- pis ]

--- a/saw-central/src/SAWCentral/Crucible/Common/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/Override.hs
@@ -552,7 +552,7 @@ refreshTerms sc ss =
   where
     freshenTerm (TypedExtCns _cty ec) =
       do ec' <- liftIO $ scFreshEC sc (toShortName (ecName ec)) (ecType ec)
-         new <- liftIO $ scExtCns sc ec'
+         new <- liftIO $ scVariable sc ec'
          return (ecVarIndex ec, new)
 
 -- | An override packaged together with its preconditions, labeled with some
@@ -723,7 +723,7 @@ matchTerm sc md prepost real expect =
   do let loc = MS.conditionLoc md
      free <- OM (use osFree)
      case unwrapTermF expect of
-       FTermF (ExtCns ec)
+       FTermF (Variable ec)
          | Set.member (ecVarIndex ec) free ->
          do assignTerm sc md prepost (ecVarIndex ec) real
 

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -790,7 +790,7 @@ verifyPoststate cc mspec env0 globals ret mdMap =
            [ (ecVarIndex ec, ec)
            | tt <- mspec ^. MS.csPreState . MS.csFreshVars
            , let ec = tecExt tt ]
-     terms0 <- io $ traverse (scExtCns sc) ecs0
+     terms0 <- io $ traverse (scVariable sc) ecs0
 
      let initialFree = Set.fromList (map (ecVarIndex . tecExt)
                                     (view (MS.csPostState . MS.csFreshVars) mspec))

--- a/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
@@ -712,7 +712,7 @@ setupSimpleLoopFixpointFeature sym sc sawst cfg mvar func =
                && not (List.isPrefixOf "calign_amount" $ show $ W4.printSymExpr variable))
              uninterpreted_constants
        body_tms <- mapM (viewSome $ toSC sym sawst) filtered_uninterpreted_constants
-       implicit_parameters <- mapM (scExtCns sc) $ Set.toList $ foldMap getAllExtSet body_tms
+       implicit_parameters <- mapM (scVariable sc) $ Set.toList $ foldMap getAllExtSet body_tms
 
        arguments <- forM fixpoint_substitution_as_list $ \(MapF.Pair _ fixpoint_entry) ->
          toSC sym sawst $ Crucible.LLVM.Fixpoint.headerValue fixpoint_entry
@@ -792,7 +792,7 @@ setupSimpleLoopFixpointCHCFeature sym sc sawst cfg mvar func = do
                && not (List.isPrefixOf "calign_amount" $ show $ W4.printSymExpr variable))
              uninterpreted_constants
        tms <- mapM (viewSome $ toSC sym sawst) filtered_uninterpreted_constants
-       implicit_parameters <- mapM (scExtCns sc) $ Set.toList $ foldMap getAllExtSet tms
+       implicit_parameters <- mapM (scVariable sc) $ Set.toList $ foldMap getAllExtSet tms
        arguments <- forM fixpoint_substitution_as_list $ \(MapF.Pair _ fixpoint_entry) ->
          toSC sym sawst $ Crucible.LLVM.FixpointCHC.headerValue fixpoint_entry
        arguments_tuple <- scTuple sc arguments
@@ -875,7 +875,7 @@ setupSimpleLoopInvariantFeature sym printFn loopNum sc sawst mdMap cfg mvar func
              )
              implicit_params
        body_tms <- mapM (viewSome $ toSC sym sawst) filtered_implicit_params
-       implicit_params' <- mapM (scExtCns sc) $ Set.toList $ foldMap getAllExtSet body_tms
+       implicit_params' <- mapM (scVariable sc) $ Set.toList $ foldMap getAllExtSet body_tms
        initial_exprs <-
          forM subst_pairs $
            \ (MapF.Pair _var (SimpleInvariant.InvariantEntry initVal _current)) ->
@@ -1501,7 +1501,7 @@ assertPost path func env premem preregs mdMap = do
       ]
     initialFree = Set.fromList . fmap (ecVarIndex . tecExt) $ ms ^. MS.csPostState . MS.csFreshVars
 
-  initialTerms <- liftIO $ traverse (scExtCns sc) initialECs
+  initialTerms <- liftIO $ traverse (scVariable sc) initialECs
 
   result <- liftIO
     . O.runOverrideMatcher sym globals env initialTerms initialFree (ms ^. MS.csLoc)

--- a/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
@@ -1168,7 +1168,7 @@ verifyPoststate cc mspec env0 globals ret mdMap =
            [ (ecVarIndex ec, ec)
            | tt <- mspec ^. MS.csPreState . MS.csFreshVars
            , let ec = tecExt tt ]
-     terms0 <- io $ traverse (scExtCns sc) ecs0
+     terms0 <- io $ traverse (scVariable sc) ecs0
 
      let initialFree = Set.fromList (map (ecVarIndex . tecExt)
                                     (view (MS.csPostState . MS.csFreshVars) mspec))

--- a/saw-central/src/SAWCentral/ImportAIG.hs
+++ b/saw-central/src/SAWCentral/ImportAIG.hs
@@ -123,7 +123,7 @@ networkAsSharedTerms ntk sc inputTerms outputLits = do
 -- | Create vector for each input literal from expected types.
 bitblastVarsAsInputLits :: SharedContext -> [ExtCns Term] -> ExceptT String IO (V.Vector Term)
 bitblastVarsAsInputLits sc args = do
-  inputs <- liftIO $ mapM (scExtCns sc) args
+  inputs <- liftIO $ mapM (scVariable sc) args
   fmap snd $ runTypeParser V.empty $ do
     zipWithM_ (bitblastSharedTerm sc) inputs (map ecType args)
 

--- a/saw-central/src/SAWCentral/JavaExpr.hs
+++ b/saw-central/src/SAWCentral/JavaExpr.hs
@@ -162,7 +162,7 @@ jeVarName = map dotToUnderscore . ppJavaExpr
         dotToUnderscore c = c
 
 asJavaExpr :: Term -> Maybe String
-asJavaExpr (asExtCns -> Just ec) = Just (Text.unpack (toShortName (ecName ec))) -- TODO?
+asJavaExpr (asVariable -> Just ec) = Just (Text.unpack (toShortName (ecName ec))) -- TODO?
 asJavaExpr _ = Nothing
 
 isRefJavaExpr :: JavaExpr -> Bool

--- a/saw-central/src/SAWCentral/MRSolver/SMT.hs
+++ b/saw-central/src/SAWCentral/MRSolver/SMT.hs
@@ -304,7 +304,7 @@ mrProvable bool_tm =
   where -- | Create a new global variable of the given name and type
         instUVar :: LocalName -> Term -> MRM t Term
         instUVar nm =
-          liftSC1 scWhnf >=> liftSC2 scFreshEC nm >=> liftSC1 scExtCns
+          liftSC1 scWhnf >=> liftSC2 scFreshEC nm >=> liftSC1 scVariable
 
 
 ----------------------------------------------------------------------

--- a/saw-central/src/SAWCentral/MRSolver/Solver.hs
+++ b/saw-central/src/SAWCentral/MRSolver/Solver.hs
@@ -485,9 +485,9 @@ FIXME HERE NOW: match a tuple projection of a MultiFixS
                                                  normCompTerm t'
            _ -> throwMRFailure (MalformedComp t)
 
-    -- For an ExtCns, we have to check what sort of variable it is
+    -- For a Variable, we have to check what sort of variable it is
     -- FIXME: substitute for evars if they have been instantiated
-    ((asExtCns -> Just ec), args) ->
+    ((asVariable -> Just ec), args) ->
       do fun_name <- extCnsToFunName ec
          FunBind fun_name args <$> mkCompFunReturn <$>
            mrFunOutType fun_name args

--- a/saw-central/src/SAWCentral/MRSolver/Term.hs
+++ b/saw-central/src/SAWCentral/MRSolver/Term.hs
@@ -114,8 +114,8 @@ asGlobalFunName _ = Nothing
 
 -- | Convert a 'FunName' to an unshared term, for printing
 funNameTerm :: FunName -> Term
-funNameTerm (CallSName var) = Unshared $ FTermF $ ExtCns $ unMRVar var
-funNameTerm (EVarFunName var) = Unshared $ FTermF $ ExtCns $ unMRVar var
+funNameTerm (CallSName var) = Unshared $ FTermF $ Variable $ unMRVar var
+funNameTerm (EVarFunName var) = Unshared $ FTermF $ Variable $ unMRVar var
 funNameTerm (GlobalName gdef []) = globalDefTerm gdef
 funNameTerm (GlobalName gdef (TermProjLeft:projs)) =
   Unshared $ FTermF $ PairLeft $ funNameTerm (GlobalName gdef projs)

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -1333,7 +1333,7 @@ predicateToProp sc quant = loop
                        Universal -> scEqTrue sc t0
                        Existential -> scEqTrue sc =<< scNot sc t0
                toPi (ec : ecs) t1 =
-                 do t2 <- scApply sc t1 =<< scExtCns sc ec
+                 do t2 <- scApply sc t1 =<< scVariable sc ec
                     t3 <- toPi ecs t2
                     scGeneralizeExts sc [ec] t3
            Prop <$> toPi argTs t
@@ -1765,7 +1765,7 @@ checkEvidence sc what4PushMuxOps = \e p -> do
                      , showTerm ty'
                      , showTerm ty
                      ]
-                   x' <- scExtCns sc x
+                   x' <- scVariable sc x
                    body' <- scInstantiateExt sc (IntMap.singleton (ecVarIndex ec) x') body
                    check nenv e' (mkSqt (Prop body'))
 
@@ -2079,7 +2079,7 @@ tacticIntro sc usernm = Tactic \goal ->
              let tp = ecType ec
              let name = if Text.null usernm then nm else usernm
              xv <- liftIO $ scFreshEC sc name tp
-             x  <- liftIO $ scExtCns sc xv
+             x  <- liftIO $ scVariable sc xv
              tt <- liftIO $ mkTypedTerm sc x
              body' <- liftIO $ scInstantiateExt sc (IntMap.singleton (ecVarIndex ec) x) body
              let goal' = goal { goalSequent = mkSqt (Prop body') }

--- a/saw-central/src/SAWCentral/Yosys/Cell.hs
+++ b/saw-central/src/SAWCentral/Yosys/Cell.hs
@@ -151,9 +151,9 @@ primCellToMap sc c args = case c ^. cellType of
   CellTypeReduceXnor -> bvReduce True =<< do
     boolTy <- liftIO $ SC.scBoolType sc
     xEC <- liftIO $ SC.scFreshEC sc "x" boolTy
-    x <- liftIO $ SC.scExtCns sc xEC
+    x <- liftIO $ SC.scVariable sc xEC
     yEC <- liftIO $ SC.scFreshEC sc "y" boolTy
-    y <- liftIO $ SC.scExtCns sc yEC
+    y <- liftIO $ SC.scVariable sc yEC
     r <- liftIO $ SC.scXor sc x y
     res <- liftIO $ SC.scNot sc r
     liftIO $ SC.scAbstractExts sc [xEC, yEC] res
@@ -261,8 +261,8 @@ primCellToMap sc c args = case c ^. cellType of
     bitEC <- liftIO $ SC.scFreshEC sc "bit" bool
     accEC <- liftIO $ SC.scFreshEC sc "acc" accTy
     fun <- liftIO . SC.scAbstractExts sc [bitEC, accEC] =<< do
-      bit <- liftIO $ SC.scExtCns sc bitEC
-      acc <- liftIO $ SC.scExtCns sc accEC
+      bit <- liftIO $ SC.scVariable sc bitEC
+      acc <- liftIO $ SC.scVariable sc accEC
       idx <- liftIO $ SC.scPairLeft sc acc
       aval <- liftIO $ SC.scPairRight sc acc
       bval <- liftIO $ SC.scAtWithDefault sc swidth widthBv aval splitb idx

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -191,7 +191,7 @@ convertModule sc env m = do
   inputRecordType <- cryptolRecordType sc inputFields
   outputRecordType <- cryptolRecordType sc outputFields
   inputRecordEC <- liftIO $ SC.scFreshEC sc "input" inputRecordType
-  inputRecord <- liftIO $ SC.scExtCns sc inputRecordEC
+  inputRecord <- liftIO $ SC.scVariable sc inputRecordEC
 
   derivedInputs <- forM (Map.assocs inputPorts) $ \(nm, inp) -> do
     t <- liftIO $ cryptolRecordSelect sc inputFields inputRecord nm

--- a/saw-central/src/SAWCentral/Yosys/State.hs
+++ b/saw-central/src/SAWCentral/Yosys/State.hs
@@ -131,7 +131,7 @@ convertModuleInline sc m = do
 
   -- convert module into term
   domainRecordEC <- liftIO $ SC.scFreshEC sc "input" domainRecordType
-  domainRecord <- liftIO $ SC.scExtCns sc domainRecordEC
+  domainRecord <- liftIO $ SC.scVariable sc domainRecordEC
 
   derivedInputs <- forM (Map.assocs inputPorts) $ \(nm, inp) -> do
     t <- liftIO $ cryptolRecordSelect sc domainFields domainRecord nm
@@ -215,7 +215,7 @@ composeYosysSequentialHelper sc s n = do
   extendedInputType <- fieldsToType sc extendedInputFields
   extendedInputCryptolType <- fieldsToCryptolType extendedInputFields
   extendedInputRecordEC <- liftIO $ SC.scFreshEC sc "input" extendedInputType
-  extendedInputRecord <- liftIO $ SC.scExtCns sc extendedInputRecordEC
+  extendedInputRecord <- liftIO $ SC.scVariable sc extendedInputRecordEC
   extendedOutputCryptolType <- fieldsToCryptolType extendedOutputFields
 
   allInputs <- fmap Map.fromList . forM (Map.keys extendedInputFields) $ \nm -> do
@@ -263,7 +263,7 @@ composeYosysSequentialHelper sc s n = do
 
   stateType <- fieldsToType sc $ s ^. yosysSequentialStateFields
   initialStateEC <- liftIO $ SC.scFreshEC sc "initial_state" stateType
-  initialState <- liftIO $ SC.scExtCns sc initialStateEC
+  initialState <- liftIO $ SC.scVariable sc initialStateEC
   (_, outputs) <- foldM (\acc i -> compose1 i acc) (initialState, Map.empty) [0..n]
 
   outputRecord <- cryptolRecord sc outputs

--- a/saw-central/src/SAWCentral/Yosys/Theorem.hs
+++ b/saw-central/src/SAWCentral/Yosys/Theorem.hs
@@ -63,7 +63,7 @@ theoremProp ::
   m SC.TypedTerm
 theoremProp sc thm = do
   ec <- liftIO $ SC.scFreshEC sc "r" $ thm ^. theoremInputType
-  r <- liftIO $ SC.scExtCns sc ec
+  r <- liftIO $ SC.scVariable sc ec
   modr <- liftIO $ SC.scApply sc (thm ^. theoremModule) r
   bodyr <- liftIO $ SC.scApply sc (thm ^. theoremBody) r
   equality <- liftIO $ eqBvRecords sc (thm ^. theoremOutputCryptolType) modr bodyr
@@ -88,7 +88,7 @@ theoremReplacement ::
   m SC.Term
 theoremReplacement sc thm = do
   ec <- liftIO $ SC.scFreshEC sc "r" $ thm ^. theoremInputType
-  r <- liftIO $ SC.scExtCns sc ec
+  r <- liftIO $ SC.scVariable sc ec
   body <- case thm ^. theoremPrecond of
     Nothing -> liftIO $ SC.scApply sc (thm ^. theoremBody) r
     Just pc -> do

--- a/saw-core-coq/src/SAWCoreCoq/Term.hs
+++ b/saw-core-coq/src/SAWCoreCoq/Term.hs
@@ -470,7 +470,7 @@ flatTermFToExpr tf = -- traceFTermF "flatTermFToExpr" tf $
       return $ Coq.List elems
     StringLit s -> pure (Coq.Scope (Coq.StringLit (Text.unpack s)) "string")
 
-    ExtCns ec ->
+    Variable ec ->
       do env <- view namedEnvironment <$> askTR
          let nm = Name (ecVarIndex ec) (ecName ec)
          case Map.lookup nm env of

--- a/saw-core-what4/src/SAWCoreWhat4/ReturnTrip.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/ReturnTrip.hs
@@ -62,7 +62,6 @@ import           What4.Symbol
 
 import qualified SAWCore.Name as SC
 import qualified SAWCore.SharedTerm as SC
-import qualified SAWCore.Term.Functor as SC
 
 import           SAWCoreWhat4.Panic
 
@@ -156,7 +155,7 @@ sawCreateVar :: SAWCoreState n
 sawCreateVar st nm tp = do
   let sc = saw_ctx st
   ec <- SC.scFreshEC sc nm tp
-  t <- SC.scFlatTermF sc (SC.ExtCns ec)
+  t <- SC.scVariable sc ec
   modifyIORef (saw_inputs st) (\xs -> xs Seq.|> ec)
   return t
 

--- a/saw-core/src/SAWCore/Conversion.hs
+++ b/saw-core/src/SAWCore/Conversion.hs
@@ -53,7 +53,7 @@ module SAWCore.Conversion
   , asSort
   , asAnyNatLit
   , asAnyVecLit
-  , asExtCns
+  , asVariable
   , asLocalVar
     -- ** Prelude matchers
   , asBoolType
@@ -279,9 +279,9 @@ asAnyNatLit = asVar $ \t -> do NatLit i <- R.asFTermF t; return i
 asAnyVecLit :: Matcher (Term, V.Vector Term)
 asAnyVecLit = asVar $ \t -> do ArrayValue u xs <- R.asFTermF t; return (u,xs)
 
--- | Match any external constant.
-asExtCns :: Matcher (ExtCns Term)
-asExtCns = asVar $ \t -> do ExtCns ec <- R.asFTermF t; return ec
+-- | Match any named variable.
+asVariable :: Matcher (ExtCns Term)
+asVariable = asVar R.asVariable
 
 -- | Returns index of local var if any.
 asLocalVar :: Matcher DeBruijnIndex

--- a/saw-core/src/SAWCore/ExternalFormat.hs
+++ b/saw-core/src/SAWCore/ExternalFormat.hs
@@ -174,15 +174,15 @@ scWriteExternal t0 =
             ArrayValue e v      -> pure $ unwords ("Array" : show e :
                                             map show (V.toList v))
             StringLit s         -> pure $ unwords ["String", show s]
-            ExtCns ec ->
+            Variable ec ->
                do stashEC ec
-                  pure $ unwords ["ExtCns",show (ecVarIndex ec), show (ecType ec)]
+                  pure $ unwords ["Variable",show (ecVarIndex ec), show (ecType ec)]
 
 
 -- | During parsing, we maintain two maps used for renumbering: The
 -- first is for the 'Int' values that appear in the external core
 -- file, and the second is for the 'VarIndex' values that appear
--- inside 'Constant' and 'ExtCns' constructors. We do not reuse any
+-- inside 'Constant' and 'Variable' constructors. We do not reuse any
 -- such numbers that appear in the external file, but generate fresh
 -- ones that are valid in the current 'SharedContext'.
 type ReadM = State.StateT (Map Int Term, Map VarIndex NameInfo, Map VarIndex VarIndex) IO
@@ -343,5 +343,5 @@ scReadExternal sc input =
         ["Nat", n]          -> FTermF <$> (NatLit <$> readM n)
         ("Array" : e : es)  -> FTermF <$> (ArrayValue <$> readIdx e <*> (V.fromList <$> traverse readIdx es))
         ("String" : ts)     -> FTermF <$> (StringLit <$> (readM (unwords ts)))
-        ["ExtCns", i, t] -> FTermF <$> (ExtCns <$> readEC i t)
+        ["Variable", i, t]  -> FTermF <$> (Variable <$> readEC i t)
         _ -> fail $ "Parse error: " ++ unwords tokens

--- a/saw-core/src/SAWCore/OpenTerm.hs
+++ b/saw-core/src/SAWCore/OpenTerm.hs
@@ -65,7 +65,7 @@ module SAWCore.OpenTerm (
   tupleOpenTerm, tupleTypeOpenTerm, projTupleOpenTerm,
   tupleOpenTerm', tupleTypeOpenTerm', projTupleOpenTerm',
   recordOpenTerm, recordTypeOpenTerm, projRecordOpenTerm,
-  ctorOpenTerm, dataTypeOpenTerm, globalOpenTerm, identOpenTerm, extCnsOpenTerm,
+  ctorOpenTerm, dataTypeOpenTerm, globalOpenTerm, identOpenTerm, variableOpenTerm,
   applyOpenTerm, applyOpenTermMulti, applyGlobalOpenTerm,
   applyPiOpenTerm, piArgOpenTerm, lambdaOpenTerm, lambdaOpenTermMulti,
   piOpenTerm, piOpenTermMulti, arrowOpenTerm, letOpenTerm, sawLetOpenTerm,
@@ -376,9 +376,9 @@ identOpenTerm ident =
   do ident_app <- liftTCM scGlobalDef ident
      typeInferComplete ident_app
 
--- | Build an 'OpenTerm' for an external constant
-extCnsOpenTerm :: ExtCns Term -> OpenTerm
-extCnsOpenTerm ec = OpenTerm (liftTCM scExtCns ec >>= typeInferComplete)
+-- | Build an 'OpenTerm' for a named variable.
+variableOpenTerm :: ExtCns Term -> OpenTerm
+variableOpenTerm ec = OpenTerm (liftTCM scVariable ec >>= typeInferComplete)
 
 -- | Apply an 'OpenTerm' to another
 applyOpenTerm :: OpenTerm -> OpenTerm -> OpenTerm
@@ -1198,5 +1198,5 @@ sawLetMinimize sc t_top =
   slMinTermF' tf@(Constant _) = liftIO (scTermF sc tf)
 
   slMinFTermF :: FlatTermF Term -> SLMinM Term
-  slMinFTermF ftf@(ExtCns _) = liftIO $ scFlatTermF sc ftf
+  slMinFTermF ftf@(Variable _) = liftIO $ scFlatTermF sc ftf
   slMinFTermF ftf = traverse slMinTerm ftf >>= liftIO . scFlatTermF sc

--- a/saw-core/src/SAWCore/Recognizer.hs
+++ b/saw-core/src/SAWCore/Recognizer.hs
@@ -52,7 +52,7 @@ module SAWCore.Recognizer
   , asPiList
   , asLocalVar
   , asConstant
-  , asExtCns
+  , asVariable
   , asSort
   , asSortWithFlags
     -- * Prelude recognizers.
@@ -344,12 +344,12 @@ asConstant :: Recognizer Term Name
 asConstant (unwrapTermF -> Constant nm) = pure nm
 asConstant _ = Nothing
 
-asExtCns :: Recognizer Term (ExtCns Term)
-asExtCns t = do
-  ftf <- asFTermF t
-  case ftf of
-    ExtCns ec -> return ec
-    _         -> Nothing
+asVariable :: Recognizer Term (ExtCns Term)
+asVariable t =
+  do ftf <- asFTermF t
+     case ftf of
+       Variable ec -> pure ec
+       _           -> Nothing
 
 asSort :: Recognizer Term Sort
 asSort t = do

--- a/saw-core/src/SAWCore/SCTypeCheck.hs
+++ b/saw-core/src/SAWCore/SCTypeCheck.hs
@@ -484,7 +484,7 @@ typeInferConstant nm =
 -- with special cases for primitives and constants to avoid re-type-checking
 -- their types as we are assuming they were type-checked when they were created
 instance TypeInfer (FlatTermF Term) where
-  typeInfer (ExtCns ec) = return $ ecType ec
+  typeInfer (Variable ec) = return $ ecType ec
   typeInfer t = typeInfer =<< mapM typeInferComplete t
   typeInferComplete ftf =
     SCTypedTerm <$> liftTCM scFlatTermF ftf
@@ -572,7 +572,7 @@ instance TypeInfer (FlatTermF SCTypedTerm) where
        forM_ vs $ \v_elem -> checkSubtype v_elem tp'
        liftTCM scVecType n tp'
   typeInfer (StringLit{}) = liftTCM scStringType
-  typeInfer (ExtCns ec) =
+  typeInfer (Variable ec) =
     -- FIXME: should we check that the type of ecType is a sort?
     typeCheckWHNF $ typedVal $ ecType ec
 

--- a/saw-core/src/SAWCore/Simulator.hs
+++ b/saw-core/src/SAWCore/Simulator.hs
@@ -262,7 +262,7 @@ evalTermF cfg lam recEval tf env =
 
         StringLit s         -> return $ VString s
 
-        ExtCns ec           -> do ec' <- traverse evalType ec
+        Variable ec         -> do ec' <- traverse evalType ec
                                   simExtCns cfg tf ec'
   where
     evalType :: Term -> EvalM l (TValue l)

--- a/saw-core/src/SAWCore/Simulator/TermModel.hs
+++ b/saw-core/src/SAWCore/Simulator/TermModel.hs
@@ -129,7 +129,7 @@ replace sc cfg mapref ec = loop [] (ecType ec)
          ty' <- readBackTValue sc cfg ty
          newec <- scFreshEC sc (toShortName (ecName ec)) ty'
          modifyIORef mapref (Map.alter (Just . ((newec,args):) . fromMaybe []) (ecVarIndex ec))
-         reflectTerm sc cfg ty =<< scFlatTermF sc (ExtCns newec)
+         reflectTerm sc cfg ty =<< scVariable sc newec
 
 normalizeSharedTerm ::
   SharedContext ->
@@ -295,7 +295,7 @@ readBackTValue sc cfg = loop
     do t' <- loop t
        ec <- scFreshEC sc nm t'
        ?recordEC ec
-       ecTm <- scExtCns sc ec
+       ecTm <- scVariable sc ec
        ecVal <- delay (reflectTerm sc cfg t ecTm)
        body <- applyPiBody pibody ecVal
        (ecs,body') <- readBackPis body
@@ -479,7 +479,7 @@ readBackValue sc cfg = loop
       do t' <- readBackTValue sc cfg tv
          ec <- scFreshEC sc nm t'
          ?recordEC ec
-         ecTm <- scExtCns sc ec
+         ecTm <- scVariable sc ec
          ecVal <- delay (reflectTerm sc cfg tv ecTm)
          tbody <- applyPiBody pibody ecVal
          body  <- f ecVal
@@ -871,7 +871,7 @@ prims sc cfg =
       do bvty <- scBitvector sc n
          ec   <- scFreshEC sc "x" bvty
          ?recordEC ec
-         ecTm <- scExtCns sc ec
+         ecTm <- scVariable sc ec
          res  <- f (Left (n,ecTm))
          case res of
            -- computed a constant boolean without consulting the variable, just return it

--- a/saw-core/src/SAWCore/Term/CtxTerm.hs
+++ b/saw-core/src/SAWCore/Term/CtxTerm.hs
@@ -75,7 +75,7 @@ asCtorDTApp d params dt_ixs (ctxAsDataTypeApp d params dt_ixs ->
     -- variables, one for each parameter
     isVarList :: [ExtCns Term] -> [Term] -> Bool
     isVarList _ [] = True
-    isVarList (p : ps) ((asExtCns -> Just ec) : ts) =
+    isVarList (p : ps) ((asVariable -> Just ec) : ts) =
       ec == p && isVarList ps ts
     isVarList _ _ = False
 asCtorDTApp _ _ _ _ = Nothing

--- a/saw-core/src/SAWCore/Term/Functor.hs
+++ b/saw-core/src/SAWCore/Term/Functor.hs
@@ -234,8 +234,8 @@ data FlatTermF e
     -- | String literal
   | StringLit !Text
 
-    -- | An external constant with a name.
-  | ExtCns !(ExtCns e)
+    -- | A named variable with a type.
+  | Variable !(ExtCns e)
   deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
 
 instance Hashable e => Hashable (FlatTermF e) -- automatically derived
@@ -342,7 +342,7 @@ zipWithFlatTermF f = go
     go (ArrayValue tx vx) (ArrayValue ty vy)
       | V.length vx == V.length vy
       = Just $ ArrayValue (f tx ty) (V.zipWith f vx vy)
-    go (ExtCns ec1) (ExtCns ec2) = ExtCns <$> zipExtCns f ec1 ec2
+    go (Variable ec1) (Variable ec2) = Variable <$> zipExtCns f ec1 ec2
 
     go _ _ = Nothing
 

--- a/saw-core/src/SAWCore/Term/Pretty.hs
+++ b/saw-core/src/SAWCore/Term/Pretty.hs
@@ -441,7 +441,7 @@ ppFlatTermF prec tf =
     ArrayValue _ args   ->
       ppArrayValue <$> mapM (ppTerm' PrecTerm) (V.toList args)
     StringLit s -> return $ viaShow s
-    ExtCns cns -> annotate PPS.ExtCnsStyle <$> ppExtCns cns
+    Variable ec -> annotate PPS.ExtCnsStyle <$> ppExtCns ec
 
 -- | Pretty-print a big endian list of bit values as a hexadecimal number
 ppBitsToHex :: [Bool] -> String
@@ -565,7 +565,7 @@ shouldMemoizeTerm t =
     FTermF NatLit{} -> False
     FTermF (ArrayValue _ v) | V.length v == 0 -> False
     FTermF StringLit{} -> False
-    FTermF ExtCns{} -> False
+    FTermF Variable{} -> False
     Constant{} -> False
     LocalVar{} -> False
     _ -> True

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -113,7 +113,7 @@ inferResolveNameApp n args =
          do t <- typeInferComplete (LocalVar i :: TermF SCTypedTerm)
             inferApplyAll t args
        (_, Just ec, _) ->
-         do t <- typeInferComplete (FTermF (ExtCns ec))
+         do t <- typeInferComplete (FTermF (Variable ec))
             inferApplyAll t args
        (_, _, Just (ResolvedCtor ctor)) ->
          do let c = ctorName ctor


### PR DESCRIPTION
Also rename various term-building and recognizer functions accordingly.