### PR TITLE
Revert "saw-central: Revert back to rewriteSharedTerm in ResolveSetupValue."

### DIFF
--- a/saw-central/src/SAWCentral/Crucible/Common/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/ResolveSetupValue.hs
@@ -29,7 +29,7 @@ import SAWCoreWhat4.ReturnTrip
 import SAWCentral.Crucible.Common
 
 import SAWCentral.Proof (TheoremNonce)
-import SAWCore.Rewriter (Simpset, rewriteSharedTerm)
+import SAWCore.Rewriter (Simpset, rewriteSharedTermTypeSafe)
 import SAWCoreWhat4.What4(w4EvalAny, valueToSymExpr)
 
 import Cryptol.TypeCheck.Type (tIsBit, tIsSeq, tIsNum)
@@ -94,7 +94,7 @@ resolveTerm sym unint bt rr tm =
   basicRewrite sc =
     case rrBasicSS rr of
       Nothing -> pure
-      Just ss -> \t -> snd <$> rewriteSharedTerm sc ss t
+      Just ss -> \t -> snd <$> rewriteSharedTermTypeSafe sc ss t
 
   checkType sc =
     do


### PR DESCRIPTION
This PR reverts commit 6ccb58dbc3760c50208fe8c0bc7c651f72fde84a (#2805), reinstating the use of `rewriteSharedTermTypeSafe` from #2750 that had previously caused a CI failure. Now that #2806 is merged, `rewriteSharedTermTypeSafe` works successfully once more.
