### PR TITLE
saw-core: Make scConstant fail on terms containing free variables.

### DIFF
--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -1946,13 +1946,10 @@ scConstant :: SharedContext
 scConstant sc name rhs ty =
   do unless (termIsClosed rhs) $
        fail "scConstant: term contains loose variables"
-     let ecs = getAllExts rhs
-     rhs' <- scAbstractExts sc ecs rhs
-     ty' <- scFunAll sc (map ecType ecs) ty
+     unless (null (getAllExts rhs)) $
+       fail "scConstant: term contains free variables"
      nm <- scFreshName sc name
-     t <- scDeclareDef sc nm NoQualifier ty' (Just rhs')
-     args <- mapM (scVariable sc) ecs
-     scApplyAll sc t args
+     scDeclareDef sc nm NoQualifier ty (Just rhs)
 
 -- FIXME: Regarding comments,
 --  - PROBLEM: the previous and the next function have the same
@@ -1972,14 +1969,11 @@ scConstant' :: SharedContext
 scConstant' sc nmi rhs ty =
   do unless (termIsClosed rhs) $
        fail "scConstant: term contains loose variables"
-     let ecs = getAllExts rhs
-     rhs' <- scAbstractExts sc ecs rhs
-     ty' <- scFunAll sc (map ecType ecs) ty
+     unless (null (getAllExts rhs)) $
+       fail "scConstant: term contains free variables"
      i <- scRegisterName sc nmi
      let nm = Name i nmi
-     t <- scDeclareDef sc nm NoQualifier ty' (Just rhs')
-     args <- mapM (scVariable sc) ecs
-     scApplyAll sc t args
+     scDeclareDef sc nm NoQualifier ty (Just rhs)
 
 
 -- | Create an abstract and opaque constant with the specified name and type.


### PR DESCRIPTION
Fixes #2476.