### PR TITLE
Branch release 1.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# next -- TBA
+# Version 1.4 -- date still TBD
 
 This release supports [version
 4](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#4) of

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# next -- TBA
+
+This release supports [version
+4](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#4) of
+`mir-json`'s schema.
+
+Nothing yet.
+
 # Version 1.4 -- date still TBD
 
 This release supports [version

--- a/saw-python/CHANGELOG.md
+++ b/saw-python/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for saw-client
 
-## next -- TBA
+## 1.4 - release date still TBD
 
 * Require urllib 2.5.0 or later to avoid a security alert.
   This in turn requires Python 3.9, so Python 3.8 is no longer supported.

--- a/saw-python/CHANGELOG.md
+++ b/saw-python/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for saw-client
 
+## next -- TBA
+
+Nothing yet
+
 ## 1.4 - release date still TBD
 
 * Require urllib 2.5.0 or later to avoid a security alert.

--- a/saw-python/pyproject.toml
+++ b/saw-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "saw-client"
-version = "1.3.0.99"
+version = "1.3.0.99.99"
 readme = "README.md"
 description = "SAW client for the SAW RPC server"
 authors = ["Galois, Inc. <saw@galois.com>"]

--- a/saw-python/pyproject.toml
+++ b/saw-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "saw-client"
-version = "1.3.0.99.99"
+version = "1.4.0.99"
 readme = "README.md"
 description = "SAW client for the SAW RPC server"
 authors = ["Galois, Inc. <saw@galois.com>"]

--- a/saw-remote-api/CHANGELOG.md
+++ b/saw-remote-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for saw-remote-api
 
+## next -- TBA
+
+Nothing yet.
+
 ## 1.4 -- release date still TBD
 
 * Add a `"mutable globals"` field to specification objects, which contains a

--- a/saw-remote-api/CHANGELOG.md
+++ b/saw-remote-api/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for saw-remote-api
 
-## next -- TBA
+## 1.4 -- release date still TBD
 
 * Add a `"mutable globals"` field to specification objects, which contains a
   list of strings representing the names of mutable global variables that

--- a/saw.cabal
+++ b/saw.cabal
@@ -1,6 +1,6 @@
 Cabal-version:      3.0
 Name:               saw
-Version:            1.3.0.99.99
+Version:            1.4.0.99
 Author:             Galois, Inc.
 Maintainer:         saw@galois.com
 Build-type:         Simple

--- a/saw.cabal
+++ b/saw.cabal
@@ -1,6 +1,6 @@
 Cabal-version:      3.0
 Name:               saw
-Version:            1.3.0.99
+Version:            1.3.0.99.99
 Author:             Galois, Inc.
 Maintainer:         saw@galois.com
 Build-type:         Simple


### PR DESCRIPTION
This pull request contains version bump and CHANGES adjustments for creating the SAW 1.4 release branch. (It doesn't create the branch itself, that's something one does by hand afterwards. The branch point is the first of the two commits in here.)

Things this does _not_ contain that will need to be applied to the release branch later include (but may not be limited to):

- further submodule bumps to point at the release versions of crucible/cryptol and probably others
- the release date needs to be entered into CHANGES.md, saw-remote-api/CHANGELOG.md, and saw-python/CHANGELOG.md
- the release date needs to be entered into doc/scripts/epoch.mk
- after updating epoch.mk the checked-in doc PDFs need to be rebuilt
- the actual release commit that changes the version to 1.4 needs to be made (the version on the branch will be 1.3.0.99.99 until then)

The reason to make the branch now is that we want to remove Heapster and Mr. Solver (#2576) because they're holding things up, and that should really come after the release.