### PR TITLE
saw-core: Move 'Variable' constructor from FlatTermF to TermF.

### DIFF
--- a/cryptol-saw-core/src/CryptolSAWCore/Monadify.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Monadify.hs
@@ -173,7 +173,7 @@ asTypedGlobalDef t =
     Constant nm ->
       let ty = resolvedNameType (requireNameInMap nm ?mm)
       in Just $ GlobalDef (nameInfo nm) (nameIndex nm) ty t
-    FTermF (Variable ec) ->
+    Variable ec ->
       Just $ GlobalDef (ecName ec) (ecVarIndex ec) (ecType ec) t
     _ -> Nothing
 

--- a/saw-central/src/SAWCentral/Crucible/Common/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/Override.hs
@@ -111,7 +111,7 @@ import qualified SAWSupport.Pretty as PPS (defaultOpts, limitMaxDepth)
 import           SAWCore.Name (toShortName)
 import           SAWCore.Prelude as SAWVerifier (scEq)
 import           SAWCore.SharedTerm as SAWVerifier
-import           SAWCore.Term.Functor (FlatTermF(..), unwrapTermF)
+import           SAWCore.Term.Functor (unwrapTermF)
 import           SAWCore.Term.Pretty (ppTerm, scPrettyTerm)
 import           CryptolSAWCore.TypedTerm as SAWVerifier
 
@@ -723,7 +723,7 @@ matchTerm sc md prepost real expect =
   do let loc = MS.conditionLoc md
      free <- OM (use osFree)
      case unwrapTermF expect of
-       FTermF (Variable ec)
+       Variable ec
          | Set.member (ecVarIndex ec) free ->
          do assignTerm sc md prepost (ecVarIndex ec) real
 

--- a/saw-central/src/SAWCentral/MRSolver/Monad.hs
+++ b/saw-central/src/SAWCentral/MRSolver/Monad.hs
@@ -1015,7 +1015,7 @@ extCnsToFunName ec =
        Just (EVarInfo _ _) -> return $ EVarFunName var
        Just (CallVarInfo _) -> return $ CallSName var
        Nothing
-         | Just glob <- asTypedGlobalDef (Unshared $ FTermF $ Variable ec) ->
+         | Just glob <- asTypedGlobalDef (Unshared $ Variable ec) ->
            return $ GlobalName glob []
        _ -> error "extCnsToFunName: unreachable"
 

--- a/saw-central/src/SAWCentral/MRSolver/Term.hs
+++ b/saw-central/src/SAWCentral/MRSolver/Term.hs
@@ -114,8 +114,8 @@ asGlobalFunName _ = Nothing
 
 -- | Convert a 'FunName' to an unshared term, for printing
 funNameTerm :: FunName -> Term
-funNameTerm (CallSName var) = Unshared $ FTermF $ Variable $ unMRVar var
-funNameTerm (EVarFunName var) = Unshared $ FTermF $ Variable $ unMRVar var
+funNameTerm (CallSName var) = Unshared $ Variable $ unMRVar var
+funNameTerm (EVarFunName var) = Unshared $ Variable $ unMRVar var
 funNameTerm (GlobalName gdef []) = globalDefTerm gdef
 funNameTerm (GlobalName gdef (TermProjLeft:projs)) =
   Unshared $ FTermF $ PairLeft $ funNameTerm (GlobalName gdef projs)

--- a/saw-core-coq/src/SAWCoreCoq/Term.hs
+++ b/saw-core-coq/src/SAWCoreCoq/Term.hs
@@ -470,13 +470,6 @@ flatTermFToExpr tf = -- traceFTermF "flatTermFToExpr" tf $
       return $ Coq.List elems
     StringLit s -> pure (Coq.Scope (Coq.StringLit (Text.unpack s)) "string")
 
-    Variable ec ->
-      do env <- view namedEnvironment <$> askTR
-         let nm = Name (ecVarIndex ec) (ecName ec)
-         case Map.lookup nm env of
-           Just ident -> pure (Coq.Var ident)
-           Nothing -> translateConstant nm
-
     -- The translation of a record type {fld1:tp1, ..., fldn:tpn} is
     -- RecordTypeCons fld1 tp1 (... (RecordTypeCons fldn tpn RecordTypeNil)...).
     -- Note that SAW core equates record types up to reordering, so we sort our
@@ -799,6 +792,13 @@ translateTermUnshared t = do
 
     -- Constants
     Constant n -> translateConstant n
+
+    Variable ec ->
+      do nenv <- view namedEnvironment <$> askTR
+         let nm = Name (ecVarIndex ec) (ecName ec)
+         case Map.lookup nm nenv of
+           Just ident -> pure (Coq.Var ident)
+           Nothing -> translateConstant nm
 
   where
     badTerm          = Except.throwError $ BadTerm t

--- a/saw-core/src/SAWCore/ExternalFormat.hs
+++ b/saw-core/src/SAWCore/ExternalFormat.hs
@@ -134,6 +134,9 @@ scWriteExternal t0 =
         Constant nm    ->
             do stashName nm
                pure $ unwords ["Constant", show (nameIndex nm)]
+        Variable ec ->
+           do stashEC ec
+              pure $ unwords ["Variable", show (ecVarIndex ec), show (ecType ec)]
         FTermF ftf     ->
           case ftf of
             UnitValue           -> pure $ unwords ["Unit"]
@@ -174,9 +177,6 @@ scWriteExternal t0 =
             ArrayValue e v      -> pure $ unwords ("Array" : show e :
                                             map show (V.toList v))
             StringLit s         -> pure $ unwords ["String", show s]
-            Variable ec ->
-               do stashEC ec
-                  pure $ unwords ["Variable",show (ecVarIndex ec), show (ecType ec)]
 
 
 -- | During parsing, we maintain two maps used for renumbering: The
@@ -343,5 +343,5 @@ scReadExternal sc input =
         ["Nat", n]          -> FTermF <$> (NatLit <$> readM n)
         ("Array" : e : es)  -> FTermF <$> (ArrayValue <$> readIdx e <*> (V.fromList <$> traverse readIdx es))
         ("String" : ts)     -> FTermF <$> (StringLit <$> (readM (unwords ts)))
-        ["Variable", i, t]  -> FTermF <$> (Variable <$> readEC i t)
+        ["Variable", i, t]  -> Variable <$> readEC i t
         _ -> fail $ "Parse error: " ++ unwords tokens

--- a/saw-core/src/SAWCore/OpenTerm.hs
+++ b/saw-core/src/SAWCore/OpenTerm.hs
@@ -1196,7 +1196,7 @@ sawLetMinimize sc t_top =
   slMinTermF' tf@(LocalVar i) =
     tell (varOccs1 i) >> liftIO (scTermF sc tf)
   slMinTermF' tf@(Constant _) = liftIO (scTermF sc tf)
+  slMinTermF' tf@(Variable _) = liftIO (scTermF sc tf)
 
   slMinFTermF :: FlatTermF Term -> SLMinM Term
-  slMinFTermF ftf@(Variable _) = liftIO $ scFlatTermF sc ftf
   slMinFTermF ftf = traverse slMinTerm ftf >>= liftIO . scFlatTermF sc

--- a/saw-core/src/SAWCore/Recognizer.hs
+++ b/saw-core/src/SAWCore/Recognizer.hs
@@ -346,10 +346,9 @@ asConstant _ = Nothing
 
 asVariable :: Recognizer Term (ExtCns Term)
 asVariable t =
-  do ftf <- asFTermF t
-     case ftf of
-       Variable ec -> pure ec
-       _           -> Nothing
+  case unwrapTermF t of
+    Variable ec -> pure ec
+    _           -> Nothing
 
 asSort :: Recognizer Term Sort
 asSort t = do

--- a/saw-core/src/SAWCore/SCTypeCheck.hs
+++ b/saw-core/src/SAWCore/SCTypeCheck.hs
@@ -484,7 +484,6 @@ typeInferConstant nm =
 -- with special cases for primitives and constants to avoid re-type-checking
 -- their types as we are assuming they were type-checked when they were created
 instance TypeInfer (FlatTermF Term) where
-  typeInfer (Variable ec) = return $ ecType ec
   typeInfer t = typeInfer =<< mapM typeInferComplete t
   typeInferComplete ftf =
     SCTypedTerm <$> liftTCM scFlatTermF ftf
@@ -518,6 +517,9 @@ instance TypeInfer (TermF SCTypedTerm) where
          error ("Context = " ++ show ctx)
          -- throwTCError (DanglingVar (i - length ctx))
   typeInfer (Constant nm) = typeInferConstant nm
+  typeInfer (Variable ec) =
+    -- FIXME: should we check that the type of ecType is a sort?
+    typeCheckWHNF $ typedVal $ ecType ec
 
   typeInferComplete tf =
     SCTypedTerm <$> liftTCM scTermF (fmap typedVal tf)
@@ -572,9 +574,6 @@ instance TypeInfer (FlatTermF SCTypedTerm) where
        forM_ vs $ \v_elem -> checkSubtype v_elem tp'
        liftTCM scVecType n tp'
   typeInfer (StringLit{}) = liftTCM scStringType
-  typeInfer (Variable ec) =
-    -- FIXME: should we check that the type of ecType is a sort?
-    typeCheckWHNF $ typedVal $ ecType ec
 
   typeInferComplete ftf =
     SCTypedTerm <$> liftTCM scFlatTermF (fmap typedVal ftf)

--- a/saw-core/src/SAWCore/Term/Functor.hs
+++ b/saw-core/src/SAWCore/Term/Functor.hs
@@ -523,6 +523,7 @@ alphaEquiv = term
     termf (Pi _ t1 u1) (Pi _ t2 u2) = term t1 t2 && term u1 u2
     termf (LocalVar i1) (LocalVar i2) = i1 == i2
     termf (Constant x1) (Constant x2) = x1 == x2
+    termf (Variable x1) (Variable x2) = x1 == x2
     termf _ _ = False
 
     ftermf :: FlatTermF Term -> FlatTermF Term -> Bool

--- a/saw-core/src/SAWCore/Term/Pretty.hs
+++ b/saw-core/src/SAWCore/Term/Pretty.hs
@@ -441,7 +441,6 @@ ppFlatTermF prec tf =
     ArrayValue _ args   ->
       ppArrayValue <$> mapM (ppTerm' PrecTerm) (V.toList args)
     StringLit s -> return $ viaShow s
-    Variable ec -> annotate PPS.ExtCnsStyle <$> ppExtCns ec
 
 -- | Pretty-print a big endian list of bit values as a hexadecimal number
 ppBitsToHex :: [Bool] -> String
@@ -494,6 +493,7 @@ ppTermF prec (Pi x tp body) =
    ppTermInBinder PrecLambda x body)
 ppTermF _ (LocalVar x) = annotate PPS.LocalVarStyle <$> pretty <$> varLookupM x
 ppTermF _ (Constant nm) = annotate PPS.ConstantStyle <$> ppBestName nm
+ppTermF _ (Variable ec) = annotate PPS.ExtCnsStyle <$> ppExtCns ec
 
 
 -- | Internal function to recursively pretty-print a term
@@ -565,9 +565,9 @@ shouldMemoizeTerm t =
     FTermF NatLit{} -> False
     FTermF (ArrayValue _ v) | V.length v == 0 -> False
     FTermF StringLit{} -> False
-    FTermF Variable{} -> False
     Constant{} -> False
     LocalVar{} -> False
+    Variable{} -> False
     _ -> True
 
 -- | Compute a memoization table for a term, and pretty-print the term using the

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -113,7 +113,7 @@ inferResolveNameApp n args =
          do t <- typeInferComplete (LocalVar i :: TermF SCTypedTerm)
             inferApplyAll t args
        (_, Just ec, _) ->
-         do t <- typeInferComplete (FTermF (Variable ec))
+         do t <- typeInferComplete (Variable ec)
             inferApplyAll t args
        (_, _, Just (ResolvedCtor ctor)) ->
          do let c = ctorName ctor


### PR DESCRIPTION
With the plan to move away from de Bruijn indices for variable binding, the 'Variable' constructor will play a more specialized role, and so it makes more sense to be out of FlatTermF.