### PR TITLE
saw-core: Make saw-core simulator handle muxes on datatypes.

### DIFF
--- a/intTests/test2337/test.cry
+++ b/intTests/test2337/test.cry
@@ -1,0 +1,17 @@
+enum Letter = A | B
+
+eqLetter : Letter -> Letter -> Bit
+eqLetter l1 l2 =
+  case l1 of
+    A ->
+      case l2 of
+        A -> True
+        B -> False
+    B ->
+      case l2 of
+        A -> False
+        B -> True
+
+letterA : Bool -> Letter
+letterA x =
+  if x then A else B

--- a/intTests/test2337/test.saw
+++ b/intTests/test2337/test.saw
@@ -1,0 +1,3 @@
+import "test.cry";
+
+prove_print z3 {{\(x : Bit) -> (eqLetter l l where l = letterA x) }};

--- a/intTests/test2337/test.sh
+++ b/intTests/test2337/test.sh
@@ -1,0 +1,2 @@
+set -e
+$SAW test.saw

--- a/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
+++ b/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
@@ -467,6 +467,7 @@ bitBlastBasic be m addlPrims ecMap t = do
          (const Nothing)
          neutral
          primHandler
+         (Prims.lazyMuxValue (prims be))
   Sim.evalSharedTerm cfg t
 
 bitBlastExtCns ::

--- a/saw-core-sbv/src/SAWCoreSBV/SBV.hs
+++ b/saw-core-sbv/src/SAWCoreSBV/SBV.hs
@@ -633,7 +633,8 @@ sbvSolveBasic sc addlPrims unintSet t = do
         | otherwise                           = Nothing
   let neutral _env nt = fail ("sbvSolveBasic: could not evaluate neutral term: " ++ show nt)
   let primHandler = Sim.defaultPrimHandler
-  cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted neutral primHandler
+  let mux = Prims.lazyMuxValue prims
+  cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted neutral primHandler mux
   Sim.evalSharedTerm cfg t
 
 parseUninterpreted :: [SVal] -> String -> TValue SBV -> IO SValue
@@ -721,8 +722,9 @@ sbvSATQuery sc addlPrims query =
                 | otherwise                           = Nothing
           let neutral _env nt = fail ("sbvSATQuery: could not evaluate neutral term: " ++ show nt)
           let primHandler = Sim.defaultPrimHandler
+          let mux = Prims.lazyMuxValue prims
 
-          cfg  <- liftIO (Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted neutral primHandler)
+          cfg  <- liftIO (Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted neutral primHandler mux)
           bval <- liftIO (Sim.evalSharedTerm cfg t)
 
           case bval of

--- a/saw-core-what4/src/SAWCoreWhat4/What4.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/What4.hs
@@ -887,7 +887,8 @@ w4SolveBasic sym sc addlPrims ecMap ref unintSet t =
            | otherwise                           = Nothing
      let neutral _ nt = fail ("w4SolveBasic: could not evaluate neutral term: " ++ show nt)
      let primHandler = Sim.defaultPrimHandler
-     cfg <- Sim.evalGlobal m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral primHandler
+     let mux = Prims.lazyMuxValue (prims sym)
+     cfg <- Sim.evalGlobal m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral primHandler mux
      Sim.evalSharedTerm cfg t
 
 
@@ -1431,6 +1432,8 @@ rebuildTerm sym st sc tv sv =
              ]
     VCtorApp _ _ _ ->
       chokeOn "constructors (VCtorApp)"
+    VCtorMux {} ->
+      chokeOn "constructors (VCtorMux)"
     VVector xs ->
       case tv of
         VVecType _ tx ->
@@ -1554,7 +1557,8 @@ w4EvalBasic sym st sc m addlPrims ref unintSet t =
            | otherwise                           = Nothing
      let neutral _env nt = fail ("w4EvalBasic: could not evaluate neutral term: " ++ show nt)
      let primHandler = Sim.defaultPrimHandler
-     cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral primHandler
+     let mux = Prims.lazyMuxValue (prims sym)
+     cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral primHandler mux
      Sim.evalSharedTerm cfg t
 
 -- | Evaluate a saw-core term to a What4 value for the purposes of
@@ -1582,8 +1586,9 @@ w4SimulatorEval sym st sc m addlPrims ref constantFilter t =
           if constantFilter ec then Nothing else Just (X.throwIO (NeutralTermEx (ecName ec)))
      let neutral _env nt = fail ("w4SimulatorEval: could not evaluate neutral term: " ++ show nt)
      let primHandler = Sim.defaultPrimHandler
+     let mux = Prims.lazyMuxValue (prims sym)
      res <- X.try $ do
-              cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral primHandler
+              cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral primHandler mux
               Sim.evalSharedTerm cfg t
      case res of
        Left (NeutralTermEx nmi) -> pure (Left nmi)

--- a/saw-core/src/SAWCore/Simulator/Concrete.hs
+++ b/saw-core/src/SAWCore/Simulator/Concrete.hs
@@ -46,10 +46,11 @@ import SAWCore.SharedTerm
 evalSharedTerm :: ModuleMap -> Map Ident CPrim -> Map VarIndex CValue -> Term -> CValue
 evalSharedTerm m addlPrims ecVals t =
   runIdentity $ do
-    cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns (const Nothing) neutral primHandler
+    cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns (const Nothing) neutral primHandler lazymux
     Sim.evalSharedTerm cfg t
   where
     neutral _env nt = return $ Prim.userError $ "Cannot evaluate neutral term\n" ++ show nt
+    lazymux = Prims.lazyMuxValue prims
     extcns ec =
       case Map.lookup (ecVarIndex ec) ecVals of
         Just v  -> return v

--- a/saw-core/src/SAWCore/Simulator/RME.hs
+++ b/saw-core/src/SAWCore/Simulator/RME.hs
@@ -59,6 +59,7 @@ evalSharedTerm m addlPrims t =
   runIdentity $ do
     cfg <- Sim.evalGlobal m (Map.union constMap addlPrims)
            extcns (const Nothing) neutral primHandler
+           (Prims.lazyMuxValue prims)
     Sim.evalSharedTerm cfg t
   where
     extcns ec = return $ Prim.userError $ "Unimplemented: external constant " ++ show (ecName ec)
@@ -415,6 +416,7 @@ bitBlastBasic m addlPrims ecMap t = runIdentity $ do
          (const Nothing)
          neutral
          primHandler
+         (Prims.lazyMuxValue prims)
   Sim.evalSharedTerm cfg t
 
 


### PR DESCRIPTION
To model values that are symbolic muxes between different datatype constructors, we introduce a new 'Value' constructor 'VCtorMux' that encodes a mux tree over multiple data type constructors.

Fixes #2337.