### PR TITLE
Fix detection of JVMSetup errors

### DIFF
--- a/intTests/test_jvm_setup_errors/test.saw
+++ b/intTests/test_jvm_setup_errors/test.saw
@@ -597,7 +597,7 @@ check_fails test "get"
   };
 
 print "jvm_return missing when one was expected";
-KNOWN_FALSE_POSITIVE test "get"
+check_fails test "get"
   do {
     this <- jvm_alloc_object "Test";
     val <- jvm_fresh_var "val" java_long;


### PR DESCRIPTION
All of the known false positives in `test_jvm_setup_errors` are now detected correctly. Fixes #938 and #946.

Issue #2506 is fixed just for JVM; a similar fix should be applied to the corresponding LLVM and MIR commands.