### PR TITLE
`crucible-mir-comp`: Load `cryptol-saw-core`'s `Cryptol` module consistently

### DIFF
--- a/crucible-mir-comp/src/Mir/Compositional/Override.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Override.hs
@@ -50,6 +50,7 @@ import qualified SAWCore.Name as SAW
 import qualified SAWCore.Prelude as SAW
 import qualified SAWCore.Recognizer as SAW
 import qualified SAWCore.SharedTerm as SAW
+import qualified CryptolSAWCore.Prelude as SAW
 import qualified CryptolSAWCore.TypedTerm as SAW
 
 import qualified SAWCentral.Crucible.Common.MethodSpec as MS
@@ -158,6 +159,7 @@ runSpec myCS mh ms = ovrWithBackend $ \bak ->
 
     sc <- liftIO $ SAW.mkSharedContext
     liftIO $ SAW.scLoadPreludeModule sc
+    liftIO $ SAW.scLoadCryptolModule sc
 
     -- `eval` converts `W4.Expr`s to `SAW.Term`s.  We take what4 exprs from the
     -- context (e.g., in the actual arguments passed to the override) and

--- a/crux-mir-comp/test/symb_eval/comp/crux_spec_for_array.cry
+++ b/crux-mir-comp/test/symb_eval/comp/crux_spec_for_array.cry
@@ -1,0 +1,7 @@
+module test::symb_eval::comp::crux_spec_for_array where
+
+foo : [2][8] -> [2][8]
+foo x = x
+
+goo : [2][8] -> [2][8]
+goo x = foo x

--- a/crux-mir-comp/test/symb_eval/comp/crux_spec_for_array.good
+++ b/crux-mir-comp/test/symb_eval/comp/crux_spec_for_array.good
@@ -1,0 +1,4 @@
+test crux_spec_for_array/<DISAMB>::verification[0]::f_equiv[0]: ok
+test crux_spec_for_array/<DISAMB>::verification[0]::g_equiv[0]: ok
+
+[Crux] Overall status: Valid.

--- a/crux-mir-comp/test/symb_eval/comp/crux_spec_for_array.rs
+++ b/crux-mir-comp/test/symb_eval/comp/crux_spec_for_array.rs
@@ -1,0 +1,58 @@
+// A regression test for #2873. crucible-mir-comp's override machinery needs to
+// load the `Cryptol.seq` identifier when simulating the override arising from
+// `f_equiv()`, and in order for this to work, we need to ensure that
+// crucible-mir-comp loads the contents of cryptol-saw-core's `Cryptol` module
+// beforehand.
+
+pub fn f(x: [u8; 2]) -> [u8; 2] {
+    x
+}
+
+pub fn g(x: [u8; 2]) -> [u8; 2] {
+    f(x)
+}
+
+#[cfg(crux)]
+mod verification {
+    use super::*;
+    extern crate crucible;
+    extern crate crucible_proc_macros;
+    use crucible::{Symbolic, crucible_assert, override_};
+    use crucible::cryptol::uninterp;
+    use crucible_proc_macros::crux_spec_for;
+
+    mod cry {
+        use super::crucible::cryptol;
+        cryptol! {
+            path "test::symb_eval::comp::crux_spec_for_array";
+            pub fn foo(x: [u8; 2]) -> [u8; 2] = r"foo";
+            pub fn goo(x: [u8; 2]) -> [u8; 2] = r"goo";
+        }
+    }
+
+    #[crux_spec_for(f)]
+    pub fn f_equiv() {
+        let x = <[u8; 2]>::symbolic("x");
+        let expected = cry::foo(x);
+        let actual = f(x);
+        crucible_assert!(expected == actual);
+    }
+
+    #[crux::test]
+    pub fn g_equiv() {
+        uninterp("foo");
+
+        f_equiv_spec().enable();
+
+        let x = <[u8; 2]>::symbolic("x");
+        let expected = cry::goo(x);
+        let actual = g(x);
+        crucible_assert!(
+            expected == actual,
+            "x: {:?}, expected: {:?}, actual: {:?}",
+            x,
+            expected,
+            actual,
+        );
+    }
+}


### PR DESCRIPTION
The `Cryptol` SAWCore module from `cryptol-saw-core` was not always being loaded in all `crucible-mir-comp` code paths, which led to the panic seen in issue #2873. Fix this by fixing up the one place in `crucible-mir-comp` that wasn't loading the `Cryptol` module to do so.

Fixes #2873.