### PR TITLE
saw-core: Add missing checks to scTypedLambda and scTypedPi.

### DIFF
--- a/saw-core/src/SAWCore/SCTypedTerm.hs
+++ b/saw-core/src/SAWCore/SCTypedTerm.hs
@@ -162,8 +162,7 @@ scTypedLambda :: SharedContext -> VarName -> SCTypedTerm -> SCTypedTerm -> IO SC
 scTypedLambda sc x t body =
   do _s <- ensureSort sc (typedType t)
      tm <- scLambda sc x (typedVal t) (typedVal body)
-     when (any (IntSet.member (vnIndex x) . freeVars) (typedCtx body)) $
-       fail $ "Variable occurs free in context: " ++ show (vnName x)
+     ensureNotFreeInContext x body
      _ <- unifyContexts "scTypedLambda" (IntMap.singleton (vnIndex x) (typedVal t)) (typedCtx body)
      ctx <- unifyContexts "scTypedLambda" (typedCtx t) (IntMap.delete (vnIndex x) (typedCtx body))
      tp <- scPi sc x (typedVal t) (typedType body)
@@ -173,8 +172,7 @@ scTypedLambda sc x t body =
 scTypedPi :: SharedContext -> VarName -> SCTypedTerm -> SCTypedTerm -> IO SCTypedTerm
 scTypedPi sc x t body =
   do tm <- scPi sc x (typedVal t) (typedVal body)
-     when (any (IntSet.member (vnIndex x) . freeVars) (typedCtx body)) $
-       fail $ "Variable occurs free in context: " ++ show (vnName x)
+     ensureNotFreeInContext x body
      _ <- unifyContexts "scTypedPi" (IntMap.singleton (vnIndex x) (typedVal t)) (typedCtx body)
      ctx <- unifyContexts "scTypedPi" (typedCtx t) (IntMap.delete (vnIndex x) (typedCtx body))
      s1 <- ensureSort sc (typedType t)
@@ -363,7 +361,6 @@ unifyContexts msg ctx1 ctx2 =
      sequence_ (IntMap.intersectionWith check ctx1 ctx2)
      pure (IntMap.union ctx1 ctx2)
 
-
 unifyContextList :: String -> [IntMap Term] -> IO (IntMap Term)
 unifyContextList msg = foldM (unifyContexts msg) IntMap.empty
 
@@ -392,3 +389,11 @@ ensureRecordType sc tp = ensureRecognizer "RecordType" sc asRecordType tp
 
 piSort :: Sort -> Sort -> Sort
 piSort s1 s2 = if s2 == propSort then propSort else max s1 s2
+
+-- | Check whether the given 'VarName' occurs free in the type of
+-- another variable in the context of the given 'SCTypedTerm', and
+-- fail if it does.
+ensureNotFreeInContext :: VarName -> SCTypedTerm -> IO ()
+ensureNotFreeInContext x body =
+  when (any (IntSet.member (vnIndex x) . freeVars) (typedCtx body)) $
+    fail $ "Variable occurs free in context: " ++ show (vnName x)


### PR DESCRIPTION
Now both of these functions check that the variable we're binding does not occur free in the type of any other variable in the typing context of the body. This would lead to the variable escaping from its scope (#2555).