### PR TITLE
cryptol-saw-core: Add `natConversions` to Cryptol simpset.

### DIFF
--- a/cryptol-saw-core/src/CryptolSAWCore/Simpset.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Simpset.hs
@@ -13,6 +13,7 @@ module CryptolSAWCore.Simpset
   ( mkCryptolSimpset
   ) where
 
+import SAWCore.Conversion (natConversions)
 import SAWCore.Module (moduleDefs, Def(..))
 import SAWCore.Name
 import SAWCore.Rewriter
@@ -30,7 +31,7 @@ import SAWCore.SharedTerm
 mkCryptolSimpset :: SharedContext -> IO (Simpset a)
 mkCryptolSimpset sc =
   do m <- scFindModule sc cryptolModuleName
-     scSimpset sc (cryptolDefs m) idents []
+     scSimpset sc (cryptolDefs m) idents natConversions
   where
     cryptolDefs m = filter (not . excluded) $ moduleDefs m
     excluded d =


### PR DESCRIPTION
The cryptol importer generates various operations on type-level nats, but since rewritingSharedContext was removed (#2684), cryptol_ss has not been able to reduce these completely.

Fixes #2793.