### PR TITLE
Switch from ExtCns to VarName in SATQuery and related code.

### DIFF
--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -527,7 +527,7 @@ resolveNames nms =
      Set.fromList . mconcat <$> mapM (resolveName sc) nms
 
 -- | Given a user-provided name, resolve it to (potentially several)
--- 'ExtCns' that each represent an unfoldable 'Constant' value or a
+-- 'VarIndex'es that each represent an unfoldable 'Constant' value or a
 -- fresh uninterpreted constant.
 -- The given name is searched for in both the local Cryptol environment
 -- and the SAWCore naming environment.
@@ -551,7 +551,7 @@ resolveNameIO sc cenv nm =
        Nothing -> pure scnms
 
 -- | Given a user-provided name, resolve it to (potentially several)
--- 'ExtCns' that each represent an unfoldable 'Constant' value or a
+-- 'VarIndex'es that each represent an unfoldable 'Constant' value or a
 -- fresh uninterpreted constant.
 -- The given name is searched for in both the local Cryptol environment
 -- and the SAWCore naming environment. If it is found in neither, an
@@ -1478,7 +1478,7 @@ quickCheckPrintPrim sc opts numTests tt =
      runManyTests testGen numTests >>= \case
         Nothing -> printOutLn opts Info $ "All " ++ show numTests ++ " tests passed!"
         Just cex ->
-          do let cex' = [ (Text.unpack (ecShortName ec), v) | (ec,v) <- cex ]
+          do let cex' = [ (Text.unpack (vnName x), v) | (x, v) <- cex ]
              printOutLn opts OnlyCounterExamples $
                "----------Counterexample----------\n" ++
                showList cex' ""

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -111,7 +111,7 @@ import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Context as Ctx
 
 import SAWCore.FiniteValue (ppFirstOrderValue)
-import SAWCore.Name (ecShortName)
+import SAWCore.Name (VarName(..))
 import SAWCore.SharedTerm
 import CryptolSAWCore.TypedTerm
 
@@ -348,8 +348,8 @@ verifyObligations cc mspec tactic assumes asserts =
            printOutLnTop Info (show stats)
            printOutLnTop OnlyCounterExamples "----------Counterexample----------"
            opts <- rwPPOpts <$> getTopLevelRW
-           let showEC ec = Text.unpack (ecShortName ec)
-           let showAssignment (name, val) = "  " ++ showEC name ++ ": " ++ show (ppFirstOrderValue opts val)
+           let showVar x = Text.unpack (vnName x)
+           let showAssignment (name, val) = "  " ++ showVar name ++ ": " ++ show (ppFirstOrderValue opts val)
            mapM_ (printOutLnTop OnlyCounterExamples . showAssignment) vals
            io $ fail "Proof failed." -- Mirroring behavior of llvm_verify
          UnfinishedProof pst ->

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
@@ -170,7 +170,7 @@ import qualified SAWCentral.Crucible.LLVM.CrucibleLLVM as Crucible
 
 -- saw-core
 import SAWCore.FiniteValue (ppFirstOrderValue)
-import SAWCore.Name (ecShortName)
+import SAWCore.Name (VarName(..))
 import SAWCore.SharedTerm
 import SAWCore.Recognizer
 import SAWCore.Term.Pretty (showTerm)
@@ -840,8 +840,8 @@ verifyObligations cc mspec tactic assumes asserts =
                  if null vals then
                    printOutLnTop OnlyCounterExamples "<<All settings of the symbolic variables constitute a counterexample>>"
                  else
-                   let showEC ec = Text.unpack (ecShortName ec) in
-                   let showAssignment (ec, val) = "  " ++ showEC ec ++ ": " ++ show (ppFirstOrderValue opts val) in
+                   let showVar x = Text.unpack (vnName x) in
+                   let showAssignment (x, val) = "  " ++ showVar x ++ ": " ++ show (ppFirstOrderValue opts val) in
                    mapM_ (printOutLnTop OnlyCounterExamples . showAssignment) vals
                  printOutLnTop OnlyCounterExamples "----------------------------------"
                  throwTopLevel "Proof failed." -- Mirroring behavior of llvm_verify

--- a/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
@@ -73,7 +73,7 @@ import Data.Parameterized.Context hiding (view, zipWithM)
 import CryptolSAWCore.CryptolEnv
 import SAWCore.FiniteValue
 import SAWCore.Module (Def(..), ResolvedName(..), lookupVarIndexInMap)
-import SAWCore.Name (Name(..), ecShortName)
+import SAWCore.Name (Name(..), VarName(..))
 import SAWCore.Prelude
 import SAWCore.Recognizer
 import SAWCore.SharedTerm
@@ -1630,9 +1630,9 @@ checkGoals bak opts nm loc sc tactic mdMap invSubst loopFunEquivConds = do
         ppOpts <- rwPPOpts <$> getTopLevelRW
         case vals of
           [] -> printOutLnTop OnlyCounterExamples "<<All settings of the symbolic variables constitute a counterexample>>"
-          _ -> let showEC ec = Text.unpack (ecShortName ec) in
-               let showAssignment (ec, val) =
-                     mconcat [ " ", showEC ec, ": ", show $ ppFirstOrderValue ppOpts val ]
+          _ -> let showVar x = Text.unpack (vnName x) in
+               let showAssignment (x, val) =
+                     mconcat [ " ", showVar x, ": ", show $ ppFirstOrderValue ppOpts val ]
                in mapM_ (printOutLnTop OnlyCounterExamples . showAssignment) vals
         printOutLnTop OnlyCounterExamples "----------------------------------"
         throwTopLevel "Proof failed."

--- a/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
@@ -147,7 +147,7 @@ import qualified What4.Interface as W4
 import qualified What4.ProgramLoc as W4
 
 import SAWCore.FiniteValue (ppFirstOrderValue)
-import SAWCore.Name (ecShortName)
+import SAWCore.Name (VarName(..))
 import SAWCore.Recognizer ((:*:)(..), asTupleType, asVecType)
 import SAWCore.SharedTerm
 import SAWCore.Term.Pretty (ppTerm)
@@ -1384,8 +1384,8 @@ verifyObligations cc mspec tactic assumes asserts =
            printOutLnTop Info (show stats)
            printOutLnTop OnlyCounterExamples "----------Counterexample----------"
            opts <- rwPPOpts <$> getTopLevelRW
-           let showEC ec = Text.unpack (ecShortName ec)
-           let showAssignment (name, val) = "  " ++ showEC name ++ ": " ++ show (ppFirstOrderValue opts val)
+           let showVar x = Text.unpack (vnName x)
+           let showAssignment (name, val) = "  " ++ showVar name ++ ": " ++ show (ppFirstOrderValue opts val)
            mapM_ (printOutLnTop OnlyCounterExamples . showAssignment) vals
            io $ fail "Proof failed." -- Mirroring behavior of llvm_verify
          UnfinishedProof pst ->

--- a/saw-central/src/SAWCentral/Prover/ABC.hs
+++ b/saw-central/src/SAWCentral/Prover/ABC.hs
@@ -102,7 +102,7 @@ w4AbcAIGER =
   where cmd tmp tmpCex = "read_aiger " ++ tmp ++ "; sat; write_cex " ++ tmpCex
 
 w4AbcExternal ::
-  (FilePath -> SATQuery -> TopLevel [(ExtCns Term, FiniteType)]) ->
+  (FilePath -> SATQuery -> TopLevel [(VarName, FiniteType)]) ->
   (String -> String -> String) ->
   Bool ->
   SATQuery ->
@@ -194,7 +194,7 @@ abcSatExternal proxy sc doCNF execName args g = liftIO $
          (["s SATISFIABLE"], _) -> do
            let bs = parseDimacsSolution variables vls
            let r = liftCexBB (map snd shapes) bs
-               argNames = map (Text.unpack . ecShortName . fst) shapes
+               argNames = map (Text.unpack . vnName . fst) shapes
                ecs = map fst shapes
            case r of
              Left msg -> fail $ "Can't parse counterexample: " ++ msg

--- a/saw-central/src/SAWCentral/Prover/Exporter.hs
+++ b/saw-central/src/SAWCentral/Prover/Exporter.hs
@@ -76,7 +76,7 @@ import CryptolSAWCore.Prelude (cryptolModule, scLoadPreludeModule, scLoadCryptol
 import SAWCore.ExternalFormat(scWriteExternal)
 import SAWCore.FiniteValue
 import SAWCore.Module (emptyModule, moduleDecls)
-import SAWCore.Name (mkModuleName, ecShortName)
+import SAWCore.Name (VarName(..), mkModuleName)
 import SAWCore.Prelude (preludeModule)
 import SAWCore.Recognizer (asPi)
 import SAWCore.SATQuery
@@ -139,7 +139,7 @@ proveWithPropExporter exporter path goal =
 writeAIG_SAT ::
   FilePath ->
   SATQuery ->
-  TopLevel [(ExtCns Term, FiniteType)]
+  TopLevel [(VarName, FiniteType)]
 writeAIG_SAT f satq =
   do AIGProxy proxy <- getProxy
      sc <- getSharedContext
@@ -330,7 +330,7 @@ writeCore path t = io $ writeFile path (scWriteExternal t)
 write_verilog :: SharedContext -> FilePath -> Term -> TopLevel ()
 write_verilog sc path t = io $ writeVerilog sc path t
 
-writeVerilogSAT :: FilePath -> SATQuery -> TopLevel [(ExtCns Term, FiniteType)]
+writeVerilogSAT :: FilePath -> SATQuery -> TopLevel [(VarName, FiniteType)]
 writeVerilogSAT path satq = getSharedContext >>= \sc -> io $
   do sym <- newSAWCoreExprBuilder sc False
      -- For SAT checking, we don't care what order the variables are in,
@@ -345,7 +345,7 @@ writeVerilogSAT path satq = getSharedContext >>= \sc -> io $
                    Nothing -> fail $ "writeVerilogSAT: Unsupported argument type " ++ show fot
                    Just ft -> return ft
      let argSValues = map (snd . snd) vars
-     let argSValueNames = zip argSValues (map ecShortName argNames)
+     let argSValueNames = zip argSValues (map vnName argNames)
      argTys' <- traverse f argTys
      let mkInput (v, nm) = map (,nm) <$> flattenSValue sym v
      ins <- concat <$> mapM mkInput argSValueNames

--- a/saw-central/src/SAWCentral/Prover/What4.hs
+++ b/saw-central/src/SAWCentral/Prover/What4.hs
@@ -18,6 +18,7 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           System.IO
 
+import SAWCore.Name (VarName)
 import SAWCore.SharedTerm
 import SAWCore.FiniteValue
 import SAWCore.SATQuery (SATQuery(..))
@@ -184,7 +185,7 @@ setupWhat4_solver :: forall st t ff.
   B.ExprBuilder t st ff {- ^ The glorious sym -}  ->
   SharedContext      {- ^ Context for working with terms -} ->
   SATQuery           {- ^ The query to be proved/checked. -} ->
-  IO ( [ExtCns Term]
+  IO ( [VarName]
      , [W.Labeler (B.ExprBuilder t st ff)]
      , [Pred (B.ExprBuilder t st ff)]
      , Text)

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -250,7 +250,7 @@ import SAWCentral.Yosys.IR
 import SAWCentral.Yosys.Theorem (YosysImport, YosysTheorem)
 import SAWCentral.Yosys.State (YosysSequential)
 
-import SAWCore.Name (ecShortName, DisplayNameEnv, emptyDisplayNameEnv)
+import SAWCore.Name (VarName(..), DisplayNameEnv, emptyDisplayNameEnv)
 import CryptolSAWCore.CryptolEnv as CEnv
 import SAWCore.FiniteValue (FirstOrderValue, ppFirstOrderValue)
 import SAWCore.Rewriter (Simpset, lhsRewriteRule, rhsRewriteRule, ctxtRewriteRule, listRules)
@@ -592,7 +592,7 @@ data BuiltinContext = BuiltinContext { biSharedContext :: SharedContext
 
 data SatResult
   = Unsat SolverStats
-  | Sat SolverStats [(ExtCns Term, FirstOrderValue)]
+  | Sat SolverStats [(VarName, FirstOrderValue)]
   | SatUnknown
     deriving (Show)
 
@@ -604,8 +604,8 @@ showsProofResult opts r =
     UnfinishedProof st  -> showString "Unfinished: " . shows (length (psGoals st)) . showString " goals remaining"
   where
     showVal t = shows (ppFirstOrderValue opts t)
-    showEqn (x, t) = showEC x . showString " = " . showVal t
-    showEC ec = showString (Text.unpack (ecShortName ec))
+    showEqn (x, t) = showVarName x . showString " = " . showVal t
+    showVarName vn = showString (Text.unpack (vnName vn))
 
     showMulti _ [] = showString "]"
     showMulti s (eqn : eqns) = showString s . showEqn eqn . showMulti ", " eqns
@@ -618,8 +618,8 @@ showsSatResult opts r =
     SatUnknown  -> showString "Unknown"
   where
     showVal t = shows (ppFirstOrderValue opts t)
-    showEC ec = showString (Text.unpack (ecShortName ec))
-    showEqn (x, t) = showEC x . showString " = " . showVal t
+    showVarName vn = showString (Text.unpack (vnName vn))
+    showEqn (x, t) = showVarName x . showString " = " . showVal t
     showMulti _ [] = showString "]"
     showMulti s (eqn : eqns) = showString s . showEqn eqn . showMulti ", " eqns
 

--- a/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
+++ b/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
@@ -530,12 +530,12 @@ asFiniteType sc t =
              scPrettyTerm PPS.defaultOpts t
 
 processVar ::
-  (ExtCns Term, FirstOrderType) ->
-  IO (ExtCns Term, FiniteType)
-processVar (ec, fot) =
+  (VarName, FirstOrderType) ->
+  IO (VarName, FiniteType)
+processVar (vn, fot) =
   case toFiniteType fot of
     Nothing -> fail ("ABC solver does not support variables of type " ++ show fot)
-    Just ft -> pure (ec, ft)
+    Just ft -> pure (vn, ft)
 
 
 withBitBlastedSATQuery ::
@@ -544,7 +544,7 @@ withBitBlastedSATQuery ::
   SharedContext ->
   PrimMap l g ->
   SATQuery ->
-  (forall s. g s -> l s -> [(ExtCns Term, FiniteType)] -> IO a) ->
+  (forall s. g s -> l s -> [(VarName, FiniteType)] -> IO a) ->
   IO a
 withBitBlastedSATQuery proxy sc addlPrims satq cont =
   do unless (Set.null (satUninterp satq)) $ fail
@@ -554,7 +554,7 @@ withBitBlastedSATQuery proxy sc addlPrims satq cont =
      modmap <- scGetModuleMap sc
      AIG.withNewGraph proxy $ \be ->
        do vars <- traverse (traverse (newVars be)) varShapes
-          let varMap = Map.fromList [ (ecVarIndex ec, v) | (ec,v) <- vars ]
+          let varMap = Map.fromList [ (vnIndex x, v) | (x, v) <- vars ]
           x <- bitBlastBasic be modmap addlPrims varMap t
           case x of
             VBool l -> cont be l varShapes

--- a/saw-core-what4/src/SAWCoreWhat4/What4.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/What4.hs
@@ -1109,11 +1109,11 @@ w4Solve :: forall sym.
   sym ->
   SharedContext ->
   SATQuery ->
-  IO ([(ExtCns Term, (Labeler sym, SValue sym))], [SBool sym])
+  IO ([(VarName, (Labeler sym, SValue sym))], [SBool sym])
 w4Solve sym sc satq =
   do let varList  = Map.toList (satVariables satq)
      vars <- evalStateT (traverse (traverse (newVarFOT sym)) varList) 0
-     let varMap   = Map.fromList [ (ecVarIndex ec, v) | (ec, (_,v)) <- vars ]
+     let varMap   = Map.fromList [ (vnIndex x, v) | (x, (_,v)) <- vars ]
      ref <- newIORef Map.empty
 
      bvals <- mapM (w4SolveAssert sym sc varMap ref (satUninterp satq)) (satAsserts satq)

--- a/saw-core/src/SAWCore/SATQuery.hs
+++ b/saw-core/src/SAWCore/SATQuery.hs
@@ -21,7 +21,7 @@ import SAWCore.SharedTerm
 --   and a collection of @VarIndex@ values identifying
 --   subterms that should be considered uninterpreted.
 --
---   All the @ExtCns@ values in the query should
+--   All the free variables in the query should
 --   appear either in @satVariables@ or @satUninterp@.
 --   Constant values for which definitions are provided
 --   may also appear in @satUninterp@, in which case
@@ -32,11 +32,10 @@ import SAWCore.SharedTerm
 --   and will fail if presented a query that requests them.
 data SATQuery =
   SATQuery
-  { satVariables :: Map (ExtCns Term) FirstOrderType
+  { satVariables :: Map VarName FirstOrderType
       -- ^ The variables in the query, for which we
       --   expect the solver to find values in satisfiable
-      --   cases.  INVARIANT: The type of the @ExtCns@ keys
-      --   should correspond to the @FirstOrderType@ values.
+      --   cases.
 
   , satUninterp  :: Set VarIndex
       -- ^ A set indicating which variables and constant

--- a/saw-core/src/SAWCore/Simulator/RME.hs
+++ b/saw-core/src/SAWCore/Simulator/RME.hs
@@ -439,18 +439,18 @@ bitBlastBasic m addlPrims varMap t = runIdentity $ do
 
 
 processVar ::
-  (ExtCns Term, FirstOrderType) ->
-  IO (ExtCns Term, FiniteType)
-processVar (ec, fot) =
+  (VarName, FirstOrderType) ->
+  IO (VarName, FiniteType)
+processVar (vn, fot) =
   case toFiniteType fot of
     Nothing -> fail ("RME solver does not support variables of type " ++ show fot)
-    Just ft -> pure (ec, ft)
+    Just ft -> pure (vn, ft)
 
 withBitBlastedSATQuery ::
   SharedContext ->
   Map Ident RPrim ->
   SATQuery ->
-  (RME -> [(ExtCns Term, FiniteType)] -> IO a) ->
+  (RME -> [(VarName, FiniteType)] -> IO a) ->
   IO a
 withBitBlastedSATQuery sc addlPrims satq cont =
   do unless (Set.null (satUninterp satq)) $ fail
@@ -459,7 +459,7 @@ withBitBlastedSATQuery sc addlPrims satq cont =
      varShapes <- mapM processVar (Map.toList (satVariables satq))
      modmap <- scGetModuleMap sc
      let vars = evalState (traverse (traverse newVars) varShapes) 0
-     let varMap = Map.fromList [ (ecVarIndex ec, v) | (ec,v) <- vars ]
+     let varMap = Map.fromList [ (vnIndex x, v) | (x, v) <- vars ]
      let bval = bitBlastBasic modmap addlPrims varMap t
      case bval of
        VBool anf -> cont anf varShapes

--- a/saw-server/src/SAWServer/ProofScript.hs
+++ b/saw-server/src/SAWServer/ProofScript.hs
@@ -48,7 +48,7 @@ import SAWServer.Exceptions ( notASimpset )
 import SAWServer.OK ( OK, ok )
 import SAWServer.TopLevel ( tl )
 import SAWCore.FiniteValue (FirstOrderValue(..))
-import SAWCore.Name (ecShortName)
+import SAWCore.Name (VarName(..))
 import SAWCore.Rewriter (emptySimpset)
 import SAWCore.TermNet (merge)
 
@@ -273,11 +273,11 @@ prove params = do
       return ProofValid
     PF.InvalidProof _ cex _ ->
       do cexVals <- forM cex $
-                      \(ec, v) ->
+                      \(x, v) ->
                          do e <- case exportFirstOrderExpression v of
                                    Left err -> throw $ ProveException err
                                    Right e -> return e
-                            return $ CexValue (ecShortName ec) e
+                            return $ CexValue (vnName x) e
          return $ ProofInvalid $ cexVals
     PF.UnfinishedProof{} ->
       return ProofUnknown


### PR DESCRIPTION
The type information on the `ExtCns` was redundant with the `FirstOrderType`, and was almost never used anyway.

This also contributes to the phasing out of the `ExtCns` type (#2332).