### PR TITLE
Bump pip for dependabot alert

### DIFF
--- a/doc/scripts/requirements.txt
+++ b/doc/scripts/requirements.txt
@@ -12,7 +12,7 @@ mdit-py-plugins==0.4.2
 mdurl==0.1.2
 myst-parser==4.0.0
 packaging==24.2
-pip==24.3.1
+pip==25.2
 Pygments==2.19.1
 PyYAML==6.0.2
 requests==2.32.4


### PR DESCRIPTION
Does not seem to require bumping anything else.