### PR TITLE
Add a way do declare that names should be kept opaque during LLVM symbolic simulation

### DIFF
--- a/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
@@ -31,6 +31,7 @@ module SAWCentral.Crucible.LLVM.Builtins
     , llvm_return
     , llvm_precond
     , llvm_postcond
+    , llvm_unint
     , llvm_assert
     , llvm_cfg
     , llvm_extract
@@ -169,7 +170,7 @@ import qualified SAWCentral.Crucible.LLVM.CrucibleLLVM as Crucible
 
 -- saw-core
 import SAWCore.FiniteValue (ppFirstOrderValue)
-import SAWCore.Name (ecShortName)
+import SAWCore.Name (ecShortName, nameIndex)
 import SAWCore.SharedTerm
 import SAWCore.Recognizer
 import SAWCore.Term.Pretty (showTerm)
@@ -205,6 +206,7 @@ import qualified SAWCentral.Crucible.Common.Vacuity as Vacuity
 import SAWCentral.Crucible.LLVM.Override
 import SAWCentral.Crucible.LLVM.ResolveSetupValue
 import SAWCentral.Crucible.LLVM.MethodSpecIR
+import SAWCentral.Crucible.LLVM.Setup.Value(ccUninterp)
 import SAWCentral.Panic (panic)
 
 type AssumptionReason = (MS.ConditionMetadata, String)
@@ -580,17 +582,18 @@ withMethodSpec pathSat lm nm setup action =
               -- execute commands of the method spec
               io $ W4.setCurrentProgramLoc sym setupLoc
 
-              methodSpec <-
-                view Setup.csMethodSpec <$>
+              
+              setupState  <-
                 (execStateT
                    (runReaderT (runLLVMCrucibleSetupM setup)
                                (Setup.makeCrucibleSetupRO))
                      st0)
+              let methodSpec = setupState ^. Setup.csMethodSpec
+                  cc1        = setupState ^. Setup.csCrucibleContext
+              io $ checkSpecArgumentTypes cc1 methodSpec
+              io $ checkSpecReturnType cc1 methodSpec
 
-              io $ checkSpecArgumentTypes cc methodSpec
-              io $ checkSpecReturnType cc methodSpec
-
-              action cc methodSpec
+              action cc1 methodSpec
 
 verifyMethodSpec ::
   ( ?lc :: Crucible.TypeContext
@@ -1777,6 +1780,7 @@ setupLLVMCrucibleContext pathSat lm action =
                                      , _ccLLVMSimContext = lsimctx
                                      , _ccLLVMGlobals = lglobals
                                      , _ccBasicSS = basic_ss
+                                     , _ccUninterp = Set.empty
                                      }
           action cc
 
@@ -2005,6 +2009,21 @@ llvm_postcond term =
   LLVMCrucibleSetupM $
   do loc <- getW4Position "llvm_postcond"
      Setup.crucible_postcond loc term
+
+llvm_unint :: TypedTerm -> LLVMCrucibleSetupM ()
+llvm_unint term =
+  LLVMCrucibleSetupM $
+    do
+      prePost <- use Setup.csPrePost
+      case prePost of
+        PreState ->
+          case asConstant (ttTerm term) of
+            Nothing -> fail "The argument to `llvm_unint` should be a name."
+            Just n ->
+              do 
+                 Setup.csCrucibleContext . ccUninterp . contains (nameIndex n) .= True
+        PostState -> fail "`llvm_unint` works only int the pre-condition of a specification."
+          
 
 llvm_return ::
   AllLLVM MS.SetupValue ->

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Setup/Value.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Setup/Value.hs
@@ -64,6 +64,7 @@ module SAWCentral.Crucible.LLVM.Setup.Value
   , ccLLVMGlobals
   , ccBasicSS
   , ccBackend
+  , ccUninterp
     -- * PointsTo
   , LLVMPointsTo(..)
   , LLVMPointsToValue(..)
@@ -90,6 +91,7 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Type.Equality (TestEquality(..))
 import           Data.Void (Void)
+import           Data.Set(Set)
 import qualified Prettyprinter as PPL
 import qualified Text.LLVM.AST as L
 import qualified Text.LLVM.PP as L
@@ -270,7 +272,6 @@ showLLVMModule (LLVMModule name m _) =
 -- ** CrucibleContext
 
 type instance Setup.CrucibleContext (LLVM arch) = LLVMCrucibleContext arch
-
 data LLVMCrucibleContext arch =
   LLVMCrucibleContext
   { _ccLLVMModule      :: LLVMModule arch
@@ -278,6 +279,7 @@ data LLVMCrucibleContext arch =
   , _ccLLVMSimContext  :: Crucible.SimContext (SAWCruciblePersonality Sym) Sym CL.LLVM
   , _ccLLVMGlobals     :: Crucible.SymGlobalState Sym
   , _ccBasicSS         :: Simpset TheoremNonce
+  , _ccUninterp        :: !(Set VarIndex)
   }
 
 makeLenses ''LLVMCrucibleContext

--- a/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
@@ -486,6 +486,7 @@ llvm_verify_x86_common (Some (llvmModule :: LLVMModule x)) path nm globsyms chec
           { _ccLLVMModule = llvmModule
           , _ccBackend = SomeOnlineBackend bak
           , _ccBasicSS = basic_ss
+          , _ccUninterp = Set.empty
 
           -- It's unpleasant that we need to do this to use resolveSetupVal.
           , _ccLLVMSimContext = error "Attempted to access ccLLVMSimContext"

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -4979,6 +4979,13 @@ primitives = Map.fromList
     Current
     [ "Legacy alternative name for `llvm_execute_func`." ]
 
+  , prim "llvm_unint" "Term -> LLVMSetup ()"
+    (pureVal llvm_unint)
+    Current
+    [ "Keep the given name opaque during symbolic simulation."
+    , "The input term should be a name."
+    ] 
+
   , prim "llvm_return" "SetupValue -> LLVMSetup ()"
     (pureVal llvm_return)
     Current


### PR DESCRIPTION
Fixes #2674

This PR introduces a new command to LLVMSetup, `llvm_uniterp` which allows us to declare that a name should be kept opaque during symbolic simulation.