### PR TITLE
Extend the Crucible timeout setting to MIR and JVM verification

### DIFF
--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -857,7 +857,8 @@ setupCrucibleContext jclass =
      sc <- getSharedContext
      pathSatSolver <- gets rwPathSatSolver
      sym <- io $ newSAWCoreExprBuilder sc False
-     bak <- io $ newSAWCoreBackend pathSatSolver sym
+     timeout <- gets rwCrucibleTimeout
+     bak <- io $ newSAWCoreBackendWithTimeout pathSatSolver sym timeout
      opts <- getOptions
      io $ CJ.setSimulatorVerbosity (simVerbose opts) sym
 

--- a/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
@@ -2124,7 +2124,9 @@ setupCrucibleContext rm =
      sc <- getSharedContext
      pathSatSolver <- gets rwPathSatSolver
      sym <- io $ newSAWCoreExprBuilder sc False
-     someBak@(SomeOnlineBackend bak) <- io $ newSAWCoreBackend pathSatSolver sym
+     timeout <- gets rwCrucibleTimeout
+     someBak@(SomeOnlineBackend bak) <- io $
+           newSAWCoreBackendWithTimeout pathSatSolver sym timeout
      let cs     = rm ^. Mir.rmCS
      let col    = cs ^. Mir.collection
      let cfgMap = rm ^. Mir.rmCFGs

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -3299,10 +3299,9 @@ primitives = Map.fromList $
   , prim "set_crucible_timeout" "Int -> TopLevel ()"
     (pureVal set_crucible_timeout)
     Experimental
-    -- XXX this is ignored by JVM/MIR verification; see #2803
-    [ "Set the timeout for the SMT solver during the LLVM and x86"
-    , "Crucible symbolic execution, in milliseconds. The default is"
-    , "10000 (10 seconds). Set it to 0 to disable the timeout."
+    [ "Set the timeout for the SMT solver during Crucible symbolic"
+    , "execution, in milliseconds. The default is 10000 (10 seconds)."
+    , "Set it to 0 to disable the timeout."
     , ""
     , "This setting is used for path-satisfiability checks and"
     , "satisfiability checks when applying overrides."


### PR DESCRIPTION
Closes #2803.