### PR TITLE
Test sawcore type errors

### DIFF
--- a/intTests/test_sawcore_type_errors/Makefile
+++ b/intTests/test_sawcore_type_errors/Makefile
@@ -1,0 +1,5 @@
+all: ;
+clean:
+	sh ./test.sh clean
+
+.PHONY: all clean

--- a/intTests/test_sawcore_type_errors/core001.sawcore
+++ b/intTests/test_sawcore_type_errors/core001.sawcore
@@ -1,0 +1,6 @@
+-- DeclError "More variables than length of function type"
+
+module core001 where import Prelude;
+
+foo : Bool -> Bool -> Bool;
+foo x y z = x;

--- a/intTests/test_sawcore_type_errors/core002.sawcore
+++ b/intTests/test_sawcore_type_errors/core002.sawcore
@@ -1,0 +1,5 @@
+-- DeclError "Definition without defining equation"
+
+module core002 where import Prelude;
+
+foo : Bool -> Bool -> Bool;

--- a/intTests/test_sawcore_type_errors/core003.sawcore
+++ b/intTests/test_sawcore_type_errors/core003.sawcore
@@ -1,0 +1,6 @@
+-- DeclError "Primitive or axiom with definition"
+
+module core003 where import Prelude;
+
+primitive foo : Bool -> Bool -> Bool;
+foo x y = and x y;

--- a/intTests/test_sawcore_type_errors/core004.sawcore
+++ b/intTests/test_sawcore_type_errors/core004.sawcore
@@ -1,0 +1,5 @@
+-- DeclError "Dangling definition without a type"
+
+module core004 where import Prelude;
+
+foo x y = and x y;

--- a/intTests/test_sawcore_type_errors/core005.sawcore
+++ b/intTests/test_sawcore_type_errors/core005.sawcore
@@ -1,0 +1,7 @@
+-- DeclError "Wrong form for type of datatype"
+
+module core005 where import Prelude;
+
+data Foo : isort 1 where {
+  MkFoo : Foo;
+}

--- a/intTests/test_sawcore_type_errors/core006.sawcore
+++ b/intTests/test_sawcore_type_errors/core006.sawcore
@@ -1,0 +1,7 @@
+-- DeclError "Universe level of parameters should be no greater than that of the datatype"
+
+module core006 where import Prelude;
+
+data Foo (a : sort 1) : sort 0 where {
+  MkFoo : a -> Foo;
+}

--- a/intTests/test_sawcore_type_errors/core007.sawcore
+++ b/intTests/test_sawcore_type_errors/core007.sawcore
@@ -1,0 +1,7 @@
+-- DeclError "Universe level of indices should be strictly contained in that of the datatype"
+
+module core007 where import Prelude;
+
+data Foo : (t : sort 0) -> sort 0 where {
+  MkFoo : (t : sort 0) -> Foo t;
+}

--- a/intTests/test_sawcore_type_errors/core008.sawcore
+++ b/intTests/test_sawcore_type_errors/core008.sawcore
@@ -1,0 +1,7 @@
+-- DeclError "Universe level of constructors should be strictly contained in that of the datatype"
+
+module core008 where import Prelude;
+
+data Foo (t : sort 0) : sort 0 where {
+  MkFoo : (a : sort 0) -> t -> a -> Foo t;
+}

--- a/intTests/test_sawcore_type_errors/test.log.good
+++ b/intTests/test_sawcore_type_errors/test.log.good
@@ -30,7 +30,7 @@ Stack trace:
    test.saw:4:17-4:54 in parse
    test.saw:13:1-13:73 (at top level)
 .:1:0:
-Recursor not fully applied: EC {ecName = Name {nameIndex = 145, nameInfo = ModuleIdentifier Prelude.Either}, ecType = STApp {stAppIndex = 7211, stAppHash = -726703236893067481, stAppLooseVars = BitSet 0, stAppFreeVars = fromList [], stAppTermF = Pi "s" (STApp {stAppIndex = 0, stAppHash = 6482440611836299967, stAppLooseVars = BitSet 0, stAppFreeVars = fromList [], stAppTermF = FTermF (Sort (sort 0) )}) (STApp {stAppIndex = 7210, stAppHash = 8514227583290284448, stAppLooseVars = BitSet 0, stAppFreeVars = fromList [], stAppTermF = Pi "t" (STApp {stAppIndex = 0, stAppHash = 6482440611836299967, stAppLooseVars = BitSet 0, stAppFreeVars = fromList [], stAppTermF = FTermF (Sort (sort 0) )}) (STApp {stAppIndex = 0, stAppHash = 6482440611836299967, stAppLooseVars = BitSet 0, stAppFreeVars = fromList [], stAppTermF = FTermF (Sort (sort 0) )})})}}
+Recursor not fully applied: ModuleIdentifier Prelude.Either
 
  Not a sort (lambda)
 == Anticipated failure message ==

--- a/intTests/test_sawcore_type_errors/test.log.good
+++ b/intTests/test_sawcore_type_errors/test.log.good
@@ -58,7 +58,7 @@ Stack trace:
 .:1:11:
 While typechecking term:
   (x : Prelude.True)
--> Prelude.Bool
+  -> Prelude.Bool
 .:1:11:
 Not a sort
   Prelude.Bool
@@ -74,7 +74,7 @@ Stack trace:
 .:1:11:
 While typechecking term:
   (x : Prelude.Bool)
--> Prelude.False
+  -> Prelude.False
 .:1:11:
 Not a sort
   Prelude.Bool

--- a/intTests/test_sawcore_type_errors/test.log.good
+++ b/intTests/test_sawcore_type_errors/test.log.good
@@ -244,7 +244,7 @@ Stack trace:
    test.saw:57:1-57:23 (at top level)
 core001.sawcore:5:0:
 Malformed declaration for "foo"
-More variables [TermVar (PosPair {_pos = Pos {posBase = ".", posPath = "core001.sawcore", posLine = 6, posCol = 4}, val = "x"}),TermVar (PosPair {_pos = Pos {posBase = ".", posPath = "core001.sawcore", posLine = 6, posCol = 6}, val = "y"}),TermVar (PosPair {_pos = Pos {posBase = ".", posPath = "core001.sawcore", posLine = 6, posCol = 8}, val = "z"})] than length of function type:
+More variables ["x","y","z"] than length of function type:
 Prelude.Bool
 -> Prelude.Bool
 -> Prelude.Bool

--- a/intTests/test_sawcore_type_errors/test.log.good
+++ b/intTests/test_sawcore_type_errors/test.log.good
@@ -1,0 +1,343 @@
+ Loading file "test.saw"
+ Unbound name
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:7:1-7:14 (at top level)
+.:1:0:
+Unbound name: "false"
+
+ No such data type
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:10:1-10:35 (at top level)
+.:1:0:
+No such data type: ModuleIdentifier Cryptol.String
+
+ Recursor not fully applied
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:13:1-13:73 (at top level)
+.:1:0:
+Recursor not fully applied: EC {ecName = Name {nameIndex = 145, nameInfo = ModuleIdentifier Prelude.Either}, ecType = STApp {stAppIndex = 7211, stAppHash = -726703236893067481, stAppLooseVars = BitSet 0, stAppFreeVars = fromList [], stAppTermF = Pi "s" (STApp {stAppIndex = 0, stAppHash = 6482440611836299967, stAppLooseVars = BitSet 0, stAppFreeVars = fromList [], stAppTermF = FTermF (Sort (sort 0) )}) (STApp {stAppIndex = 7210, stAppHash = 8514227583290284448, stAppLooseVars = BitSet 0, stAppFreeVars = fromList [], stAppTermF = Pi "t" (STApp {stAppIndex = 0, stAppHash = 6482440611836299967, stAppLooseVars = BitSet 0, stAppFreeVars = fromList [], stAppTermF = FTermF (Sort (sort 0) )}) (STApp {stAppIndex = 0, stAppHash = 6482440611836299967, stAppLooseVars = BitSet 0, stAppFreeVars = fromList [], stAppTermF = FTermF (Sort (sort 0) )})})}}
+
+ Not a sort (lambda)
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:16:1-16:26 (at top level)
+.:1:0:
+While typechecking term: 
+  \(x : Prelude.True) -> x
+.:1:0:
+Not a sort
+  Prelude.Bool
+
+ Not a sort (pi)
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:19:1-19:27 (at top level)
+.:1:11:
+While typechecking term: 
+  (x : Prelude.True)
+-> Prelude.Bool
+.:1:11:
+Not a sort
+  Prelude.Bool
+
+ Not a sort (pi)
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:22:1-22:28 (at top level)
+.:1:11:
+While typechecking term: 
+  (x : Prelude.Bool)
+-> Prelude.False
+.:1:11:
+Not a sort
+  Prelude.Bool
+
+ Not a sort (pair type)
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:25:1-25:21 (at top level)
+.:1:2:
+While typechecking term: 
+  Prelude.True * Prelude.Nat
+.:1:2:
+Not a sort
+  Prelude.Bool
+
+ Not a sort (pair type)
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:28:1-28:19 (at top level)
+.:1:2:
+While typechecking term: 
+  Prelude.Bool * 5
+.:1:2:
+Not a sort
+  Prelude.Nat
+
+ Not a sort (record type)
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:31:1-31:37 (at top level)
+.:1:0:
+While typechecking term: 
+  #{foo : Prelude.Bool,bar : Prelude.False}
+.:1:0:
+Not a sort
+  Prelude.Bool
+
+ Motive function should return a sort
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:34:1-34:59 (at top level)
+.:1:15:
+Malformed recursor
+  Prelude.Void#rec (\(_ : Prelude.Void) -> Prelude.True) ()
+Motive function should return a sort
+
+ Function application with non-function type
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:37:1-37:18 (at top level)
+.:1:0:
+While typechecking term: 
+  Prelude.True Prelude.True
+.:1:0:
+Function application with non-function type
+For term:
+  Prelude.True
+With type:
+  Prelude.Bool
+To argument:
+  Prelude.True
+
+ Tuple field projection with non-tuple type
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:40:1-40:15 (at top level)
+.:1:0:
+While typechecking term: 
+  Prelude.True.1
+.:1:0:
+Tuple field projection with non-tuple type
+  Prelude.Bool
+
+ Record field projection with non-record type
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:43:1-43:18 (at top level)
+.:1:0:
+While typechecking term: 
+  Prelude.False.foo
+.:1:0:
+Record field projection with non-record type
+  Prelude.Bool
+In term:
+  Prelude.False
+
+ Bad record field for type
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:46:1-46:34 (at top level)
+.:1:0:
+While typechecking term: 
+  {a = Prelude.True,b = Prelude.False}.c
+.:1:0:
+Bad record field ("c") for type
+  #{a : Prelude.Bool,b : Prelude.Bool}
+
+ Inferred type not a subtype of expected type
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:49:1-49:45 (at top level)
+.:1:1:
+While typechecking term: 
+  (\(x : Prelude.Bool) -> Prelude.implies x Prelude.False) 5
+.:1:1:
+Inferred type
+  Prelude.Nat
+Not a subtype of expected type
+  Prelude.Bool
+For term
+  5
+
+ Empty vector literal
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in parse_core
+   test.saw:4:36-4:50 in (callback)
+   (builtin) in fails
+   test.saw:4:17-4:54 in parse
+   test.saw:52:1-52:38 (at top level)
+.:1:26:
+Empty vector literal
+
+ More variables than length of function type
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in load_sawcore_from_file
+   test.saw:3:28-3:59 in (callback)
+   (builtin) in fails
+   test.saw:3:21-3:59 in load
+   test.saw:57:1-57:23 (at top level)
+core001.sawcore:5:0:
+Malformed declaration for "foo"
+More variables [TermVar (PosPair {_pos = Pos {posBase = ".", posPath = "core001.sawcore", posLine = 6, posCol = 4}, val = "x"}),TermVar (PosPair {_pos = Pos {posBase = ".", posPath = "core001.sawcore", posLine = 6, posCol = 6}, val = "y"}),TermVar (PosPair {_pos = Pos {posBase = ".", posPath = "core001.sawcore", posLine = 6, posCol = 8}, val = "z"})] than length of function type:
+Prelude.Bool
+-> Prelude.Bool
+-> Prelude.Bool
+
+
+ Definition without defining equation
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in load_sawcore_from_file
+   test.saw:3:28-3:59 in (callback)
+   (builtin) in fails
+   test.saw:3:21-3:59 in load
+   test.saw:60:1-60:23 (at top level)
+core002.sawcore:5:0:
+Malformed declaration for "foo"
+Definition without defining equation
+
+
+ Primitive or axiom with definition
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in load_sawcore_from_file
+   test.saw:3:28-3:59 in (callback)
+   (builtin) in fails
+   test.saw:3:21-3:59 in load
+   test.saw:63:1-63:23 (at top level)
+core003.sawcore:5:10:
+Malformed declaration for "foo"
+Primitive or axiom with definition
+
+
+ Dangling definition without a type
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in load_sawcore_from_file
+   test.saw:3:28-3:59 in (callback)
+   (builtin) in fails
+   test.saw:3:21-3:59 in load
+   test.saw:66:1-66:23 (at top level)
+core004.sawcore:5:0:
+Malformed declaration for "foo"
+Dangling definition without a type
+
+
+ Wrong form for type of datatype
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in load_sawcore_from_file
+   test.saw:3:28-3:59 in (callback)
+   (builtin) in fails
+   test.saw:3:21-3:59 in load
+   test.saw:69:1-69:23 (at top level)
+core005.sawcore:5:5:
+Malformed declaration for "Foo"
+Wrong form for type of datatype
+
+
+ Universe level of parameters should be no greater than that of the datatype
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in load_sawcore_from_file
+   test.saw:3:28-3:59 in (callback)
+   (builtin) in fails
+   test.saw:3:21-3:59 in load
+   test.saw:72:1-72:23 (at top level)
+core006.sawcore:5:5:
+Malformed declaration for "Foo"
+Universe level of parameters should be no greater than that of the datatype
+
+
+ Universe level of indices should be strictly contained in that of the datatype
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in load_sawcore_from_file
+   test.saw:3:28-3:59 in (callback)
+   (builtin) in fails
+   test.saw:3:21-3:59 in load
+   test.saw:75:1-75:23 (at top level)
+core007.sawcore:5:5:
+Malformed declaration for "Foo"
+Universe level of indices should be strictly contained in that of the datatype
+
+
+ Universe level of constructors should be strictly contained in that of the datatype
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in load_sawcore_from_file
+   test.saw:3:28-3:59 in (callback)
+   (builtin) in fails
+   test.saw:3:21-3:59 in load
+   test.saw:78:1-78:23 (at top level)
+core008.sawcore:5:5:
+Malformed declaration for "Foo"
+Universe level of constructors should be strictly contained in that of the datatype
+
+

--- a/intTests/test_sawcore_type_errors/test.log.good
+++ b/intTests/test_sawcore_type_errors/test.log.good
@@ -41,7 +41,7 @@ Stack trace:
    test.saw:4:17-4:54 in parse
    test.saw:16:1-16:26 (at top level)
 .:1:0:
-While typechecking term: 
+While typechecking term:
   \(x : Prelude.True) -> x
 .:1:0:
 Not a sort
@@ -56,7 +56,7 @@ Stack trace:
    test.saw:4:17-4:54 in parse
    test.saw:19:1-19:27 (at top level)
 .:1:11:
-While typechecking term: 
+While typechecking term:
   (x : Prelude.True)
 -> Prelude.Bool
 .:1:11:
@@ -72,7 +72,7 @@ Stack trace:
    test.saw:4:17-4:54 in parse
    test.saw:22:1-22:28 (at top level)
 .:1:11:
-While typechecking term: 
+While typechecking term:
   (x : Prelude.Bool)
 -> Prelude.False
 .:1:11:
@@ -88,7 +88,7 @@ Stack trace:
    test.saw:4:17-4:54 in parse
    test.saw:25:1-25:21 (at top level)
 .:1:2:
-While typechecking term: 
+While typechecking term:
   Prelude.True * Prelude.Nat
 .:1:2:
 Not a sort
@@ -103,7 +103,7 @@ Stack trace:
    test.saw:4:17-4:54 in parse
    test.saw:28:1-28:19 (at top level)
 .:1:2:
-While typechecking term: 
+While typechecking term:
   Prelude.Bool * 5
 .:1:2:
 Not a sort
@@ -118,7 +118,7 @@ Stack trace:
    test.saw:4:17-4:54 in parse
    test.saw:31:1-31:37 (at top level)
 .:1:0:
-While typechecking term: 
+While typechecking term:
   #{foo : Prelude.Bool,bar : Prelude.False}
 .:1:0:
 Not a sort
@@ -146,7 +146,7 @@ Stack trace:
    test.saw:4:17-4:54 in parse
    test.saw:37:1-37:18 (at top level)
 .:1:0:
-While typechecking term: 
+While typechecking term:
   Prelude.True Prelude.True
 .:1:0:
 Function application with non-function type
@@ -166,7 +166,7 @@ Stack trace:
    test.saw:4:17-4:54 in parse
    test.saw:40:1-40:15 (at top level)
 .:1:0:
-While typechecking term: 
+While typechecking term:
   Prelude.True.1
 .:1:0:
 Tuple field projection with non-tuple type
@@ -181,7 +181,7 @@ Stack trace:
    test.saw:4:17-4:54 in parse
    test.saw:43:1-43:18 (at top level)
 .:1:0:
-While typechecking term: 
+While typechecking term:
   Prelude.False.foo
 .:1:0:
 Record field projection with non-record type
@@ -198,7 +198,7 @@ Stack trace:
    test.saw:4:17-4:54 in parse
    test.saw:46:1-46:34 (at top level)
 .:1:0:
-While typechecking term: 
+While typechecking term:
   {a = Prelude.True,b = Prelude.False}.c
 .:1:0:
 Bad record field ("c") for type
@@ -213,7 +213,7 @@ Stack trace:
    test.saw:4:17-4:54 in parse
    test.saw:49:1-49:45 (at top level)
 .:1:1:
-While typechecking term: 
+While typechecking term:
   (\(x : Prelude.Bool) -> Prelude.implies x Prelude.False) 5
 .:1:1:
 Inferred type

--- a/intTests/test_sawcore_type_errors/test.saw
+++ b/intTests/test_sawcore_type_errors/test.saw
@@ -1,0 +1,78 @@
+enable_experimental;
+
+let load filename = fails (load_sawcore_from_file filename);
+let parse str = fails do { return (parse_core str); };
+
+print "Unbound name";
+parse "false";
+
+print "No such data type";
+parse "String#rec Bool True False";
+
+print "Recursor not fully applied";
+parse "Either#rec Bool Nat (\\ (_ : Either Bool Nat) -> Bool) (id Bool)";
+
+print "Not a sort (lambda)";
+parse "\\(x : True) -> x";
+
+print "Not a sort (pi)";
+parse "(x : True) -> Bool";
+
+print "Not a sort (pi)";
+parse "(x : Bool) -> False";
+
+print "Not a sort (pair type)";
+parse "#(True, Nat)";
+
+print "Not a sort (pair type)";
+parse "#(Bool, 5)";
+
+print "Not a sort (record type)";
+parse "#{ foo : Bool, bar : False }";
+
+print "Motive function should return a sort";
+parse "\\(v : Void) -> Void#rec (\\ (_ : Void) -> True) v";
+
+print "Function application with non-function type";
+parse "True True";
+
+print "Tuple field projection with non-tuple type";
+parse "True.1";
+
+print "Record field projection with non-record type";
+parse "False.foo";
+
+print "Bad record field for type";
+parse "{ a = True, b = False }.c";
+
+print "Inferred type not a subtype of expected type";
+parse "(\\ (x : Bool) -> implies x False) 5";
+
+print "Empty vector literal";
+parse "(\\ (x : Vec 0 Bool) -> x) []";
+
+////////////////////////////////////////////////////////////
+
+print "More variables than length of function type";
+load "core001.sawcore";
+
+print "Definition without defining equation";
+load "core002.sawcore";
+
+print "Primitive or axiom with definition";
+load "core003.sawcore";
+
+print "Dangling definition without a type";
+load "core004.sawcore";
+
+print "Wrong form for type of datatype";
+load "core005.sawcore";
+
+print "Universe level of parameters should be no greater than that of the datatype";
+load "core006.sawcore";
+
+print "Universe level of indices should be strictly contained in that of the datatype";
+load "core007.sawcore";
+
+print "Universe level of constructors should be strictly contained in that of the datatype";
+load "core008.sawcore";

--- a/intTests/test_sawcore_type_errors/test.sh
+++ b/intTests/test_sawcore_type_errors/test.sh
@@ -1,0 +1,1 @@
+exec ${TEST_SHELL:-bash} ../support/test-and-diff.sh "$@"

--- a/saw-core/src/SAWCore/SCTypeCheck.hs
+++ b/saw-core/src/SAWCore/SCTypeCheck.hs
@@ -203,7 +203,7 @@ data TCError
   | NoSuchDataType NameInfo
   | NoSuchCtor NameInfo
   | NoSuchConstant NameInfo
-  | NotFullyAppliedRec Name
+  | NotFullyAppliedRec NameInfo
   | BadRecursorApp Term [Term] Term
   | BadConstType NameInfo Term Term
   | MalformedRecursor Term String

--- a/saw-core/src/SAWCore/SCTypeCheck.hs
+++ b/saw-core/src/SAWCore/SCTypeCheck.hs
@@ -291,7 +291,7 @@ prettyTCError e = runReader (helper e) ([], Nothing) where
   helper (ErrorCtx x _ err) =
     local (\(ctx,p) -> (x:ctx, p)) $ helper err
   helper (ErrorTerm tm err) = do
-    info <- ppWithPos [ return ("While typechecking term: ")
+    info <- ppWithPos [ return ("While typechecking term:")
                       , ishow tm ]
     cont <- helper err
     return (info ++ cont)

--- a/saw-core/src/SAWCore/SCTypeCheck.hs
+++ b/saw-core/src/SAWCore/SCTypeCheck.hs
@@ -193,7 +193,6 @@ data TCError
   | NotFuncTypeInApp SCTypedTerm SCTypedTerm
   | NotTupleType Term
   | BadTupleIndex Int Term
-  | NotStringLit Term
   | NotRecordType SCTypedTerm
   | BadRecordField FieldName Term
   | DanglingVar Int
@@ -205,7 +204,6 @@ data TCError
   | NoSuchConstant NameInfo
   | NotFullyAppliedRec NameInfo
   | BadRecursorApp Term [Term] Term
-  | BadConstType NameInfo Term Term
   | MalformedRecursor Term String
   | DeclError Text String
   | ErrorPos Pos TCError
@@ -248,8 +246,6 @@ prettyTCError e = runReader (helper e) ([], Nothing) where
   helper (BadTupleIndex n ty) =
       ppWithPos [ return ("Bad tuple index (" ++ show n ++ ") for type")
                 , ishow ty ]
-  helper (NotStringLit trm) =
-      ppWithPos [ return "Record selector is not a string literal", ishow trm ]
   helper (NotRecordType (SCTypedTerm trm tp _ctx)) =
       ppWithPos [ return "Record field projection with non-record type"
                 , ishow tp
@@ -278,9 +274,6 @@ prettyTCError e = runReader (helper e) ([], Nothing) where
     ppWithPos [ return ("No such constant: " ++ show c) ]
   helper (NotFullyAppliedRec i) =
       ppWithPos [ return ("Recursor not fully applied: " ++ show i) ]
-  helper (BadConstType n rty ty) =
-    ppWithPos [ return ("Type of constant " ++ show n), ishow rty
-              , return "doesn't match declared type", ishow ty ]
   helper (MalformedRecursor trm reason) =
       ppWithPos [ return "Malformed recursor",
                   ishow trm, return reason ]

--- a/saw-core/src/SAWCore/SCTypeCheck.hs
+++ b/saw-core/src/SAWCore/SCTypeCheck.hs
@@ -298,10 +298,14 @@ prettyTCError e = runReader (helper e) ([], Nothing) where
   helper (ExpectedRecursor ttm) =
     ppWithPos [ return "Expected recursor value", ishow (typedVal ttm), ishow (typedType ttm)]
 
+  -- | Add prefix to every line, but remove final trailing newline
+  indent :: String -> String -> String
+  indent prefix s = init (unlines (map (prefix ++) (lines s)))
+
   ishow :: Term -> PPErrM String
   ishow tm =
     -- return $ show tm
-    (\(ctx,_) -> "  " ++ scPrettyTermInCtx PPS.defaultOpts ctx tm) <$> ask
+    (\(ctx,_) -> indent "  " $ scPrettyTermInCtx PPS.defaultOpts ctx tm) <$> ask
 
 instance Show TCError where
   show = unlines . prettyTCError

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -52,6 +52,7 @@ import SAWCore.Module
   , DataType(..)
   , DefQualifier(..)
   )
+import SAWCore.Name (Name(..))
 import qualified SAWCore.Parser.AST as Un
 import SAWCore.Parser.Position
 import SAWCore.Term.Functor
@@ -222,7 +223,7 @@ typeInferCompleteTerm (matchAppliedRecursor -> Just (str, args)) =
             typed_r <- typeInferComplete (RecursorApp r ixs arg)
             inferApplyAll typed_r rem_args
 
-       _ -> throwTCError $ NotFullyAppliedRec (dtName dt)
+       _ -> throwTCError $ NotFullyAppliedRec (nameInfo (dtName dt))
 
 typeInferCompleteTerm (Un.Recursor _) =
   error "typeInferComplete: found a bare Recursor, which should never happen!"

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -355,7 +355,7 @@ processDecls (Un.TypeDecl NoQualifier (PosPair p nm) tp :
          Just x -> return x
          Nothing ->
              throwTCError $
-             DeclError nm ("More variables " ++ show vars ++
+             DeclError nm ("More variables " ++ show (map Un.termVarLocalName vars) ++
                            " than length of function type:\n" ++
                            showTerm (typedVal typed_tp))
 


### PR DESCRIPTION
Add `intTests/test_sawcore_type_errors`. Fixes #2641.

Note that this test suite only covers those type error messages that can be triggered via sawcore syntax. There are additional kinds of type errors that can only be triggered via the Haskell programming interface, and cannot be tested via SAWScript.

This PR also cleans up the formatting of a few SAWCore type error messages.