### PR TITLE
Remove "{{{" and "}}}" from comments.

### DIFF
--- a/examples/ecdsa/cryptol-spec/ec_point_ops.cry
+++ b/examples/ecdsa/cryptol-spec/ec_point_ops.cry
@@ -62,7 +62,7 @@ ec_jacobian_eq(f, a, b)
 	bz2 = f.sq(b.z)
 	bz3 = f.mul(b.z, bz2)
 
-/* Point operations {{{1 */
+/* Point operations */
 
 type PointOps fv gv = {
        field : FieldRep fv

--- a/examples/ecdsa/cryptol-spec/ecc.cry
+++ b/examples/ecdsa/cryptol-spec/ecc.cry
@@ -11,7 +11,7 @@ import p384_field
 import p384_ec_point_ops
 import p384_ec_mul
 
-/* Scalar multiply operations {{{1 */
+/* Scalar multiply operations */
 
 
 test_params : ([384], AffinePoint [384], [384], AffinePoint [384])
@@ -27,7 +27,7 @@ test_params =
     , y=0x4d6b2b937c85b3c0c3cd2df85e9307cc89e0093f336af3b4531aa126bbdbec466562d8aa0dc1cf360fc1f1d0951e3ad1
     })
 
-/* ECDSA Operations {{{1 */
+/* ECDSA Operations */
 
 /** Operations for ECDSA abstraction layer */
 type Curve fv gv = {
@@ -120,9 +120,9 @@ ecdsa_public_verify_imp(c, e, (r, s), q)
     carrybits = (sum < r) && (sum < p384_group_size)
     k = f.mul(sum, r2zsq)
 
-/* P384 reference definitions {{{1 */
+/* P384 reference definitions */
 
-/* Utility functions {{{2 */
+/* Utility functions */
 
 type RsltWithCarry a b = { carrybits : a , rslt : b }
 
@@ -138,17 +138,17 @@ p384_decFieldPrime x = { carrybits = if (bs @ 0) then -1 else 0
                        }
   where bs = safe_sub(x, p384_prime)
 
-/* P384 modular arithmetic definitions. {{{2 */
+/* P384 modular arithmetic definitions. */
 
 
-/* P384 field definitions. {{{2 */
+/* P384 field definitions. */
 
 
 p384_field_cube(x)       = p384_field_mul(x, p384_field_sq(x))
 
-/* P384 group field operations {{{2 */
+/* P384 group field operations */
 
-/** P384 curve operations {{{2 */
+/** P384 curve operations */
 
 p384_base : AffinePoint [384]
 p384_base = nzAffinePoint(
@@ -179,7 +179,7 @@ p384_ecdsa_public_verify : ([384], [384], [384], AffinePoint [384]) -> Bit
 p384_ecdsa_public_verify(e,pr,ps,q) =
   ecdsa_public_verify_imp(p384_curve,e,(pr,ps),q)
 
-/* P384 test code {{{2 */
+/* P384 test code */
 
 /* Curve "a" parameter, defined in [FIPS-186-3, page 87] to be -3 */
 p384_a : [384]
@@ -215,6 +215,6 @@ p384_is_affine_point p =
   p384_field_add(p384_field_cube(p.x),
                  p384_field_add(p384_field_mul(p384_a, p.x), p384_b))
 
-/* P384 implementation curve definition {{{1 */
+/* P384 implementation curve definition */
 
-/* Chunked arithmetic routines {{{2 */
+/* Chunked arithmetic routines */

--- a/examples/ecdsa/src/com/galois/ecc/ECCProvider.java
+++ b/examples/ecdsa/src/com/galois/ecc/ECCProvider.java
@@ -9,14 +9,14 @@ Copyright 2012 Galois, Inc.  All rights reserved.
 
 package com.galois.ecc;
 
-// Class definition {{{1
+// Class definition
 
 /**
  * Abstract class that provides Elliptic Curve cryptography services
  * for a particular curve.
  */
 public abstract class ECCProvider {
-  // Constants {{{2
+  // Constants
 
   /**
    * Number of elements required in array for storing field and group values.
@@ -53,7 +53,7 @@ public abstract class ECCProvider {
    */
   protected final int[] group_order;
 
-  // Intermediate values {{{2
+  // Intermediate values
   private int[] h;
   private int[] t1;
   private int[] t2;
@@ -72,7 +72,7 @@ public abstract class ECCProvider {
    */
   private final AffinePoint qPoint;
 
-  // Constructor and cleanup operations {{{2
+  // Constructor and cleanup operations
 
   /**
    * Construct a new ECCProvider given the constants for configuration.
@@ -151,7 +151,7 @@ public abstract class ECCProvider {
     qPoint.clear();
   }
 
-  // Static large word operations {{{2
+  // Static large word operations
 
   /** Let w = z -p, and return carry bit. */
   static private boolean is_zero(int[] x) {
@@ -227,8 +227,8 @@ public abstract class ECCProvider {
   public abstract void field_red(int[] z, int[] a);
   public abstract int field_red_aux(int[] z, int[] a);
 
-  // Abstract operations {{{2
-  // Large word operations {{{3
+  // Abstract operations
+  // Large word operations
   /**
    * Assigns z = x + y, and returns carry bit.
    */
@@ -249,7 +249,7 @@ public abstract class ECCProvider {
    */
   protected abstract int sub(int[] z, int[] x, int[] y);
 
-  // Field operations {{{3
+  // Field operations
 
   /**
    * Assigns x = x - field_prime, and returns carry value (0 or -1).
@@ -279,7 +279,7 @@ public abstract class ECCProvider {
    */
   protected abstract void group_mul(int[] r, int[] x, int[] y);
 
-  // Predefined field operations {{{2
+  // Predefined field operations
   /**
    * Assigns z = x + y (mod field_prime).
    */
@@ -380,7 +380,7 @@ public abstract class ECCProvider {
     if (c != 0 || leq(group_order, z)) sub(z, z, group_order);
   }
 
-  // Generic field operations {{{2
+  // Generic field operations
 
   /**
    * Assigns z = x - y (mod p).
@@ -442,7 +442,7 @@ public abstract class ECCProvider {
     if (swapped) assign(rb, ra);
   }
 
-  // Point operations {{{2
+  // Point operations
 
   /**
    * Assigns r the point represented by s.
@@ -971,7 +971,7 @@ public abstract class ECCProvider {
       }
     }
 
-  // ECDSA operations {{{2
+  // ECDSA operations
   /**
    * Attempt to sign a given hash using a randomly generated ephermeral key.
    * The signing attempt may fail with probability <code>2/group_order</code>.
@@ -1167,5 +1167,4 @@ public abstract class ECCProvider {
     cleanup();
     return false;
   }
-  // }}}2
 }

--- a/examples/ecdsa/src/com/galois/ecc/NISTCurveFactory.java
+++ b/examples/ecdsa/src/com/galois/ecc/NISTCurveFactory.java
@@ -10,7 +10,7 @@ Copyright 2012 Galois, Inc.  All rights reserved.
 
 package com.galois.ecc;
 
-// NIST32 subclass {{{1
+// NIST32 subclass
 
 /**
  * Defines arithmetic routines for ECC over prime fields using only 32-bit
@@ -49,7 +49,7 @@ abstract class NIST32 extends ECCProvider {
     super.cleanup();
   }
 
-  // Bitvector operations {{{3
+  // Bitvector operations
   static final int INT_MASK = 0xFFFF;
 
   protected int add(int[] z, int[] x, int[] y) {
@@ -303,7 +303,7 @@ abstract class NIST32 extends ECCProvider {
     return c;
   }
 
-  // Underlying field operations {{{3
+  // Underlying field operations
 
   protected void field_mul(int[] z, int[] x, int[] y) {
     imul(a, 0, x, 0, y, 0, x.length);
@@ -315,7 +315,7 @@ abstract class NIST32 extends ECCProvider {
     field_red(z, a);
   }
 
-  // Group Field operations {{{3
+  // Group Field operations
 
   /**
    * Reduces bit vector (r + x * (2 ** 384)) modulo group_order
@@ -381,7 +381,7 @@ abstract class NIST32 extends ECCProvider {
   }
 }
 
-// NIST64 subclass {{{1
+// NIST64 subclass
 
 /**
  * Defines arithmetic routines for ECC over prime fields using a mix of
@@ -409,7 +409,7 @@ abstract class NIST64 extends ECCProvider {
     super.cleanup();
   }
 
-  // Bitvector operations {{{2
+  // Bitvector operations
 
   static final long LONG_MASK = 0xFFFFFFFFL;
 
@@ -564,7 +564,7 @@ abstract class NIST64 extends ECCProvider {
     return (int) b;
   }
 
-  // Underlying field operations {{{2
+  // Underlying field operations
 
   protected void field_mul(int[] z, int[] x, int[] y) {
     mul(a, x, y);
@@ -576,7 +576,7 @@ abstract class NIST64 extends ECCProvider {
     field_red(z, a);
   }
 
-  // Underlying group scalar operations {{{3
+  // Underlying group scalar operations
 
   private long group_red_aux(int[] r, int aj, int j, long c, long b) {
     long m = c * (aj & LONG_MASK);
@@ -645,7 +645,7 @@ abstract class NIST64 extends ECCProvider {
   }
 }
 
-// P384 specific constants {{{1
+// P384 specific constants
 
 /**
  * Defines constants for P384 curve used by both 32 and 64-bit implementations.
@@ -668,7 +668,7 @@ class P384Constants {
       0x289a147c, 0xf8f41dbd, 0x9292dc29, 0x5d9e98bf, 0x96262c6f, 0x3617de4a });
 }
 
-// P384ECC32 subclass {{{1
+// P384ECC32 subclass
 class P384ECC32 extends NIST32 {
 
   P384ECC32() {
@@ -884,7 +884,7 @@ class P384ECC32 extends NIST32 {
   }
 }
 
-// P384ECC64 subclass {{{1
+// P384ECC64 subclass
 class P384ECC64 extends NIST64 {
   P384ECC64() {
     super(12,
@@ -1057,7 +1057,7 @@ class P384ECC64 extends NIST64 {
   }
 }
 
-// NISTCurveFactory {{{1
+// NISTCurveFactory
 
 /**
  * Provides static methods for constructing <code>ECCProviders</code>

--- a/saw-central/src/SAWCentral/AST.hs
+++ b/saw-central/src/SAWCentral/AST.hs
@@ -57,7 +57,7 @@ import           Prettyprinter (Pretty)
 import qualified Cryptol.Parser.AST as P (ImportSpec(..), ModName)
 import qualified Cryptol.Utils.Ident as P (identText, modNameChunks)
 
--- Lifecycle / Deprecation {{{
+-- Lifecycle / Deprecation
 
 -- | Position in the life cycle of a primitive.
 data PrimitiveLifecycle
@@ -78,15 +78,13 @@ everythingAvailable = Set.fromList [minBound .. maxBound]
 defaultAvailable :: Set PrimitiveLifecycle
 defaultAvailable = Set.fromList [Current, WarnDeprecated]
 
--- }}}
 
--- Names {{{
+-- Names
 
 type Name = Text
 
--- }}}
 
--- Expr Level {{{
+-- Expr Level
 
 data Import = Import
   { iIsSubmodule :: Bool
@@ -221,9 +219,8 @@ data Decl
 instance Positioned Decl where
   getPos = dPos
 
--- }}}
 
--- Type Level {{{
+-- Type Level
 
 -- | Type for the hardwired monad types. Note that these days the
 --   @LLVMSetup@, @JVMSetup@, and @MIRSetup@ monad types are ordinary
@@ -305,10 +302,9 @@ data SchemaPattern = SchemaPattern [(Pos, Name)] [Type]
 -- carry the kind information.
 data NamedType = ConcreteType Type | AbstractType Kind
 
--- }}}
 
 ------------------------------------------------------------
--- Kinds {{{
+-- Kinds
 
 --
 -- For the time being we can handle kinds using the number of expected
@@ -339,10 +335,7 @@ instance PPS.PrettyPrec Kind where
      PP.viaShow $ intercalate " -> " $ genericReplicate (n + 1) "*"
 
 
--- }}}
-
-
--- Pretty Printing {{{
+-- Pretty Printing
 
 prettyWholeModule :: [Stmt] -> PP.Doc ann
 prettyWholeModule = (PP.<> PP.line') . vcatWithSemi . map PP.pretty
@@ -532,9 +525,8 @@ instance PPS.PrettyPrec NamedType where
     ConcreteType ty' -> PPS.prettyPrec par ty'
     AbstractType kind -> "<opaque " PP.<> PPS.prettyPrec 0 kind PP.<> ">"
 
--- }}}
 
--- Type Constructors {{{
+-- Type Constructors
 
 tMono :: Type -> Schema
 tMono = Forall []
@@ -596,9 +588,8 @@ tContext pos c = TyCon pos (ContextCon c) []
 tVar :: Pos -> Name -> Type
 tVar pos n = TyVar pos n
 
--- }}}
 
--- Type Classifiers {{{
+-- Type Classifiers
 
 -- The idea is that calling these is/should be less messy than direct
 -- pattern matching, and also help a little to avoid splattering the
@@ -612,5 +603,3 @@ isContext ::
 isContext c ty = case ty of
   TyCon _pos (ContextCon c') [] | c' == c -> True
   _ -> False
-
--- }}}

--- a/saw-central/src/SAWCentral/ASTUtil.hs
+++ b/saw-central/src/SAWCentral/ASTUtil.hs
@@ -21,7 +21,7 @@ import SAWCentral.Position
 import SAWCentral.AST
 
 ------------------------------------------------------------
--- NamedTyVars {{{
+-- NamedTyVars
 
 --
 -- namedTyVars is a type-class-polymorphic function for extracting named
@@ -52,7 +52,7 @@ instance NamedTyVars Schema where
 
 
 ------------------------------------------------------------
--- SubstituteTyVars {{{
+-- SubstituteTyVars
 
 --
 -- substituteTyVars is a typeclass-polymorphic function for
@@ -138,11 +138,9 @@ instance SubstituteTyVars' Type where
                     AbstractType _kind -> ty
                     ConcreteType ty' -> ty'
 
--- }}}
-
 
 ------------------------------------------------------------
--- Deprecation {{{
+-- Deprecation
 
 isDeprecated :: PrimitiveLifecycle -> Bool
 isDeprecated lc = case lc of
@@ -150,6 +148,3 @@ isDeprecated lc = case lc of
     WarnDeprecated -> True
     HideDeprecated -> True
     Experimental -> False
-
-
--- }}}

--- a/saw-central/src/SAWCentral/CongruenceClosure.hs
+++ b/saw-central/src/SAWCentral/CongruenceClosure.hs
@@ -47,7 +47,7 @@ import Data.Traversable
 import Prelude hiding (const, mapM)
 
 
--- Functor typeclass extensions {{{1
+-- Functor typeclass extensions
 
 class EqFoldable f where
   -- | Compares equality of arguments.
@@ -63,7 +63,7 @@ class ShowFoldable f where
   fshows :: Show x => f x -> ShowS
   fshows x = (fshow x ++)
 
--- Term {{{1
+-- Term
 
 -- | A term with the given operator.
 newtype Term f = Term { unTerm :: f (Term f) }
@@ -86,12 +86,12 @@ foldTerm :: Functor f => (f r -> r) -> Term f -> r
 foldTerm f = go
   where go (Term x) = f (fmap go x)
 
--- Class {{{1
+-- Class
 
 newtype Class = Class Integer
   deriving (Eq, Ord)
 
--- ClassApp {{{1
+-- ClassApp
 
 newtype ClassApp f = ClassApp (f Class)
 
@@ -101,7 +101,7 @@ instance EqFoldable f => Eq (ClassApp f) where
 instance OrdFoldable f => Ord (ClassApp f) where
   (ClassApp x) `compare` (ClassApp y) = x `fcompare` y
 
--- CCSet {{{1
+-- CCSet
 
 data CCSet f = CC {
          -- | Number of classes added so far.
@@ -201,7 +201,7 @@ fromList = foldl' (flip insertEquivalenceClass) empty
 toList :: OrdFoldable f => CCSet f -> [[Term f]]
 toList = map Set.toList . Set.toList . toSet
 
--- CCSet implementation {{{1
+-- CCSet implementation
 
 -- | Returns a class for term if one exists.
 getExistingClass :: (OrdFoldable f, Traversable f) => CCSet f -> Term f -> Maybe Class

--- a/saw-central/src/SAWCentral/JavaExpr.hs
+++ b/saw-central/src/SAWCentral/JavaExpr.hs
@@ -49,7 +49,7 @@ module SAWCentral.JavaExpr
   , JavaType(..)
   ) where
 
--- Imports {{{2
+-- Imports
 
 import Control.Monad.Trans
 import Control.Monad.Trans.Except
@@ -82,7 +82,7 @@ data MethodLocation
    | LineExact Integer
   deriving (Show)
 
--- JavaExpr {{{1
+-- JavaExpr
 
 data JavaExprF v
   = ReturnVal JSS.Type
@@ -188,7 +188,7 @@ exprDepth _ = 1
 isScalarExpr :: JavaExpr -> Bool
 isScalarExpr = JSS.isPrimitiveType . exprType
 
--- LogicExpr {{{1
+-- LogicExpr
 
 data LogicExpr =
   LogicExpr { -- | A term, possibly function type, which does _not_
@@ -215,7 +215,7 @@ useLogicExpr sc (LogicExpr t _) args = scApplyAll sc t args
 typeOfLogicExpr :: SharedContext -> LogicExpr -> IO Term
 typeOfLogicExpr sc (LogicExpr t _) = scTypeOf sc t
 
--- MixedExpr {{{1
+-- MixedExpr
 
 -- | A logic or Java expression.
 data MixedExpr

--- a/saw-central/src/SAWCentral/Utils.hs
+++ b/saw-central/src/SAWCentral/Utils.hs
@@ -55,7 +55,7 @@ mapInsertKeys keys val m = foldr (\i -> Map.insert i val) m keys
 mapLookupAny :: Ord k => [k] -> Map k a -> Maybe a
 mapLookupAny keys m = listToMaybe $ catMaybes $ map (\k -> Map.lookup k m) keys
 
--- ExecException {{{1
+-- ExecException
 
 -- | Class of exceptions thrown by SBV parser.
 data ExecException = ExecException Pos          -- Position
@@ -73,7 +73,7 @@ throwIOExecException site errorMsg resolution = liftIO $ throwIO (ExecException 
 throwExecException :: Pos -> Doc Void -> String -> m a
 throwExecException site errorMsg resolution = throw (ExecException site errorMsg resolution)
 
--- Timing {{{1
+-- Timing
 
 -- | Return a string representation of the elapsed time since start
 timeIt :: (NFData a, MonadIO m) => m a -> m (a, String)
@@ -99,7 +99,7 @@ showDuration n = printf "%02d:%s" m (show s)
         m :: Int
         m = floor ((toRational n) * (1 % 60))
 
--- Java lookup functions {{{1
+-- Java lookup functions
 
 -- | Atempt to find class with given name, or throw ExecException if no class
 -- with that name exists. Class name should be in slash-separated form.

--- a/saw-script/src/SAWScript/Search.hs
+++ b/saw-script/src/SAWScript/Search.hs
@@ -107,7 +107,7 @@ unifyVarPanic who what =
     panic ("search / " <> who) [what <> " contained a unification var"]
 
 ------------------------------------------------------------
--- Exact matching {{{
+-- Exact matching
 
 -- | Match two types exactly (no alpha equivalence, no substitutions, etc.)
 --
@@ -135,11 +135,9 @@ matchExact ty1 ty2 = case (ty1, ty2) of
     (TyUnifyVar _ _, _) ->
         False
 
--- }}}
-
 
 ------------------------------------------------------------
--- Substitutions {{{
+-- Substitutions
 
 -- | A single match candidate
 --
@@ -230,11 +228,9 @@ data Match = Match {
     mTgtForalls :: Set Name   -- ^ forall-bound tyvars in the match target
  }
 
--- }}}
-
 
 ------------------------------------------------------------
--- Selectivity {{{
+-- Selectivity
 
 -- | Compare two type pattern fragments by how selective they are.
 -- Approximately.
@@ -278,11 +274,9 @@ compareBySelectivity ctx ty1 ty2 =
           TyUnifyVar _pos _x ->
               unifyVarPanic "compareBySelectivity" "pattern"
 
--- }}}
-
 
 ------------------------------------------------------------
--- Full matching {{{
+-- Full matching
 
 -- Match types according to a current substitution, on the assumption
 -- that the target type and pattern must correspond fully.
@@ -401,11 +395,9 @@ matchFullAllPairs ctx cand0 pairs =
           Just cand -> matchFullOnce ctx cand tgtType patType
     in foldr once (Just cand0) pairs
 
--- }}}
-
 
 ------------------------------------------------------------
--- Fragment matching {{{
+-- Fragment matching
 
 -- Match a target type against a pattern, trying to find a subsection
 -- of the target type that the pattern successfully matches. Since in
@@ -468,11 +460,9 @@ matchFragList ctx cand0 tgtType patTypes =
     in
     foldr oneType (Set.singleton cand0) patTypes'
 
--- }}}
-
 
 ------------------------------------------------------------
--- External interface {{{
+-- External interface
 
 -- | Check and compile a type schema pattern.
 --
@@ -516,5 +506,3 @@ matchSearchPattern pattern (Forall tgtForallList tgtType) =
       cands = matchFragList ctx emptyCandidate tgtType (spTypes pattern)
   in
   not $ Set.null cands
-
--- }}}

--- a/saw-script/src/SAWScript/Typechecker.hs
+++ b/saw-script/src/SAWScript/Typechecker.hs
@@ -47,7 +47,7 @@ type TyEnv = Map Name (PrimitiveLifecycle, NamedType)
 
 
 ------------------------------------------------------------
--- UnifyVars {{{
+-- UnifyVars
 
 --
 -- unifyVars is a type-class-polymorphic function for extracting
@@ -86,11 +86,9 @@ instance UnifyVars NamedType where
     ConcreteType ty -> unifyVars ty
     AbstractType _kind -> Map.empty
 
--- }}}
-
 
 ------------------------------------------------------------
--- Substitutions {{{
+-- Substitutions
 
 -- Subst is the type of a substitution map for unification vars.
 newtype Subst = Subst { unSubst :: Map TypeIndex Type } deriving (Show)
@@ -249,11 +247,9 @@ instance AppSubst NamedType where
     ConcreteType ty -> ConcreteType $ appSubst s ty
     AbstractType kind -> AbstractType kind
 
--- }}}
-
 
 ------------------------------------------------------------
--- Context names {{{
+-- Context names
 
 -- Type errors include a "context name" that's typically the name (and
 -- position) of the enclosing function. This should probably be removed
@@ -266,11 +262,9 @@ instance Show ContextName where
   show (ContextName pos name) = show name ++ " (" ++ show pos ++ ")"
 
 
--- }}}
-
 
 ------------------------------------------------------------
--- Pass context {{{
+-- Pass context
 
 --
 -- The monad for this pass is "TI", which is composed of a "readonly"
@@ -477,11 +471,9 @@ patternBindingsWithSchema pat sch =
             concat $ zipWith once ps ts'
           _ -> []
 
--- }}}
-
 
 ------------------------------------------------------------
--- Unification {{{
+-- Unification
 
 --
 -- Error reporting.
@@ -804,11 +796,9 @@ matches t1 t2 = do
     Right _ -> return True
     Left _ -> return False
 
--- }}}
-
 
 ------------------------------------------------------------
--- Inspect for free type variables {{{
+-- Inspect for free type variables
 
 -- We want to allow declaring polymorphic functions by introducing
 -- type variables in the function header (rather than requiring an
@@ -899,11 +889,9 @@ inspectDeclFTVs (Decl _dpos pat _mty e0) = do
     return $ Map.unions [nameFTVs, argFTVs, retFTVs]
 
 
--- }}}
-
 
 ------------------------------------------------------------
--- Main recursive pass {{{
+-- Main recursive pass
 
 type OutExpr = Expr
 type OutStmt = Stmt
@@ -1920,11 +1908,9 @@ checkType kind ty = case ty of
       -- need to do anything.
       return ty
 
--- }}}
-
 
 ------------------------------------------------------------
--- External interface {{{
+-- External interface
 
 -- Some short names for use in the signatures below
 type MsgList = [(Pos, String)]
@@ -2104,8 +2090,6 @@ checkSchemaPattern _avail _env _tenv pat =
     -- to keep this hook and keep knowledge of its internals private
     -- here even though for now it's a nop.
     (Right pat, [])
-
--- }}}
 
 
 {-


### PR DESCRIPTION
These are related to an editor-specific code-folding feature that one of the SAW developers used long ago.