### PR TITLE
cryptol-saw-core: Rename TypedExtCns to TypedVariable

### DIFF
--- a/crucible-mir-comp/src/Mir/Compositional/Builder.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Builder.hs
@@ -45,6 +45,7 @@ import Lang.Crucible.Backend
 import Lang.Crucible.Simulator
 import Lang.Crucible.Types
 
+import qualified SAWCore.Name as SAW (VarName(..))
 import qualified SAWCore.Recognizer as SAW (asVariable)
 import qualified SAWCore.SharedTerm as SAW
 import qualified SAWCoreWhat4.ReturnTrip as SAW
@@ -569,10 +570,10 @@ finish msb =
     eval = msb ^. msbEval
 
     evalVar :: forall tp.
-        W4.ExprBoundVar t tp -> IO SAW.TypedExtCns
+        W4.ExprBoundVar t tp -> IO SAW.TypedVariable
     evalVar var = do
         tt <- eval (W4.BoundVarExpr var) >>= SAW.mkTypedTerm sc
-        case SAW.asTypedExtCns tt of
+        case SAW.asTypedVariable tt of
             Just x -> return x
             Nothing -> error $ "BoundVarExpr translated to non-ExtCns term? " ++ show tt
 
@@ -612,7 +613,7 @@ substMethodSpec sc sm ms = do
         pointsTos' <- mapM goPointsTo $ ss ^. MS.csPointsTos
         conditions' <- mapM goSetupCondition $ ss ^. MS.csConditions
         let freshVars' =
-                filter (\tec -> not $ IntMap.member (SAW.ecVarIndex $ SAW.tecExt tec) sm) $
+                filter (\tv -> not $ IntMap.member (SAW.vnIndex $ SAW.tvName tv) sm) $
                     ss ^. MS.csFreshVars
         return $ ss
             & MS.csPointsTos .~ pointsTos'

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -1647,10 +1647,10 @@ lambdas :: [TypedTerm] -> TypedTerm -> TopLevel TypedTerm
 lambdas vars tt =
   do tecs <- traverse checkVar vars
      sc <- getSharedContext
-     io $ abstractTypedExts sc tecs tt
+     io $ abstractTypedVars sc tecs tt
   where
     checkVar v =
-      case asTypedExtCns v of
+      case asTypedVariable v of
         Just tec -> pure tec
         Nothing -> fail "lambda: argument not a valid symbolic variable"
 
@@ -1665,16 +1665,16 @@ implies_term x y =
 
 generalize_term :: [TypedTerm] -> TypedTerm -> TopLevel TypedTerm
 generalize_term vars tt =
-  do tecs <- traverse checkVar vars
+  do tvs <- traverse checkVar vars
      sc <- getSharedContext
-     tm <- io $ scGeneralizeExts sc (map tecExt tecs) (ttTerm tt)
+     tm <- io $ scPiList sc (map (\tv -> (tvName tv, tvType tv)) tvs) (ttTerm tt)
      _tp <- io $ scTypeCheckError sc tm -- sanity check the term
      io $ mkTypedTerm sc tm
 
   where
     checkVar v =
-      case asTypedExtCns v of
-        Just tec -> pure tec
+      case asTypedVariable v of
+        Just tv -> pure tv
         Nothing -> fail "generalize_term: argument not a valid symbolic variable"
 
 -- | Apply the given Term to the given values, and evaluate to a

--- a/saw-central/src/SAWCentral/Crucible/Common/MethodSpec.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/MethodSpec.hs
@@ -406,7 +406,7 @@ data StateSpec ext = StateSpec
     -- ^ points-to statements
   , _csConditions    :: [SetupCondition ext]
     -- ^ equality, propositions, and ghost-variable conditions
-  , _csFreshVars     :: [TypedExtCns]
+  , _csFreshVars     :: [TypedVariable]
     -- ^ fresh variables created in this state
   , _csVarTypeNames  :: !(Map AllocIndex (TypeName ext))
     -- ^ names for types of variables, for diagnostics

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -786,10 +786,10 @@ verifyPoststate cc mspec env0 globals ret mdMap =
      let ecs0 = IntMap.fromList
            [ (ecVarIndex ec, ec)
            | tt <- mspec ^. MS.csPreState . MS.csFreshVars
-           , let ec = tecExt tt ]
+           , let ec = EC (tvName tt) (tvType tt) ]
      terms0 <- io $ traverse (scVariable sc) ecs0
 
-     let initialFree = Set.fromList (map (ecVarIndex . tecExt)
+     let initialFree = Set.fromList (map (vnIndex . tvName)
                                     (view (MS.csPostState . MS.csFreshVars) mspec))
      matchPost <- io $
           runOverrideMatcher sym globals env0 terms0 initialFree poststateLoc $

--- a/saw-central/src/SAWCentral/Crucible/JVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Override.hs
@@ -95,6 +95,7 @@ import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Some (Some(Some))
 
 -- saw-core
+import           SAWCore.Name (VarName(..))
 import           SAWCore.SharedTerm
 import           CryptolSAWCore.TypedTerm
 
@@ -204,7 +205,7 @@ methodSpecHandler opts sc cc top_loc _mdMap css h =
     do g0 <- Crucible.readGlobals
        forM css $ \cs -> liftIO $
          let initialFree =
-               Set.fromList (cs ^.. MS.csPreState. MS.csFreshVars . each . to tecExt . to ecVarIndex)
+               Set.fromList (cs ^.. MS.csPreState. MS.csFreshVars . each . to tvName . to vnIndex)
           in runOverrideMatcher sym g0 Map.empty IntMap.empty initialFree (view MS.csLoc cs)
                       (do methodSpecHandler_prestate opts sc cc args cs
                           return cs)

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
@@ -121,6 +121,7 @@ import           Data.Parameterized.NatRepr
 import           Data.Parameterized.Some (Some(..))
 import qualified Data.BitVector.Sized as BV
 
+import           SAWCore.Name (VarName(..))
 import           SAWCore.SCTypeCheck (scTypeCheckWHNF)
 import           SAWCore.SharedTerm
 import           SAWCore.Recognizer
@@ -334,7 +335,7 @@ methodSpecHandler opts sc cc mdMap css h =
   prestates <-
     do g0 <- Crucible.readGlobals
        forM css $ \cs -> liftIO $
-         let initialFree = Set.fromList (map (ecVarIndex . tecExt)
+         let initialFree = Set.fromList (map (vnIndex . tvName)
                                            (view (MS.csPreState . MS.csFreshVars) cs))
           in runOverrideMatcher sym g0 Map.empty IntMap.empty initialFree (view MS.csLoc cs)
                       (do methodSpecHandler_prestate opts sc cc args cs

--- a/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
@@ -1498,9 +1498,9 @@ assertPost path func env premem preregs mdMap = do
     initialECs = IntMap.fromList
       [ (ecVarIndex ec, ec)
       | tt <- ms ^. MS.csPreState . MS.csFreshVars
-      , let ec = tecExt tt
+      , let ec = EC (tvName tt) (tvType tt)
       ]
-    initialFree = Set.fromList . fmap (ecVarIndex . tecExt) $ ms ^. MS.csPostState . MS.csFreshVars
+    initialFree = Set.fromList . fmap (vnIndex . tvName) $ ms ^. MS.csPostState . MS.csFreshVars
 
   initialTerms <- liftIO $ traverse (scVariable sc) initialECs
 

--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -75,6 +75,7 @@ import qualified What4.LabeledPred as W4
 import qualified What4.Partial as W4
 import qualified What4.ProgramLoc as W4
 
+import SAWCore.Name (VarName(..))
 import SAWCore.SharedTerm
 import SAWCoreWhat4.ReturnTrip (saw_ctx, toSC)
 import CryptolSAWCore.TypedTerm
@@ -1699,7 +1700,7 @@ methodSpecHandler opts sc cc mdMap css h =
   prestates <-
     do g0 <- Crucible.readGlobals
        forM css $ \cs -> liftIO $
-         let initialFree = Set.fromList (map (ecVarIndex . tecExt)
+         let initialFree = Set.fromList (map (vnIndex . tvName)
                                            (view (MS.csPreState . MS.csFreshVars) cs))
           in runOverrideMatcher sym g0 Map.empty IntMap.empty initialFree (view MS.csLoc cs)
                       (do methodSpecHandler_prestate opts sc cc args cs


### PR DESCRIPTION
This is another step in the phasing out of the `ExtCns` type (#2332).