### PR TITLE
python: bump urllib3 to at least 2.6.0 for a security notice

### DIFF
--- a/doc/scripts/requirements.txt
+++ b/doc/scripts/requirements.txt
@@ -29,7 +29,7 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
-urllib3==2.5.0
+urllib3==2.6.0
 
 -e ./saw-lexer
 -e ./sphinx-download-dir

--- a/saw-python/poetry.lock
+++ b/saw-python/poetry.lock
@@ -417,23 +417,23 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
-    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
+    {file = "urllib3-2.6.0-py3-none-any.whl", hash = "sha256:c90f7a39f716c572c4e3e58509581ebd83f9b59cced005b7db7ad2d22b0db99f"},
+    {file = "urllib3-2.6.0.tar.gz", hash = "sha256:cb9bcef5a4b345d5da5d145dc3e30834f58e8018828cbc724d30b4cb7d4d49f1"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "d6185e598224ebd708d6c07cfe3d56ab959684431e0b784a677eb93e680240a8"
+content-hash = "d1e2d9cf647cc1690c18a613a2479f8f59079ce487d69b2f1e16757360737ccd"

--- a/saw-python/pyproject.toml
+++ b/saw-python/pyproject.toml
@@ -22,7 +22,7 @@ python-dateutil = "^2.8.2"
 # Add a fake dep on urllib3 (we don't directly depend on it but
 # some of the above packages do) to add a constraint for a security
 # issue.
-urllib3 = ">=2.5.0"
+urllib3 = ">=2.6.0"
 
 [tool.poetry.dev-dependencies]
 mypy = "^1.10"


### PR DESCRIPTION
Supersedes #2880, which is both partial and incorrect.