### PR TITLE
SAWScript: Prohibit redefining types with `typedef`

### DIFF
--- a/intTests/test_type_errors/err061.log.good
+++ b/intTests/test_type_errors/err061.log.good
@@ -1,0 +1,3 @@
+ Loading file "err061.saw"
+ err061.saw:4:1-4:19: Redefinition of type Foo
+FAILED

--- a/intTests/test_type_errors/err061.saw
+++ b/intTests/test_type_errors/err061.saw
@@ -1,0 +1,4 @@
+// multiple typedefs of the same name are illegal
+
+typedef Foo = Int;
+typedef Foo = Bool;

--- a/intTests/test_type_errors/err062.log.good
+++ b/intTests/test_type_errors/err062.log.good
@@ -1,0 +1,3 @@
+ Loading file "err062.saw"
+ err062.saw:3:1-3:23: Redefinition of type JVMValue
+FAILED

--- a/intTests/test_type_errors/err062.saw
+++ b/intTests/test_type_errors/err062.saw
@@ -1,0 +1,3 @@
+// typedefing over a builtin abstract type is illegal
+
+typedef JVMValue = Int;

--- a/intTests/test_type_errors/err063.log.good
+++ b/intTests/test_type_errors/err063.log.good
@@ -1,0 +1,3 @@
+ Loading file "err063.saw"
+ err063.saw:4:1-4:29: Redefinition of type __DEPRECATED__ (which is not currently visible)
+FAILED

--- a/intTests/test_type_errors/err063.saw
+++ b/intTests/test_type_errors/err063.saw
@@ -1,0 +1,4 @@
+// typedefing over a builtin abstract type is illegal
+// (even if the type isn't visible)
+
+typedef __DEPRECATED__ = Int;


### PR DESCRIPTION
Closes #2775.

