### PR TITLE
saw-core: Remove unused field from 'CtorArgStruct' data type.

### DIFF
--- a/saw-core/src/SAWCore/Module.hs
+++ b/saw-core/src/SAWCore/Module.hs
@@ -148,10 +148,8 @@ data CtorArgStruct =
     -- ^ earlier ctorParams are in scope
     ctorArgs :: [(Name, CtorArg)],
     -- ^ ctorParams and earlier ctorArgs are in scope
-    ctorIndices :: [Term],
+    ctorIndices :: [Term]
     -- ^ ctorParams and ctorArgs are in scope
-    dataTypeIndices :: [ExtCns Term]
-    -- ^ ctorParams and earlier dataTypeIndices are in scope
   }
 
 -- | A specification of a constructor

--- a/saw-core/src/SAWCore/Term/CtxTerm.hs
+++ b/saw-core/src/SAWCore/Term/CtxTerm.hs
@@ -152,4 +152,4 @@ mkCtorArgStruct sc d params dt_ixs ctor_tp =
   mkCtorArgsIxs sc d params dt_ixs ctor_tp >>= \case
     Nothing -> pure Nothing
     Just (args, ctor_ixs) ->
-      pure $ Just (CtorArgStruct params args ctor_ixs dt_ixs)
+      pure $ Just (CtorArgStruct params args ctor_ixs)


### PR DESCRIPTION
I was wondering what this field was for... Nothing, as it turns out.