### PR TITLE
`cryptol-saw-core`: Typecheck the innermost expression in a list comprehension with a known type

### DIFF
--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -1810,7 +1810,7 @@ importComp sc env lenT elemT expr mss =
      coerceTerm sc env (C.tSeq lenT' elemT) (C.tSeq lenT elemT) ys
 
 lambdaTuples :: SharedContext -> Env -> C.Type -> C.Expr -> [[(C.Name, C.Type)]] -> IO Term
-lambdaTuples sc env _ty expr [] = importExpr sc env expr
+lambdaTuples sc env ty expr [] = importExpr' sc env (C.tMono ty) expr
 lambdaTuples sc env ty expr (args : argss) =
   do f <- lambdaTuple sc env ty expr argss args
      if null args || null argss

--- a/intTests/test2865/test.saw
+++ b/intTests/test2865/test.saw
@@ -1,0 +1,9 @@
+// A regression test for #2865. When converting `f` to SAWCore, we need to
+// insert a coercion around `x # zero` to cast it from type `[n + (8 - n)]` to
+// type `[8]`. This test ensures that that coercion is inserted.
+
+let
+{{
+f : {n} (8 >= n) => [1][n] -> [1][8]
+f xs = [x # zero | x <- xs]
+}};

--- a/intTests/test2865/test.sh
+++ b/intTests/test2865/test.sh
@@ -1,0 +1,3 @@
+set -e
+
+$SAW test.saw


### PR DESCRIPTION
When typechecking `[e | x <- xs] : [n]ty`, we were inferring the type of `e`, which means that if `e`'s type wasn't the same as `ty`, then SAWCore would reject it when building up the type of the overall expression. Inferring `e`'s type is silly, however, as we know that its type should be `ty` in the end. As such, we now check `e : ty` using `importExpr'` (instead of inferring it with `importExpr`), which ensures that we cast `e` to type `ty` with `coerce` if necessary.

Fixes #2865.