### PR TITLE
Update rme references in saw.cabal

### DIFF
--- a/saw.cabal
+++ b/saw.cabal
@@ -141,9 +141,9 @@ library saw-core
 
     -- packages in git submodules
     parameterized-utils,
+    rme,
 
     -- internal subpackages in the saw tree
-    rme,
     saw:saw-support,
 
   hs-source-dirs: saw-core/src
@@ -576,13 +576,13 @@ library saw-central
     macaw-symbolic,
     macaw-x86-symbolic,
     parameterized-utils,
+    rme,
     what4 >= 0.4,
     what4-transition-system,
     -- apparently no longer used:
     --   flexdis86
 
     -- internal subpackages/sublibraries in the saw tree
-    rme,
     saw:saw-support,
     saw:saw-core,
     saw:saw-core-aig,


### PR DESCRIPTION
The references to packages are grouped by how we get them, and since rme has moved from a subpackage to a submodule it goes in a different group now. Overlooked in #2570.