### PR TITLE
cryptol-saw-core: Avoid generating unnecessary coercions in importer.

### DIFF
--- a/saw-core/src/SAWCore/Term/Certified.hs
+++ b/saw-core/src/SAWCore/Term/Certified.hs
@@ -13,6 +13,8 @@ module SAWCore.Term.Certified
   , rawType
   , scTypeCheckWHNF
   , scTypeOf
+  , scTypeConvertible
+  , scSubtype
   , scWHNF
     -- * Building certified terms
   , scApply


### PR DESCRIPTION
Since rewritingSharedContext was removed (#2684), there are now more opportunities to see imported Cryptol types involving type- level numerals that are convertible but not syntactically equal. We now do a convertibility/subtype check instead of just an equality check to decide whether a coercion is necessary for type correctness.