### PR TITLE
Docker CI: Free up some extra disk space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -865,6 +865,18 @@ jobs:
       - name: capture git state in GitRev.hs
         run: ./build.sh gitrev
 
+      - name: Clear up some disk space
+        run: |
+          # The crux-mir-comp Docker image is rather large (~1GB compressed),
+          # and the mere act of building the image requires just over 14 GB of
+          # disk space, which exceeds the maximum provided by a GitHub Action
+          # CI runner. To clear up some extra space, we delete ~10GB worth of
+          # pre-installed GitHub Actions tools, none of which we make use of.
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" # Python installations
+
       - uses: rlespinasse/github-slug-action@v3.x
 
       - id: common-tag


### PR DESCRIPTION
These tools take up about 10GB of extra space. We are just barely exceeding GitHub Action's maximum disk size of 14GB when building the `crux-mir-comp` Docker image, so having some extra disk space would be welcome indeed.

Fixes #2823.