### PR TITLE
Yet more recursor simplification

### DIFF
--- a/saw-core/src/SAWCore/Module.hs
+++ b/saw-core/src/SAWCore/Module.hs
@@ -180,13 +180,6 @@ data Ctor =
     --   The arguments to this function are the recusor value, the
     --   the map from the recursor that maps constructors to eliminator
     --   functions, and the arguments to the constructor.
-
-  , ctorIotaTemplate :: Term
-    -- ^ Cached term used for computing iota reductions.  It has free variables
-    --   @rec@, @elim@ and @args@, in that order so that the last @arg@ is the
-    --   most recently-bound variable with deBruijn index 0.  The @rec@ variable
-    --   represents the recursor value, @elim@ represents the eliminator function
-    --   for the constructor, and @args@ represent the arguments to this constructor.
   }
 
 -- | Return the number of parameters of a constructor

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -846,8 +846,7 @@ scBuildCtor sc d c arg_struct =
     elim_var <- scLocalVar sc num_args
     rec_var  <- scLocalVar sc (num_args+1)
 
-    -- Step 3: pass these variables to ctxReduceRecursor to build the
-    -- ctorIotaTemplate field
+    -- Step 3: pass these variables to ctxReduceRecursor to build a template
     iota_red <- ctxReduceRecursor sc rec_var elim_var vars arg_struct
 
     -- Step 4: build the API function that shuffles the terms around in the
@@ -867,7 +866,6 @@ scBuildCtor sc d c arg_struct =
       , ctorArgStruct = arg_struct
       , ctorDataType = d
       , ctorType = tp
-      , ctorIotaTemplate  = iota_red
       , ctorIotaReduction = iota_fun
       }
 


### PR DESCRIPTION
This PR gets rid of the last explicit uses of de Bruijn indices in the code implementing SAWCore recursors, paving the way to finish #2671. The `ctorIotaTemplate` field of type `Ctor`, which used to contain an open de Bruijn term, is now gone.