### PR TITLE
`traverseMirAggregate`: Add a special case for empty `MirAggregate`s

### DIFF
--- a/crux-mir-comp/test/symb_eval/comp/clobber_globals_closure.good
+++ b/crux-mir-comp/test/symb_eval/comp/clobber_globals_closure.good
@@ -1,0 +1,3 @@
+test clobber_globals_closure/<DISAMB>::foo_equiv[0]: ok
+
+[Crux] Overall status: Valid.

--- a/crux-mir-comp/test/symb_eval/comp/clobber_globals_closure.rs
+++ b/crux-mir-comp/test/symb_eval/comp/clobber_globals_closure.rs
@@ -1,0 +1,28 @@
+// A regression test for #2687. rustc will promote the closure used in the body
+// of the mk_closure() function to a static item, which means that the value
+// of this static will be clobbered as part of proving foo_equiv(). Because
+// this closure does not capture any variables, it is represented as an empty
+// MirAggregate in crucible-mir. There was a subtle bug involving mistreatment
+// of empty MirAggregates that #2687 uncovered, and this test case aims to
+// ensure that this bug remains fixed.
+
+extern crate crucible;
+extern crate crucible_proc_macros;
+use crucible::crucible_assert;
+use crucible_proc_macros::crux_spec_for;
+
+// The closure must be promoted to get 'static lifetime
+fn mk_closure() -> &'static impl Fn() -> u32 {
+    &|| 42u32
+}
+
+pub fn foo() -> u32 {
+    mk_closure()()
+}
+
+#[crux_spec_for(foo)]
+pub fn foo_equiv() {
+    let expected = 42u32;
+    let actual = foo();
+    crucible_assert!(expected == actual);
+}

--- a/saw-central/src/SAWCentral/Crucible/MIR/TypeShape.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/TypeShape.hs
@@ -454,7 +454,7 @@ shapeToTerm' sc = go
         ty <- go sub shp
         liftIO (mkVec n ty)
     go (AdaptDerefSlice col n ada) (SliceShape _ elT M.Immut tpr) =
-      do et <- go ada (tyToShapeEq col elT tpr) 
+      do et <- go ada (tyToShapeEq col elT tpr)
          liftIO (mkVec n et)
     go _ada shp = fail $ "shapeToTerm: unsupported type " ++ show (shapeType shp)
 
@@ -568,6 +568,7 @@ buildMirAggregate sym elems xs f = do
 -- offset, size, type, and value of the entry, and its result is stored as the
 -- new value in the output.
 traverseMirAggregate ::
+  forall sym m.
   (IsSymInterface sym, Monad m, MonadFail m, MonadIO m) =>
   sym ->
   [AgElemShape] ->
@@ -576,7 +577,35 @@ traverseMirAggregate ::
   m (MirAggregate sym)
 traverseMirAggregate sym elems (MirAggregate totalSize m) f = do
   agCheckKeysEq "traverseMirAggregate" elems m
-  m' <- sequence $ IntMap.mergeWithKey
+  m' <-
+    -- Hack: we include a special case for when the list of AgElemShapes and
+    -- the MirAggregate are both empty, skipping the call to mergeEntries
+    -- entirely if this is the case. This is because mergeEntries calls
+    -- IntMap.mergeWithKey under the hood, and prior to containers-0.8, the
+    -- implementation of IntMap.mergeWithKey had a bug where merging two empty
+    -- IntMaps would invoke the third callback argument instead of just
+    -- returning an empty map. (See
+    -- https://github.com/haskell/containers/issues/979.) Note that
+    -- mergeEntries uses the third callback argument to panic, however, and we
+    -- definitely don't want to panic if the IntMaps are both empty!
+    --
+    -- Because SAW still supports GHC versions that bundle versions of
+    -- containers that are older than 0.8 (and therefore do not contain a fix
+    -- for the issue above), we include this special case as a workaround. Once
+    -- SAW drops support for pre-0.8 versions of containers, we can remove this
+    -- special case.
+    if null elems && IntMap.null m
+      then pure IntMap.empty
+      else mergeEntries
+  return $ MirAggregate totalSize m'
+ where
+  -- Merge the existing MirAggregate's entries together with the new entries
+  -- from the list of AgElemShapes.
+  --
+  -- Precondition: both the list of AgElemShapes and the MirAggregate are
+  -- non-empty (see the comments above near mergeEntries' call site).
+  mergeEntries :: m (IntMap (MirAggregateEntry sym))
+  mergeEntries = sequence $ IntMap.mergeWithKey
     (\_off' (AgElemShape off _sz' shp) (MirAggregateEntry sz tpr rvPart) -> Just $ do
         Refl <- case testEquality tpr (shapeType shp) of
             Just pf -> return pf
@@ -590,7 +619,6 @@ traverseMirAggregate sym elems (MirAggregate totalSize m) f = do
     (\_ -> panic "traverseMirAggregate" ["mismatched keys in aggregate"])
     (IntMap.fromList [(fromIntegral off, e) | e@(AgElemShape off _ _) <- elems])
     m
-  return $ MirAggregate totalSize m'
 
 -- | Extract values from a `MirAggregate`, one for each entry.  The callback
 -- gets the offset, size, type, and value of the entry.  Callback results are


### PR DESCRIPTION
Doing so is necessary to work around a bug in the implementation of `IntMap.mergeWithKey` that exists in pre-0.8 versions of the `containers` library (https://github.com/haskell/containers/issues/979), which all currently supported versions of GHC currently use. See the newly added comments in `traverseMirAggregate` for the full story.

Fixes #2687.