### PR TITLE
`cryptol-saw-core`: Only import nominal types from non-parameterized modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,6 +119,11 @@ This release supports [version
   allows extracting a MIR function to a term. See the SAW manual for details on
   what types of MIR functions are supported for extraction.
 
+## Bug Fixes
+
+* Fix a bug that would cause SAW to crash when loading an instantiation of a
+  parameterized Cryptol module that contains newtypes or enums (#2673).
+
 # Version 1.4 -- date still TBD
 
 This release supports [version

--- a/intTests/test2673/A.cry
+++ b/intTests/test2673/A.cry
@@ -1,0 +1,7 @@
+module A where
+
+parameter
+  type n : #
+
+newtype E = { unE : [n] }
+enum F = MkF [n]

--- a/intTests/test2673/B.cry
+++ b/intTests/test2673/B.cry
@@ -1,0 +1,3 @@
+module B = A where
+
+type n = 8

--- a/intTests/test2673/test.saw
+++ b/intTests/test2673/test.saw
@@ -1,0 +1,4 @@
+import "B.cry";
+
+prove_print z3 {{ \(x : [8]) -> (E { unE = x }).unE == x }};
+prove_print z3 {{ \(x : [8]) -> case MkF x of MkF y -> x == y }};

--- a/intTests/test2673/test.sh
+++ b/intTests/test2673/test.sh
@@ -1,0 +1,3 @@
+set -e
+
+$SAW test.saw


### PR DESCRIPTION
Don't import nominal types from parameterized modules, as SAW doesn't know how to reason about these yet. (This was the cause of the panic seen in #2673.)

Fixes #2673.