### PR TITLE
parser: parse type applications left-associatively

### DIFF
--- a/intTests/test_type_errors/err034.log.good
+++ b/intTests/test_type_errors/err034.log.good
@@ -1,15 +1,1 @@
  Loading file "err034.saw"
- err034.saw:7:28-7:36: Type mismatch.
-    Mismatch of type constructors. Expected: <Block> but got Int
-    err034.saw:7:18-7:25: The type Int Int arises from this type annotation
-    err034.saw:7:35-7:36: The type Int arises from the type of this term
-
-    Expected: Int Int
-    Found:    Int
-
-    Expected: TopLevel (Int Int)
-    Found:    t.2 Int
-
-    within "x" (err034.saw:7:5-7:6)
-
-FAILED

--- a/intTests/test_type_errors/err034.saw
+++ b/intTests/test_type_errors/err034.saw
@@ -1,7 +1,7 @@
 //
 // Too many arguments for type constructor: monads
 //
-// Currently this trips on `Block`; the desired kind mismatch message in
-// the typechecker is unreachable.
+// This should produce a kind mismatch error, but currently does not produce any
+// error at all.
 
 let x : TopLevel Int Int = return 0;

--- a/saw-script/src/SAWScript/Parser.y
+++ b/saw-script/src/SAWScript/Parser.y
@@ -226,7 +226,7 @@ Type :: { Type }
 
 AppliedType :: { Type }
  : BaseType                             { $1                            }
- | BaseType AppliedType                 { tBlock (maxSpan' $1 $2) $1 $2 }
+ | AppliedType BaseType                 { tBlock (maxSpan' $1 $2) $1 $2 }
 
 -- special case of function type that can be followed by more base types
 -- without requiring parens


### PR DESCRIPTION
Fixes #2755.

The change in `err034.saw`'s behavior is unfortunate, but I think it's a natural consequence of SAW's lack of kind checking. I've opened #2764 for this.