### PR TITLE
saw-core: Remove tupleConversion and recordConversion.

### DIFF
--- a/saw-central/src/SAWCentral/Prover/Rewrite.hs
+++ b/saw-central/src/SAWCentral/Prover/Rewrite.hs
@@ -64,8 +64,7 @@ basic_ss sc =
          , "bvNat_bvToNat"
          ]
        defs = map (mkIdent (mkModuleName ["Cryptol"])) ["seq", "ecEq", "ecNotEq"]
-       procs = [tupleConversion, recordConversion] ++
-               bvConversions ++ natConversions ++ vecConversions
+       procs = bvConversions ++ natConversions ++ vecConversions
 
 
 

--- a/saw-core/src/SAWCore/Conversion.hs
+++ b/saw-core/src/SAWCore/Conversion.hs
@@ -63,8 +63,6 @@ module SAWCore.Conversion
   , runConversion
   , conversionPat
     -- ** Prelude conversions
-  , tupleConversion
-  , recordConversion
   , natConversions
   , vecConversions
   , bvConversions
@@ -86,14 +84,12 @@ import Control.Monad (guard, liftM2, (>=>), (<=<))
 import Data.Bits
 import qualified Data.Text as Text
 import Data.Map (Map)
-import qualified Data.Map as Map
 import qualified Data.Vector as V
 import Numeric.Natural (Natural)
 
 import SAWCore.Name
 import SAWCore.OpenTerm (OpenTerm)
 import qualified SAWCore.OpenTerm as OT
-import SAWCore.Panic (panic)
 import qualified SAWCore.Prim as Prim
 import SAWCore.Recognizer ((:*:)(..))
 import SAWCore.Prim
@@ -429,24 +425,6 @@ globalConv ident f = convOfMatcher (thenMatcher (asGlobalDef ident) (const (Just
 
 ----------------------------------------------------------------------
 -- Conversions for Prelude operations
-
--- | Conversion for selector on a tuple
-tupleConversion :: Conversion
-tupleConversion = Conversion False $ thenMatcher (asTupleSelector asAnyTupleValue) action
-  where
-    action (ts, i)
-      | i > length ts =
-          panic "SAWCore.tupleConversion" [
-              "index " <> Text.pack (show i) <> " out of bounds; limit is " <>
-                  Text.pack (show $ length ts)
-          ]
-      | otherwise =
-          Just (OT.term (ts !! (i - 1)))
-
--- | Conversion for selector on a record
-recordConversion :: Conversion
-recordConversion = Conversion False $ thenMatcher (asRecordSelector asAnyRecordValue) action
-  where action (m, i) = fmap OT.term (Map.lookup i m)
 
 -- | Conversions for operations on Nat literals
 natConversions :: [Conversion]


### PR DESCRIPTION
These conversions are completely redundant, as the rewriter reduces pair and record redexes automatically.

They also cause a performance problem for the rewriter, because each of these conversions has a matcherPat consisting of just "_", meaning that in a simpset they will try to match *any* subterm.