### PR TITLE
saw-core: Use named variables for Lambda and Pi binders.

### DIFF
--- a/intTests/test2049/test.log.1.good
+++ b/intTests/test2049/test.log.1.good
@@ -11,9 +11,7 @@
  Subgoal failed: zero test.saw:52:4: error: in ghost_value
 Literal equality postcondition
 Expected term: 
-let { x@1 = Prelude.Vec 8 Prelude.Bool
-    }
- in zero::table
+zero::table
 Actual term:
 let { x@1 = Prelude.Vec 8 Prelude.Bool
     }

--- a/intTests/test2049/test.log.2.good
+++ b/intTests/test2049/test.log.2.good
@@ -11,9 +11,7 @@
  Subgoal failed: zero test.saw:52:4: error: in ghost_value
 Literal equality postcondition
 Expected term: 
-let { x@1 = Prelude.Vec 8 Prelude.Bool
-    }
- in zero::table
+zero::table
 Actual term:
 let { x@1 = Prelude.Vec 8 Prelude.Bool
     }

--- a/intTests/test_solver_cache/test_basics.saw
+++ b/intTests/test_solver_cache/test_basics.saw
@@ -10,32 +10,32 @@ test_solver_cache_stats 0 0 0 0 0;
 prove_print z3 {{ \(x:[64]) -> x == x }};
 test_solver_cache_stats 1 0 0 1 0;
 
-// Testing that cached results do not depend on variable names - thus, the
-// cache should now have one more usage, but not a new entry or insertion
+// Testing that cached results depend on variable names - thus, the cache
+// should now have one more entry and one more insertion, but not a new usage
 prove_print z3 {{ \(new_name:[64]) -> new_name == new_name }};
-test_solver_cache_stats 1 1 0 1 0;
+test_solver_cache_stats 2 0 0 2 0;
 
 // Testing that cached results depend on the backend used - thus, the cache
 // should now have one more entry and one more insertion, but not a new usage
 prove_print (w4_unint_z3 []) {{ \(x:[64]) -> x == x }};
-test_solver_cache_stats 2 1 0 2 0;
+test_solver_cache_stats 3 0 0 3 0;
 
 // Testing that cached results depend on the options passed to the given
 // backend - thus, the cache should now have one more entry and one more
 // insertion, but not a new usage
 prove_print (w4_unint_z3_using "qfnia" []) {{ \(x:[64]) -> x == x }};
-test_solver_cache_stats 3 1 0 3 0;
+test_solver_cache_stats 4 0 0 4 0;
 
 // Same as the above but for sat results
 
 fails (prove_print z3 {{ \(x:[64])(y:[64]) -> x == y }});
-test_solver_cache_stats 4 1 0 4 0;
+test_solver_cache_stats 5 0 0 5 0;
 
 fails (prove_print z3 {{ \(new_name_1:[64])(new_name_2:[64]) -> new_name_1 == new_name_2 }});
-test_solver_cache_stats 4 2 0 4 0;
+test_solver_cache_stats 6 0 0 6 0;
 
 fails (prove_print w4 {{ \(x:[64])(y:[64]) -> x == y }});
-test_solver_cache_stats 5 2 0 5 0;
+test_solver_cache_stats 7 0 0 7 0;
 
 fails (prove_print (w4_unint_z3_using "qfnia" []) {{ \(x:[64])(y:[64]) -> x == y }});
-test_solver_cache_stats 6 2 0 6 0;
+test_solver_cache_stats 8 0 0 8 0;

--- a/intTests/test_solver_cache/test_clean.saw
+++ b/intTests/test_solver_cache/test_clean.saw
@@ -3,7 +3,7 @@
 set_solver_cache_path "test_solver_cache.cache";
 
 // The cache still has entries from prior runs
-test_solver_cache_stats 6 0 0 0 0;
+test_solver_cache_stats 8 0 0 0 0;
 
 // After cleaning, all SBV entries should be removed (see test.sh)
 clean_mismatched_versions_solver_cache;
@@ -13,4 +13,4 @@ test_solver_cache_stats 4 0 0 0 0;
 // as many insertions as there were SBV entries, and as many usages as there
 // were in test_path_second less the number of SBV entries
 include "test_ops.saw";
-test_solver_cache_stats 6 6 0 2 0;
+test_solver_cache_stats 8 4 0 4 0;

--- a/intTests/test_solver_cache/test_path_and_reuse.saw
+++ b/intTests/test_solver_cache/test_path_and_reuse.saw
@@ -3,10 +3,10 @@
 set_solver_cache_path "test_solver_cache.cache";
 
 // The cache still has entries from the last run
-test_solver_cache_stats 6 0 0 0 0;
+test_solver_cache_stats 8 0 0 0 0;
 
 // After running test_path_ops, we should have the same number of entries, but
 // no insertions and and as many usages as there were insertions plus usages
 // the first time
 include "test_ops.saw";
-test_solver_cache_stats 6 8 0 0 0;
+test_solver_cache_stats 8 8 0 0 0;

--- a/otherTests/saw-core/Tests/Functor.hs
+++ b/otherTests/saw-core/Tests/Functor.hs
@@ -50,7 +50,6 @@ shared :: TermIndex -> TermF Term -> Term
 shared ix t = STApp {
     stAppIndex = ix,
     stAppHash = hash t,
-    stAppLooseVars = emptyBitSet,
     stAppFreeVars = mempty,
     stAppTermF = t
  }
@@ -175,7 +174,7 @@ instance TestIt Term where
         let depth' = depth + 1
             unit = Unshared $ FTermF $ UnitValue
             zero = Unshared $ FTermF $ NatLit 0
-            localvar = Unshared $ LocalVar 0
+            localvar = Unshared $ Variable vnBar t
         testOne depth' $ PairValue t t
         testOne depth' $ PairValue t zero
         testOne depth' $ PairValue unit t

--- a/otherTests/saw-core/Tests/Functor.hs
+++ b/otherTests/saw-core/Tests/Functor.hs
@@ -55,10 +55,10 @@ shared ix t = STApp {
     stAppTermF = t
  }
 
--- | Some LocalNames (LocalName is just Text)
-lnFoo, lnBar :: LocalName
-lnFoo = "foo"
-lnBar = "bar"
+-- | Some variable names
+vnFoo, vnBar :: VarName
+vnFoo = VarName 2 "foo"
+vnBar = VarName 3 "bar"
 
 -- | An external constant
 nmFoo :: Name
@@ -75,7 +75,7 @@ nmFoo = Name {
 type Failure = (String, String, String)
 type Result = Either Failure ()
 
--- | Check a result. 
+-- | Check a result.
 check :: Failure -> Bool -> Result
 check _ True = Right ()
 check f False = Left f
@@ -182,12 +182,12 @@ instance TestIt Term where
         testOne depth' $ App t t
         testOne depth' $ App t zero
         testOne depth' $ App unit t
-        testOne depth' $ Lambda lnFoo t t
-        testOne depth' $ Lambda lnBar t localvar
-        testOne depth' $ Pi lnFoo t t
-        testOne depth' $ Pi lnBar t localvar
-        testTwo depth' GT (Lambda lnFoo t t) (Lambda lnBar t t)
-        testTwo depth' GT (Pi lnFoo t t) (Pi lnBar t t)
+        testOne depth' $ Lambda vnFoo t t
+        testOne depth' $ Lambda vnBar t localvar
+        testOne depth' $ Pi vnFoo t t
+        testOne depth' $ Pi vnBar t localvar
+        testTwo depth' LT (Lambda vnFoo t t) (Lambda vnBar t t)
+        testTwo depth' LT (Pi vnFoo t t) (Pi vnBar t t)
         testTwo depth' EQ (Constant nmFoo :: TermF Term) (Constant nmFoo :: TermF Term)
 
   testTwo depth comp t1 t2 = do
@@ -197,12 +197,12 @@ instance TestIt Term where
       when (depth < 2 && comp /= EQ) $ do
         let depth' = depth + 1
         -- check that the variable name affects the comparison
-        testTwo depth' comp (Lambda lnFoo t1 t1) (Lambda lnFoo t2 t2)
-        testTwo depth' GT (Lambda lnFoo t1 t1) (Lambda lnBar t2 t2)
-        testTwo depth' LT (Lambda lnBar t1 t1) (Lambda lnFoo t2 t2)
-        testTwo depth' comp (Pi lnFoo t1 t1) (Pi lnFoo t2 t2)
-        testTwo depth' GT (Pi lnFoo t1 t1) (Pi lnBar t2 t2)
-        testTwo depth' LT (Pi lnBar t1 t1) (Pi lnFoo t2 t2)
+        testTwo depth' comp (Lambda vnFoo t1 t1) (Lambda vnFoo t2 t2)
+        testTwo depth' LT (Lambda vnFoo t1 t1) (Lambda vnBar t2 t2)
+        testTwo depth' GT (Lambda vnBar t1 t1) (Lambda vnFoo t2 t2)
+        testTwo depth' comp (Pi vnFoo t1 t1) (Pi vnFoo t2 t2)
+        testTwo depth' LT (Pi vnFoo t1 t1) (Pi vnBar t2 t2)
+        testTwo depth' GT (Pi vnBar t1 t1) (Pi vnFoo t2 t2)
         pure ()
 
 -- | Run some tests

--- a/otherTests/saw-core/Tests/Parser.hs
+++ b/otherTests/saw-core/Tests/Parser.hs
@@ -24,11 +24,11 @@ checkDef :: Def -> Assertion
 checkDef d = do
   let sym = nameInfo (defName d)
   let tp = defType d
-  assertBool (namedMsg sym "Type is not ground.") (termIsClosed tp)
+  assertBool (namedMsg sym "Type is not ground.") (closedTerm tp)
   case defBody d of
     Nothing -> return ()
     Just body ->
-      assertBool (namedMsg sym "Body is not ground.") (termIsClosed body)
+      assertBool (namedMsg sym "Body is not ground.") (closedTerm body)
 
 checkPrelude :: Assertion
 checkPrelude =

--- a/saw-central/src/SAWCentral/Bisimulation.hs
+++ b/saw-central/src/SAWCentral/Bisimulation.hs
@@ -259,7 +259,6 @@ openConstantApp :: TypedTerm
                 -- 'Constant' (will be unfolded).
                 -> TopLevel (ExtCns Term, TermF Term)
 openConstantApp constant t = do
-  sc <- getSharedContext
   -- Unfold constant
   name <- constantName (unwrapTermF (ttTerm t))
   tUnfolded <- unfold_term [name] t
@@ -269,15 +268,15 @@ openConstantApp constant t = do
 
   -- Replace outer function's argument with an 'ExtCns'
   -- NOTE: The bisimulation relation type ensures this is a single argument
-  -- lambda, so it's OK to apply scOpenTerm once and not recurse
-  (ec, tExtconsified) <- io $ scOpenTerm sc nm tp 0 body
-  extractedF <- extractApp constant tExtconsified
+  -- lambda, so it's OK to not recurse
+  let ec = EC nm tp
+  extractedF <- extractApp constant body
   pure (ec, extractedF)
 
   where
     -- Break down lambda into its component parts.  Fails if 'tt' is not a
     -- lambda.
-    lambdaOrFail :: TypedTerm -> TopLevel (LocalName, Term, Term)
+    lambdaOrFail :: TypedTerm -> TopLevel (VarName, Term, Term)
     lambdaOrFail tt =
       case asLambda (ttTerm tt) of
         Just lambda -> return lambda

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -272,10 +272,10 @@ replacePrim pat replace t = do
   let tpat  = ttTerm pat
   let trepl = ttTerm replace
 
-  unless (termIsClosed tpat) $ fail $ unlines
+  unless (closedTerm tpat) $ fail $ unlines
     [ "pattern term is not closed", show tpat ]
 
-  unless (termIsClosed trepl) $ fail $ unlines
+  unless (closedTerm trepl) $ fail $ unlines
     [ "replacement term is not closed", show trepl ]
 
   io $ do
@@ -732,13 +732,13 @@ build_congruence sc tm =
      case asPiList ty of
        ([],_) -> fail "congruence_for: Term is not a function"
        (pis, body) ->
-         if termIsClosed body then
+         if closedTerm body then
            loop pis []
          else
            fail "congruence_for: cannot build congruence for dependent functions"
  where
   loop ((nm,tp):pis) vars =
-    if termIsClosed tp then
+    if closedTerm tp then
       do l <- scFreshEC sc (vnName nm <> "_1") tp
          r <- scFreshEC sc (vnName nm <> "_2") tp
          loop pis ((l,r):vars)

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -1953,7 +1953,7 @@ parseCoreMod mnm_str input =
      let mnm =
            mkModuleName $ Text.splitOn "." mnm_str
      _ <- io $ scFindModule sc mnm -- Check that mnm exists
-     err_or_t <- io $ inferCompleteTermCtx sc (Just mnm) [] uterm
+     err_or_t <- io $ inferCompleteTermCtx sc (Just mnm) mempty uterm
      case err_or_t of
        Left err -> fail (show err)
        Right x -> pure x

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -71,7 +71,7 @@ import SAWCore.FiniteValue
   , FirstOrderValue(..)
   , scFirstOrderValue
   )
-import SAWCore.Name (ecShortName)
+import SAWCore.Name (VarName(..), ecShortName)
 import SAWCore.SATQuery
 import SAWCore.SCTypeCheck
 import SAWCore.Recognizer
@@ -739,8 +739,8 @@ build_congruence sc tm =
  where
   loop ((nm,tp):pis) vars =
     if termIsClosed tp then
-      do l <- scFreshEC sc (nm <> "_1") tp
-         r <- scFreshEC sc (nm <> "_2") tp
+      do l <- scFreshEC sc (vnName nm <> "_1") tp
+         r <- scFreshEC sc (vnName nm <> "_2") tp
          loop pis ((l,r):vars)
      else
        fail "congruence_for: cannot build congruence for dependent functions"

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -1396,8 +1396,8 @@ proveByBVInduction script t =
   -- and the width of the bitvector we are doing induction on.
   checkInductionScheme sc opts pis ty =
     do ty' <- scWhnf sc ty
-       scAsPi sc ty' >>= \case
-         Just (ec, body) -> checkInductionScheme sc opts (ec : pis) body
+       case asPi ty' of
+         Just (nm, tp, body) -> checkInductionScheme sc opts (EC nm tp : pis) body
          Nothing ->
            case asTupleType ty' of
              Just [bv, bool] ->

--- a/saw-central/src/SAWCentral/Crucible/Common/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/Override.hs
@@ -108,7 +108,7 @@ import           Data.Parameterized.TraversableFC (toListFC)
 
 import qualified SAWSupport.Pretty as PPS (defaultOpts, limitMaxDepth)
 
-import           SAWCore.Name (ecShortName)
+import           SAWCore.Name (VarName(..), ecShortName)
 import           SAWCore.Prelude as SAWVerifier (scEq)
 import           SAWCore.SharedTerm as SAWVerifier
 import           SAWCore.Term.Functor (unwrapTermF)
@@ -723,9 +723,9 @@ matchTerm sc md prepost real expect =
   do let loc = MS.conditionLoc md
      free <- OM (use osFree)
      case unwrapTermF expect of
-       Variable ec
-         | Set.member (ecVarIndex ec) free ->
-         do assignTerm sc md prepost (ecVarIndex ec) real
+       Variable vn _tp
+         | Set.member (vnIndex vn) free ->
+         do assignTerm sc md prepost (vnIndex vn) real
 
        _ ->
          do t <- liftIO $ scEq sc real expect

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -256,23 +256,23 @@ splitIte sc (Prop p) =
 -- | Attempt to split a conjunctive proposition into two propositions.
 splitConj :: SharedContext -> Prop -> IO (Maybe (Prop, Prop))
 splitConj sc (Prop p) =
-  do (vars, body) <- scAsPiList sc p
+  do let (vars, body) = asPiList p
      case (isGlobalDef "Prelude.and" <@> return <@> return) =<< asEqTrue body of
        Nothing -> pure Nothing
        Just (_ :*: p1 :*: p2) ->
-         do t1 <- scGeneralizeExts sc vars =<< scEqTrue sc p1
-            t2 <- scGeneralizeExts sc vars =<< scEqTrue sc p2
+         do t1 <- scPiList sc vars =<< scEqTrue sc p1
+            t2 <- scPiList sc vars =<< scEqTrue sc p2
             return (Just (Prop t1,Prop t2))
 
 -- | Attempt to split a disjunctive proposition into two propositions.
 splitDisj :: SharedContext -> Prop -> IO (Maybe (Prop, Prop))
 splitDisj sc (Prop p) =
-  do (vars, body) <- scAsPiList sc p
+  do let (vars, body) = asPiList p
      case (isGlobalDef "Prelude.or" <@> return <@> return) =<< asEqTrue body of
        Nothing -> pure Nothing
        Just (_ :*: p1 :*: p2) ->
-         do t1 <- scGeneralizeExts sc vars =<< scEqTrue sc p1
-            t2 <- scGeneralizeExts sc vars =<< scEqTrue sc p2
+         do t1 <- scPiList sc vars =<< scEqTrue sc p1
+            t2 <- scPiList sc vars =<< scEqTrue sc p2
             return (Just (Prop t1,Prop t2))
 
 -- | Attempt to split an implication into a hypothesis and a conclusion
@@ -449,7 +449,9 @@ hoistIfsInProp sc p = do
 --   fresh ExtCns values, being careful to ensure that
 --   dependent types are properly substituted.
 unbindAndFreshenProp :: SharedContext -> Prop -> IO ([ExtCns Term], Term)
-unbindAndFreshenProp sc (Prop p0) = scAsPiList sc p0
+unbindAndFreshenProp _sc (Prop p0) =
+  do let (vars, body) = asPiList p0
+     pure (map (uncurry EC) vars, body)
 
 -- | Evaluate the given proposition by round-tripping
 --   through the What4 formula representation.  This will
@@ -489,10 +491,10 @@ trivialProofTerm :: SharedContext -> Prop -> IO (Either String Term)
 trivialProofTerm sc (Prop p) = runExceptT (loop =<< lift (scWhnf sc p))
   where
     loop t =
-      lift (scAsPi sc t) >>= \case
-        Just (ec, body) ->
+      case asPi t of
+        Just (nm, tp, body) ->
           do pf <- loop =<< lift (scWhnf sc body)
-             lift $ scAbstractExts sc [ec] pf
+             lift $ scLambda sc nm tp pf
         Nothing ->
           case asEq t of
             Just (tp, x, _y) ->
@@ -1312,12 +1314,12 @@ predicateToProp :: SharedContext -> Quantification -> Term -> IO Prop
 predicateToProp sc quant = loop
   where
   loop t =
-    scAsLambda sc t >>= \case
-      Just (x, body) ->
+    case asLambda t of
+      Just (x, ty, body) ->
         do Prop body' <- loop body
-           Prop <$> scGeneralizeExts sc [x] body'
+           Prop <$> scPi sc x ty body'
       Nothing ->
-        do (argTs, resT) <- scAsPiList sc =<< scTypeOf sc t
+        do (argTs, resT) <- asPiList <$> scTypeOf sc t
            let toPi [] t0 =
                  case asBoolType resT of
                    Nothing -> fail $ unlines ["predicateToProp : Expected boolean result type but got", showTerm resT]
@@ -1325,10 +1327,10 @@ predicateToProp sc quant = loop
                      case quant of
                        Universal -> scEqTrue sc t0
                        Existential -> scEqTrue sc =<< scNot sc t0
-               toPi (ec : ecs) t1 =
-                 do t2 <- scApply sc t1 =<< scVariable sc ec
-                    t3 <- toPi ecs t2
-                    scGeneralizeExts sc [ec] t3
+               toPi ((x, xT) : tys) t1 =
+                 do t2 <- scApply sc t1 =<< scVariable sc (EC x xT)
+                    t3 <- toPi tys t2
+                    scPi sc x xT t3
            Prop <$> toPi argTs t
 
 
@@ -1735,11 +1737,10 @@ checkEvidence sc what4PushMuxOps = \e p -> do
           Unfocused -> fail "Intro evidence requires a focused sequent"
           HypFocus _ _ -> fail "Intro evidence apply in hypothesis"
           ConclFocus (Prop ptm) mkSqt ->
-            scAsPi sc ptm >>= \case
+            case asPi ptm of
               Nothing -> fail $ unlines ["Intro evidence expected function prop", showTerm ptm]
-              Just (ec, body) ->
-                do let ty = ecType ec
-                   let ty' = ecType x
+              Just (nm, ty, body) ->
+                do let ty' = ecType x
                    ok <- scConvertible sc False ty ty'
                    unless ok $ fail $ unlines
                      ["Intro evidence types do not match"
@@ -1747,7 +1748,7 @@ checkEvidence sc what4PushMuxOps = \e p -> do
                      , showTerm ty
                      ]
                    x' <- scVariable sc x
-                   body' <- scInstantiateExt sc (IntMap.singleton (ecVarIndex ec) x') body
+                   body' <- scInstantiateExt sc (IntMap.singleton (vnIndex nm) x') body
                    check nenv e' (mkSqt (Prop body'))
 
 passthroughEvidence :: [Evidence] -> IO Evidence
@@ -1890,12 +1891,12 @@ predicateToSATQuery sc unintSet tm0 =
         Just fot -> filterFirstOrderVars mmap (Map.insert e fot fovars) absvars es
 
     processTerm mmap vars tm =
-      scAsLambda sc tm >>= \case
-        Just (ec, body) ->
-          case evalFOT mmap (ecType ec) of
-            Nothing -> fail ("predicateToSATQuery: expected first order type: " ++ showTerm (ecType ec))
+      case asLambda tm of
+        Just (nm, tp, body) ->
+          case evalFOT mmap tp of
+            Nothing -> fail ("predicateToSATQuery: expected first order type: " ++ showTerm tp)
             Just fot ->
-              processTerm mmap (Map.insert ec fot vars) body
+              processTerm mmap (Map.insert (EC nm tp) fot vars) body
 
           -- TODO: check that the type is a boolean
         Nothing ->
@@ -1950,14 +1951,13 @@ sequentToSATQuery sc unintSet sqt =
       do -- TODO: See related TODO in processConcl
          let tm' = tm
 
-         scAsPi sc tm' >>= \case
-           Just (ec, body) ->
-             do let tp = ecType ec
-                -- TODO, same issue
+         case asPi tm' of
+           Just (nm, tp, body) ->
+             do -- TODO, same issue
                 let tp' = tp
                 case evalFOT mmap tp' of
                   Just fot ->
-                    processUnivAssert mmap ((ec, fot) : vars) xs body
+                    processUnivAssert mmap ((EC nm tp, fot) : vars) xs body
                   Nothing
                     | IntSet.null (foldr IntSet.delete (freeVars body) (map (ecVarIndex . fst) vars)) ->
                       case asEqTrue tp' of
@@ -1980,15 +1980,14 @@ sequentToSATQuery sc unintSet sqt =
          -- tm' <- scWhnf sc tm
          let tm' = tm
 
-         scAsPi sc tm' >>= \case
-           Just (ec, body) ->
-             do let tp = ecType ec
-                -- same issue with WHNF
+         case asPi tm' of
+           Just (nm, tp, body) ->
+             do -- same issue with WHNF
                 -- tp' <- scWhnf sc tp
                 let tp' = tp
                 case evalFOT mmap tp' of
                   Just fot ->
-                    processConcl mmap (Map.insert ec fot vars, xs) body
+                    processConcl mmap (Map.insert (EC nm tp) fot vars, xs) body
                   Nothing
                     | IntSet.null (foldr IntSet.delete (freeVars body) (map ecVarIndex (Map.keys vars))) ->
                         do asrt <- processAssert mmap tp
@@ -2011,7 +2010,7 @@ propApply ::
   Prop {- ^ propsition to apply (usually a quantified and/or implication term) -} ->
   Prop {- ^ goal to apply the proposition to -} ->
   IO (Maybe [Either Term Prop])
-propApply sc rule goal = applyFirst =<< asPiLists (unProp rule)
+propApply sc rule goal = applyFirst (asPiLists (unProp rule))
   where
     applyFirst :: [([ExtCns Term], Term)] -> IO (Maybe [Either Term Prop])
     applyFirst [] = pure Nothing
@@ -2036,13 +2035,12 @@ propApply sc rule goal = applyFirst =<< asPiLists (unProp rule)
                           pure (Left tm)
                 Just <$> traverse mkNewGoal ruleArgs
 
-    asPiLists :: Term -> IO [([ExtCns Term], Term)]
+    asPiLists :: Term -> [([ExtCns Term], Term)]
     asPiLists t =
-      scAsPi sc t >>= \case
-        Nothing -> pure [([], t)]
-        Just (ec, body) ->
-          do lists <- asPiLists body
-             pure $ [ (ec : args, concl) | (args, concl) <- lists ] ++ [([], t)]
+      case asPi t of
+        Nothing -> [([], t)]
+        Just (nm, tp, body) ->
+          [ (EC nm tp : args, concl) | (args, concl) <- asPiLists body ] ++ [([], t)]
 
 
 -- | Attempt to prove a universally quantified goal by introducing a fresh variable
@@ -2054,15 +2052,14 @@ tacticIntro :: (F.MonadFail m, MonadIO m) =>
 tacticIntro sc usernm = Tactic \goal ->
   case sequentState (goalSequent goal) of
     ConclFocus p mkSqt ->
-      liftIO (scAsPi sc (unProp p)) >>= \case
-        Just (ec, body) ->
-          do let nm = ecShortName ec
-             let tp = ecType ec
+      case asPi (unProp p) of
+        Just (vn, tp, body) ->
+          do let nm = vnName vn
              let name = if Text.null usernm then nm else usernm
              xv <- liftIO $ scFreshEC sc name tp
              x  <- liftIO $ scVariable sc xv
              tt <- liftIO $ mkTypedTerm sc x
-             body' <- liftIO $ scInstantiateExt sc (IntMap.singleton (ecVarIndex ec) x) body
+             body' <- liftIO $ scInstantiateExt sc (IntMap.singleton (vnIndex vn) x) body
              let goal' = goal { goalSequent = mkSqt (Prop body') }
              return (tt, mempty, [goal'], introEvidence xv)
 

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -1223,7 +1223,7 @@ specializeTheorem sc what4PushMuxOps db loc rsn thm ts =
          constructTheorem sc what4PushMuxOps db p' (ApplyEvidence thm (map Left ts)) loc Nothing rsn 0
 
 specializeProp :: SharedContext -> Prop -> [Term] -> IO (Either TC.TCError Prop)
-specializeProp sc (Prop p0) ts0 = TC.runTCM (loop p0 ts0) sc []
+specializeProp sc (Prop p0) ts0 = TC.runTCM (loop p0 ts0) sc mempty
  where
   loop p [] = return (Prop p)
   loop p (t:ts) =
@@ -1550,7 +1550,7 @@ checkEvidence sc what4PushMuxOps = \e p -> do
                     p_typed <- TC.typeInferComplete p
                     let err = TC.NotFuncTypeInApp p_typed tm'
                     TC.applyPiTyped err p tm'
-         res <- TC.runTCM m sc []
+         res <- TC.runTCM m sc mempty
          case res of
            Left msg -> fail (unlines (TC.prettyTCError msg))
            Right p' -> checkApply nenv mkSqt (Prop p') es

--- a/saw-central/src/SAWCentral/Yosys/Utils.hs
+++ b/saw-central/src/SAWCentral/Yosys/Utils.hs
@@ -155,7 +155,7 @@ validateTermAtType :: MonadIO m => SC.SharedContext -> Text ->
                       SC.Term -> SC.Term -> m ()
 validateTermAtType sc msg trm tp =
   liftIO (SC.TC.runTCM (SC.TC.typeInferComplete trm >>= \tp_trm ->
-                         SC.TC.checkSubtype tp_trm tp) sc []) >>= \case
+                         SC.TC.checkSubtype tp_trm tp) sc mempty) >>= \case
   Right _ -> return ()
   Left err ->
     throw

--- a/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
+++ b/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
@@ -482,7 +482,7 @@ asPiTypes sc t =
        Nothing -> pure ([], t)
        Just (n, t1, t2) ->
          do (args, ret) <- asPiTypes sc t2
-            pure ((Text.unpack n, t1) : args, ret)
+            pure ((Text.unpack (vnName n), t1) : args, ret)
 
 bitBlastTerm ::
   AIG.IsAIG l g =>

--- a/saw-core-coq/src/SAWCoreCoq/Term.hs
+++ b/saw-core-coq/src/SAWCoreCoq/Term.hs
@@ -80,10 +80,6 @@ data TranslationReader = TranslationReader
   { _currentModule  :: Maybe ModuleName
     -- ^ The current Coq module for the translation
 
-  , _localEnvironment  :: [Coq.Ident]
-    -- ^ The list of Coq identifiers associated with the current SAW core
-    -- Bruijn-indexed local variables in scope, innermost (index 0) first
-
   , _namedEnvironment  :: Map.Map VarName Coq.Ident
     -- ^ The map of Coq identifiers associated with the SAW core named
     -- variables in scope
@@ -269,7 +265,6 @@ runTermTranslationMonad configuration mname mm globalDecls localEnv =
   runTranslationMonad configuration
   (TranslationReader {
       _currentModule = mname
-      , _localEnvironment = localEnv
       , _namedEnvironment = Map.empty
       , _unavailableIdents  = Set.union reservedIdents (Set.fromList localEnv)
       , _sharedNames        = IntMap.empty
@@ -482,7 +477,6 @@ withTopTranslationState m =
   localTR (\r ->
             TranslationReader {
               _currentModule     = view currentModule r,
-              _localEnvironment  = [],
               _namedEnvironment  = Map.empty,
               _unavailableIdents = reservedIdents,
               _sharedNames       = IntMap.empty,

--- a/saw-core-what4/src/SAWCoreWhat4/What4.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/What4.hs
@@ -1495,7 +1495,7 @@ w4EvalAny sym st sc ps unintSet t =
      ty <- eval =<< scTypeOf sc t
 
      -- get the names of the arguments to the function
-     let lamNames = map (Text.unpack . fst) (fst (R.asLambdaList t))
+     let lamNames = map (Text.unpack . vnName . fst) (fst (R.asLambdaList t))
      let varNames = [ "var" ++ show (i :: Integer) | i <- [0 ..] ]
      let argNames = zipWith (++) varNames (map ("_" ++) lamNames ++ repeat "")
 

--- a/saw-core/src/SAWCore/Conversion.hs
+++ b/saw-core/src/SAWCore/Conversion.hs
@@ -54,7 +54,6 @@ module SAWCore.Conversion
   , asAnyNatLit
   , asAnyVecLit
   , asVariable
-  , asLocalVar
     -- ** Prelude matchers
   , asBoolType
   , asSuccLit
@@ -282,10 +281,6 @@ asAnyVecLit = asVar $ \t -> do ArrayValue u xs <- R.asFTermF t; return (u,xs)
 -- | Match any named variable.
 asVariable :: Matcher (ExtCns Term)
 asVariable = asVar R.asVariable
-
--- | Returns index of local var if any.
-asLocalVar :: Matcher DeBruijnIndex
-asLocalVar = asVar $ \t -> do i <- R.asLocalVar t; return i
 
 ----------------------------------------------------------------------
 -- Prelude matchers

--- a/saw-core/src/SAWCore/ExternalFormat.hs
+++ b/saw-core/src/SAWCore/ExternalFormat.hs
@@ -116,7 +116,6 @@ scWriteExternal t0 =
         Pi s t e       ->
           do stashVarName s
              pure $ unwords ["Pi", show (vnIndex s), show t, show e]
-        LocalVar i     -> pure $ unwords ["Var", show i]
         Constant nm    ->
             do stashName nm
                pure $ unwords ["Constant", show (nameIndex nm)]
@@ -253,7 +252,6 @@ scReadExternal sc input =
         ["App", e1, e2]     -> App <$> readIdx e1 <*> readIdx e2
         ["Lam", s, t, e]    -> Lambda <$> readVarName s <*> readIdx t <*> readIdx e
         ["Pi", s, t, e]     -> Pi <$> readVarName s <*> readIdx t <*> readIdx e
-        ["Var", i]          -> pure $ LocalVar (read i)
         ["Constant",i]      -> Constant <$> readName i
         ["ConstantOpaque",i]  -> Constant <$> readName i
         ["Unit"]            -> pure $ FTermF UnitValue

--- a/saw-core/src/SAWCore/OpenTerm.hs
+++ b/saw-core/src/SAWCore/OpenTerm.hs
@@ -52,7 +52,7 @@ SAW core 'Term'.
 
 module SAWCore.OpenTerm (
   -- * Open terms and converting to closed terms
-  OpenTerm(..), completeOpenTerm, completeNormOpenTerm, completeOpenTermType,
+  OpenTerm(..), completeOpenTerm, completeOpenTermType,
   -- * Basic operations for building open terms
   closedOpenTerm, openOpenTerm, failOpenTerm,
   bindTCMOpenTerm, bindPPOpenTerm, openTermType,
@@ -80,19 +80,12 @@ module SAWCore.OpenTerm (
   pairTermLike, pairTypeTermLike, pairLeftTermLike, pairRightTermLike,
   tupleTermLike, tupleTypeTermLike, projTupleTermLike,
   letTermLike, sawLetTermLike,
-  -- * Other exported helper functions
-  sawLetMinimize
   ) where
 
 import qualified Data.Vector as V
-import Control.Monad.State
-import Control.Monad.Writer
 import Control.Monad.Reader
 import Data.Text (Text)
 import Numeric.Natural
-
-import Data.IntMap.Strict (IntMap)
-import qualified Data.IntMap.Strict as IntMap
 
 import qualified SAWSupport.Pretty as PPS (defaultOpts, render)
 
@@ -106,7 +99,6 @@ import SAWCore.Module
   ( ctorName
   , dtName
   )
-import SAWCore.Recognizer
 
 
 -- | An open term is represented as a type-checking computation that computes a
@@ -119,11 +111,6 @@ completeOpenTerm :: SharedContext -> OpenTerm -> IO Term
 completeOpenTerm sc (OpenTerm termM) =
   either (fail . show) return =<<
   runTCM (typedVal <$> termM) sc []
-
--- | \"Complete\" an 'OpenTerm' to a closed term and 'betaNormalize' the result
-completeNormOpenTerm :: SharedContext -> OpenTerm -> IO Term
-completeNormOpenTerm sc m =
-  completeOpenTerm sc m >>= sawLetMinimize sc >>= betaNormalize sc
 
 -- | \"Complete\" an 'OpenTerm' to a closed term for its type
 completeOpenTermType :: SharedContext -> OpenTerm -> IO Term
@@ -628,104 +615,3 @@ sawLetTermLike :: OpenTermLike t => LocalName -> t -> t -> t -> (t -> t) -> t
 sawLetTermLike x tp tp_ret rhs body_f =
   applyTermLikeMulti (globalTermLike "Prelude.sawLet")
   [tp, tp_ret, rhs, lambdaTermLike x tp body_f]
-
-
---------------------------------------------------------------------------------
--- sawLet-minimization
-
--- | A map from each deBruijn index to a count of its occurrences in a term
-newtype VarOccs = VarOccs [Integer]
-
--- | Make a 'VarOccs' with a single occurrence of a deBruijn index
-varOccs1 :: DeBruijnIndex -> VarOccs
-varOccs1 i = VarOccs (take i (repeat 0) ++ [1])
-
--- | Move a 'VarOccs' out of a binder by returning the number of occurrences of
--- deBruijn index 0 along with the result of subtracting 1 from all other indices
-unconsVarOccs :: VarOccs -> (Integer, VarOccs)
-unconsVarOccs (VarOccs []) = (0, VarOccs [])
-unconsVarOccs (VarOccs (cnt:occs)) = (cnt, VarOccs occs)
-
--- | Multiply every index in a 'VarOccs' by a constant
-multVarOccs :: Integer -> VarOccs -> VarOccs
-multVarOccs i (VarOccs occs) = VarOccs $ map (* i) occs
-
--- | The infinite list of zeroes
-zeroes :: [Integer]
-zeroes = 0:zeroes
-
-instance Semigroup VarOccs where
-  (VarOccs occs1) <> (VarOccs occs2)
-    | length occs1 < length occs2
-    = VarOccs (zipWith (+) (occs1 ++ zeroes) occs2)
-  (VarOccs occs1) <> (VarOccs occs2)
-    = VarOccs (zipWith (+) occs1 (occs2 ++ zeroes))
-
-instance Monoid VarOccs where
-  mempty = VarOccs []
-
--- | 'listen' to the output of a writer computation and return that output but
--- drop it from the writer output of the computation
-listenDrop :: MonadWriter w m => m a -> m (a, w)
-listenDrop m = pass (listen m >>= \aw -> return (aw, const mempty))
-
--- | The monad for sawLet minimization
-type SLMinM = StateT (IntMap (Term, VarOccs)) (WriterT VarOccs IO)
-
--- | Find every subterm of the form @sawLet a b rhs (\ x -> body)@ and, whenever
--- @x@ occurs at most once in @body@, unfold the @sawLet@ by substituting @rhs@
--- into @body@
-sawLetMinimize :: SharedContext -> Term -> IO Term
-sawLetMinimize sc t_top =
-  fst <$> runWriterT (evalStateT (slMinTerm t_top) IntMap.empty) where
-  slMinTerm :: Term -> SLMinM Term
-  slMinTerm (Unshared tf) = slMinTermF tf
-  slMinTerm t@(STApp { stAppIndex = i }) =
-    do memo_table <- get
-       case IntMap.lookup i memo_table of
-         Just (t', occs) ->
-           -- NOTE: the fact that we explicitly tell occs here means that we are
-           -- going to double-count variable occurrences for multiple
-           -- occurrences of the same subterm. That is, a variable occurence
-           -- counts for each copy of a shared subterm.
-           tell occs >> return t'
-         Nothing ->
-           do (t', occs) <- listen $ slMinTermF (unwrapTermF t)
-              modify $ IntMap.insert i (t', occs)
-              return t'
-
-  slMinTermF :: TermF Term -> SLMinM Term
-  slMinTermF tf@(App (asApplyAll ->
-                      (isGlobalDef "Prelude.sawLet" -> Just _, [_a, _b, rhs]))
-                 (asLambda -> Just (_, _, body))) =
-    do (body', (unconsVarOccs ->
-                (x_cnt, body_occs))) <- listenDrop $ slMinTerm body
-       if x_cnt > 1 then slMinTermF' tf else
-         do (rhs', rhs_occs) <- listenDrop $ slMinTerm rhs
-            tell (multVarOccs x_cnt rhs_occs <> body_occs)
-            liftIO $ instantiateVar sc 0 rhs' body'
-  slMinTermF tf = slMinTermF' tf
-
-  slMinTermF' :: TermF Term -> SLMinM Term
-  slMinTermF' (FTermF ftf) = slMinFTermF ftf
-  slMinTermF' (App f arg) =
-    do f' <- slMinTerm f
-       arg' <- slMinTerm arg
-       liftIO $ scTermF sc (App f' arg')
-  slMinTermF' (Lambda x tp body) =
-    do tp' <- slMinTerm tp
-       (body', body_occs) <- listenDrop $ slMinTerm body
-       tell $ snd $ unconsVarOccs body_occs
-       liftIO $ scTermF sc (Lambda x tp' body')
-  slMinTermF' (Pi x tp body) =
-    do tp' <- slMinTerm tp
-       (body', body_occs) <- listenDrop $ slMinTerm body
-       tell $ snd $ unconsVarOccs body_occs
-       liftIO $ scTermF sc (Pi x tp' body')
-  slMinTermF' tf@(LocalVar i) =
-    tell (varOccs1 i) >> liftIO (scTermF sc tf)
-  slMinTermF' tf@(Constant _) = liftIO (scTermF sc tf)
-  slMinTermF' tf@(Variable {}) = liftIO (scTermF sc tf)
-
-  slMinFTermF :: FlatTermF Term -> SLMinM Term
-  slMinFTermF ftf = traverse slMinTerm ftf >>= liftIO . scFlatTermF sc

--- a/saw-core/src/SAWCore/OpenTerm.hs
+++ b/saw-core/src/SAWCore/OpenTerm.hs
@@ -110,20 +110,20 @@ newtype OpenTerm = OpenTerm { unOpenTerm :: TCM SCTypedTerm }
 completeOpenTerm :: SharedContext -> OpenTerm -> IO Term
 completeOpenTerm sc (OpenTerm termM) =
   either (fail . show) return =<<
-  runTCM (typedVal <$> termM) sc []
+  runTCM (typedVal <$> termM) sc mempty
 
 -- | \"Complete\" an 'OpenTerm' to a closed term for its type
 completeOpenTermType :: SharedContext -> OpenTerm -> IO Term
 completeOpenTermType sc (OpenTerm termM) =
   either (fail . show) return =<<
-  runTCM (typedType <$> termM) sc []
+  runTCM (typedType <$> termM) sc mempty
 
 -- | Embed a closed 'Term' into an 'OpenTerm'
 closedOpenTerm :: Term -> OpenTerm
 closedOpenTerm t = OpenTerm $ typeInferComplete t
 
 -- | Embed a 'Term' in the given typing context into an 'OpenTerm'
-openOpenTerm :: [(LocalName, Term)] -> Term -> OpenTerm
+openOpenTerm :: [(VarName, Term)] -> Term -> OpenTerm
 openOpenTerm ctx t =
   -- Extend the local type-checking context, wherever this OpenTerm gets used,
   -- by appending ctx to the end, so that variables 0..length ctx-1 all get

--- a/saw-core/src/SAWCore/Prelude.hs
+++ b/saw-core/src/SAWCore/Prelude.hs
@@ -119,12 +119,12 @@ scDecEq sc fot args = case fot of
       Just (x,y) ->
            mkRecordEqBody (Map.toList fs) x y
 
-      Nothing -> 
-        do x <- scLocalVar sc 1
-           y <- scLocalVar sc 0
-           tp   <- scFirstOrderType sc fot
-           body <-  mkRecordEqBody (Map.toList fs) x y
-           scLambdaList sc [("x",tp),("y",tp)] body
+      Nothing ->
+        do tp <- scFirstOrderType sc fot
+           x <- scFreshVariable sc "x" tp
+           y <- scFreshVariable sc "y" tp
+           body <- mkRecordEqBody (Map.toList fs) x y
+           scAbstractTerms sc [x, y] body
 
  where
   mkRecordEqBody [] _x _y = scBool sc True

--- a/saw-core/src/SAWCore/Recognizer.hs
+++ b/saw-core/src/SAWCore/Recognizer.hs
@@ -49,7 +49,6 @@ module SAWCore.Recognizer
   , asLambdaList
   , asPi
   , asPiList
-  , asLocalVar
   , asConstant
   , asVariable
   , asSort
@@ -328,10 +327,6 @@ asPiList :: Term -> ([(VarName, Term)], Term)
 asPiList = go []
   where go r (asPi -> Just (nm,tp,rhs)) = go ((nm,tp):r) rhs
         go r rhs = (reverse r, rhs)
-
-asLocalVar :: Recognizer Term DeBruijnIndex
-asLocalVar (unwrapTermF -> LocalVar i) = return i
-asLocalVar _ = Nothing
 
 asConstant :: Recognizer Term Name
 asConstant (unwrapTermF -> Constant nm) = pure nm

--- a/saw-core/src/SAWCore/Recognizer.hs
+++ b/saw-core/src/SAWCore/Recognizer.hs
@@ -309,22 +309,22 @@ asArrayValue _ = Nothing
 asStringLit :: Recognizer Term Text
 asStringLit t = do StringLit i <- asFTermF t; return i
 
-asLambda :: Recognizer Term (LocalName, Term, Term)
+asLambda :: Recognizer Term (VarName, Term, Term)
 asLambda (unwrapTermF -> Lambda s ty body) = return (s, ty, body)
 asLambda _ = Nothing
 
-asLambdaList :: Term -> ([(LocalName, Term)], Term)
+asLambdaList :: Term -> ([(VarName, Term)], Term)
 asLambdaList = go []
   where go r (asLambda -> Just (nm,tp,rhs)) = go ((nm,tp):r) rhs
         go r rhs = (reverse r, rhs)
 
-asPi :: Recognizer Term (LocalName, Term, Term)
+asPi :: Recognizer Term (VarName, Term, Term)
 asPi (unwrapTermF -> Pi nm tp body) = return (nm, tp, body)
 asPi _ = Nothing
 
 -- | Decomposes a term into a list of pi bindings, followed by a right
 -- term that is not a pi binding.
-asPiList :: Term -> ([(LocalName, Term)], Term)
+asPiList :: Term -> ([(VarName, Term)], Term)
 asPiList = go []
   where go r (asPi -> Just (nm,tp,rhs)) = go ((nm,tp):r) rhs
         go r rhs = (reverse r, rhs)
@@ -340,8 +340,8 @@ asConstant _ = Nothing
 asVariable :: Recognizer Term (ExtCns Term)
 asVariable t =
   case unwrapTermF t of
-    Variable ec -> pure ec
-    _           -> Nothing
+    Variable nm tp -> pure (EC nm tp)
+    _              -> Nothing
 
 asSort :: Recognizer Term Sort
 asSort t = do

--- a/saw-core/src/SAWCore/SCTypeCheck.hs
+++ b/saw-core/src/SAWCore/SCTypeCheck.hs
@@ -640,7 +640,7 @@ inferRecursor r =
 -- | Compute the type of an 'SCTypedTerm'.
 scTypeOfTypedTerm :: SharedContext -> SCTypedTerm -> IO SCTypedTerm
 scTypeOfTypedTerm sc (SCTypedTerm _tm tp ctx) =
-  do tp_tp <- scTypeOf' sc [] tp
+  do tp_tp <- scTypeOf' sc ctx tp
      pure (SCTypedTerm tp tp_tp ctx)
 
 -- | Reduce an 'SCTypedTerm' to WHNF (see also 'scTypeCheckWHNF').

--- a/saw-core/src/SAWCore/SCTypeCheck.hs
+++ b/saw-core/src/SAWCore/SCTypeCheck.hs
@@ -468,16 +468,6 @@ instance TypeInfer (TermF SCTypedTerm) where
        -- when b is a Prop (this is a forall proposition), otherwise it is a
        -- (Type (max (sortOf a) (sortOf b)))
        liftTCM scSort $ if s2 == propSort then propSort else max s1 s2
-  typeInfer (LocalVar i) =
-    do ctx <- askCtx
-       if i < length ctx then
-         -- The ith type in the current variable typing context is well-typed
-         -- relative to the suffix of the context after it, so we have to lift it
-         -- (i.e., call incVars) to make it well-typed relative to all of ctx
-         liftTCM incVars 0 (i+1) (snd (ctx !! i))
-         else
-         error ("Context = " ++ show ctx)
-         -- throwTCError (DanglingVar (i - length ctx))
   typeInfer (Constant nm) = typeInferConstant nm
   typeInfer (Variable _nm tp) =
     -- FIXME: should we check that the type of ecType is a sort?
@@ -654,9 +644,7 @@ inferRecursor r =
 scTypeOfTypedTerm :: SharedContext -> SCTypedTerm -> IO SCTypedTerm
 scTypeOfTypedTerm sc (SCTypedTerm _tm tp ctx) =
   do tp_tp <- scTypeOf' sc ctx tp
-     -- Shrink de Bruijn context if possible
-     let ctx' = take (bitSetBound (looseVars tp_tp)) ctx
-     pure (SCTypedTerm tp tp_tp ctx')
+     pure (SCTypedTerm tp tp_tp ctx)
 
 -- | Reduce an 'SCTypedTerm' to WHNF (see also 'scTypeCheckWHNF').
 scTypedTermWHNF :: SharedContext -> SCTypedTerm -> IO SCTypedTerm

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -1671,9 +1671,12 @@ scApplyAll sc = foldlM (scApply sc)
 
 -- | Apply a function to an argument, beta-reducing if the function is a lambda
 scApplyBeta :: SharedContext -> Term -> Term -> IO Term
-scApplyBeta sc (asLambda -> Just (_, _, body)) arg =
-  instantiateVar sc 0 arg body
-scApplyBeta sc f arg = scApply sc f arg
+scApplyBeta sc f arg =
+  case asLambda f of
+    Just (name, _, body) ->
+      scInstantiateExt sc (IntMap.singleton (vnIndex name) arg) body
+    Nothing ->
+      scApply sc f arg
 
 -- | Apply a function 'Term' to zero or more arguments, beta reducing any time
 -- the function is a lambda

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -2650,7 +2650,8 @@ getConstantSet t = snd $ go (IntSet.empty, Map.empty) t
 -- to the terms in the substitution map.
 scInstantiateExt :: SharedContext -> IntMap Term -> Term -> IO Term
 scInstantiateExt sc vmap t0 =
-  do let rangeVars = foldMap freeVars vmap
+  do let domainVars = IntMap.keysSet vmap
+     let rangeVars = foldMap freeVars vmap
      tcache <- newCacheIntMap
      let memo :: Term -> IO Term
          memo t =
@@ -2659,7 +2660,7 @@ scInstantiateExt sc vmap t0 =
              STApp {stAppIndex = i} -> useCache tcache i (go t)
          go :: Term -> IO Term
          go t
-           -- - | IntSet.disjoint vs (freeVars t) = pure t
+           | IntSet.disjoint domainVars (freeVars t) = pure t
            | otherwise =
              case unwrapTermF t of
                FTermF ftf     -> scFlatTermF sc =<< traverse memo ftf

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -232,13 +232,6 @@ module SAWCore.SharedTerm
   , scArrayCopy
   , scArraySet
   , scArrayRangeEq
-    -- ** Utilities
---  , scTrue
---  , scFalse
-  , scAsLambda
-  , scAsLambdaList
-  , scAsPi
-  , scAsPiList
     -- ** Variable substitution
   , betaNormalize
   , getAllExts
@@ -2908,46 +2901,3 @@ scTreeSizeAux = go
         Just sz' -> (sz + sz', seen)
         Nothing -> (sz + sz', Map.insert idx sz' seen')
           where (sz', seen') = foldl' go (1, seen) tf
-
-
--- | Deconstruct a lambda term into a bound variable and a body, using
--- a fresh 'ExtCns' for the bound variable.
-scAsLambda :: SharedContext -> Term -> IO (Maybe (ExtCns Term, Term))
-scAsLambda _sc t =
-  case asLambda t of
-    Nothing -> pure Nothing
-    Just (nm, tp, body) -> pure $ Just (EC nm tp, body)
-
--- | Deconstruct a nested lambda term with 0 or more binders into a
--- list of bound variables and a body, using a fresh 'ExtCns' for each
--- bound variable.
-scAsLambdaList :: SharedContext -> Term -> IO ([ExtCns Term], Term)
-scAsLambdaList _sc = loop []
-  where
-    loop ecs t =
-      case asLambda t of
-        Nothing ->
-          pure (reverse ecs, t)
-        Just (nm, tp, body) ->
-          loop (EC nm tp : ecs) body
-
--- | Deconstruct a pi term into a bound variable and a body, using
--- a fresh 'ExtCns' for the bound variable.
-scAsPi :: SharedContext -> Term -> IO (Maybe (ExtCns Term, Term))
-scAsPi _sc t =
-  case asPi t of
-    Nothing -> pure Nothing
-    Just (nm, tp, body) -> pure $ Just (EC nm tp, body)
-
--- | Deconstruct a nested pi term with 0 or more binders into a list
--- of bound variables and a body, using a fresh 'ExtCns' for each
--- bound variable.
-scAsPiList :: SharedContext -> Term -> IO ([ExtCns Term], Term)
-scAsPiList _sc = loop []
-  where
-    loop ecs t =
-      case asPi t of
-        Nothing ->
-          pure (reverse ecs, t)
-        Just (nm, tp, body) ->
-          loop (EC nm tp : ecs) body

--- a/saw-core/src/SAWCore/Simulator.hs
+++ b/saw-core/src/SAWCore/Simulator.hs
@@ -161,8 +161,6 @@ evalTermF cfg lam recEval tf env env' =
                                       VNondependentPi . toTValue <$> lam t2 env env'
                                   return $ TValue $ VPiType v body
 
-    LocalVar i              -> force (env !! i)
-
     Constant nm             -> do let r = requireNameInMap nm (simModMap cfg)
                                   ty' <- evalType (resolvedNameType r)
                                   case simConstant cfg tf nm ty' of
@@ -624,7 +622,6 @@ mkMemoLocal cfg memoClosed t env env' = go mempty t
                               go memo' t2
         Lambda _ t1 _   -> go memo t1
         Pi _ t1 _       -> go memo t1
-        LocalVar _      -> pure memo
         Constant{}      -> pure memo
         Variable _nm tp -> go memo tp
 

--- a/saw-core/src/SAWCore/Term/Functor.hs
+++ b/saw-core/src/SAWCore/Term/Functor.hs
@@ -60,6 +60,7 @@ module SAWCore.Term.Functor
   , bitSetBound
   , looseVars, smallestLooseVar, termIsClosed
   , freesTermF, freeVars
+  , closedTerm
   ) where
 
 import Data.Bits
@@ -613,3 +614,7 @@ freesTermF tf =
 freeVars :: Term -> IntSet
 freeVars STApp{ stAppFreeVars = s } = s
 freeVars (Unshared tf) = freesTermF (fmap freeVars tf)
+
+-- | Test whether a 'Term' is closed, i.e., it has no free variables.
+closedTerm :: Term -> Bool
+closedTerm t = IntSet.null (freeVars t)

--- a/saw-core/src/SAWCore/Term/Functor.hs
+++ b/saw-core/src/SAWCore/Term/Functor.hs
@@ -30,7 +30,6 @@ module SAWCore.Term.Functor
   , identText
   , identPieces
     -- * Data types and definitions
-  , DeBruijnIndex
   , FieldName
   , LocalName
   , ExtCns(..)
@@ -45,7 +44,6 @@ module SAWCore.Term.Functor
   , TermF(..)
   , FlatTermF(..)
   , zipWithFlatTermF
-  , looseTermF
   , unwrapTermF
   , termToPat
   , alphaEquiv
@@ -54,16 +52,10 @@ module SAWCore.Term.Functor
   , Sort(..), mkSort, propSort, sortOf, maxSort
   , SortFlags(..), noFlags, sortFlagsLift2, sortFlagsToList, sortFlagsFromList
     -- * Sets of free variables
-  , BitSet, emptyBitSet, inBitSet, unionBitSets, intersectBitSets
-  , decrBitSet, multiDecrBitSet, completeBitSet, singletonBitSet, bitSetElems
-  , smallestBitSetElem
-  , bitSetBound
-  , looseVars, smallestLooseVar, termIsClosed
   , freesTermF, freeVars
   , closedTerm
   ) where
 
-import Data.Bits
 import qualified Data.Foldable as Foldable (and, foldl')
 import Data.Hashable
 import Data.IntMap (IntMap)
@@ -75,7 +67,6 @@ import qualified Data.Text as Text
 import Data.Typeable (Typeable)
 import Data.Vector (Vector)
 import qualified Data.Vector as V
-import Data.Word
 import GHC.Generics (Generic)
 import Numeric.Natural
 
@@ -85,13 +76,8 @@ import Instances.TH.Lift () -- for instance TH.Lift Text
 import SAWCore.Name
 import qualified SAWCore.TermNet as Net
 
-type DeBruijnIndex = Int
 type FieldName = Text
 type LocalName = Text
-  -- ^ 'LocalName' is used for pretty printing purposes, but does not affect the semantics of SAWCore terms,
-  -- rather, the 'DeBruijnIndex'-s are what is used to reference variables.
-  -- FIXME: Verify the above statement
-  -- FIXME: Possibly, change to a name that suggests this use.
 
 instance Hashable a => Hashable (Vector a) where
     hashWithSalt x v = hashWithSalt x (V.toList v)
@@ -340,8 +326,6 @@ data TermF e
       -- ^ Function abstractions
     | Pi !VarName !e !e
       -- ^ The type of a (possibly) dependent function
-    | LocalVar !DeBruijnIndex
-      -- ^ Local variables are referenced by deBruijn index.
     | Constant !Name
       -- ^ A global constant identified by its name.
     | Variable !VarName !e
@@ -381,9 +365,6 @@ data Term
        -- ^ The hash, according to 'hash', of the 'stAppTermF' field associated
        -- with this 'Term'. This should be as unique as a hash can be, but is
        -- not guaranteed unique as 'stAppIndex' is.
-     , stAppLooseVars :: !BitSet
-       -- ^ A set containing the 'DeBruijnIndex' of each of the loose
-       -- de Bruijn indices from 'LocalVar' constructors in the term.
      , stAppFreeVars :: !IntSet
        -- ^ A set containing the 'VarIndex' of each of the free named
        -- variables from 'Variable' constructors in the term.
@@ -444,7 +425,7 @@ equalTerm (STApp{stAppIndex = i1, stAppHash = h1, stAppTermF = tf1})
   -- inequality.
 
 -- | Return 'True' iff the given terms are equal modulo alpha equivalence (i.e.
--- 'LocalNames' in 'Lambda' and 'Pi' expressions) and sharing (i.e. 'STApp' vs.
+-- 'VarName's in 'Lambda' and 'Pi' expressions) and sharing (i.e. 'STApp' vs.
 -- 'Unshared' expressions).
 alphaEquiv :: Term -> Term -> Bool
 alphaEquiv = term IntMap.empty
@@ -467,7 +448,6 @@ alphaEquiv = term IntMap.empty
     termf vm (Pi (vnIndex -> i1) t1 u1) (Pi (vnIndex -> i2) t2 u2) =
       let vm' = if i1 == i2 then vm else IntMap.insert i1 i2 vm
       in term vm t1 t2 && term vm' u1 u2
-    termf _vm (LocalVar i1) (LocalVar i2) = i1 == i2
     termf _vm (Constant x1) (Constant x2) = x1 == x2
     termf vm (Variable x1 _t1) (Variable x2 _t2) =
       case IntMap.lookup (vnIndex x1) vm of
@@ -477,7 +457,6 @@ alphaEquiv = term IntMap.empty
     termf _ App{}      _ = False
     termf _ Lambda{}   _ = False
     termf _ Pi{}       _ = False
-    termf _ LocalVar{} _ = False
     termf _ Constant{} _ = False
     termf _ Variable{} _ = False
 
@@ -510,100 +489,6 @@ unwrapTermF STApp{stAppTermF = tf} = tf
 unwrapTermF (Unshared tf) = tf
 
 
--- Free de Bruijn Variables ----------------------------------------------------
-
--- | A @BitSet@ represents a set of natural numbers.
--- Bit n is a 1 iff n is in the set.
-newtype BitSet = BitSet Integer deriving (Eq, Ord, Show)
-
--- | The empty 'BitSet'
-emptyBitSet :: BitSet
-emptyBitSet = BitSet 0
-
--- | The singleton 'BitSet'
-singletonBitSet :: Int -> BitSet
-singletonBitSet = BitSet . bit
-
--- | Test if a number is in a 'BitSet'
-inBitSet :: Int -> BitSet -> Bool
-inBitSet i (BitSet j) = testBit j i
-
--- | Union two 'BitSet's
-unionBitSets :: BitSet -> BitSet -> BitSet
-unionBitSets (BitSet i1) (BitSet i2) = BitSet (i1 .|. i2)
-
--- | Intersect two 'BitSet's
-intersectBitSets :: BitSet -> BitSet -> BitSet
-intersectBitSets (BitSet i1) (BitSet i2) = BitSet (i1 .&. i2)
-
--- | Decrement all elements of a 'BitSet' by 1, removing 0 if it is in the
--- set. This is useful for moving a 'BitSet' out of the scope of a variable.
-decrBitSet :: BitSet -> BitSet
-decrBitSet (BitSet i) = BitSet (shiftR i 1)
-
--- | Decrement all elements of a 'BitSet' by some non-negative amount @N@,
--- removing any value less than @N@. This is the same as calling 'decrBitSet'
--- @N@ times.
-multiDecrBitSet :: Int -> BitSet -> BitSet
-multiDecrBitSet n (BitSet i) = BitSet (shiftR i n)
-
--- | The 'BitSet' containing all elements less than a given index @i@
-completeBitSet :: Int -> BitSet
-completeBitSet i = BitSet (bit i - 1)
-
--- | Compute the smallest element of a 'BitSet', if any
-smallestBitSetElem :: BitSet -> Maybe Int
-smallestBitSetElem (BitSet 0) = Nothing
-smallestBitSetElem (BitSet i) | i < 0 = error "smallestBitSetElem"
-smallestBitSetElem (BitSet i) = Just $ go 0 i where
-  go :: Int -> Integer -> Int
-  go !shft !x
-    | xw == 0   = go (shft+64) (shiftR x 64)
-    | otherwise = shft + countTrailingZeros xw
-    where xw :: Word64
-          xw = fromInteger x
-
--- | Compute the list of all elements of a 'BitSet'
-bitSetElems :: BitSet -> [Int]
-bitSetElems = go 0 where
-  -- Return the addition of shft to all elements of a BitSet
-  go :: Int -> BitSet -> [Int]
-  go shft bs = case smallestBitSetElem bs of
-    Nothing -> []
-    Just i ->
-      shft + i : go (shft + i + 1) (multiDecrBitSet (i + 1) bs)
-
--- | Return the smallest non-negative integer greater than every
--- element of the 'BitSet'.
-bitSetBound :: BitSet -> Int
-bitSetBound b = length $ takeWhile (/= emptyBitSet) $ iterate decrBitSet b
-
--- | Compute the loose de Bruijn indices of a term given the loose
--- indices for its immediate subterms.
-looseTermF :: TermF BitSet -> BitSet
-looseTermF tf =
-    case tf of
-      FTermF ftf -> Foldable.foldl' unionBitSets emptyBitSet ftf
-      App l r -> unionBitSets l r
-      Lambda _name tp rhs -> unionBitSets tp rhs
-      Pi _name lhs rhs -> unionBitSets lhs rhs
-      LocalVar i -> singletonBitSet i
-      Constant {} -> emptyBitSet -- assume type is a closed term
-      Variable _name tp -> tp
-
--- | Return a bitset containing indices of all loose de Bruijn indices.
-looseVars :: Term -> BitSet
-looseVars STApp{ stAppLooseVars = x } = x
-looseVars (Unshared f) = looseTermF (fmap looseVars f)
-
--- | Compute the value of the smallest variable in the term, if any.
-smallestLooseVar :: Term -> Maybe Int
-smallestLooseVar = smallestBitSetElem . looseVars
-
--- | Test whether a 'Term' is closed, i.e., has no loose de Bruijn indices.
-termIsClosed :: Term -> Bool
-termIsClosed t = looseVars t == emptyBitSet
-
 -- Free Named Variables --------------------------------------------------------
 
 -- | Compute an 'IntSet' containing the 'VarIndex' of the free
@@ -616,7 +501,6 @@ freesTermF tf =
     App l r -> IntSet.union l r
     Lambda nm tp rhs -> IntSet.union tp (IntSet.delete (vnIndex nm) rhs)
     Pi nm lhs rhs -> IntSet.union lhs (IntSet.delete (vnIndex nm) rhs)
-    LocalVar _ -> IntSet.empty
     Constant {} -> IntSet.empty
     Variable nm tp -> IntSet.insert (vnIndex nm) tp
 

--- a/saw-core/src/SAWCore/Term/Pretty.hs
+++ b/saw-core/src/SAWCore/Term/Pretty.hs
@@ -561,6 +561,7 @@ scTermCountAux doBinders = go
             Lambda _ t1 _ | not doBinders  -> [t1]
             Pi _ t1 _     | not doBinders  -> [t1]
             Constant{}                     -> []
+            Variable{}                     -> []
             FTermF (Recursor _)            -> []
             tf                             -> Fold.toList tf
 

--- a/saw-core/src/SAWCore/Term/Pretty.hs
+++ b/saw-core/src/SAWCore/Term/Pretty.hs
@@ -169,7 +169,6 @@ termVarNames t0 = evalState (go t0) IntMap.empty
         App e1 e2 -> Set.union e1 e2
         Lambda x e1 e2 -> Set.union e1 (Set.delete x e2)
         Pi x e1 e2 -> Set.union e1 (Set.delete x e2)
-        LocalVar _ -> Set.empty
         Constant _ -> Set.empty
         Variable vn e1 -> Set.insert vn e1
 
@@ -503,7 +502,6 @@ ppTermF prec (Pi x tp body) =
   ppParensPrec prec PrecLambda <$>
   (ppPi <$> ppTerm' PrecApp tp <*>
    ppTermInBinder PrecLambda x body)
-ppTermF _ (LocalVar x) = pure $ annotate PPS.LocalVarStyle $ pretty ("!" ++ show x)
 ppTermF _ (Constant nm) = annotate PPS.ConstantStyle <$> ppBestName nm
 ppTermF _ (Variable vn _tp) = annotate PPS.ExtCnsStyle <$> ppVarName vn
 
@@ -578,7 +576,6 @@ shouldMemoizeTerm t =
     FTermF (ArrayValue _ v) | V.length v == 0 -> False
     FTermF StringLit{} -> False
     Constant{} -> False
-    LocalVar{} -> False
     Variable{} -> False
     _ -> True
 
@@ -600,7 +597,7 @@ filterOccurenceMap min_occs global_p =
     IntMap.filter
       (\(t,cnt) ->
         cnt >= min_occs && shouldMemoizeTerm t &&
-        (if global_p then termIsClosed t else True))
+        (if global_p then closedTerm t else True))
 
 
 -- For each (TermIndex, Term) pair in the occurrence map, pretty-print the

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -447,7 +447,7 @@ processDecls (Un.DataDecl (PosPair p nm) param_ctx dt_tp c_decls : rest) =
                    "Type of that type: " <> Text.pack (showTerm $ typedType typed_tp)
                ]
        let tp = typedVal typed_tp
-       result <- lift $ TC.liftTCM mkCtorArgStruct pn dtParams dtIndices tp
+       let result = mkCtorArgStruct pn dtParams dtIndices tp
        case result of
          Just arg_struct ->
            lift $ TC.liftTCM scBuildCtor pn (mkIdent mnm c) arg_struct


### PR DESCRIPTION
This PR removes de Bruijn indices from SAWCore, replacing them with named variables in all SAWCore binding constructs. Fixes #2328.