### PR TITLE
Simplify SAWCore simulator

### DIFF
--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -2015,7 +2015,7 @@ scCryptolType sc t =
           Just ts -> return (Right (C.tTuple (t1 : ts)))
           Nothing -> return (Right (C.tTuple [t1, t2]))
 
-      SC.VPiType _nm v1 (SC.VNondependentPi v2) ->
+      SC.VPiType v1 (SC.VNondependentPi v2) ->
         do Right t1 <- asCryptolTypeValue v1
            Right t2 <- asCryptolTypeValue v2
            return (Right (C.tFun t1 t2))
@@ -2025,7 +2025,7 @@ scCryptolType sc t =
         | otherwise     -> Nothing
 
       -- TODO?
-      SC.VPiType _nm _v1 (SC.VDependentPi _) -> Nothing
+      SC.VPiType _v1 (SC.VDependentPi _) -> Nothing
       SC.VStringType -> Nothing
       SC.VRecordType{} -> Nothing
       SC.VTyTerm{} -> Nothing

--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -1998,14 +1998,14 @@ scCryptolType sc t =
         Right t2 <- asCryptolTypeValue v2
         return (Right (C.tSeq (C.tNum n) t2))
 
-      SC.VDataType (nameInfo -> ModuleIdentifier "Prelude.Stream") _ [SC.TValue v1] [] ->
+      SC.VDataType (nameInfo -> ModuleIdentifier "Prelude.Stream") [SC.TValue v1] [] ->
           do Right t1 <- asCryptolTypeValue v1
              return (Right (C.tSeq C.tInf t1))
 
-      SC.VDataType (nameInfo -> ModuleIdentifier "Cryptol.Num") _ [] [] ->
+      SC.VDataType (nameInfo -> ModuleIdentifier "Cryptol.Num") [] [] ->
         return (Left C.KNum)
 
-      SC.VDataType _ _ _ _ -> Nothing
+      SC.VDataType {} -> Nothing
 
       SC.VUnitType -> return (Right (C.tTuple []))
       SC.VPairType v1 v2 -> do

--- a/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
+++ b/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
@@ -457,12 +457,10 @@ bitBlastBasic :: AIG.IsAIG l g
               -> Term
               -> IO (BValue (l s))
 bitBlastBasic be m addlPrims ecMap t = do
-  let neutral _env nt = fail ("bitBlastBasic: could not evaluate neutral term: " ++ show nt)
   let primHandler = Sim.defaultPrimHandler
   cfg <- Sim.evalGlobal m (Map.union (beConstMap be) (addlPrims be))
          (bitBlastExtCns ecMap)
          (\_ _ -> Nothing)
-         neutral
          primHandler
          (Prims.lazyMuxValue (prims be))
   Sim.evalSharedTerm cfg t

--- a/saw-core-sbv/src/SAWCoreSBV/SBV.hs
+++ b/saw-core-sbv/src/SAWCoreSBV/SBV.hs
@@ -631,10 +631,9 @@ sbvSolveBasic sc addlPrims unintSet t = do
         | Set.member (nameIndex nm) unintSet =
           let vn = VarName (nameIndex nm) (toShortName (nameInfo nm)) in Just (extcns (EC vn ty))
         | otherwise                          = Nothing
-  let neutral _env nt = fail ("sbvSolveBasic: could not evaluate neutral term: " ++ show nt)
   let primHandler = Sim.defaultPrimHandler
   let mux = Prims.lazyMuxValue prims
-  cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted neutral primHandler mux
+  cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted primHandler mux
   Sim.evalSharedTerm cfg t
 
 parseUninterpreted :: [SVal] -> String -> TValue SBV -> IO SValue
@@ -723,11 +722,10 @@ sbvSATQuery sc addlPrims query =
                   let vn = VarName (nameIndex nm) (toShortName (nameInfo nm))
                   in Just (mkUninterp vn ty)
                 | otherwise                          = Nothing
-          let neutral _env nt = fail ("sbvSATQuery: could not evaluate neutral term: " ++ show nt)
           let primHandler = Sim.defaultPrimHandler
           let mux = Prims.lazyMuxValue prims
 
-          cfg  <- liftIO (Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted neutral primHandler mux)
+          cfg  <- liftIO (Sim.evalGlobal m (Map.union constMap addlPrims) extcns uninterpreted primHandler mux)
           bval <- liftIO (Sim.evalSharedTerm cfg t)
 
           case bval of

--- a/saw-core-sbv/src/SAWCoreSBV/SBV.hs
+++ b/saw-core-sbv/src/SAWCoreSBV/SBV.hs
@@ -284,7 +284,7 @@ flattenSValue nm v = do
         VNat n                    -> return ([], "_" ++ show n)
         TValue (suffixTValue -> Just s)
                                   -> return ([], s)
-        VFun _ _ -> fail $ "Cannot create uninterpreted higher-order function " ++ show nm
+        VFun {} -> fail $ "Cannot create uninterpreted higher-order function " ++ show nm
         _ -> fail $ "Cannot create uninterpreted function " ++ show nm ++ " with argument " ++ show v
 
 vWord :: SWord -> SValue
@@ -640,9 +640,9 @@ sbvSolveBasic sc addlPrims unintSet t = do
 parseUninterpreted :: [SVal] -> String -> TValue SBV -> IO SValue
 parseUninterpreted cws nm ty =
   case ty of
-    (VPiType fnm _ body)
+    (VPiType _ body)
       -> return $
-         VFun fnm $ \x ->
+         VFun $ \x ->
            do x' <- force x
               (cws', suffix) <- flattenSValue nm x'
               t2 <- applyPiBody body (ready x')

--- a/saw-core-what4/src/SAWCoreWhat4/What4.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/What4.hs
@@ -946,8 +946,8 @@ parseUninterpreted ::
   TValue (What4 sym) -> IO (SValue sym)
 parseUninterpreted sym ref app ty =
   case ty of
-    VPiType nm _ body
-      -> pure $ VFun nm $ \x ->
+    VPiType _ body
+      -> pure $ VFun $ \x ->
            do x' <- force x
               app' <- applyUnintApp sym app x'
               t2 <- applyPiBody body (ready x')
@@ -1069,7 +1069,7 @@ applyUnintApp sym app0 v =
                                    where app' = suffixUnintApp ("_" ++ show w) app0
     TValue (suffixTValue -> Just s)
                               -> return (suffixUnintApp s app0)
-    VFun _ _ ->
+    VFun {} ->
       fail $
       "Cannot create uninterpreted higher-order function " ++
       show (stringOfUnintApp app0)
@@ -1209,7 +1209,7 @@ argTypes v =
      _ -> panic "argTypes" ["Expected type value: " <> Text.pack (show v)]
 
   where
-    loop (VPiType _nm v1 body) =
+    loop (VPiType v1 body) =
       do x  <- delay (fail "argTypes: unsupported dependent SAW-Core type")
          v2 <- applyPiBody body x
          vs <- loop v2
@@ -1416,7 +1416,7 @@ rebuildTerm sym st sc tv sv =
               show sv)
   in
   case sv of
-    VFun _ _ ->
+    VFun {} ->
       chokeOn "lambdas (VFun)"
     VUnit ->
       scUnitValue sc
@@ -1618,8 +1618,8 @@ parseUninterpretedSAW ::
   IO (SValue (B.ExprBuilder n st fs))
 parseUninterpretedSAW sym st sc ref trm app ty =
   case ty of
-    VPiType nm t1 body
-      -> pure $ VFun nm $ \x ->
+    VPiType t1 body
+      -> pure $ VFun $ \x ->
            do x' <- force x
               app' <- applyUnintApp sym app x'
               arg <- mkArgTerm sc t1 x'

--- a/saw-core-what4/src/SAWCoreWhat4/What4.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/What4.hs
@@ -885,10 +885,9 @@ w4SolveBasic sym sc addlPrims ecMap ref unintSet t =
              let vn = VarName (nameIndex nm) (toShortName (nameInfo nm))
              in Just (extcns (EC vn ty))
            | otherwise                          = Nothing
-     let neutral _ nt = fail ("w4SolveBasic: could not evaluate neutral term: " ++ show nt)
      let primHandler = Sim.defaultPrimHandler
      let mux = Prims.lazyMuxValue (prims sym)
-     cfg <- Sim.evalGlobal m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral primHandler mux
+     cfg <- Sim.evalGlobal m (constMap sym `Map.union` addlPrims) extcns uninterpreted primHandler mux
      Sim.evalSharedTerm cfg t
 
 
@@ -1559,10 +1558,9 @@ w4EvalBasic sym st sc m addlPrims ecCons ref unintSet t =
              let vn = VarName (nameIndex nm) (toShortName (nameInfo nm))
              in Just (extcns tf (EC vn ty))
            | otherwise                          = Nothing
-     let neutral _env nt = fail ("w4EvalBasic: could not evaluate neutral term: " ++ show nt)
      let primHandler = Sim.defaultPrimHandler
      let mux = Prims.lazyMuxValue (prims sym)
-     cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral primHandler mux
+     cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted primHandler mux
      Sim.evalSharedTerm cfg t
 
 -- | Evaluate a saw-core term to a What4 value for the purposes of
@@ -1588,11 +1586,10 @@ w4SimulatorEval sym st sc m addlPrims ref constantFilter t =
               parseUninterpretedSAW sym st sc ref trm (mkUnintApp (Text.unpack nm ++ "_" ++ show ix)) ty
      let uninterpreted _tf nm ty =
           if constantFilter nm ty then Nothing else Just (X.throwIO (NeutralTermEx (nameInfo nm)))
-     let neutral _env nt = fail ("w4SimulatorEval: could not evaluate neutral term: " ++ show nt)
      let primHandler = Sim.defaultPrimHandler
      let mux = Prims.lazyMuxValue (prims sym)
      res <- X.try $ do
-              cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted neutral primHandler mux
+              cfg <- Sim.evalGlobal' m (constMap sym `Map.union` addlPrims) extcns uninterpreted primHandler mux
               Sim.evalSharedTerm cfg t
      case res of
        Left (NeutralTermEx nmi) -> pure (Left nmi)

--- a/saw-core/src/SAWCore/Simulator.hs
+++ b/saw-core/src/SAWCore/Simulator.hs
@@ -668,11 +668,11 @@ evalPrim fallback = loop []
     loop :: Env l -> Prims.Prim l -> MValue l
     loop env (Prims.PrimFun f) =
       pure $ VFun $ \x ->
-        do loop (x : env) (f x)
+        loop (x : env) (f x)
 
     loop env (Prims.PrimStrict f) =
       pure $ vStrictFun $ \x ->
-        do loop (ready x : env) (f x)
+        loop (ready x : env) (f x)
 
     loop env (Prims.PrimFilterFun msg r f) =
       pure $ vStrictFun $ \x ->

--- a/saw-core/src/SAWCore/Simulator.hs
+++ b/saw-core/src/SAWCore/Simulator.hs
@@ -174,7 +174,7 @@ evalTermF cfg lam recEval tf env =
                                         ResolvedCtor ctor ->
                                           ctorValue nm ty' (ctorNumParams ctor) (ctorNumArgs ctor)
                                         ResolvedDataType dt ->
-                                          dtValue nm ty' (dtNumParams dt) (dtNumIndices dt)
+                                          dtValue nm (dtNumParams dt) (dtNumIndices dt)
                                         ResolvedDef d ->
                                           case defBody d of
                                             Just t -> recEval t
@@ -308,11 +308,11 @@ evalTermF cfg lam recEval tf env =
       vFunList j $ \args ->
       pure $ VCtorApp nm tv params args
 
-    dtValue :: Name -> TValue l -> Int -> Int -> MValue l
-    dtValue nm tv i j =
+    dtValue :: Name -> Int -> Int -> MValue l
+    dtValue nm i j =
       vStrictFunList i $ \params ->
       vStrictFunList j $ \idxs ->
-      pure $ TValue $ VDataType nm tv params idxs
+      pure $ TValue $ VDataType nm params idxs
 
 -- | Create a 'Value' for a lazy multi-argument function.
 vFunList :: forall l. VMonad l => Int -> ([Thunk l] -> MValue l) -> MValue l

--- a/saw-core/src/SAWCore/Simulator/Concrete.hs
+++ b/saw-core/src/SAWCore/Simulator/Concrete.hs
@@ -46,10 +46,9 @@ import SAWCore.SharedTerm
 evalSharedTerm :: ModuleMap -> Map Ident CPrim -> Map VarIndex CValue -> Term -> CValue
 evalSharedTerm m addlPrims ecVals t =
   runIdentity $ do
-    cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns (\_ _ -> Nothing) neutral primHandler lazymux
+    cfg <- Sim.evalGlobal m (Map.union constMap addlPrims) extcns (\_ _ -> Nothing) primHandler lazymux
     Sim.evalSharedTerm cfg t
   where
-    neutral _env nt = return $ Prim.userError $ "Cannot evaluate neutral term\n" ++ show nt
     lazymux = Prims.lazyMuxValue prims
     extcns ec =
       case Map.lookup (ecVarIndex ec) ecVals of

--- a/saw-core/src/SAWCore/Simulator/Concrete.hs
+++ b/saw-core/src/SAWCore/Simulator/Concrete.hs
@@ -54,7 +54,7 @@ evalSharedTerm m addlPrims ecVals t =
       case Map.lookup (ecVarIndex ec) ecVals of
         Just v  -> return v
         Nothing -> return $ Prim.userError $ "Unimplemented: external constant " ++ show (ecName ec)
-    primHandler nm _ msg env _tv =
+    primHandler nm msg env =
       return $ Prim.userError $ unlines
         [ "Could not evaluate primitive " ++ Text.unpack (toAbsoluteName (nameInfo nm))
         , "On argument " ++ show (length env)

--- a/saw-core/src/SAWCore/Simulator/RME.hs
+++ b/saw-core/src/SAWCore/Simulator/RME.hs
@@ -63,7 +63,7 @@ evalSharedTerm m addlPrims t =
     Sim.evalSharedTerm cfg t
   where
     extcns ec = return $ Prim.userError $ "Unimplemented: external constant " ++ show (ecName ec)
-    primHandler nm _ msg env _tv =
+    primHandler nm msg env =
       return $ Prim.userError $ unlines
         [ "Could not evaluate primitive " ++ Text.unpack (toAbsoluteName (nameInfo nm))
         , "On argument " ++ show (length env)
@@ -399,7 +399,7 @@ bitBlastBasic :: ModuleMap
               -> Term
               -> RValue
 bitBlastBasic m addlPrims ecMap t = runIdentity $ do
-  let primHandler nm _ msg env _tv =
+  let primHandler nm msg env =
          return $ Prim.userError $ unlines
            [ "Could not evaluate primitive " ++ Text.unpack (toAbsoluteName (nameInfo nm))
            , "On argument " ++ show (length env)

--- a/saw-core/src/SAWCore/Simulator/RME.hs
+++ b/saw-core/src/SAWCore/Simulator/RME.hs
@@ -58,12 +58,11 @@ evalSharedTerm :: ModuleMap -> Map Ident RPrim -> Term -> RValue
 evalSharedTerm m addlPrims t =
   runIdentity $ do
     cfg <- Sim.evalGlobal m (Map.union constMap addlPrims)
-           extcns (\_ _ -> Nothing) neutral primHandler
+           extcns (\_ _ -> Nothing) primHandler
            (Prims.lazyMuxValue prims)
     Sim.evalSharedTerm cfg t
   where
     extcns ec = return $ Prim.userError $ "Unimplemented: external constant " ++ show (ecName ec)
-    neutral _env nt = return $ Prim.userError $ "Could not evaluate neutral term\n:" ++ show nt
     primHandler nm _ msg env _tv =
       return $ Prim.userError $ unlines
         [ "Could not evaluate primitive " ++ Text.unpack (toAbsoluteName (nameInfo nm))
@@ -400,7 +399,6 @@ bitBlastBasic :: ModuleMap
               -> Term
               -> RValue
 bitBlastBasic m addlPrims ecMap t = runIdentity $ do
-  let neutral _env nt = return $ Prim.userError $ "Could not evaluate neutral term\n:" ++ show nt
   let primHandler nm _ msg env _tv =
          return $ Prim.userError $ unlines
            [ "Could not evaluate primitive " ++ Text.unpack (toAbsoluteName (nameInfo nm))
@@ -413,7 +411,6 @@ bitBlastBasic m addlPrims ecMap t = runIdentity $ do
                    Just v -> pure v
                    Nothing -> error ("RME: unknown ExtCns: " ++ show (ecName ec)))
          (\_ _ -> Nothing)
-         neutral
          primHandler
          (Prims.lazyMuxValue prims)
   Sim.evalSharedTerm cfg t

--- a/saw-core/src/SAWCore/Simulator/Value.hs
+++ b/saw-core/src/SAWCore/Simulator/Value.hs
@@ -95,7 +95,7 @@ data TValue l
   | VStringType
   | VUnitType
   | VPairType !(TValue l) !(TValue l)
-  | VDataType !Name !(TValue l) ![Value l] ![Value l]
+  | VDataType !Name ![Value l] ![Value l] -- ^ name, parameters, indices
   | VRecordType ![(FieldName, TValue l)]
   | VSort !Sort
   | VTyTerm !Sort !Term
@@ -205,7 +205,7 @@ instance Show (Extra l) => Show (TValue l) where
                         (shows t . showString " -> ...")
       VUnitType      -> showString "#()"
       VPairType x y  -> showParen True (shows x . showString " * " . shows y)
-      VDataType s _ ps vs
+      VDataType s ps vs
         | null (ps++vs) -> shows s
         | otherwise  -> shows s . showList (ps++vs)
       VRecordType [] -> showString "{}"

--- a/saw-core/src/SAWCore/Simulator/Value.hs
+++ b/saw-core/src/SAWCore/Simulator/Value.hs
@@ -81,13 +81,8 @@ data Value l
 data VRecursor l
   = VRecursor
      !Name -- data type name
-     !(TValue l) -- data type kind
-     ![Value l]  -- data type parameters
      !Int        -- number of index parameters
-     !(Value l)  -- motive function
-     !(TValue l) -- type of motive
-     !(Map VarIndex (Thunk l)) -- constructor eliminators and their types
-     !(TValue l) -- type of recursor function
+     !(Map VarIndex (Thunk l)) -- constructor eliminators
 
 -- | The subset of values that represent types.
 data TValue l

--- a/saw-core/src/SAWCore/Simulator/Value.hs
+++ b/saw-core/src/SAWCore/Simulator/Value.hs
@@ -86,7 +86,7 @@ data VRecursor l
      !Int        -- number of index parameters
      !(Value l)  -- motive function
      !(TValue l) -- type of motive
-     !(Map VarIndex (Thunk l, TValue l)) -- constructor eliminators and their types
+     !(Map VarIndex (Thunk l)) -- constructor eliminators and their types
      !(TValue l) -- type of recursor function
 
 -- | The subset of values that represent types.


### PR DESCRIPTION
We remove lots of plumbing from the SAWCore simulator that was there primarily to support the `TermModel` backend, which has recently been removed (#2660).