### PR TITLE
Adapt MRSolver to use named variables instead of de Bruijn indices.

### DIFF
--- a/saw-central/src/SAWCentral/MRSolver/SMT.hs
+++ b/saw-central/src/SAWCentral/MRSolver/SMT.hs
@@ -234,21 +234,6 @@ mrNormTerm t =
   mrDebugPPInCtx 2 t >>
   liftSC1 smtNorm t
 
--- | Normalize an open term by wrapping it in lambdas, normalizing, and then
--- removing those lambdas
-mrNormOpenTerm :: Term -> MRM t Term
-mrNormOpenTerm body =
-  do length_ctx <- mrVarCtxLength <$> mrUVars
-     fun_term <- lambdaUVarsM body
-     normed_fun <- mrNormTerm fun_term
-     return (peel_lambdas length_ctx normed_fun)
-       where
-         peel_lambdas :: Int -> Term -> Term
-         peel_lambdas 0 t = t
-         peel_lambdas i (asLambda -> Just (_, _, t)) = peel_lambdas (i-1) t
-         peel_lambdas _ _ = error "mrNormOpenTerm: unexpected non-lambda term!"
-
-
 ----------------------------------------------------------------------
 -- * Checking Provability with SMT
 ----------------------------------------------------------------------

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -248,7 +248,7 @@ import SAWCentral.Options (Options, printOutLn, Verbosity(..))
 import qualified SAWCentral.Options as Opt
 import SAWCentral.Proof
 import SAWCentral.Prover.SolverStats
-import SAWCentral.MRSolver.Term (funNameTerm, mrVarCtxInnerToOuter, ppTermAppInCtx)
+import SAWCentral.MRSolver.Term (funNameTerm, ppTermAppInCtx)
 import SAWCentral.MRSolver.Evidence as MRSolver
 import SAWCentral.SolverCache
 import SAWCentral.Crucible.LLVM.Skeleton
@@ -686,8 +686,8 @@ showRefnset opts ss =
        , PP.pretty ("|=" :: String) PP.<+> ppFunAssumpRHS ctx rhs ])
     ppFunAssumpRHS ctx (OpaqueFunAssump f args) =
       ppTermAppInCtx opts ctx (funNameTerm f) args
-    ppFunAssumpRHS ctx (RewriteFunAssump rhs) =
-      SAWCorePP.ppTermInCtx opts (map fst $ mrVarCtxInnerToOuter ctx) rhs
+    ppFunAssumpRHS _ctx (RewriteFunAssump rhs) =
+      SAWCorePP.ppTerm opts rhs
 
 -- XXX the precedence in here needs to be cleaned up
 showsPrecValue :: PPS.Opts -> DisplayNameEnv -> Int -> Value -> ShowS


### PR DESCRIPTION
This is another step toward removing de Bruijn indices (#2328).