### PR TITLE
Simplify SAWCore recursor implementation

### DIFF
--- a/saw-core/src/SAWCore/Module.hs
+++ b/saw-core/src/SAWCore/Module.hs
@@ -167,15 +167,6 @@ data Ctor =
     -- where the @pi@ are the 'ctorParams', the @argi@ are the types specified
     -- by the 'ctorArgs', and the @ixi@ are the 'ctorDataTypeIndices'. Note that
     -- this type should always be top-level, i.e., have no free variables.
-  , ctorElimTypeFun :: [Term] -> Term -> IO Term
-    -- ^ Cached function for generating the type of an eliminator for this
-    -- constructor by passing it a list of parameters and a @p_ret@ function,
-    -- also known as the "motive function", which itself must have type
-    --
-    -- > (x1::ix1) -> .. -> (xm::ixm) -> d p1 .. pn x1 .. xm -> Type i
-    --
-    -- where the @ps@ are the parameters and the @ix@s are the indices of
-    -- datatype @d@
   , ctorIotaReduction ::
        Term {- ^ recursor term -} ->
        Map VarIndex Term {- ^ constructor eliminators -} ->


### PR DESCRIPTION
Simplify some recursor-related code, inlining a couple of intermediate functions, removing a higher-order record field from the `Ctor` datatype, and avoiding one explicit use of de Bruijn variables.