### PR TITLE
MIR backend: Remove `equalRefsPred`

### DIFF
--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -120,10 +120,11 @@ assignVar ::
   OverrideMatcher MIR w ()
 
 assignVar cc md var sref@(Some ref) =
+  mccWithBackend cc $ \bak ->
   do old <- OM (setupValueSub . at var <<.= Just sref)
      let loc = MS.conditionLoc md
      F.for_ old $ \(Some ref') ->
-       do p <- liftIO (equalRefsPred cc ref ref')
+       do p <- liftIO (Mir.mirRef_eqIO bak (ref^.mpRef) (ref'^.mpRef))
           addAssert p md (Crucible.SimError loc (Crucible.AssertFailureSimError "equality of aliased references" ""))
 
 -- | When a specification is used as a composition override, this function

--- a/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
@@ -24,7 +24,6 @@ module SAWCentral.Crucible.MIR.ResolveSetupValue
   , indexSeqTerm
   , indexMirVector
   , usizeBvLit
-  , equalRefsPred
   , equalValsPred
   , checkCompatibleTys
   , readMaybeType
@@ -1186,19 +1185,6 @@ indexMirVector sym i elemShp vec =
 -- | Create a symbolic @usize@ from an 'Int'.
 usizeBvLit :: Sym -> Int -> IO (W4.SymBV Sym Mir.SizeBits)
 usizeBvLit sym = W4.bvLit sym W4.knownNat . BV.mkBV W4.knownNat . toInteger
-
--- | Check if two MIR references are equal.
-equalRefsPred ::
-  MIRCrucibleContext ->
-  MirPointer Sym tp1 ->
-  MirPointer Sym tp2 ->
-  IO (W4.Pred Sym)
-equalRefsPred cc mp1 mp2 =
-  mccWithBackend cc $ \bak ->
-  let sym = backendGetSym bak in
-  case W4.testEquality (mp1^.mpType) (mp2^.mpType) of
-    Nothing -> pure $ W4.falsePred sym
-    Just Refl -> Mir.mirRef_eqIO bak (mp1^.mpRef) (mp2^.mpRef)
 
 -- | Check if two 'MIRVal's are equal.
 equalValsPred ::


### PR DESCRIPTION
It is overly conservative in requiring that both pointers to have the same type, even though pointers with identical memory addresses can legitimately have different types.

Without the `typeEquality` check, there's not much point in having a dedicated `equalRefsPred` function, so this removes it and updates its one call site to just call `mirRef_eqIO` instead. (Note that unlike `equalRefsPred`, `mirRef_eqIO` has no issue in checking pointers of different types for equality.)

Fixes https://github.com/GaloisInc/saw-script/issues/2697.