### PR TITLE
Fix scoping of do-blocks in the SAWScript typechecker

### DIFF
--- a/intTests/test_type_errors/err064.log.good
+++ b/intTests/test_type_errors/err064.log.good
@@ -1,0 +1,3 @@
+ Loading file "err064.saw"
+ err064.saw:9:12-9:13: Unbound variable: "x" (err064.saw:9:12-9:13)
+FAILED

--- a/intTests/test_type_errors/err064.saw
+++ b/intTests/test_type_errors/err064.saw
@@ -1,0 +1,13 @@
+// make sure nested do-blocks are scoped
+// (cut-down version of the example from #2824)
+
+let f = do {
+    let g = do {
+        x <- return 42;
+        return ();
+    };
+    return x;
+};
+
+q <- f;
+print q;

--- a/saw-script/src/SAWScript/Typechecker.hs
+++ b/saw-script/src/SAWScript/Typechecker.hs
@@ -1041,7 +1041,10 @@ inferExpr (ln, expr) = case expr of
       ctx <- getFreshTyVar pos
       tyResult <- getFreshTyVar pos
       let ty = tBlock (PosInferred InfTerm pos) ctx tyResult
+      saveVarEnv <- gets varEnv
+      saveTyEnv <- gets tyEnv
       body' <- inferBlock ln pos ctx ty body
+      modify (\rw -> rw { varEnv = saveVarEnv, tyEnv = saveTyEnv })
       return (Block pos body', ty)
 
   Tuple pos es -> do


### PR DESCRIPTION
Closes #2824.
