### PR TITLE
saw-central: Revert back to rewriteSharedTerm in ResolveSetupValue.

### DIFF
--- a/saw-central/src/SAWCentral/Crucible/Common/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/ResolveSetupValue.hs
@@ -29,7 +29,7 @@ import SAWCoreWhat4.ReturnTrip
 import SAWCentral.Crucible.Common
 
 import SAWCentral.Proof (TheoremNonce)
-import SAWCore.Rewriter (Simpset, rewriteSharedTermTypeSafe)
+import SAWCore.Rewriter (Simpset, rewriteSharedTerm)
 import SAWCoreWhat4.What4(w4EvalAny, valueToSymExpr)
 
 import Cryptol.TypeCheck.Type (tIsBit, tIsSeq, tIsNum)
@@ -94,7 +94,7 @@ resolveTerm sym unint bt rr tm =
   basicRewrite sc =
     case rrBasicSS rr of
       Nothing -> pure
-      Just ss -> \t -> snd <$> rewriteSharedTermTypeSafe sc ss t
+      Just ss -> \t -> snd <$> rewriteSharedTerm sc ss t
 
   checkType sc =
     do


### PR DESCRIPTION
This is a quick fix to get intTests/test_hash_table working again, after a bad interaction between PRs #2750 and #2797 caused a failure in the merge commit. This PR reverts a small part of #2750.