### PR TITLE
saw-core: Switch from ExtCns to VarName in SATAssert and SATResult.

### DIFF
--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -1959,9 +1959,9 @@ sequentToSATQuery sc unintSet sqt =
                 let tp' = tp
                 case evalFOT mmap tp' of
                   Just fot ->
-                    processUnivAssert mmap ((EC nm tp, fot) : vars) xs body
+                    processUnivAssert mmap ((nm, fot) : vars) xs body
                   Nothing
-                    | IntSet.null (foldr IntSet.delete (freeVars body) (map (ecVarIndex . fst) vars)) ->
+                    | IntSet.null (foldr IntSet.delete (freeVars body) (map (vnIndex . fst) vars)) ->
                       case asEqTrue tp' of
                         Just x  -> processUnivAssert mmap vars (x:xs) body
                         Nothing ->


### PR DESCRIPTION
This is a follow-up to #2725 (and probably should have been part of it). It makes more progress toward #2332.