### PR TITLE
crux-mir-comp: fix interaction between clobber_globals and promoted enum constants

### DIFF
--- a/crucible-mir-comp/src/Mir/Compositional/Clobber.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Clobber.hs
@@ -120,7 +120,7 @@ traverseVariantShape :: forall sym p t st fs tp0 rtp args ret.
   OverrideSim (p sym) sym MIR rtp args ret (VariantBranch sym tp0)
 traverseVariantShape sym f (VariantShape flds) (VB pe) =
   case pe of
-    W4.Unassigned -> return $ VB $ W4.Unassigned
+    W4.Unassigned -> return $ VB W4.Unassigned
     -- `rv` is known to be `RegValue _ (StructRepr ctx)`, which is represented
     -- as `Ctx.Assignment RegValue' ctx`.  So we can directly zip `rv` with
     -- another assignment (`flds`).

--- a/crux-mir-comp/test/symb_eval/comp/clobber_globals_promoted_enum.good
+++ b/crux-mir-comp/test/symb_eval/comp/clobber_globals_promoted_enum.good
@@ -1,0 +1,3 @@
+test clobber_globals_promoted_enum/<DISAMB>::f_test[0]: ok
+
+[Crux] Overall status: Valid.

--- a/crux-mir-comp/test/symb_eval/comp/clobber_globals_promoted_enum.rs
+++ b/crux-mir-comp/test/symb_eval/comp/clobber_globals_promoted_enum.rs
@@ -1,0 +1,8 @@
+extern crate crucible;
+use crucible::method_spec::clobber_globals;
+
+#[crux::test]
+fn f_test() {
+    clobber_globals();
+    let b = None::<()> == None;
+}


### PR DESCRIPTION
Currently, `clobber_globals` will fail if code elsewhere in the tests includes a promoted constant of enum type (e.g. `&None`).  The promoted constant becomes a static, `clobber_globals` tries to clobber that static, but `clobber_globals` doesn't support clobbering enums.  This branch adds an `EnumShape` case to `clobberImmutSymbolic`.  Const promotion always produces immutable statics, so this covers `&None` and similar cases.  There is still no support for `EnumShape` in mutable statics or under `UnsafeCell`, since those cases are more complex.

Fixes #2536