### PR TITLE
Refactor data types to use `Name` type

### DIFF
--- a/crucible-mir-comp/src/Mir/Compositional/Override.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Override.hs
@@ -167,7 +167,7 @@ runSpec myCS mh ms = ovrWithBackend $ \bak ->
     let postFresh = ms ^. MS.csPostState . MS.csFreshVars
     postFreshTermSub <- liftM IntMap.fromList $ forM postFresh $ \tec -> do
         let ec = SAW.tecExt tec
-        let nameStr = Text.unpack $ SAW.toShortName $ SAW.ecName ec
+        let nameStr = Text.unpack $ SAW.toShortName $ SAW.ecNameInfo ec
         let nameSymbol = W4.safeSymbol nameStr
         Some btpr <- liftIO $ termToType sym (SAW.ecType ec)
         expr <- liftIO $ W4.freshConstant sym nameSymbol btpr

--- a/crucible-mir-comp/src/Mir/Compositional/Override.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Override.hs
@@ -47,10 +47,10 @@ import Lang.Crucible.FunctionHandle
 import Lang.Crucible.Simulator
 import Lang.Crucible.Types
 
+import qualified SAWCore.Name as SAW
 import qualified SAWCore.Prelude as SAW
 import qualified SAWCore.Recognizer as SAW
 import qualified SAWCore.SharedTerm as SAW
-import qualified SAWCore.Term.Functor as SAW
 import qualified CryptolSAWCore.TypedTerm as SAW
 
 import qualified SAWCentral.Crucible.Common.MethodSpec as MS
@@ -167,7 +167,7 @@ runSpec myCS mh ms = ovrWithBackend $ \bak ->
     let postFresh = ms ^. MS.csPostState . MS.csFreshVars
     postFreshTermSub <- liftM IntMap.fromList $ forM postFresh $ \tec -> do
         let ec = SAW.tecExt tec
-        let nameStr = Text.unpack $ SAW.toShortName $ SAW.ecNameInfo ec
+        let nameStr = Text.unpack $ SAW.ecShortName ec
         let nameSymbol = W4.safeSymbol nameStr
         Some btpr <- liftIO $ termToType sym (SAW.ecType ec)
         expr <- liftIO $ W4.freshConstant sym nameSymbol btpr

--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -2000,11 +2000,11 @@ scCryptolType sc t =
         Right t2 <- asCryptolTypeValue v2
         return (Right (C.tSeq (C.tNum n) t2))
 
-      SC.VDataType (ecName -> ModuleIdentifier "Prelude.Stream") [SC.TValue v1] [] ->
+      SC.VDataType (ecNameInfo -> ModuleIdentifier "Prelude.Stream") [SC.TValue v1] [] ->
           do Right t1 <- asCryptolTypeValue v1
              return (Right (C.tSeq C.tInf t1))
 
-      SC.VDataType (ecName -> ModuleIdentifier "Cryptol.Num") [] [] ->
+      SC.VDataType (ecNameInfo -> ModuleIdentifier "Cryptol.Num") [] [] ->
         return (Left C.KNum)
 
       SC.VDataType _ _ _ -> Nothing

--- a/cryptol-saw-core/src/CryptolSAWCore/Monadify.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Monadify.hs
@@ -141,9 +141,7 @@ import GHC.Stack
 
 -- FIXME: move to OpenTerm.hs
 
--- | A global definition, which is either a primitive or a constant. As
--- described in the documentation for 'ExtCns', the names need not be unique,
--- but the 'VarIndex' is, and this is what is used to index 'GlobalDef's.
+-- | A global definition, which is either a primitive or a constant.
 data GlobalDef = GlobalDef { globalDefName :: Name,
                              globalDefType :: Term,
                              globalDefTerm :: Term }

--- a/cryptol-saw-core/src/CryptolSAWCore/Monadify.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Monadify.hs
@@ -174,7 +174,7 @@ asTypedGlobalDef t =
       let ty = resolvedNameType (requireNameInMap nm ?mm)
       in Just $ GlobalDef (nameInfo nm) (nameIndex nm) ty t
     Variable ec ->
-      Just $ GlobalDef (ecName ec) (ecVarIndex ec) (ecType ec) t
+      Just $ GlobalDef (ecNameInfo ec) (ecVarIndex ec) (ecType ec) t
     _ -> Nothing
 
 -- FIXME HERE NOW: remove these if no longer needed
@@ -827,15 +827,15 @@ mkCtorArgMonTerm ec
   | not (isFirstOrderType (ecType ec)) =
     failArgMonTerm (monadifyType [] $ ecType ec)
     ("monadification failed: cannot handle constructor "
-     ++ Text.unpack (toAbsoluteName (ecName ec)) ++ " with higher-order type")
+     ++ Text.unpack (toAbsoluteName (ecNameInfo ec)) ++ " with higher-order type")
 mkCtorArgMonTerm ec =
-  case ecName ec of
+  case ecNameInfo ec of
     ModuleIdentifier ident ->
       fromSemiPureTermFun (monadifyType [] $ ecType ec) (ctorOpenTerm ident)
     ImportedName{} ->
       failArgMonTerm (monadifyType [] $ ecType ec)
       ("monadification failed: cannot handle constructor "
-       ++ Text.unpack (toAbsoluteName (ecName ec)) ++ " with non-ident name")
+       ++ Text.unpack (toAbsoluteName (ecNameInfo ec)) ++ " with non-ident name")
 
 
 ----------------------------------------------------------------------

--- a/cryptol-saw-core/src/CryptolSAWCore/Simpset.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Simpset.hs
@@ -14,9 +14,9 @@ module CryptolSAWCore.Simpset
   ) where
 
 import SAWCore.Module (moduleDefs, Def(..))
+import SAWCore.Name
 import SAWCore.Rewriter
 import SAWCore.SharedTerm
-import SAWCore.Term.Functor
 
 mkCryptolSimpset :: SharedContext -> IO (Simpset a)
 mkCryptolSimpset sc =
@@ -25,7 +25,7 @@ mkCryptolSimpset sc =
   where
     cryptolDefs m = filter (not . excluded) $ moduleDefs m
     excluded d =
-      case defNameInfo d of
+      case nameInfo (defName d) of
         ModuleIdentifier ident -> ident `elem` excludedNames
         ImportedName{} -> True
 

--- a/cryptol-saw-core/src/CryptolSAWCore/TypedTerm.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/TypedTerm.hs
@@ -74,7 +74,7 @@ ppTypedTermType (TypedTermOther tp) =
 
 ppTypedExtCns :: TypedExtCns -> PP.Doc ann
 ppTypedExtCns (TypedExtCns tp ec) =
-  PP.unAnnotate (ppName (ecName ec))
+  PP.unAnnotate (ppName (ecNameInfo ec))
   PP.<+> PP.pretty ":" PP.<+>
   PP.viaShow (C.ppPrec 0 tp)
 

--- a/otherTests/saw-core/Tests/Parser.hs
+++ b/otherTests/saw-core/Tests/Parser.hs
@@ -11,6 +11,7 @@ module Tests.Parser where
 import Test.Tasty
 import Test.Tasty.HUnit
 import SAWCore.Module
+import SAWCore.Name
 import SAWCore.Prelude
 import SAWCore.SharedTerm
 import SAWCore.Term.Functor
@@ -21,7 +22,7 @@ namedMsg sym msg = "In " ++ show (toAbsoluteName sym) ++ ": " ++ msg
 
 checkDef :: Def -> Assertion
 checkDef d = do
-  let sym = defNameInfo d
+  let sym = nameInfo (defName d)
   let tp = defType d
   assertBool (namedMsg sym "Type is not ground.") (termIsClosed tp)
   case defBody d of

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -72,6 +72,7 @@ import SAWCore.FiniteValue
   , scFirstOrderValue
   )
 import SAWCore.Module (ModuleMap)
+import SAWCore.Name (ecShortName)
 import SAWCore.SATQuery
 import SAWCore.SCTypeCheck
 import SAWCore.Recognizer
@@ -1358,7 +1359,7 @@ proveByBVInduction script t =
             vars  <- io $ mapM (scVariable sc) pis
             innerVars <-
               io $ sequence $
-              [ scFreshGlobal sc ("i_" <> toShortName (ecNameInfo ec)) (ecType ec) | ec <- pis ]
+              [ scFreshGlobal sc ("i_" <> ecShortName ec) (ecType ec) | ec <- pis ]
             t1    <- io $ scApplyAllBeta sc (ttTerm t) vars
             tsz   <- io $ scTupleSelector sc t1 1 2 -- left element
             tbody <- io $ scEqTrue sc =<< scTupleSelector sc t1 2 2 -- rightmost tuple element
@@ -1566,7 +1567,7 @@ quickCheckPrintPrim sc opts numTests tt =
      runManyTests testGen numTests >>= \case
         Nothing -> printOutLn opts Info $ "All " ++ show numTests ++ " tests passed!"
         Just cex ->
-          do let cex' = [ (Text.unpack (toShortName (ecNameInfo ec)), v) | (ec,v) <- cex ]
+          do let cex' = [ (Text.unpack (ecShortName ec), v) | (ec,v) <- cex ]
              printOutLn opts OnlyCounterExamples $
                "----------Counterexample----------\n" ++
                showList cex' ""

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -1358,7 +1358,7 @@ proveByBVInduction script t =
             vars  <- io $ mapM (scVariable sc) pis
             innerVars <-
               io $ sequence $
-              [ scFreshGlobal sc ("i_" <> toShortName (ecName ec)) (ecType ec) | ec <- pis ]
+              [ scFreshGlobal sc ("i_" <> toShortName (ecNameInfo ec)) (ecType ec) | ec <- pis ]
             t1    <- io $ scApplyAllBeta sc (ttTerm t) vars
             tsz   <- io $ scTupleSelector sc t1 1 2 -- left element
             tbody <- io $ scEqTrue sc =<< scTupleSelector sc t1 2 2 -- rightmost tuple element
@@ -1566,7 +1566,7 @@ quickCheckPrintPrim sc opts numTests tt =
      runManyTests testGen numTests >>= \case
         Nothing -> printOutLn opts Info $ "All " ++ show numTests ++ " tests passed!"
         Just cex ->
-          do let cex' = [ (Text.unpack (toShortName (ecName ec)), v) | (ec,v) <- cex ]
+          do let cex' = [ (Text.unpack (toShortName (ecNameInfo ec)), v) | (ec,v) <- cex ]
              printOutLn opts OnlyCounterExamples $
                "----------Counterexample----------\n" ++
                showList cex' ""

--- a/saw-central/src/SAWCentral/Crucible/Common/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/Override.hs
@@ -551,7 +551,7 @@ refreshTerms sc ss =
      OM (termSub %= IntMap.union extension)
   where
     freshenTerm (TypedExtCns _cty ec) =
-      do ec' <- liftIO $ scFreshEC sc (toShortName (ecName ec)) (ecType ec)
+      do ec' <- liftIO $ scFreshEC sc (toShortName (ecNameInfo ec)) (ecType ec)
          new <- liftIO $ scVariable sc ec'
          return (ecVarIndex ec, new)
 

--- a/saw-central/src/SAWCentral/Crucible/Common/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/Override.hs
@@ -108,7 +108,7 @@ import           Data.Parameterized.TraversableFC (toListFC)
 
 import qualified SAWSupport.Pretty as PPS (defaultOpts, limitMaxDepth)
 
-import           SAWCore.Name (toShortName)
+import           SAWCore.Name (ecShortName)
 import           SAWCore.Prelude as SAWVerifier (scEq)
 import           SAWCore.SharedTerm as SAWVerifier
 import           SAWCore.Term.Functor (unwrapTermF)
@@ -551,7 +551,7 @@ refreshTerms sc ss =
      OM (termSub %= IntMap.union extension)
   where
     freshenTerm (TypedExtCns _cty ec) =
-      do ec' <- liftIO $ scFreshEC sc (toShortName (ecNameInfo ec)) (ecType ec)
+      do ec' <- liftIO $ scFreshEC sc (ecShortName ec) (ecType ec)
          new <- liftIO $ scVariable sc ec'
          return (ecVarIndex ec, new)
 

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -110,7 +110,7 @@ import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Context as Ctx
 
 import SAWCore.FiniteValue (ppFirstOrderValue)
-import SAWCore.Name (toShortName)
+import SAWCore.Name (ecShortName)
 import SAWCore.SharedTerm
 import CryptolSAWCore.TypedTerm
 
@@ -346,7 +346,7 @@ verifyObligations cc mspec tactic assumes asserts =
            printOutLnTop Info (show stats)
            printOutLnTop OnlyCounterExamples "----------Counterexample----------"
            opts <- rwPPOpts <$> getTopLevelRW
-           let showEC ec = Text.unpack (toShortName (ecNameInfo ec))
+           let showEC ec = Text.unpack (ecShortName ec)
            let showAssignment (name, val) = "  " ++ showEC name ++ ": " ++ show (ppFirstOrderValue opts val)
            mapM_ (printOutLnTop OnlyCounterExamples . showAssignment) vals
            io $ fail "Proof failed." -- Mirroring behavior of llvm_verify

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -346,7 +346,7 @@ verifyObligations cc mspec tactic assumes asserts =
            printOutLnTop Info (show stats)
            printOutLnTop OnlyCounterExamples "----------Counterexample----------"
            opts <- rwPPOpts <$> getTopLevelRW
-           let showEC ec = Text.unpack (toShortName (ecName ec))
+           let showEC ec = Text.unpack (toShortName (ecNameInfo ec))
            let showAssignment (name, val) = "  " ++ showEC name ++ ": " ++ show (ppFirstOrderValue opts val)
            mapM_ (printOutLnTop OnlyCounterExamples . showAssignment) vals
            io $ fail "Proof failed." -- Mirroring behavior of llvm_verify

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
@@ -847,7 +847,7 @@ verifyObligations cc mspec tactic assumes asserts =
                  if null vals then
                    printOutLnTop OnlyCounterExamples "<<All settings of the symbolic variables constitute a counterexample>>"
                  else
-                   let showEC ec = Text.unpack (toShortName (ecName ec)) in
+                   let showEC ec = Text.unpack (toShortName (ecNameInfo ec)) in
                    let showAssignment (ec, val) = "  " ++ showEC ec ++ ": " ++ show (ppFirstOrderValue opts val) in
                    mapM_ (printOutLnTop OnlyCounterExamples . showAssignment) vals
                  printOutLnTop OnlyCounterExamples "----------------------------------"

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
@@ -181,9 +181,9 @@ import qualified Data.Parameterized.TraversableFC as Ctx
 
 -- saw-core
 import SAWCore.FiniteValue (ppFirstOrderValue)
+import SAWCore.Name (ecShortName)
 import SAWCore.SharedTerm
 import SAWCore.Recognizer
-import SAWCore.Term.Functor
 import SAWCore.Term.Pretty (showTerm)
 
 import SAWCoreWhat4.ReturnTrip
@@ -847,7 +847,7 @@ verifyObligations cc mspec tactic assumes asserts =
                  if null vals then
                    printOutLnTop OnlyCounterExamples "<<All settings of the symbolic variables constitute a counterexample>>"
                  else
-                   let showEC ec = Text.unpack (toShortName (ecNameInfo ec)) in
+                   let showEC ec = Text.unpack (ecShortName ec) in
                    let showAssignment (ec, val) = "  " ++ showEC ec ++ ": " ++ show (ppFirstOrderValue opts val) in
                    mapM_ (printOutLnTop OnlyCounterExamples . showAssignment) vals
                  printOutLnTop OnlyCounterExamples "----------------------------------"

--- a/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
@@ -1629,7 +1629,7 @@ checkGoals bak opts nm loc sc tactic mdMap invSubst loopFunEquivConds = do
         ppOpts <- rwPPOpts <$> getTopLevelRW
         case vals of
           [] -> printOutLnTop OnlyCounterExamples "<<All settings of the symbolic variables constitute a counterexample>>"
-          _ -> let showEC ec = Text.unpack (toShortName (ecName ec)) in
+          _ -> let showEC ec = Text.unpack (toShortName (ecNameInfo ec)) in
                let showAssignment (ec, val) =
                      mconcat [ " ", showEC ec, ": ", show $ ppFirstOrderValue ppOpts val ]
                in mapM_ (printOutLnTop OnlyCounterExamples . showAssignment) vals

--- a/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
@@ -73,7 +73,7 @@ import Data.Parameterized.Context hiding (view, zipWithM)
 import CryptolSAWCore.CryptolEnv
 import SAWCore.FiniteValue
 import SAWCore.Module (Def(..), ResolvedName(..), lookupVarIndexInMap)
-import SAWCore.Name (Name(..), toShortName)
+import SAWCore.Name (Name(..), ecShortName)
 import SAWCore.Prelude
 import SAWCore.Recognizer
 import SAWCore.SharedTerm
@@ -1629,7 +1629,7 @@ checkGoals bak opts nm loc sc tactic mdMap invSubst loopFunEquivConds = do
         ppOpts <- rwPPOpts <$> getTopLevelRW
         case vals of
           [] -> printOutLnTop OnlyCounterExamples "<<All settings of the symbolic variables constitute a counterexample>>"
-          _ -> let showEC ec = Text.unpack (toShortName (ecNameInfo ec)) in
+          _ -> let showEC ec = Text.unpack (ecShortName ec) in
                let showAssignment (ec, val) =
                      mconcat [ " ", showEC ec, ": ", show $ ppFirstOrderValue ppOpts val ]
                in mapM_ (printOutLnTop OnlyCounterExamples . showAssignment) vals

--- a/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
@@ -1208,7 +1208,7 @@ verifyObligations cc mspec tactic assumes asserts =
            printOutLnTop Info (show stats)
            printOutLnTop OnlyCounterExamples "----------Counterexample----------"
            opts <- rwPPOpts <$> getTopLevelRW
-           let showEC ec = Text.unpack (toShortName (ecName ec))
+           let showEC ec = Text.unpack (toShortName (ecNameInfo ec))
            let showAssignment (name, val) = "  " ++ showEC name ++ ": " ++ show (ppFirstOrderValue opts val)
            mapM_ (printOutLnTop OnlyCounterExamples . showAssignment) vals
            io $ fail "Proof failed." -- Mirroring behavior of llvm_verify

--- a/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
@@ -136,7 +136,7 @@ import qualified What4.Interface as W4
 import qualified What4.ProgramLoc as W4
 
 import SAWCore.FiniteValue (ppFirstOrderValue)
-import SAWCore.Name (toShortName)
+import SAWCore.Name (ecShortName)
 import SAWCore.SharedTerm
 import SAWCoreWhat4.ReturnTrip
 import CryptolSAWCore.TypedTerm
@@ -1208,7 +1208,7 @@ verifyObligations cc mspec tactic assumes asserts =
            printOutLnTop Info (show stats)
            printOutLnTop OnlyCounterExamples "----------Counterexample----------"
            opts <- rwPPOpts <$> getTopLevelRW
-           let showEC ec = Text.unpack (toShortName (ecNameInfo ec))
+           let showEC ec = Text.unpack (ecShortName ec)
            let showAssignment (name, val) = "  " ++ showEC name ++ ": " ++ show (ppFirstOrderValue opts val)
            mapM_ (printOutLnTop OnlyCounterExamples . showAssignment) vals
            io $ fail "Proof failed." -- Mirroring behavior of llvm_verify

--- a/saw-central/src/SAWCentral/JavaExpr.hs
+++ b/saw-central/src/SAWCentral/JavaExpr.hs
@@ -162,7 +162,7 @@ jeVarName = map dotToUnderscore . ppJavaExpr
         dotToUnderscore c = c
 
 asJavaExpr :: Term -> Maybe String
-asJavaExpr (asVariable -> Just ec) = Just (Text.unpack (toShortName (ecName ec))) -- TODO?
+asJavaExpr (asVariable -> Just ec) = Just (Text.unpack (toShortName (ecNameInfo ec))) -- TODO?
 asJavaExpr _ = Nothing
 
 isRefJavaExpr :: JavaExpr -> Bool

--- a/saw-central/src/SAWCentral/JavaExpr.hs
+++ b/saw-central/src/SAWCentral/JavaExpr.hs
@@ -72,7 +72,7 @@ import Text.Read hiding (lift)
 import Lang.JVM.Codebase as JSS
 
 import CryptolSAWCore.Cryptol
-import SAWCore.Name (toShortName)
+import SAWCore.Name (ecShortName)
 import SAWCore.Recognizer
 import SAWCore.SharedTerm
 
@@ -162,7 +162,7 @@ jeVarName = map dotToUnderscore . ppJavaExpr
         dotToUnderscore c = c
 
 asJavaExpr :: Term -> Maybe String
-asJavaExpr (asVariable -> Just ec) = Just (Text.unpack (toShortName (ecNameInfo ec))) -- TODO?
+asJavaExpr (asVariable -> Just ec) = Just (Text.unpack (ecShortName ec)) -- TODO?
 asJavaExpr _ = Nothing
 
 isRefJavaExpr :: JavaExpr -> Bool

--- a/saw-central/src/SAWCentral/MRSolver/Evidence.hs
+++ b/saw-central/src/SAWCentral/MRSolver/Evidence.hs
@@ -39,6 +39,7 @@ import qualified Data.Set as Set
 import qualified SAWSupport.Pretty as PPS (Opts, defaultOpts)
 
 import SAWCore.Module (ModuleMap)
+import SAWCore.Name (Name(..))
 import SAWCore.Term.Functor
 import SAWCore.Recognizer
 import CryptolSAWCore.Monadify
@@ -146,13 +147,13 @@ emptyRefnset = HashMap.empty
 -- | Given a 'FunName' and a 'Refnset', return the 'FunAssump' which has
 -- the given 'FunName' as its LHS function, if possible
 lookupFunAssump :: FunName -> Refnset t -> Maybe (FunAssump t)
-lookupFunAssump (GlobalName (GlobalDef _ ix _ _) projs) refSet =
+lookupFunAssump (GlobalName (GlobalDef (nameIndex -> ix) _ _) projs) refSet =
     HashMap.lookup ix refSet >>= Map.lookup projs
 lookupFunAssump _ _ = Nothing
 
 -- | Add a 'FunAssump' to a 'Refnset'
 addFunAssump :: FunAssump t -> Refnset t -> Refnset t
-addFunAssump fa@(fassumpFun -> GlobalName (GlobalDef _ ix _ _) projs) =
+addFunAssump fa@(fassumpFun -> GlobalName (GlobalDef (nameIndex -> ix) _ _) projs) =
     HashMap.insertWith (\_ -> Map.insert projs fa) ix
                        (Map.singleton projs fa)
 addFunAssump _ = error "Cannot insert a non-global name into a Refnset"

--- a/saw-central/src/SAWCentral/MRSolver/Monad.hs
+++ b/saw-central/src/SAWCentral/MRSolver/Monad.hs
@@ -53,6 +53,7 @@ import Prettyprinter
 
 import qualified SAWSupport.Pretty as PPS (Doc, Opts, render)
 
+import SAWCore.Name (Name(..))
 import SAWCore.Term.Functor
 import SAWCore.Term.Pretty
 import SAWCore.SCTypeCheck
@@ -1033,7 +1034,7 @@ mrFunNameBody (CallSName var) =
   _ -> error "mrFunBody: unknown letrec var"
 mrFunNameBody (GlobalName glob projs) =
   do mm <- liftSC0 scGetModuleMap
-     case lookupVarIndexInMap (globalDefIndex glob) mm of
+     case lookupVarIndexInMap (nameIndex (globalDefName glob)) mm of
        Just (ResolvedDef (defBody -> Just body)) ->
          Just <$> foldM doTermProj body projs
        _ -> pure Nothing

--- a/saw-central/src/SAWCentral/MRSolver/SMT.hs
+++ b/saw-central/src/SAWCentral/MRSolver/SMT.hs
@@ -284,7 +284,7 @@ mrProvableRaw prop_term =
        Right (stats, SolveCounterexample cex) ->
          mrDebugPrint 2 "SMT solver response: not provable" >>
          mrDebugPrint 3 ("Counterexample:" ++ concatMap (\(x,v) ->
-           "\n - " ++ show (ppName $ ecName x) ++
+           "\n - " ++ show (ppName $ ecNameInfo x) ++
            " = " ++ PPS.render opts (ppFirstOrderValue opts v)) cex) >>
          recordUsedSolver stats prop_term >> return False
        Right (stats, SolveSuccess _) ->

--- a/saw-central/src/SAWCentral/MRSolver/Term.hs
+++ b/saw-central/src/SAWCentral/MRSolver/Term.hs
@@ -50,6 +50,7 @@ import Data.Text (Text, unpack)
 import qualified SAWSupport.Pretty as PPS (Doc, Opts, render)
 
 import SAWCore.Module (ModuleMap)
+import SAWCore.Name (Name(..))
 import SAWCore.Term.Functor
 import SAWCore.Term.Pretty
 import SAWCore.SharedTerm
@@ -566,7 +567,7 @@ instance PrettyInCtx FunName where
   prettyInCtx (EVarFunName var) = prettyInCtx var
   prettyInCtx (GlobalName g projs) =
     foldM (\pp proj -> (pp <>) <$> prettyInCtx proj) (ppName $
-                                                      globalDefName g) projs
+                                                      nameInfo $ globalDefName g) projs
 
 instance PrettyInCtx Comp where
   prettyInCtx (CompTerm t) = prettyInCtx t

--- a/saw-central/src/SAWCentral/MRSolver/Term.hs
+++ b/saw-central/src/SAWCentral/MRSolver/Term.hs
@@ -78,7 +78,7 @@ mrVarType = ecType . unMRVar
 
 -- | Print the string name of an 'MRVar'
 showMRVar :: MRVar -> String
-showMRVar = show . ppName . ecName . unMRVar
+showMRVar = show . ppName . ecNameInfo . unMRVar
 
 -- | A tuple or record projection of a 'Term'
 data TermProj = TermProjLeft | TermProjRight | TermProjRecord FieldName
@@ -527,7 +527,7 @@ instance PrettyInCtx Type where
   prettyInCtx (Type t) = prettyInCtx t
 
 instance PrettyInCtx MRVar where
-  prettyInCtx (MRVar ec) = return $ ppName $ ecName ec
+  prettyInCtx (MRVar ec) = return $ ppName $ ecNameInfo ec
 
 instance PrettyInCtx a => PrettyInCtx [a] where
   prettyInCtx xs = list <$> mapM prettyInCtx xs

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -157,7 +157,7 @@ import SAWCore.Recognizer
 import SAWCore.Rewriter
 import SAWCore.SATQuery
 import SAWCore.Module (ModuleMap)
-import SAWCore.Name (DisplayNameEnv)
+import SAWCore.Name (DisplayNameEnv, ecShortName)
 import SAWCore.SharedTerm
 import SAWCore.Term.Functor
 import CryptolSAWCore.TypedTerm
@@ -2046,7 +2046,7 @@ propApply sc rule goal = applyFirst =<< asPiLists (unProp rule)
                           -- this argument not solved by unification, so make it a goal
                           do c0 <- scInstantiateExt sc inst (ecType ec)
                              mp <- termToMaybeProp sc c0
-                             let nm = toShortName (ecNameInfo ec)
+                             let nm = ecShortName ec
                              case mp of
                                Nothing ->
                                  fail ("goal_apply: could not find instantiation for " ++ show nm)
@@ -2075,7 +2075,7 @@ tacticIntro sc usernm = Tactic \goal ->
     ConclFocus p mkSqt ->
       liftIO (scAsPi sc (unProp p)) >>= \case
         Just (ec, body) ->
-          do let nm = toShortName (ecNameInfo ec)
+          do let nm = ecShortName ec
              let tp = ecType ec
              let name = if Text.null usernm then nm else usernm
              xv <- liftIO $ scFreshEC sc name tp

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -2046,7 +2046,7 @@ propApply sc rule goal = applyFirst =<< asPiLists (unProp rule)
                           -- this argument not solved by unification, so make it a goal
                           do c0 <- scInstantiateExt sc inst (ecType ec)
                              mp <- termToMaybeProp sc c0
-                             let nm = toShortName (ecName ec)
+                             let nm = toShortName (ecNameInfo ec)
                              case mp of
                                Nothing ->
                                  fail ("goal_apply: could not find instantiation for " ++ show nm)
@@ -2075,7 +2075,7 @@ tacticIntro sc usernm = Tactic \goal ->
     ConclFocus p mkSqt ->
       liftIO (scAsPi sc (unProp p)) >>= \case
         Just (ec, body) ->
-          do let nm = toShortName (ecName ec)
+          do let nm = toShortName (ecNameInfo ec)
              let tp = ecType ec
              let name = if Text.null usernm then nm else usernm
              xv <- liftIO $ scFreshEC sc name tp

--- a/saw-central/src/SAWCentral/Prover/ABC.hs
+++ b/saw-central/src/SAWCentral/Prover/ABC.hs
@@ -194,7 +194,7 @@ abcSatExternal proxy sc doCNF execName args g = liftIO $
          (["s SATISFIABLE"], _) -> do
            let bs = parseDimacsSolution variables vls
            let r = liftCexBB (map snd shapes) bs
-               argNames = map (Text.unpack . toShortName . ecName . fst) shapes
+               argNames = map (Text.unpack . toShortName . ecNameInfo . fst) shapes
                ecs = map fst shapes
            case r of
              Left msg -> fail $ "Can't parse counterexample: " ++ msg

--- a/saw-central/src/SAWCentral/Prover/ABC.hs
+++ b/saw-central/src/SAWCentral/Prover/ABC.hs
@@ -194,7 +194,7 @@ abcSatExternal proxy sc doCNF execName args g = liftIO $
          (["s SATISFIABLE"], _) -> do
            let bs = parseDimacsSolution variables vls
            let r = liftCexBB (map snd shapes) bs
-               argNames = map (Text.unpack . toShortName . ecNameInfo . fst) shapes
+               argNames = map (Text.unpack . ecShortName . fst) shapes
                ecs = map fst shapes
            case r of
              Left msg -> fail $ "Can't parse counterexample: " ++ msg

--- a/saw-central/src/SAWCentral/Prover/Exporter.hs
+++ b/saw-central/src/SAWCentral/Prover/Exporter.hs
@@ -349,7 +349,7 @@ writeVerilogSAT path satq = getSharedContext >>= \sc -> io $
                    Nothing -> fail $ "writeVerilogSAT: Unsupported argument type " ++ show fot
                    Just ft -> return ft
      let argSValues = map (snd . snd) vars
-     let argSValueNames = zip argSValues (map (toShortName . ecName) argNames)
+     let argSValueNames = zip argSValues (map (toShortName . ecNameInfo) argNames)
      argTys' <- traverse f argTys
      let mkInput (v, nm) = map (,nm) <$> flattenSValue sym v
      ins <- concat <$> mapM mkInput argSValueNames

--- a/saw-central/src/SAWCentral/Prover/Exporter.hs
+++ b/saw-central/src/SAWCentral/Prover/Exporter.hs
@@ -80,7 +80,7 @@ import CryptolSAWCore.Monadify (defaultMonEnv, monadifyCryptolModule)
 import SAWCore.ExternalFormat(scWriteExternal)
 import SAWCore.FiniteValue
 import SAWCore.Module (emptyModule, moduleDecls)
-import SAWCore.Name (mkModuleName, toShortName)
+import SAWCore.Name (mkModuleName, ecShortName)
 import SAWCore.Prelude (preludeModule)
 import SAWCore.Recognizer (asPi)
 import SAWCore.SATQuery
@@ -349,7 +349,7 @@ writeVerilogSAT path satq = getSharedContext >>= \sc -> io $
                    Nothing -> fail $ "writeVerilogSAT: Unsupported argument type " ++ show fot
                    Just ft -> return ft
      let argSValues = map (snd . snd) vars
-     let argSValueNames = zip argSValues (map (toShortName . ecNameInfo) argNames)
+     let argSValueNames = zip argSValues (map ecShortName argNames)
      argTys' <- traverse f argTys
      let mkInput (v, nm) = map (,nm) <$> flattenSValue sym v
      ins <- concat <$> mapM mkInput argSValueNames

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -644,7 +644,7 @@ showsProofResult opts r =
   where
     showVal t = shows (ppFirstOrderValue opts t)
     showEqn (x, t) = showEC x . showString " = " . showVal t
-    showEC ec = showString (Text.unpack (toShortName (ecName ec)))
+    showEC ec = showString (Text.unpack (toShortName (ecNameInfo ec)))
 
     showMulti _ [] = showString "]"
     showMulti s (eqn : eqns) = showString s . showEqn eqn . showMulti ", " eqns
@@ -657,7 +657,7 @@ showsSatResult opts r =
     SatUnknown  -> showString "Unknown"
   where
     showVal t = shows (ppFirstOrderValue opts t)
-    showEC ec = showString (Text.unpack (toShortName (ecName ec)))
+    showEC ec = showString (Text.unpack (toShortName (ecNameInfo ec)))
     showEqn (x, t) = showEC x . showString " = " . showVal t
     showMulti _ [] = showString "]"
     showMulti s (eqn : eqns) = showString s . showEqn eqn . showMulti ", " eqns

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -257,7 +257,7 @@ import SAWCentral.Yosys.IR
 import SAWCentral.Yosys.Theorem (YosysImport, YosysTheorem)
 import SAWCentral.Yosys.State (YosysSequential)
 
-import SAWCore.Name (toShortName, DisplayNameEnv, emptyDisplayNameEnv)
+import SAWCore.Name (ecShortName, DisplayNameEnv, emptyDisplayNameEnv)
 import CryptolSAWCore.CryptolEnv as CEnv
 import CryptolSAWCore.Monadify as Monadify
 import SAWCore.FiniteValue (FirstOrderValue, ppFirstOrderValue)
@@ -644,7 +644,7 @@ showsProofResult opts r =
   where
     showVal t = shows (ppFirstOrderValue opts t)
     showEqn (x, t) = showEC x . showString " = " . showVal t
-    showEC ec = showString (Text.unpack (toShortName (ecNameInfo ec)))
+    showEC ec = showString (Text.unpack (ecShortName ec))
 
     showMulti _ [] = showString "]"
     showMulti s (eqn : eqns) = showString s . showEqn eqn . showMulti ", " eqns
@@ -657,7 +657,7 @@ showsSatResult opts r =
     SatUnknown  -> showString "Unknown"
   where
     showVal t = shows (ppFirstOrderValue opts t)
-    showEC ec = showString (Text.unpack (toShortName (ecNameInfo ec)))
+    showEC ec = showString (Text.unpack (ecShortName ec))
     showEqn (x, t) = showEC x . showString " = " . showVal t
     showMulti _ [] = showString "]"
     showMulti s (eqn : eqns) = showString s . showEqn eqn . showMulti ", " eqns

--- a/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
+++ b/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
@@ -33,7 +33,7 @@ import Numeric.Natural (Natural)
 import qualified SAWSupport.Pretty as PPS (defaultOpts)
 
 import SAWCore.FiniteValue (FiniteType(..),FirstOrderType(..),toFiniteType)
-import SAWCore.Name (Name(..), toShortName)
+import SAWCore.Name (Name(..), ecShortName)
 import SAWCore.Module (ModuleMap)
 import qualified SAWCore.Simulator as Sim
 import SAWCore.Simulator.Value
@@ -511,7 +511,7 @@ bitBlastTerm be sc addlPrims t = do
   modmap <- scGetModuleMap sc
   bval <- bitBlastBasic be modmap addlPrims ecMap t
   bval' <- applyAll bval argVars
-  let names =  map fst args ++ map (Text.unpack . toShortName . ecNameInfo) ecs
+  let names =  map fst args ++ map (Text.unpack . ecShortName) ecs
       shapes = argShapes ++ ecShapes
   return (bval', zip names shapes)
 

--- a/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
+++ b/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
@@ -33,7 +33,7 @@ import Numeric.Natural (Natural)
 import qualified SAWSupport.Pretty as PPS (defaultOpts)
 
 import SAWCore.FiniteValue (FiniteType(..),FirstOrderType(..),toFiniteType)
-import SAWCore.Name (toShortName)
+import SAWCore.Name (Name(..), toShortName)
 import SAWCore.Module (ModuleMap)
 import qualified SAWCore.Simulator as Sim
 import SAWCore.Simulator.Value
@@ -308,7 +308,7 @@ muxInt _ x y = if x == y then return x else fail $ "muxBVal: VInt " ++ show (x, 
 
 muxBExtra :: AIG.IsAIG l g => g s ->
   TValue (BitBlast (l s)) -> l s -> BExtra (l s) -> BExtra (l s) -> IO (BExtra (l s))
-muxBExtra be (VDataType (ecName -> ModuleIdentifier "Prelude.Stream") [TValue tp] []) c x y =
+muxBExtra be (VDataType (ecNameInfo -> ModuleIdentifier "Prelude.Stream") [TValue tp] []) c x y =
   do let f i = do xi <- lookupBStream (VExtra x) i
                   yi <- lookupBStream (VExtra y) i
                   muxBVal be tp c xi yi
@@ -473,7 +473,7 @@ bitBlastBasic be m addlPrims ecMap t = do
 bitBlastExtCns ::
   Map VarIndex (BValue (l s)) -> ExtCns (TValue (BitBlast (l s))) ->
   IO (BValue (l s))
-bitBlastExtCns ecMap (EC idx name _v) =
+bitBlastExtCns ecMap (EC (Name idx name) _v) =
   case Map.lookup idx ecMap of
     Just var -> return var
     Nothing -> fail $
@@ -511,7 +511,7 @@ bitBlastTerm be sc addlPrims t = do
   modmap <- scGetModuleMap sc
   bval <- bitBlastBasic be modmap addlPrims ecMap t
   bval' <- applyAll bval argVars
-  let names =  map fst args ++ map (Text.unpack . toShortName . ecName) ecs
+  let names =  map fst args ++ map (Text.unpack . toShortName . ecNameInfo) ecs
       shapes = argShapes ++ ecShapes
   return (bval', zip names shapes)
 

--- a/saw-core-coq/src/SAWCoreCoq/Coq.hs
+++ b/saw-core-coq/src/SAWCoreCoq/Coq.hs
@@ -29,9 +29,9 @@ import           Prettyprinter
 import qualified Language.Coq.AST                              as Coq
 import qualified Language.Coq.Pretty                           as Coq
 import           SAWCore.Module
+import           SAWCore.Name
 import           SAWCore.SharedTerm
-import           SAWCore.Term.Functor
--- import SAWCore.Term.CtxTerm
+
 import qualified SAWCoreCoq.CryptolModule    as CMT
 import qualified SAWCoreCoq.SAWModule        as SAWModuleTranslation
 import           SAWCoreCoq.Monad
@@ -107,5 +107,5 @@ translateCryptolModule sc env nm configuration globalDecls m = do
 -- | Extract out the 'String' name of a declaration in a SAW core module
 moduleDeclName :: ModuleDecl -> Maybe String
 moduleDeclName (TypeDecl (DataType { dtNameInfo })) = Just (Text.unpack (toShortName dtNameInfo))
-moduleDeclName (DefDecl  (Def      { defNameInfo })) = Just (Text.unpack (toShortName defNameInfo))
+moduleDeclName (DefDecl  (Def      { defName })) = Just (Text.unpack (toShortName (nameInfo defName)))
 moduleDeclName InjectCodeDecl{} = Nothing

--- a/saw-core-coq/src/SAWCoreCoq/Coq.hs
+++ b/saw-core-coq/src/SAWCoreCoq/Coq.hs
@@ -106,6 +106,6 @@ translateCryptolModule sc env nm configuration globalDecls m = do
 
 -- | Extract out the 'String' name of a declaration in a SAW core module
 moduleDeclName :: ModuleDecl -> Maybe String
-moduleDeclName (TypeDecl (DataType { dtNameInfo })) = Just (Text.unpack (toShortName dtNameInfo))
+moduleDeclName (TypeDecl (DataType { dtName })) = Just (Text.unpack (toShortName (nameInfo dtName)))
 moduleDeclName (DefDecl  (Def      { defName })) = Just (Text.unpack (toShortName (nameInfo defName)))
 moduleDeclName InjectCodeDecl{} = Nothing

--- a/saw-core-coq/src/SAWCoreCoq/SAWModule.hs
+++ b/saw-core-coq/src/SAWCoreCoq/SAWModule.hs
@@ -33,8 +33,9 @@ import           Prettyprinter                                 (Doc, pretty)
 import qualified Language.Coq.AST                              as Coq
 import qualified Language.Coq.Pretty                           as Coq
 import           SAWCore.Module
+import           SAWCore.Name
 import           SAWCore.SharedTerm
-import           SAWCore.Term.Functor
+
 import qualified SAWCoreCoq.Monad            as M
 import           SAWCoreCoq.SpecialTreatment
 import qualified SAWCoreCoq.Term             as TermTranslation
@@ -149,16 +150,16 @@ skipped sawIdent =
 
 translateDef :: ModuleTranslationMonad m => Def -> m Coq.Decl
 translateDef (Def {..}) = {- trace ("translateDef " ++ show defIdent) $ -} do
-  specialTreatment <- findSpecialTreatment' defNameInfo
+  specialTreatment <- findSpecialTreatment' (nameInfo defName)
   translateAccordingly (atDefSite specialTreatment)
 
   where
 
     translateAccordingly :: ModuleTranslationMonad m => DefSiteTreatment -> m Coq.Decl
-    translateAccordingly  DefPreserve           = translateNamed $ Coq.Ident (Text.unpack (toShortName defNameInfo))
+    translateAccordingly  DefPreserve           = translateNamed $ Coq.Ident (Text.unpack (toShortName (nameInfo defName)))
     translateAccordingly (DefRename targetName) = translateNamed $ targetName
     translateAccordingly (DefReplace  str)      = return $ Coq.Snippet str
-    translateAccordingly  DefSkip               = return $ skipped' defNameInfo
+    translateAccordingly  DefSkip               = return $ skipped' (nameInfo defName)
 
     translateNamed :: ModuleTranslationMonad m => Coq.Ident -> m Coq.Decl
     translateNamed name = liftTermTranslationMonad (go defQualifier defBody)

--- a/saw-core-coq/src/SAWCoreCoq/SAWModule.hs
+++ b/saw-core-coq/src/SAWCoreCoq/SAWModule.hs
@@ -90,7 +90,7 @@ translateDataType :: ModuleTranslationMonad m => DataType -> m Coq.Decl
 -- translateDataType (DataType {..})
 --   | trace ("translateDataType: " ++ show dtName) False = undefined
 translateDataType (DataType {..}) =
-  case dtNameInfo of
+  case nameInfo dtName of
     ModuleIdentifier dtIdent ->
       atDefSite <$> findSpecialTreatment dtIdent >>= \case
       DefPreserve            -> translateNamed $ Coq.Ident (identName dtIdent)
@@ -98,7 +98,7 @@ translateDataType (DataType {..}) =
       DefReplace  str        -> return $ Coq.Snippet str
       DefSkip                -> return $ skipped dtIdent
     ImportedName{} ->
-      translateNamed $ Coq.Ident (Text.unpack (toShortName dtNameInfo))
+      translateNamed $ Coq.Ident (Text.unpack (toShortName (nameInfo dtName)))
   where
     translateNamed :: ModuleTranslationMonad m => Coq.Ident -> m Coq.Decl
     translateNamed name = do

--- a/saw-core-coq/src/SAWCoreCoq/SAWModule.hs
+++ b/saw-core-coq/src/SAWCoreCoq/SAWModule.hs
@@ -66,7 +66,7 @@ translateCtor ::
   Ctor -> m Coq.Constructor
 translateCtor inductiveParameters (Ctor {..}) = do
   maybe_constructorName <-
-    case ctorNameInfo of
+    case nameInfo ctorName of
       ModuleIdentifier ident -> liftTermTranslationMonad $ TermTranslation.translateIdentToIdent ident
       ImportedName{} -> pure Nothing
   let constructorName = case maybe_constructorName of

--- a/saw-core-coq/src/SAWCoreCoq/Term.hs
+++ b/saw-core-coq/src/SAWCoreCoq/Term.hs
@@ -616,8 +616,8 @@ translateBinderEC ec f =
        where
          ty = ecType ec
          (args, pi_body) = asPiList ty
-         nm = Name (ecVarIndex ec) (ecName ec)
-         n = toShortName (ecName ec)
+         nm = ecName ec
+         n = toShortName (nameInfo nm)
          helper ::
            Coq.Ident ->
            [(Bool, (LocalName, Coq.Ident))] ->
@@ -798,7 +798,7 @@ translateTermUnshared t = do
 
     Variable ec ->
       do nenv <- view namedEnvironment <$> askTR
-         let nm = Name (ecVarIndex ec) (ecName ec)
+         let nm = ecName ec
          case Map.lookup nm nenv of
            Just ident -> pure (Coq.Var ident)
            Nothing -> translateConstant nm

--- a/saw-core-sbv/src/SAWCoreSBV/SBV.hs
+++ b/saw-core-sbv/src/SAWCoreSBV/SBV.hs
@@ -61,7 +61,7 @@ import Control.Monad.IO.Class
 import Control.Monad.State as ST (MonadState(..), StateT(..), evalStateT, modify)
 import Numeric.Natural (Natural)
 
-import SAWCore.Name (Name(..), toShortName)
+import SAWCore.Name (Name(..), ecShortName, toShortName)
 import qualified SAWCore.Prim as Prim
 import qualified SAWCore.Recognizer as R
 import qualified SAWCore.Simulator as Sim
@@ -280,7 +280,7 @@ flattenSValue nm v = do
         VIntMod n si              -> return ([svRem si (svInteger KUnbounded (toInteger n))], "")
         VWord sw                  -> return (if intSizeOf sw > 0 then [sw] else [], "")
         VCtorApp i ps ts          -> do (xss, ss) <- unzip <$> traverse (force >=> flattenSValue nm) (ps++ts)
-                                        return (concat xss, "_" ++ (Text.unpack (toShortName (ecNameInfo i))) ++ concat ss)
+                                        return (concat xss, "_" ++ (Text.unpack (ecShortName i)) ++ concat ss)
         VNat n                    -> return ([], "_" ++ show n)
         TValue (suffixTValue -> Just s)
                                   -> return ([], s)
@@ -700,7 +700,7 @@ sbvSATQuery sc addlPrims query =
   do t <- liftIO (satQueryAsTerm sc query)
      let qvars = Map.toList (satVariables query)
      let unintSet = satUninterp query
-     let ecVars (ec, fot) = newVars (Text.unpack (toShortName (ecNameInfo ec))) fot
+     let ecVars (ec, fot) = newVars (Text.unpack (ecShortName ec)) fot
 
      (labels, vars) <-
        flip evalStateT 0 $ unzip <$>
@@ -794,7 +794,7 @@ getLabels ls d args
   | length args == length xs = Just (zip args xs)
   | otherwise = error $ unwords
                 [ "SBV SAT results do not match expected arguments "
-                , show (map (toShortName . ecNameInfo) args), show xs]
+                , show (map ecShortName args), show xs]
 
   where
   xs = fmap getLabel ls

--- a/saw-core-sbv/src/SAWCoreSBV/SBV.hs
+++ b/saw-core-sbv/src/SAWCoreSBV/SBV.hs
@@ -61,7 +61,7 @@ import Control.Monad.IO.Class
 import Control.Monad.State as ST (MonadState(..), StateT(..), evalStateT, modify)
 import Numeric.Natural (Natural)
 
-import SAWCore.Name (toShortName)
+import SAWCore.Name (Name(..), toShortName)
 import qualified SAWCore.Prim as Prim
 import qualified SAWCore.Recognizer as R
 import qualified SAWCore.Simulator as Sim
@@ -280,7 +280,7 @@ flattenSValue nm v = do
         VIntMod n si              -> return ([svRem si (svInteger KUnbounded (toInteger n))], "")
         VWord sw                  -> return (if intSizeOf sw > 0 then [sw] else [], "")
         VCtorApp i ps ts          -> do (xss, ss) <- unzip <$> traverse (force >=> flattenSValue nm) (ps++ts)
-                                        return (concat xss, "_" ++ (Text.unpack (toShortName (ecName i))) ++ concat ss)
+                                        return (concat xss, "_" ++ (Text.unpack (toShortName (ecNameInfo i))) ++ concat ss)
         VNat n                    -> return ([], "_" ++ show n)
         TValue (suffixTValue -> Just s)
                                   -> return ([], s)
@@ -610,7 +610,7 @@ muxBVal :: TValue SBV -> SBool -> SValue -> SValue -> IO SValue
 muxBVal = Prims.muxValue prims
 
 muxSbvExtra :: TValue SBV -> SBool -> SbvExtra -> SbvExtra -> IO SbvExtra
-muxSbvExtra (VDataType (ecName -> ModuleIdentifier "Prelude.Stream") [TValue tp] []) c x y =
+muxSbvExtra (VDataType (ecNameInfo -> ModuleIdentifier "Prelude.Stream") [TValue tp] []) c x y =
   do let f i = do xi <- lookupSbvExtra x i
                   yi <- lookupSbvExtra y i
                   muxBVal tp c xi yi
@@ -627,7 +627,7 @@ sbvSolveBasic :: SharedContext -> Map Ident SPrim -> Set VarIndex -> Term -> IO 
 sbvSolveBasic sc addlPrims unintSet t = do
   m <- scGetModuleMap sc
 
-  let extcns (EC ix nm ty) = parseUninterpreted [] (Text.unpack (toShortName nm) ++ "#" ++ show ix) ty
+  let extcns (EC (Name ix nm) ty) = parseUninterpreted [] (Text.unpack (toShortName nm) ++ "#" ++ show ix) ty
   let uninterpreted ec
         | Set.member (ecVarIndex ec) unintSet = Just (extcns ec)
         | otherwise                           = Nothing
@@ -700,7 +700,7 @@ sbvSATQuery sc addlPrims query =
   do t <- liftIO (satQueryAsTerm sc query)
      let qvars = Map.toList (satVariables query)
      let unintSet = satUninterp query
-     let ecVars (ec, fot) = newVars (Text.unpack (toShortName (ecName ec))) fot
+     let ecVars (ec, fot) = newVars (Text.unpack (toShortName (ecNameInfo ec))) fot
 
      (labels, vars) <-
        flip evalStateT 0 $ unzip <$>
@@ -712,7 +712,7 @@ sbvSATQuery sc addlPrims query =
        do vars' <- sequence vars
           let varMap = Map.fromList (zip (map (ecVarIndex . fst) qvars) vars')
 
-          let mkUninterp (EC ix nm ty) =
+          let mkUninterp (EC (Name ix nm) ty) =
                 parseUninterpreted [] (Text.unpack (toShortName nm) ++ "#" ++ show ix) ty
           let extcns ec
                 | Just v <- Map.lookup (ecVarIndex ec) varMap = pure v
@@ -794,7 +794,7 @@ getLabels ls d args
   | length args == length xs = Just (zip args xs)
   | otherwise = error $ unwords
                 [ "SBV SAT results do not match expected arguments "
-                , show (map (toShortName . ecName) args), show xs]
+                , show (map (toShortName . ecNameInfo) args), show xs]
 
   where
   xs = fmap getLabel ls

--- a/saw-core-what4/src/SAWCoreWhat4/What4.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/What4.hs
@@ -90,7 +90,7 @@ import SAWCore.SharedTerm
 import SAWCore.Simulator.Value
 import SAWCore.FiniteValue (FirstOrderType(..), FirstOrderValue(..))
 import SAWCore.Module (ModuleMap, ResolvedName(..), ctorName, lookupVarIndexInMap)
-import SAWCore.Name (Name(..), toAbsoluteName, toShortName)
+import SAWCore.Name (Name(..), ecShortName, toAbsoluteName, toShortName)
 import SAWCore.Term.Functor (FieldName)
 
 -- what4
@@ -1063,7 +1063,7 @@ applyUnintApp sym app0 v =
     VArray (SArray sa)        -> return (extendUnintApp app0 sa (W.exprType sa))
     VWord ZBV                 -> return app0
     VCtorApp i ps xv          -> foldM (applyUnintApp sym) app' =<< traverse force (ps++xv)
-                                   where app' = suffixUnintApp ("_" ++ (Text.unpack (toShortName (ecNameInfo i)))) app0
+                                   where app' = suffixUnintApp ("_" ++ (Text.unpack (ecShortName i))) app0
     VNat n                    -> return (suffixUnintApp ("_" ++ show n) app0)
     VBVToNat w v'             -> applyUnintApp sym app' v'
                                    where app' = suffixUnintApp ("_" ++ show w) app0
@@ -1156,7 +1156,7 @@ boundFOTs sym vars =
    freshBnd :: ExtCns Term -> W.BaseTypeRepr tp -> StateT ([Some (BoundVar sym)],Integer) IO (SymExpr sym tp)
    freshBnd ec tpr =
      do (vs,n) <- get
-        let nm = Text.unpack (toShortName (ecNameInfo ec)) ++ "." ++ show n
+        let nm = Text.unpack (ecShortName ec) ++ "." ++ show n
         bvar <- lift (W.freshBoundVar sym (W.safeSymbol nm) tpr)
         put (Some bvar : vs, n+1)
         return (W.varExpr sym bvar)

--- a/saw-core-what4/src/SAWCoreWhat4/What4.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/What4.hs
@@ -90,7 +90,7 @@ import SAWCore.SharedTerm
 import SAWCore.Simulator.Value
 import SAWCore.FiniteValue (FirstOrderType(..), FirstOrderValue(..))
 import SAWCore.Module (ModuleMap, ResolvedName(..), ctorName, lookupVarIndexInMap)
-import SAWCore.Name (toAbsoluteName, toShortName)
+import SAWCore.Name (Name(..), toAbsoluteName, toShortName)
 import SAWCore.Term.Functor (FieldName)
 
 -- what4
@@ -612,7 +612,7 @@ muxBVal sym = Prims.muxValue (prims sym)
 
 muxWhat4Extra :: forall sym. Sym sym =>
   sym -> TValue (What4 sym) -> SBool sym -> What4Extra sym -> What4Extra sym -> IO (What4Extra sym)
-muxWhat4Extra sym (VDataType (ecName -> ModuleIdentifier "Prelude.Stream") [TValue tp] [] ) c x y =
+muxWhat4Extra sym (VDataType (ecNameInfo -> ModuleIdentifier "Prelude.Stream") [TValue tp] [] ) c x y =
   do let f i = do xi <- lookupSStream (VExtra x) i
                   yi <- lookupSStream (VExtra y) i
                   muxBVal sym tp c xi yi
@@ -879,7 +879,7 @@ w4SolveBasic ::
   IO (SValue sym)
 w4SolveBasic sym sc addlPrims ecMap ref unintSet t =
   do m <- scGetModuleMap sc
-     let extcns (EC ix nm ty)
+     let extcns (EC (Name ix nm) ty)
             | Just v <- Map.lookup ix ecMap = return v
             | otherwise = parseUninterpreted sym ref (mkUnintApp (Text.unpack (toShortName nm) ++ "_" ++ show ix)) ty
      let uninterpreted ec
@@ -1063,7 +1063,7 @@ applyUnintApp sym app0 v =
     VArray (SArray sa)        -> return (extendUnintApp app0 sa (W.exprType sa))
     VWord ZBV                 -> return app0
     VCtorApp i ps xv          -> foldM (applyUnintApp sym) app' =<< traverse force (ps++xv)
-                                   where app' = suffixUnintApp ("_" ++ (Text.unpack (toShortName (ecName i)))) app0
+                                   where app' = suffixUnintApp ("_" ++ (Text.unpack (toShortName (ecNameInfo i)))) app0
     VNat n                    -> return (suffixUnintApp ("_" ++ show n) app0)
     VBVToNat w v'             -> applyUnintApp sym app' v'
                                    where app' = suffixUnintApp ("_" ++ show w) app0
@@ -1156,7 +1156,7 @@ boundFOTs sym vars =
    freshBnd :: ExtCns Term -> W.BaseTypeRepr tp -> StateT ([Some (BoundVar sym)],Integer) IO (SymExpr sym tp)
    freshBnd ec tpr =
      do (vs,n) <- get
-        let nm = Text.unpack (toShortName (ecName ec)) ++ "." ++ show n
+        let nm = Text.unpack (toShortName (ecNameInfo ec)) ++ "." ++ show n
         bvar <- lift (W.freshBoundVar sym (W.safeSymbol nm) tpr)
         put (Some bvar : vs, n+1)
         return (W.varExpr sym bvar)
@@ -1550,7 +1550,7 @@ w4EvalBasic ::
   Term {- ^ term to simulate -} ->
   IO (SValue (B.ExprBuilder n st fs))
 w4EvalBasic sym st sc m addlPrims ecCons ref unintSet t =
-  do let extcns tf (EC ix nm ty)
+  do let extcns tf (EC (Name ix nm) ty)
            | Just v <- Map.lookup ix ecCons = pure v
            | otherwise =
            do trm <- ArgTermConst <$> scTermF sc tf
@@ -1583,11 +1583,11 @@ w4SimulatorEval ::
   Term {- ^ term to simulate -} ->
   IO (Either NameInfo (SValue (B.ExprBuilder n st fs)))
 w4SimulatorEval sym st sc m addlPrims ref constantFilter t =
-  do let extcns tf (EC ix nm ty) =
+  do let extcns tf (EC (Name ix nm) ty) =
            do trm <- ArgTermConst <$> scTermF sc tf
               parseUninterpretedSAW sym st sc ref trm (mkUnintApp (Text.unpack (toShortName nm) ++ "_" ++ show ix)) ty
      let uninterpreted _tf ec =
-          if constantFilter ec then Nothing else Just (X.throwIO (NeutralTermEx (ecName ec)))
+          if constantFilter ec then Nothing else Just (X.throwIO (NeutralTermEx (ecNameInfo ec)))
      let neutral _env nt = fail ("w4SimulatorEval: could not evaluate neutral term: " ++ show nt)
      let primHandler = Sim.defaultPrimHandler
      let mux = Prims.lazyMuxValue (prims sym)
@@ -1825,7 +1825,7 @@ mkArgTerm sc ty val =
          ctor <-
            case lookupVarIndexInMap (ecVarIndex i) mm of
              Just (ResolvedCtor ctor) -> pure ctor
-             _ -> panic "mkArgTerm" ["Constructor not found: " <> toAbsoluteName (ecName i)]
+             _ -> panic "mkArgTerm" ["Constructor not found: " <> toAbsoluteName (ecNameInfo i)]
          ps' <- traverse (termOfSValue sc <=< force) ps
          vv' <- traverse (termOfSValue sc <=< force) vv
          x   <- scConstApply sc (ctorName ctor) (ps' ++ vv')

--- a/saw-core/src/SAWCore/ExternalFormat.hs
+++ b/saw-core/src/SAWCore/ExternalFormat.hs
@@ -103,7 +103,7 @@ scWriteExternal t0 =
     stashEC :: ExtCns Int -> WriteM ()
     stashEC ec =
        do (m, nms, lns, x) <- State.get
-          State.put (m, Map.insert (ecVarIndex ec) (ecName ec) nms, lns, x)
+          State.put (m, Map.insert (ecVarIndex ec) (ecNameInfo ec) nms, lns, x)
 
     go :: Term -> WriteM Int
     go (Unshared tf) = do
@@ -272,17 +272,17 @@ scReadExternal sc input =
          case nmi of
            ModuleIdentifier ident ->
              lift (scResolveNameByURI sc (moduleIdentToURI ident)) >>= \case
-               Just vi' -> pure (EC vi' nmi t')
+               Just vi' -> pure (EC (Name vi' nmi) t')
                Nothing  -> lift $ fail $ "scReadExternal: missing module identifier: " ++ show ident
            ImportedName uri _aliases ->
              lift (scResolveNameByURI sc uri) >>= \case
-               Just vi' -> pure (EC vi' nmi t')
+               Just vi' -> pure (EC (Name vi' nmi) t')
                Nothing -> case Map.lookup vi vs of
-                 Just vi' -> pure $ EC vi' nmi t'
+                 Just vi' -> pure $ EC (Name vi' nmi) t'
                  Nothing ->
                    do nm <- lift $ scRegisterName sc nmi
                       State.put (ts, nms, Map.insert vi (nameIndex nm) vs)
-                      pure $ EC (nameIndex nm) nmi t'
+                      pure $ EC nm t'
 
     readEC :: String -> String -> ReadM (ExtCns Term)
     readEC i t =

--- a/saw-core/src/SAWCore/Module.hs
+++ b/saw-core/src/SAWCore/Module.hs
@@ -106,12 +106,11 @@ data DefQualifier
 
 instance Hashable DefQualifier -- automatically derived
 
--- | A Definition contains an identifier, the type of the definition, and an
--- optional body (axioms and primitives do not have a body)
+-- | A Definition contains a name, the type of the definition, and an
+-- optional body (axioms and primitives do not have a body).
 data Def =
   Def
-  { defNameInfo :: NameInfo
-  , defVarIndex :: VarIndex
+  { defName :: Name
   , defQualifier :: DefQualifier
   , defType :: Term
   , defBody :: Maybe Term
@@ -303,7 +302,7 @@ data ResolvedName
 resolvedNameInfo :: ResolvedName -> NameInfo
 resolvedNameInfo (ResolvedCtor ctor) = ctorNameInfo ctor
 resolvedNameInfo (ResolvedDataType dt) = dtNameInfo dt
-resolvedNameInfo (ResolvedDef d) = defNameInfo d
+resolvedNameInfo (ResolvedDef d) = nameInfo (defName d)
 
 -- | Get the type of a 'ResolvedName' as a 'Term'.
 resolvedNameType :: ResolvedName -> Term
@@ -319,7 +318,7 @@ resolvedNameVarIndex r =
   case r of
     ResolvedCtor ctor -> ctorVarIndex ctor
     ResolvedDataType dt -> dtVarIndex dt
-    ResolvedDef def -> defVarIndex def
+    ResolvedDef def -> nameIndex (defName def)
 
 -- | Modules define namespaces of datatypes, constructors, and definitions,
 -- i.e., mappings from 'Text' names to these objects. A module is allowed to
@@ -594,7 +593,7 @@ insDeclInMap mname decl mm =
 insDefInMap :: Def -> ModuleMap -> Either Ident ModuleMap
 insDefInMap d mm =
   insResolvedNameInMap (ResolvedDef d) $
-  case defNameInfo d of
+  case nameInfo (defName d) of
     ModuleIdentifier i ->
       insDeclInMap (identModule i) (DefDecl d) mm
     ImportedName{} -> mm

--- a/saw-core/src/SAWCore/Module.hs
+++ b/saw-core/src/SAWCore/Module.hs
@@ -26,7 +26,6 @@ module SAWCore.Module
   , CtorArg(..)
   , CtorArgStruct(..)
   , Ctor(..)
-  , ctorName
   , ctorNumParams
   , ctorNumArgs
   , DataType(..)
@@ -154,10 +153,8 @@ data CtorArgStruct =
 -- | A specification of a constructor
 data Ctor =
   Ctor
-  { ctorNameInfo :: !NameInfo
+  { ctorName :: !Name
     -- ^ The name of this constructor
-  , ctorVarIndex :: !VarIndex
-    -- ^ Unique var index for this constructor
   , ctorArgStruct :: CtorArgStruct
     -- ^ Arguments to the constructor
   , ctorDataType :: !Name
@@ -212,10 +209,6 @@ ctorNumArgs :: Ctor -> Int
 ctorNumArgs (Ctor { ctorArgStruct = CtorArgStruct {..}}) =
   length ctorArgs
 
--- | Compute the 'Name' that uniquely references a constructor
-ctorName :: Ctor -> Name
-ctorName ctor = Name (ctorVarIndex ctor) (ctorNameInfo ctor)
-
 lift2 :: (a -> b) -> (b -> b -> c) -> a -> a -> c
 lift2 f h x y = h (f x) (f y)
 
@@ -226,7 +219,7 @@ instance Ord Ctor where
   compare = lift2 ctorName compare
 
 instance Show Ctor where
-  show = show . toAbsoluteName . ctorNameInfo
+  show = show . toAbsoluteName . nameInfo . ctorName
 
 
 -- Datatypes -------------------------------------------------------------------
@@ -300,7 +293,7 @@ data ResolvedName
 
 -- | Get the 'NameInfo' for a 'ResolvedName'
 resolvedNameInfo :: ResolvedName -> NameInfo
-resolvedNameInfo (ResolvedCtor ctor) = ctorNameInfo ctor
+resolvedNameInfo (ResolvedCtor ctor) = nameInfo (ctorName ctor)
 resolvedNameInfo (ResolvedDataType dt) = dtNameInfo dt
 resolvedNameInfo (ResolvedDef d) = nameInfo (defName d)
 
@@ -316,7 +309,7 @@ resolvedNameType r =
 resolvedNameVarIndex :: ResolvedName -> VarIndex
 resolvedNameVarIndex r =
   case r of
-    ResolvedCtor ctor -> ctorVarIndex ctor
+    ResolvedCtor ctor -> nameIndex (ctorName ctor)
     ResolvedDataType dt -> dtVarIndex dt
     ResolvedDef def -> nameIndex (defName def)
 

--- a/saw-core/src/SAWCore/Module.hs
+++ b/saw-core/src/SAWCore/Module.hs
@@ -255,7 +255,7 @@ dtNumIndices dt = length $ dtIndices dt
 
 -- | Compute the ExtCns that uniquely references a datatype
 dtExtCns :: DataType -> ExtCns Term
-dtExtCns dt = EC (nameIndex (dtName dt)) (nameInfo (dtName dt)) (dtType dt)
+dtExtCns dt = EC (dtName dt) (dtType dt)
 
 instance Eq DataType where
   (==) = lift2 dtName (==)

--- a/saw-core/src/SAWCore/Name.hs
+++ b/saw-core/src/SAWCore/Name.hs
@@ -268,11 +268,7 @@ instance Hashable Name where
 
 -- External Constants ----------------------------------------------------------
 
--- | A global name with a unique ID and a type. We maintain a global
--- invariant that the 'VarIndex' and the 'NameInfo' must be in a
--- strict one-to-one correspondence: Each 'VarIndex' is paired with a
--- unique 'NameInfo', and each 'NameInfo' is paired with a unique
--- 'VarIndex'.
+-- | A global name paired with a type.
 data ExtCns e =
   EC
   { ecName :: !Name

--- a/saw-core/src/SAWCore/Name.hs
+++ b/saw-core/src/SAWCore/Name.hs
@@ -269,6 +269,8 @@ instance Hashable Name where
 -- External Constants ----------------------------------------------------------
 
 -- | A global name paired with a type.
+-- We assume a global invariant: the type should be uniquely
+-- determined by the name.
 data ExtCns e =
   EC
   { ecName :: !Name
@@ -277,16 +279,13 @@ data ExtCns e =
   deriving (Show, Functor, Foldable, Traversable)
 
 -- | Because of the global uniqueness invariant, comparing the
--- 'VarIndex' is sufficient to ensure equality of names.
+-- 'Name' is sufficient to ensure equality.
 instance Eq (ExtCns e) where
   x == y = ecName x == ecName y
 
 instance Ord (ExtCns e) where
   compare x y = compare (ecName x) (ecName y)
 
--- | For hashing, we consider only the 'NameInfo' and not the
--- 'VarIndex'; this gives a stable hash value for a particular name,
--- even if the unique IDs are assigned differently from run to run.
 instance Hashable (ExtCns e) where
   hashWithSalt x ec = hashWithSalt x (ecName ec)
 

--- a/saw-core/src/SAWCore/Name.hs
+++ b/saw-core/src/SAWCore/Name.hs
@@ -43,6 +43,7 @@ module SAWCore.Name
   , ExtCns(..)
   , ecNameInfo
   , ecVarIndex
+  , ecShortName
   , scFreshNameURI
     -- * Display Name Environments
   , DisplayNameEnv(..)
@@ -298,6 +299,9 @@ ecNameInfo ec = nameInfo (ecName ec)
 
 ecVarIndex :: ExtCns e -> VarIndex
 ecVarIndex ec = nameIndex (ecName ec)
+
+ecShortName :: ExtCns e -> Text
+ecShortName ec = toShortName (ecNameInfo ec)
 
 scFreshNameURI :: Text -> VarIndex -> URI
 scFreshNameURI nm i = fromMaybe (panic "scFreshNameURI" ["Failed to construct name URI: <> " <> nm <> "  " <> Text.pack (show i)]) $

--- a/saw-core/src/SAWCore/Name.hs
+++ b/saw-core/src/SAWCore/Name.hs
@@ -41,6 +41,8 @@ module SAWCore.Name
   , Name(..)
     -- * ExtCns
   , ExtCns(..)
+  , ecNameInfo
+  , ecVarIndex
   , scFreshNameURI
     -- * Display Name Environments
   , DisplayNameEnv(..)
@@ -272,8 +274,7 @@ instance Hashable Name where
 -- 'VarIndex'.
 data ExtCns e =
   EC
-  { ecVarIndex :: !VarIndex
-  , ecName :: !NameInfo
+  { ecName :: !Name
   , ecType :: !e
   }
   deriving (Show, Functor, Foldable, Traversable)
@@ -281,10 +282,10 @@ data ExtCns e =
 -- | Because of the global uniqueness invariant, comparing the
 -- 'VarIndex' is sufficient to ensure equality of names.
 instance Eq (ExtCns e) where
-  x == y = ecVarIndex x == ecVarIndex y
+  x == y = ecName x == ecName y
 
 instance Ord (ExtCns e) where
-  compare x y = compare (ecVarIndex x) (ecVarIndex y)
+  compare x y = compare (ecName x) (ecName y)
 
 -- | For hashing, we consider only the 'NameInfo' and not the
 -- 'VarIndex'; this gives a stable hash value for a particular name,
@@ -292,6 +293,11 @@ instance Ord (ExtCns e) where
 instance Hashable (ExtCns e) where
   hashWithSalt x ec = hashWithSalt x (ecName ec)
 
+ecNameInfo :: ExtCns e -> NameInfo
+ecNameInfo ec = nameInfo (ecName ec)
+
+ecVarIndex :: ExtCns e -> VarIndex
+ecVarIndex ec = nameIndex (ecName ec)
 
 scFreshNameURI :: Text -> VarIndex -> URI
 scFreshNameURI nm i = fromMaybe (panic "scFreshNameURI" ["Failed to construct name URI: <> " <> nm <> "  " <> Text.pack (show i)]) $

--- a/saw-core/src/SAWCore/SCTypeCheck.hs
+++ b/saw-core/src/SAWCore/SCTypeCheck.hs
@@ -709,8 +709,8 @@ compileRecursor dt params motive cs_fs =
      cs_fs' <- forM cs_fs (\e -> do ety <- typeInferComplete (typedType e)
                                     pure (e,ety))
      let d = dtName dt
-     let ctorVarIxs = map ctorVarIndex (dtCtors dt)
      let ctorOrder = map ctorName (dtCtors dt)
+     let ctorVarIxs = map nameIndex ctorOrder
      let elims = Map.fromList (zip ctorVarIxs cs_fs')
      let rec = CompiledRecursor d params motive motiveTy elims ctorOrder
      let mk_err str =

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -312,7 +312,6 @@ import SAWCore.Module
   ( beginDataType
   , completeDataType
   , dtName
-  , dtNameInfo
   , ctorNumParams
   , ctorName
   , emptyModuleMap
@@ -673,18 +672,16 @@ scBeginDataType ::
   Sort {- ^ The universe of this datatype -} ->
   IO Name
 scBeginDataType sc dtIdent dtParams dtIndices dtSort =
-  do nm <- scRegisterName sc (ModuleIdentifier dtIdent)
+  do dtName <- scRegisterName sc (ModuleIdentifier dtIdent)
      dtType <- scGeneralizeExts sc (dtParams ++ dtIndices) =<< scSort sc dtSort
-     let dtNameInfo = ModuleIdentifier dtIdent
-     let dtVarIndex = nameIndex nm
      let dt = DataType { dtCtors = [], .. }
      e <- atomicModifyIORef' (scModuleMap sc) $ \mm ->
        case beginDataType dt mm of
          Left i -> (mm, Just (DuplicateNameException (moduleIdentToURI i)))
          Right mm' -> (mm', Nothing)
      maybe (pure ()) throwIO e
-     scRegisterGlobal sc dtIdent =<< scConst sc (dtName dt)
-     pure nm
+     scRegisterGlobal sc dtIdent =<< scConst sc dtName
+     pure dtName
 
 -- | Complete a datatype, by adding its constructors. See also 'scBeginDataType'.
 scCompleteDataType :: SharedContext -> Ident -> [Ctor] -> IO ()

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -607,8 +607,7 @@ scDeclareDef ::
 scDeclareDef sc nm q ty body =
   do scInsDefInMap sc $
        Def
-       { defNameInfo = nameInfo nm
-       , defVarIndex = nameIndex nm
+       { defName = nm
        , defQualifier = q
        , defType = ty
        , defBody = body
@@ -1702,7 +1701,7 @@ scApplyAllBeta :: SharedContext -> Term -> [Term] -> IO Term
 scApplyAllBeta sc = foldlM (scApplyBeta sc)
 
 scDefTerm :: SharedContext -> Def -> IO Term
-scDefTerm sc Def{..} = scConst sc (Name defVarIndex defNameInfo)
+scDefTerm sc d = scConst sc (defName d)
 
 -- TODO: implement version of scCtorApp that looks up the arity of the
 -- constructor identifier in the module.

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -695,7 +695,7 @@ scCompleteDataType sc dtIdent ctors =
          Right mm' -> (mm', Nothing)
      maybe (pure ()) throwIO e
      forM_ ctors $ \ctor ->
-       case ctorNameInfo ctor of
+       case nameInfo (ctorName ctor) of
          ModuleIdentifier ident ->
            -- register constructor in scGlobalEnv if it has an Ident name
            scRegisterGlobal sc ident =<< scConst sc (ctorName ctor)
@@ -868,8 +868,7 @@ scBuildCtor sc d c arg_struct =
 
     -- Finally, return the required Ctor record
     return $ Ctor
-      { ctorNameInfo = ModuleIdentifier c
-      , ctorVarIndex = nameIndex cname
+      { ctorName = cname
       , ctorArgStruct = arg_struct
       , ctorDataType = d
       , ctorType = tp

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -2869,7 +2869,7 @@ scAbstractExts sc exts x = loop (zip (inits exts) exts)
     -- inside the type of ec
     loop (([],ec):ecs) =
       do tm' <- loop ecs
-         scLambda sc (toShortName (ecNameInfo ec)) (ecType ec) tm'
+         scLambda sc (ecShortName ec) (ecType ec) tm'
 
     -- ordinary case. We need to abstract over all the ExtCns in @begin@
     -- before apply scLambda.  This ensures any dependencies between the
@@ -2877,7 +2877,7 @@ scAbstractExts sc exts x = loop (zip (inits exts) exts)
     loop ((begin,ec):ecs) =
       do tm' <- loop ecs
          tp' <- scExtsToLocals sc begin (ecType ec)
-         scLambda sc (toShortName (ecNameInfo ec)) tp' tm'
+         scLambda sc (ecShortName ec) tp' tm'
 
     -- base case, convert all the exts in the body of x into deBruijn variables
     loop [] = scExtsToLocals sc exts x
@@ -2933,7 +2933,7 @@ scGeneralizeExts sc exts x = loop (zip (inits exts) exts)
     -- inside the type of ec
     loop (([],ec):ecs) =
       do tm' <- loop ecs
-         scPi sc (toShortName (ecNameInfo ec)) (ecType ec) tm'
+         scPi sc (ecShortName ec) (ecType ec) tm'
 
     -- ordinary case. We need to abstract over all the ExtCns in @begin@
     -- before apply scLambda.  This ensures any dependenices between the
@@ -2941,7 +2941,7 @@ scGeneralizeExts sc exts x = loop (zip (inits exts) exts)
     loop ((begin,ec):ecs) =
       do tm' <- loop ecs
          tp' <- scExtsToLocals sc begin (ecType ec)
-         scPi sc (toShortName (ecNameInfo ec)) tp' tm'
+         scPi sc (ecShortName ec) tp' tm'
 
     -- base case, convert all the exts in the body of x into deBruijn variables
     loop [] = scExtsToLocals sc exts x
@@ -3123,7 +3123,7 @@ scCloseTerm :: (SharedContext -> LocalName -> Term -> Term -> IO Term)
 scCloseTerm close sc ec body = do
     lv <- scLocalVar sc 0
     body' <- scInstantiateExt sc (IntMap.singleton (ecVarIndex ec) lv) =<< incVars sc 0 1 body
-    close sc (toShortName (ecNameInfo ec)) (ecType ec) body'
+    close sc (ecShortName ec) (ecType ec) body'
 
 -- | Compute the body of 0 or more nested lambda-abstractions by applying the
 -- lambdas to fresh 'ExtCns's. Note that we do this lambda-by-lambda, rather

--- a/saw-core/src/SAWCore/Simulator.hs
+++ b/saw-core/src/SAWCore/Simulator.hs
@@ -57,7 +57,7 @@ import SAWCore.Module
   , allModulePrimitives
   , ctorNumParams
   , ctorNumArgs
-  , defNameInfo
+  , defName
   , dtNumIndices
   , dtNumParams
   , findCtorInMap
@@ -500,7 +500,7 @@ checkPrimitives modmap prims = do
 
 defIdent :: Def -> Maybe Ident
 defIdent d =
-  case defNameInfo d of
+  case nameInfo (defName d) of
     ModuleIdentifier ident -> Just ident
     ImportedName{} -> Nothing
 

--- a/saw-core/src/SAWCore/Simulator.hs
+++ b/saw-core/src/SAWCore/Simulator.hs
@@ -239,7 +239,7 @@ evalTermF cfg lam recEval tf env =
                  do argv <- recEval arg
                     case evalConstructor argv of
                       Just (ctor, args)
-                        | Just (elim,elimTy) <- Map.lookup (ctorVarIndex ctor) ps_fs
+                        | Just (elim,elimTy) <- Map.lookup (nameIndex (ctorName ctor)) ps_fs
                         -> do let rTy = VRecursorType d ps motive motiveTy
                               ctorTy <- toTValue <$> lam (ctorType ctor) []
                               allArgs <- processRecArgs ps args ctorTy [(elim,elimTy),(ready r,rTy)]

--- a/saw-core/src/SAWCore/Simulator/Concrete.hs
+++ b/saw-core/src/SAWCore/Simulator/Concrete.hs
@@ -57,7 +57,7 @@ evalSharedTerm m addlPrims ecVals t =
         Nothing -> return $ Prim.userError $ "Unimplemented: external constant " ++ show (ecName ec)
     primHandler ec msg env _tv =
       return $ Prim.userError $ unlines
-        [ "Could not evaluate primitive " ++ Text.unpack (toAbsoluteName (ecName ec))
+        [ "Could not evaluate primitive " ++ Text.unpack (toAbsoluteName (ecNameInfo ec))
         , "On argument " ++ show (length env)
         , Text.unpack msg
         ]

--- a/saw-core/src/SAWCore/Simulator/Prims.hs
+++ b/saw-core/src/SAWCore/Simulator/Prims.hs
@@ -76,7 +76,7 @@ import Data.Vector (Vector)
 import qualified Data.Vector as V
 import Numeric.Natural (Natural)
 
-import SAWCore.Name (ExtCns(..), Ident, NameInfo(..))
+import SAWCore.Name (ExtCns(..), Ident, NameInfo(..), ecVarIndex, ecNameInfo)
 import SAWCore.Panic (panic)
 import SAWCore.Simulator.Value
 import SAWCore.Prim
@@ -118,8 +118,8 @@ boolFun = PrimFilterFun "expected Bool" r
 natFun :: VMonad l => (Natural -> Prim l) -> Prim l
 natFun = PrimFilterFun "expected Nat" r
   where r (VNat n) = pure n
-        r (VCtorApp (ecName -> ModuleIdentifier "Prelude.Zero") [] [])  = pure 0
-        r (VCtorApp (ecName -> ModuleIdentifier "Prelude.Succ") [] [x]) = succ <$> (r =<< lift (force x))
+        r (VCtorApp (ecNameInfo -> ModuleIdentifier "Prelude.Zero") [] [])  = pure 0
+        r (VCtorApp (ecNameInfo -> ModuleIdentifier "Prelude.Succ") [] [x]) = succ <$> (r =<< lift (force x))
         r _ = mzero
 
 -- | A primitive that requires an integer argument
@@ -549,8 +549,8 @@ natSizeFun :: (HasCallStack, VMonad l) =>
               (Either (Natural, Value l) Natural -> Prim l) -> Prim l
 natSizeFun = PrimFilterFun "expected Nat with a known size" r
   where r (VNat n) = pure (Right n)
-        r (VCtorApp (ecName -> ModuleIdentifier "Prelude.Zero") [] []) = pure (Right 0)
-        r v@(VCtorApp (ecName -> ModuleIdentifier "Prelude.Succ") [] [x]) =
+        r (VCtorApp (ecNameInfo -> ModuleIdentifier "Prelude.Zero") [] []) = pure (Right 0)
+        r v@(VCtorApp (ecNameInfo -> ModuleIdentifier "Prelude.Succ") [] [x]) =
           lift (force x) >>= r >>= bimapM (const (szPr v)) (pure . succ)
         r v = Left <$> szPr v
         szPr v = maybe mzero (pure . (,v)) (natSizeMaybe v)

--- a/saw-core/src/SAWCore/Simulator/RME.hs
+++ b/saw-core/src/SAWCore/Simulator/RME.hs
@@ -66,7 +66,7 @@ evalSharedTerm m addlPrims t =
     neutral _env nt = return $ Prim.userError $ "Could not evaluate neutral term\n:" ++ show nt
     primHandler ec msg env _tv =
       return $ Prim.userError $ unlines
-        [ "Could not evaluate primitive " ++ Text.unpack (toAbsoluteName (ecName ec))
+        [ "Could not evaluate primitive " ++ Text.unpack (toAbsoluteName (ecNameInfo ec))
         , "On argument " ++ show (length env)
         , Text.unpack msg
         ]
@@ -292,7 +292,7 @@ muxInt b x y =
     Nothing -> if x == y then x else error $ "muxRValue: VInt " ++ show (x, y)
 
 muxExtra :: TValue ReedMuller -> RME -> RExtra -> RExtra -> RExtra
-muxExtra (VDataType (ecName -> ModuleIdentifier "Prelude.Stream") [TValue tp] []) b (AStream xs) (AStream ys) =
+muxExtra (VDataType (ecNameInfo -> ModuleIdentifier "Prelude.Stream") [TValue tp] []) b (AStream xs) (AStream ys) =
   AStream (muxRValue tp b <$> xs <*> ys)
 muxExtra tp _ _ _ = panic "muxExtra" ["Type mismatch: " <> Text.pack (show tp)]
 
@@ -404,7 +404,7 @@ bitBlastBasic m addlPrims ecMap t = runIdentity $ do
   let neutral _env nt = return $ Prim.userError $ "Could not evaluate neutral term\n:" ++ show nt
   let primHandler ec msg env _tv =
          return $ Prim.userError $ unlines
-           [ "Could not evaluate primitive " ++ Text.unpack (toAbsoluteName (ecName ec))
+           [ "Could not evaluate primitive " ++ Text.unpack (toAbsoluteName (ecNameInfo ec))
            , "On argument " ++ show (length env)
            , Text.unpack msg
            ]
@@ -412,7 +412,7 @@ bitBlastBasic m addlPrims ecMap t = runIdentity $ do
   cfg <- Sim.evalGlobal m (Map.union constMap addlPrims)
          (\ec -> case Map.lookup (ecVarIndex ec) ecMap of
                    Just v -> pure v
-                   Nothing -> error ("RME: unknown ExtCns: " ++ show (ecName ec)))
+                   Nothing -> error ("RME: unknown ExtCns: " ++ show (ecNameInfo ec)))
          (const Nothing)
          neutral
          primHandler

--- a/saw-core/src/SAWCore/Simulator/TermModel.hs
+++ b/saw-core/src/SAWCore/Simulator/TermModel.hs
@@ -130,7 +130,7 @@ replace sc cfg mapref ec = loop [] (ecType ec)
     loop env ty =
       do let args = reverse env
          ty' <- readBackTValue sc cfg ty
-         newec <- scFreshEC sc (toShortName (ecNameInfo ec)) ty'
+         newec <- scFreshEC sc (ecShortName ec) ty'
          modifyIORef mapref (Map.alter (Just . ((newec,args):) . fromMaybe []) (ecVarIndex ec))
          reflectTerm sc cfg ty =<< scVariable sc newec
 

--- a/saw-core/src/SAWCore/Simulator/Value.hs
+++ b/saw-core/src/SAWCore/Simulator/Value.hs
@@ -186,7 +186,7 @@ instance Show (Extra l) => Show (Value l) where
       VFun {}        -> showString "<<fun>>"
       VUnit          -> showString "()"
       VPair{}        -> showString "<<tuple>>"
-      VCtorApp s _ps _xv -> shows (toAbsoluteName (ecName s))
+      VCtorApp s _ps _xv -> shows (toAbsoluteName (ecNameInfo s))
       VCtorMux {}    -> showString "<<constructor>>"
       VVector xv     -> showList (toList xv)
       VBool _        -> showString "<<boolean>>"

--- a/saw-core/src/SAWCore/Term/CtxTerm.hs
+++ b/saw-core/src/SAWCore/Term/CtxTerm.hs
@@ -116,7 +116,7 @@ asPiCtorArg sc d params dt_ixs t =
     Just (ec, rest) ->
       asCtorArg sc d params dt_ixs (ecType ec) >>= \case
         Nothing -> pure Nothing
-        Just arg -> pure $ Just (Name (ecVarIndex ec) (ecName ec), arg, rest)
+        Just arg -> pure $ Just (ecName ec, arg, rest)
 
 -- | Helper function for 'mkCtorArgStruct'
 mkCtorArgsIxs ::

--- a/saw-core/src/SAWCore/Term/Pretty.hs
+++ b/saw-core/src/SAWCore/Term/Pretty.hs
@@ -464,7 +464,7 @@ ppExtCns ec =
   do ne <- asks ppNamingEnv
      case bestDisplayName ne (ecVarIndex ec) of
        Just alias -> pure $ pretty alias
-       Nothing -> pure $ ppName (ecName ec)
+       Nothing -> pure $ ppName (ecNameInfo ec)
 
 -- | Pretty-print a 'Name', using the best unambiguous alias from the
 -- naming environment.

--- a/saw-core/src/SAWCore/Testing/Random.hs
+++ b/saw-core/src/SAWCore/Testing/Random.hs
@@ -19,6 +19,7 @@ import SAWCore.FiniteValue
   ( FirstOrderType(..), FirstOrderValue(..), scFirstOrderValue )
 
 import SAWCore.Module (ModuleMap)
+import SAWCore.Name (ecVarIndex)
 import SAWCore.SATQuery
 import SAWCore.SharedTerm
   ( scGetModuleMap, SharedContext, Term

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -105,7 +105,7 @@ import qualified SAWCentral.Yosys.Theorem as Yo (YosysImport, YosysTheorem)
 
 import SAWCore.Conversion
 import SAWCore.Module (Def(..), emptyModule, moduleDefs)
-import SAWCore.Name (mkModuleName)
+import SAWCore.Name (mkModuleName, Name(..))
 import SAWCore.Prim (rethrowEvalError)
 import SAWCore.Rewriter (emptySimpset, rewritingSharedContext, scSimpset)
 import SAWCore.SharedTerm
@@ -1004,7 +1004,7 @@ buildTopLevelEnv proxy opts =
                       ]
            cryptolDefs = filter defPred $ moduleDefs cryptol_mod
            defPred d =
-             case defNameInfo d of
+             case nameInfo (defName d) of
                ModuleIdentifier ident -> ident `Set.member` includedDefs
                ImportedName{} -> False
            includedDefs = Set.fromList

--- a/saw-server/src/SAWServer/ProofScript.hs
+++ b/saw-server/src/SAWServer/ProofScript.hs
@@ -48,7 +48,7 @@ import SAWServer.Exceptions ( notASimpset )
 import SAWServer.OK ( OK, ok )
 import SAWServer.TopLevel ( tl )
 import SAWCore.FiniteValue (FirstOrderValue(..))
-import SAWCore.Name (ecName, toShortName)
+import SAWCore.Name (ecNameInfo, toShortName)
 import SAWCore.Rewriter (emptySimpset)
 import SAWCore.TermNet (merge)
 
@@ -277,7 +277,7 @@ prove params = do
                          do e <- case exportFirstOrderExpression v of
                                    Left err -> throw $ ProveException err
                                    Right e -> return e
-                            return $ CexValue (toShortName (ecName ec)) e
+                            return $ CexValue (toShortName (ecNameInfo ec)) e
          return $ ProofInvalid $ cexVals
     PF.UnfinishedProof{} ->
       return ProofUnknown

--- a/saw-server/src/SAWServer/ProofScript.hs
+++ b/saw-server/src/SAWServer/ProofScript.hs
@@ -48,7 +48,7 @@ import SAWServer.Exceptions ( notASimpset )
 import SAWServer.OK ( OK, ok )
 import SAWServer.TopLevel ( tl )
 import SAWCore.FiniteValue (FirstOrderValue(..))
-import SAWCore.Name (ecNameInfo, toShortName)
+import SAWCore.Name (ecShortName)
 import SAWCore.Rewriter (emptySimpset)
 import SAWCore.TermNet (merge)
 
@@ -277,7 +277,7 @@ prove params = do
                          do e <- case exportFirstOrderExpression v of
                                    Left err -> throw $ ProveException err
                                    Right e -> return e
-                            return $ CexValue (toShortName (ecNameInfo ec)) e
+                            return $ CexValue (ecShortName ec) e
          return $ ProofInvalid $ cexVals
     PF.UnfinishedProof{} ->
       return ProofUnknown


### PR DESCRIPTION
Some internal SAWCore data types are updated to use subfields of type `Name` instead of separate `NameInfo` and `VarIndex` fields. The aim is to try to use `Name`s more abstractly instead of taking them apart and putting them together all the time.