### PR TITLE
`crucible-mir-comp`: Allocate the correct length for fresh allocations in post state of override

### DIFF
--- a/crux-mir-comp/test/symb_eval/comp/post_alloc_multi.good
+++ b/crux-mir-comp/test/symb_eval/comp/post_alloc_multi.good
@@ -1,0 +1,4 @@
+test post_alloc_multi/<DISAMB>::f_equiv[0]: ok
+test post_alloc_multi/<DISAMB>::g_equiv[0]: ok
+
+[Crux] Overall status: Valid.

--- a/crux-mir-comp/test/symb_eval/comp/post_alloc_multi.rs
+++ b/crux-mir-comp/test/symb_eval/comp/post_alloc_multi.rs
@@ -1,0 +1,40 @@
+extern crate crucible;
+extern crate crucible_proc_macros;
+
+use crucible::*;
+use crucible_proc_macros::crux_spec_for;
+
+pub fn f(vec: &Vec<u8>) -> usize {
+    vec.len()
+}
+
+pub fn g(vec: &Vec<u8>) -> usize {
+    let mut r: usize = 0;
+    for _ in vec {
+        r += f(vec)
+    }
+    r
+}
+
+fn mk_vec(arr: &[u8; 4]) -> Vec<u8> {
+    let mut v = Vec::with_capacity(4);
+    for y in arr { v.push(*y); }
+    v
+}
+
+#[crux_spec_for(f)]
+fn f_equiv() {
+    let arr = <[u8; 4]>::symbolic("arr");
+    let vec = mk_vec(&arr);
+    let output_impl = f(&vec);
+    crucible_assert!(output_impl == 4);
+}
+
+#[crux::test]
+fn g_equiv() {
+    let arr = <[u8; 4]>::symbolic("arr");
+    let vec = mk_vec(&arr);
+    f_equiv_spec().enable();
+    let output_impl = g(&vec);
+    crucible_assert!(output_impl == 16);
+}

--- a/crux-mir-comp/test/symb_eval/comp/post_alloc_multi_2.good
+++ b/crux-mir-comp/test/symb_eval/comp/post_alloc_multi_2.good
@@ -1,0 +1,4 @@
+test post_alloc_multi_2/<DISAMB>::f_equiv[0]: ok
+test post_alloc_multi_2/<DISAMB>::g_equiv[0]: ok
+
+[Crux] Overall status: Valid.

--- a/crux-mir-comp/test/symb_eval/comp/post_alloc_multi_2.rs
+++ b/crux-mir-comp/test/symb_eval/comp/post_alloc_multi_2.rs
@@ -1,0 +1,36 @@
+extern crate crucible;
+extern crate crucible_proc_macros;
+
+use crucible::*;
+use crucible_proc_macros::crux_spec_for;
+
+pub fn f(vec: &Vec<u8>) -> usize {
+    vec.len()
+}
+
+pub fn g(vec: &Vec<u8>) -> usize {
+    f(vec)
+}
+
+fn mk_vec(arr: &[u8; 4]) -> Vec<u8> {
+    let mut v = Vec::with_capacity(4);
+    for y in arr { v.push(*y); }
+    v
+}
+
+#[crux_spec_for(f)]
+fn f_equiv() {
+    let arr = <[u8; 4]>::symbolic("arr");
+    let vec = mk_vec(&arr);
+    let output_impl = f(&vec);
+    crucible_assert!(output_impl == 4);
+}
+
+#[crux::test]
+fn g_equiv() {
+    let arr = <[u8; 4]>::symbolic("arr");
+    let vec = mk_vec(&arr);
+    f_equiv_spec().enable();
+    let output_impl = g(&vec);
+    crucible_assert!(output_impl == 4);
+}


### PR DESCRIPTION
Previously, if there was a fresh allocation in the post state of a `MethodSpec`, the override allocated space for a single value of the `MirAllocSpec`'s type and ignored the `MirAllocSpec`'s length. Fix this by always allocating a `MirVector` of the correct length, whose element type is the `MirAllocSpec`'s type, the same way it is done in SAW.

This fixes one of the bugs identified in #2477. The test programs here are the ones @RyanGlScott posted in that issue.