### PR TITLE
Update cryptol-specs version

### DIFF
--- a/examples/aes/aes.saw
+++ b/examples/aes/aes.saw
@@ -1,135 +1,94 @@
-import "../../deps/cryptol-specs/Common/GF28.cry";
-import "../../deps/cryptol-specs/Primitive/Symmetric/Cipher/Block/AES.cry";
+/**
+ * Cryptol AES property verification.
+ *
+ * This module efficiently checks that decrypt is the inverse of encrypt.
+ *
+ * @copyright Galois Inc.
+ * @author Eric Mertens <emertens@galois.com>
+ */
 
-print "Proving encrypt_lemma...";
-encrypt_lemma <-
-  time (prove_print (unint_z3 ["AESRound"])
-  (rewrite (cryptol_ss())
-  {{ \(state0 : State) (ks : [13]RoundKey) ->
-      (rounds where rounds = [state0] # [ AESRound (rk, s) | rk <- ks | s <- rounds ]) ! 0 ==
-        AESRound(ks@12,AESRound(ks@11,AESRound(ks@10,AESRound(ks@9,
-          AESRound(ks@8,AESRound(ks@7,AESRound(ks@6,AESRound(ks@5,AESRound(ks@4,
-            AESRound(ks@3,AESRound(ks@2,AESRound(ks@1,AESRound(ks@0,state0)))))))))))))
-  }}));
+import "../../deps/cryptol-specs/Common/GF28.cry" as GF28;
+import "../../deps/cryptol-specs/Primitive/Symmetric/Cipher/Block/AES/Instantiations/AES256.cry";
 
-print "Proving decrypt_lemma...";
-decrypt_lemma <-
-  time (prove_print (unint_z3 ["AESInvRound"])
-  (rewrite (cryptol_ss())
-  {{ \(state0 : State) (ks : [13]RoundKey) ->
-      (rounds where rounds = [state0] # [ AESInvRound (rk, s) | rk <- reverse ks | s <- rounds ]) ! 0 ==
-        AESInvRound(ks@0,AESInvRound(ks@1,AESInvRound(ks@2,AESInvRound(ks@3,AESInvRound(ks@4,
-          AESInvRound(ks@5,AESInvRound(ks@6,AESInvRound(ks@7,AESInvRound(ks@8,
-            AESInvRound(ks@9,AESInvRound(ks@10,AESInvRound(ks@11,AESInvRound(ks@12,state0)))))))))))))
-  }}));
+let ss0 = cryptol_ss ();
 
-print "Proving msgToState_stateToMsg(rme)...";
-msgToState_stateToMsg <-
-  time (prove_print rme
-  {{ \st -> msgToState (stateToMsg st) == st }});
+print "Verifying that cipher unrolls";
+unroll_cipher <- prove_print
+    (w4_unint_z3 ["AddRoundKey", "MixColumns", "SubBytes", "ShiftRows"])
+    {{ \w pt -> cipher w pt ==
+    (stateToMsg (AddRoundKey (w@14) (ShiftRows (SubBytes (t 13 (t 12 (t 11 (t 10 (t 9 (t 8 (t 7 (t 6 (t 5 (t 4 (t 3 (t 2 (t 1 (AddRoundKey (w@0) (msgToState pt))))))))))))))))))
+        where
+        t i state = AddRoundKey (w@i) (MixColumns (ShiftRows (SubBytes state))))
+    }};
 
-print "Proving stateToMsg_msgToState(rme)...";
-stateToMsg_msgToState <-
-  time (prove_print rme
-  {{ \msg -> stateToMsg (msgToState msg) == msg }});
+print "Verifying that invCipher unrolls";
+unroll_invCipher <- prove_print
+    (w4_unint_z3 ["AddRoundKey", "InvMixColumns", "InvSubBytes", "InvShiftRows"])
+    {{ \w ct -> invCipher w ct ==
+    (stateToMsg (AddRoundKey (w@0) (InvSubBytes (InvShiftRows (t 1 (t 2 (t 3 (t 4 (t 5 (t 6 (t 7 (t 8 (t 9 (t 10 (t 11 (t 12 (t 13 (AddRoundKey (w@14) ( msgToState ct))))))))))))))))))
+        where
+        t i state = InvMixColumns (AddRoundKey (w@i) (InvSubBytes (InvShiftRows state))))
+    }};
 
-print "Proving AddRoundKey_cancel(rme)...";
-AddRoundKey_cancel <-
-  time (prove_print rme
-  {{ \rk s -> AddRoundKey (rk, AddRoundKey (rk, s)) == s }});
+print "Verifying that SBox unfolds";
+/* This performance trick is necessary because SAW doesn't memoize sboxTable */
+unfold_SBox <- prove_print (unint_z3 ["inverse", "add", "rotateR"])
+  {{ \i -> (SBox i == GF28::add [b, b >>> 4, b >>> 5, b >>> 6, b >>> 7, 0x63] where b = GF28::inverse i) }};
 
-print "Proving InvShiftRows_ShiftRows(rme)...";
-InvShiftRows_ShiftRows <-
-  time (prove_print rme
-  {{ \s -> InvShiftRows (ShiftRows s) == s }});
+print "Verifying that InvSBox unfolds";
+/* This performance trick is necessary because SAW doesn't memoize sboxInvTable */
+unfold_SBoxInv <- prove_print (unint_z3 ["inverse", "add", "rotateR"])
+  {{ \i -> SBoxInv i == GF28::inverse (GF28::add [i >>> 2, i >>> 5, i >>> 7, 0x05]) }};
 
-print "Proving InvSubByte_SubByte'(rme)...";
-InvSubByte_SubByte' <-
-  time (prove_print rme
-  {{ \x -> InvSubByte (SubByte' x) == x }});
+print "Verifying that SBoxInv inverts SBox";
+invert_SBox <- prove_print
+    do {
+        simplify (addsimps [unfold_SBox, unfold_SBoxInv] ss0);
+        rme;
+    }
+    {{ \s -> SBoxInv (SBox s) == s }};
 
-print "Proving InvSubBytes_SubBytes(rewriting,rme)...";
-InvSubBytes_SubBytes <-
-  time (prove_print do {
-    unfolding ["InvSubBytes", "SubBytes"];
-    simplify (add_prelude_eqs ["map_map"]
-             (addsimps [InvSubByte_SubByte']
-             (cryptol_ss())));
+print "Verifying that InvSubBytes inverts SubBytes";
+invert_SubBytes <- prove_print
+    do {
+        unfolding ["InvSubBytes", "SubBytes"];
+        simplify (add_prelude_eqs ["map_map"] (addsimps [invert_SBox] ss0));
+        rme;
+    }
+    {{ \s -> InvSubBytes (SubBytes s) == s }};
+
+print "Verifying that InvShiftRows inverts ShiftRows";
+invert_ShiftRows <- prove_print rme
+    {{ \s -> InvShiftRows (ShiftRows s) == s }};
+
+print "Verifying that InvMixColumns inverts MixColumns";
+invert_MixColumns <- prove_print rme
+    {{ \s -> InvMixColumns (MixColumns s) == s }};
+
+print "Verifying that msgToState inverts stateToMsg";
+invert_stateToMsg <- prove_print rme {{\s -> msgToState (stateToMsg s) == s}};
+
+print "Verifying that stateToMsg inverts msgToState";
+invert_msgToState <- prove_print rme {{\s -> stateToMsg (msgToState s) == s}};
+
+print "Verifying that AddRoundKey is involutive";
+invert_AddRoundKey <- prove_print rme
+    {{ \x y -> AddRoundKey x (AddRoundKey x y) == y }};
+
+print "Verifying that invCipher inverts cipher";
+invert_cipher <- prove_print do {
+    simplify (addsimps
+        [unroll_cipher, unroll_invCipher, invert_ShiftRows,
+         invert_MixColumns, invert_SubBytes, invert_msgToState,
+         invert_stateToMsg, invert_msgToState, invert_AddRoundKey] ss0);
     rme;
-  }
-  {{ \s -> InvSubBytes (SubBytes s) == s }});
+   }
+   {{ \w pt -> invCipher w (cipher w pt) == pt }};
 
-print "Proving InvMixColumns_MixColumns(rme)...";
-InvMixColumns_MixColumns <-
-  time (prove_print rme
-  {{ \s -> InvMixColumns (MixColumns s) == s }});
-
-print "Proving aesDecrypt_aesEncrypt(rewriting)...";
-dec_enc <-
-  time (prove_print do {
-    unfolding ["aesEncrypt", "aesEncryptWithKeySchedule", "aesDecrypt"];
-    simplify (addsimps [encrypt_lemma,
-                        decrypt_lemma]
-              (cryptol_ss()));
-    unfolding ["AESRound", "AESInvRound", "AESFinalRound", "AESFinalInvRound"];
-    simplify (add_cryptol_defs ["ecEq"]
-             (add_prelude_eqs ["bvEq_refl"]
-             (addsimps [msgToState_stateToMsg,
-                        AddRoundKey_cancel,
-                        InvShiftRows_ShiftRows,
-                        InvSubBytes_SubBytes,
-                        InvMixColumns_MixColumns,
-                        stateToMsg_msgToState]
-              (cryptol_ss()))));
-    trivial;
-  }
-  {{ \msg key -> aesDecrypt (aesEncrypt (msg, key), key) == msg }});
-
-print "Proving ShiftRows_InvShiftRows(rme)...";
-ShiftRows_InvShiftRows <-
-  time (prove_print rme
-  {{ \s -> ShiftRows (InvShiftRows s) == s }});
-
-print "Proving SubByte'_InvSubByte(rme)...";
-SubByte'_InvSubByte <-
-  time (prove_print rme
-  {{ \x -> SubByte' (InvSubByte x) == x }});
-
-print "Proving InvSubBytes_SubBytes(rewriting,rme)...";
-SubBytes_InvSubBytes <-
-  time (prove_print do {
-    unfolding ["InvSubBytes", "SubBytes"];
-    simplify (add_prelude_eqs ["map_map"]
-             (addsimps [SubByte'_InvSubByte]
-             (cryptol_ss())));
+print "Verifying that decrypt inverts encrypt";
+prove_print do {
+    unfolding ["aesIsCorrect", "encrypt", "decrypt"];
+    simplify (addsimps [invert_cipher] ss0);
     rme;
-  }
-  {{ \s -> SubBytes (InvSubBytes s) == s }});
-
-print "Proving MixColumns_InvMixColumns(rme)...";
-MixColumns_InvMixColumns <-
-  time (prove_print rme
-  {{ \s -> MixColumns (InvMixColumns s) == s }});
-
-print "Proving aesEncrypt_aesDecrypt(rewriting)...";
-enc_dec <-
-  time (prove_print do {
-    unfolding ["aesEncrypt", "aesEncryptWithKeySchedule", "aesDecrypt"];
-    simplify (addsimps [encrypt_lemma,
-                        decrypt_lemma]
-              (cryptol_ss()));
-    unfolding ["AESRound", "AESInvRound", "AESFinalRound", "AESFinalInvRound"];
-    simplify (add_cryptol_defs ["ecEq"]
-             (add_prelude_eqs ["bvEq_refl"]
-             (addsimps [msgToState_stateToMsg,
-                        AddRoundKey_cancel,
-                        ShiftRows_InvShiftRows,
-                        SubBytes_InvSubBytes,
-                        MixColumns_InvMixColumns,
-                        stateToMsg_msgToState]
-              (cryptol_ss()))));
-    trivial;
-  }
-  {{ \msg key -> aesEncrypt (aesDecrypt (msg, key), key) == msg }});
-
-exit 0;
+   }
+   {{ aesIsCorrect }};

--- a/examples/chacha20/chacha20.saw
+++ b/examples/chacha20/chacha20.saw
@@ -39,4 +39,4 @@ let stream_spec len = do {
 };
 
 print "running verification...";
-time (llvm_llvm_verify mod "crypto_stream_chacha20" [] true (stream_spec 256) abc);
+time (llvm_verify mod "crypto_stream_chacha20" [] true (stream_spec 256) abc);

--- a/examples/cryptol-2/des-cryptol2.saw
+++ b/examples/cryptol-2/des-cryptol2.saw
@@ -1,5 +1,0 @@
-m <- cryptol_load "../../deps/cryptol-specs/Primitive/Symmetric/Cipher/Block/DES.cry";
-let enc = {{ m::DES.encrypt }};
-let dec = {{ m::DES.decrypt }};
-let {{ thm key msg = dec key (enc key msg) == msg }};
-prove_print abc {{ thm }};

--- a/heapster/examples/sha512.cry
+++ b/heapster/examples/sha512.cry
@@ -4,9 +4,12 @@ module SHA512 where
 import SpecPrims
 
 // ============================================================================
-// Definitions from cryptol-specs/Primitive/Keyless/Hash/SHA512.cry, with some
-// type annotations added to SIGMA_0, SIGMA_1, sigma_0, and sigma_1 to get
-// monadification to go through
+// These definitions are modified from an outdated version of cryptol-specs's
+// SHA512 implementation.
+// @see https://github.com/GaloisInc/cryptol-specs/blob/4a0cc3ea4adfa5cffb1ba0fe12076389f0098eae/Primitive/Keyless/Hash/SHA512.cry
+//
+// The primary changes are type annotations added to SIGMA_0, SIGMA_1,
+// sigma_0, and sigma_1 to get monadification to go through.
 // ============================================================================
 
 type w = 64
@@ -49,7 +52,8 @@ sigma_1 x = (x >>> (19 : [w])) ^ (x >>> (61 : [w])) ^ (x >> (6 : [w]))
 
 
 // ============================================================================
-// Definitions from cryptol-specs/Primitive/Keyless/Hash/SHA.cry
+// Definitions from an outdated common module for SHA.
+// @see https://github.com/GaloisInc/cryptol-specs/blob/4a0cc3ea4adfa5cffb1ba0fe12076389f0098eae/Primitive/Keyless/Hash/SHA.cry
 // ============================================================================
 
 Ch : [w] -> [w] -> [w] -> [w]
@@ -119,7 +123,7 @@ processBlock_loop_spec : [w] ->
 processBlock_loop_spec i a b c d e f g h X T1 in =
   if i < 80 then processBlock_loop_spec (i+16) aF bF cF dF eF fF gF hF XF T1F in
             else (a,b,c,d,e,f,g,h,in)
-  where (a0,b0,c0,d0,e0,f0,g0,h0,X0,_,_,T10) = round_16_80_spec i  0 a  b  c  d  e  f  g  h  X  T1 
+  where (a0,b0,c0,d0,e0,f0,g0,h0,X0,_,_,T10) = round_16_80_spec i  0 a  b  c  d  e  f  g  h  X  T1
         (h1,a1,b1,c1,d1,e1,f1,g1,X1,_,_,T11) = round_16_80_spec i  1 h0 a0 b0 c0 d0 e0 f0 g0 X0 T10
         (g2,h2,a2,b2,c2,d2,e2,f2,X2,_,_,T12) = round_16_80_spec i  2 g1 h1 a1 b1 c1 d1 e1 f1 X1 T11
         (f3,g3,h3,a3,b3,c3,d3,e3,X3,_,_,T13) = round_16_80_spec i  3 f2 g2 h2 a2 b2 c2 d2 e2 X2 T12

--- a/intTests/test0035_aes_consistent/test.sh
+++ b/intTests/test0035_aes_consistent/test.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -e
-
-cp ../../examples/aes/aes.saw .
-$SAW aes.saw
-rm -f aes.saw

--- a/intTests/test_examples/test.sh
+++ b/intTests/test_examples/test.sh
@@ -1,14 +1,9 @@
 #!/bin/sh
 set -e
 
-mkdir -p tmp
-cp -r ../../examples tmp
-
 (cd ../../examples &&
 for f in `find aes fresh-post ghost java llvm multi-override partial-spec -name "*.saw"` ; do
     (cd `dirname $f` && $SAW `basename $f`)
 done)
 
 (cd ../../examples/salsa20 && $SAW salsa.saw)
-
-rm -r tmp

--- a/intTests/test_examples/test.sh
+++ b/intTests/test_examples/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-
+export CRYPTOLPATH="../../deps/cryptol-specs"
 (cd ../../examples &&
 for f in `find aes fresh-post ghost java llvm multi-override partial-spec -name "*.saw"` ; do
     (cd `dirname $f` && $SAW `basename $f`)


### PR DESCRIPTION
Closes #2499.

I updated the cryptol-specs version. It was (tentatively) not that hard, mainly because this repo only uses about 5 files from that repo (AES256 and GF28, chacha20, MD5, DES). The s2nTests all have their own repos with specified versions of cryptol-specs, but I did not touch those or try to update them.

I have some specific questions for various bits I wasn't sure what to do with, plus some inline questions. See also notes in the commit messages.
- `examples/cryptol2/des-cryptol2.saw`. This just doesn't work. I don't think it worked before the update either, because `DES.cry` was deleted [even before that](https://github.com/GaloisInc/cryptol-specs/commit/1286638195aef8e966ba23315b9bddba9e2dfaa6). I tried pulling in the older file but it still didn't run quickly (I tried for ~15 minutes).
- `examples/chacha20/chacha20.saw`. This also doesn't work, likely bitrotted? I replaced `llvm_llvm_verify` with plain-old `llvm_verify` because it looked like a typo but it didn't run in 10 minutes. I don't know how long is reasonable to wait for these examples. This file hasn't changed between the two versions of cryptol-specs.
- I noticed `test0002` has two `.saw` files, only one of which is run in the test (`test.saw`). The other one (`test2.saw`) has bitrotted and has an incorrect reference to the cryptol file. They only differ in one meaningful way: `test2` calls has a slightly different theorem, on which it calls `prove_print`. `test` calls `write_aig` instead. I could delete `test2` wholesale, or port its prove command into `test`, or fix it and add it to the test script.
