### PR TITLE
Yosys: Parse (and then ignore) debugging-only cells

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -292,6 +292,9 @@ This release supports [version
 * Fix a bug that would cause `yosys_import` to fail to parse JSON files
   produced using Yosys's `-compat-int` flag.
 
+* `yosys_import` now parses JSON files containing debugging-related cells
+  (e.g., `$scopeinfo`) instead of failing with a parse error.
+
 # Version 1.4 -- 2025-11-18
 
 This release supports [version

--- a/intTests/test2890/Makefile
+++ b/intTests/test2890/Makefile
@@ -1,0 +1,27 @@
+GHDL?=ghdl
+YOSYS?=yosys
+
+all: test.json
+
+test.json: test.vhd
+	$(GHDL) -a $<
+	$(YOSYS) -p 'ghdl add4; flatten; write_json -compat-int test.json'
+	$(MAKE) tidy
+
+.PHONY: tidy
+tidy:
+	rm -f *.o work-obj93.cf
+
+.PHONY: destroy
+destroy: tidy
+	rm -f *.json
+
+# "clean" does nothing here; just make sure it exists.
+# "clean" is for removing test run results, and we don't
+# incur any just by having test blobs.
+#
+# Unfortunately, it looks like we need a dummy rule with an invocation
+# of true to keep gmake from getting upset.
+.PHONY: clean
+clean:
+	@true

--- a/intTests/test2890/test.json
+++ b/intTests/test2890/test.json
@@ -1,0 +1,1874 @@
+{
+  "creator": "Yosys 0.50+111 (git sha1 d1222c57a, aarch64-apple-darwin23.5-clang++ 18.1.8 -fPIC -O3)",
+  "modules": {
+    "add4": {
+      "attributes": {
+      },
+      "ports": {
+        "a": {
+          "direction": "input",
+          "bits": [ 2, 3, 4, 5 ]
+        },
+        "b": {
+          "direction": "input",
+          "bits": [ 6, 7, 8, 9 ]
+        },
+        "res": {
+          "direction": "output",
+          "bits": [ 10, 11, 12, 13 ]
+        }
+      },
+      "cells": {
+        "full0": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "module": "full"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "full0.25": {
+          "hide_name": 0,
+          "type": "$or",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full0 25"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 14 ],
+            "B": [ 15 ],
+            "Y": [ 16 ]
+          }
+        },
+        "full0.half0": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "hdlname": "full0 half0",
+            "module": "half"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "full0.half0.28": {
+          "hide_name": 0,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full0 half0 28"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 2 ],
+            "B": [ 6 ],
+            "Y": [ 14 ]
+          }
+        },
+        "full0.half0.29": {
+          "hide_name": 0,
+          "type": "$xor",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full0 half0 29"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 2 ],
+            "B": [ 6 ],
+            "Y": [ 17 ]
+          }
+        },
+        "full0.half1": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "hdlname": "full0 half1",
+            "module": "half"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "full0.half1.28": {
+          "hide_name": 0,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full0 half1 28"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 17 ],
+            "B": [ "0" ],
+            "Y": [ 15 ]
+          }
+        },
+        "full0.half1.29": {
+          "hide_name": 0,
+          "type": "$xor",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full0 half1 29"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 17 ],
+            "B": [ "0" ],
+            "Y": [ 10 ]
+          }
+        },
+        "full1": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "module": "full"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "full1.25": {
+          "hide_name": 0,
+          "type": "$or",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full1 25"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 18 ],
+            "B": [ 19 ],
+            "Y": [ 20 ]
+          }
+        },
+        "full1.half0": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "hdlname": "full1 half0",
+            "module": "half"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "full1.half0.28": {
+          "hide_name": 0,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full1 half0 28"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "B": [ 7 ],
+            "Y": [ 18 ]
+          }
+        },
+        "full1.half0.29": {
+          "hide_name": 0,
+          "type": "$xor",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full1 half0 29"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "B": [ 7 ],
+            "Y": [ 21 ]
+          }
+        },
+        "full1.half1": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "hdlname": "full1 half1",
+            "module": "half"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "full1.half1.28": {
+          "hide_name": 0,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full1 half1 28"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 21 ],
+            "B": [ 16 ],
+            "Y": [ 19 ]
+          }
+        },
+        "full1.half1.29": {
+          "hide_name": 0,
+          "type": "$xor",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full1 half1 29"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 21 ],
+            "B": [ 16 ],
+            "Y": [ 11 ]
+          }
+        },
+        "full2": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "module": "full"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "full2.25": {
+          "hide_name": 0,
+          "type": "$or",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full2 25"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 22 ],
+            "B": [ 23 ],
+            "Y": [ 24 ]
+          }
+        },
+        "full2.half0": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "hdlname": "full2 half0",
+            "module": "half"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "full2.half0.28": {
+          "hide_name": 0,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full2 half0 28"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "B": [ 8 ],
+            "Y": [ 22 ]
+          }
+        },
+        "full2.half0.29": {
+          "hide_name": 0,
+          "type": "$xor",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full2 half0 29"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "B": [ 8 ],
+            "Y": [ 25 ]
+          }
+        },
+        "full2.half1": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "hdlname": "full2 half1",
+            "module": "half"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "full2.half1.28": {
+          "hide_name": 0,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full2 half1 28"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 25 ],
+            "B": [ 20 ],
+            "Y": [ 23 ]
+          }
+        },
+        "full2.half1.29": {
+          "hide_name": 0,
+          "type": "$xor",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full2 half1 29"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 25 ],
+            "B": [ 20 ],
+            "Y": [ 12 ]
+          }
+        },
+        "full3": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "module": "full"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "full3.25": {
+          "hide_name": 0,
+          "type": "$or",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full3 25"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 26 ],
+            "B": [ 27 ],
+            "Y": [ 28 ]
+          }
+        },
+        "full3.half0": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "hdlname": "full3 half0",
+            "module": "half"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "full3.half0.28": {
+          "hide_name": 0,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full3 half0 28"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 5 ],
+            "B": [ 9 ],
+            "Y": [ 26 ]
+          }
+        },
+        "full3.half0.29": {
+          "hide_name": 0,
+          "type": "$xor",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full3 half0 29"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 5 ],
+            "B": [ 9 ],
+            "Y": [ 29 ]
+          }
+        },
+        "full3.half1": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "hdlname": "full3 half1",
+            "module": "half"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "full3.half1.28": {
+          "hide_name": 0,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full3 half1 28"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 29 ],
+            "B": [ 24 ],
+            "Y": [ 27 ]
+          }
+        },
+        "full3.half1.29": {
+          "hide_name": 0,
+          "type": "$xor",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "full3 half1 29"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 29 ],
+            "B": [ 24 ],
+            "Y": [ 13 ]
+          }
+        }
+      },
+      "netnames": {
+        "$auto$ghdl.cc:806:import_module$1": {
+          "hide_name": 1,
+          "bits": [ 16 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$2": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$3": {
+          "hide_name": 1,
+          "bits": [ 20 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$4": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$5": {
+          "hide_name": 1,
+          "bits": [ 24 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$6": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$7": {
+          "hide_name": 1,
+          "bits": [ 28 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$8": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full0.$auto$ghdl.cc:806:import_module$10": {
+          "hide_name": 1,
+          "bits": [ 17 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full0.$auto$ghdl.cc:806:import_module$11": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full0.$auto$ghdl.cc:806:import_module$12": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full0.$auto$ghdl.cc:806:import_module$13": {
+          "hide_name": 1,
+          "bits": [ 16 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full0.$auto$ghdl.cc:806:import_module$9": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full0.\\half0.$auto$ghdl.cc:806:import_module$14": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full0.\\half0.$auto$ghdl.cc:806:import_module$15": {
+          "hide_name": 1,
+          "bits": [ 17 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full0.\\half1.$auto$ghdl.cc:806:import_module$14": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full0.\\half1.$auto$ghdl.cc:806:import_module$15": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full1.$auto$ghdl.cc:806:import_module$10": {
+          "hide_name": 1,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full1.$auto$ghdl.cc:806:import_module$11": {
+          "hide_name": 1,
+          "bits": [ 19 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full1.$auto$ghdl.cc:806:import_module$12": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full1.$auto$ghdl.cc:806:import_module$13": {
+          "hide_name": 1,
+          "bits": [ 20 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full1.$auto$ghdl.cc:806:import_module$9": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full1.\\half0.$auto$ghdl.cc:806:import_module$14": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full1.\\half0.$auto$ghdl.cc:806:import_module$15": {
+          "hide_name": 1,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full1.\\half1.$auto$ghdl.cc:806:import_module$14": {
+          "hide_name": 1,
+          "bits": [ 19 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full1.\\half1.$auto$ghdl.cc:806:import_module$15": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full2.$auto$ghdl.cc:806:import_module$10": {
+          "hide_name": 1,
+          "bits": [ 25 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full2.$auto$ghdl.cc:806:import_module$11": {
+          "hide_name": 1,
+          "bits": [ 23 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full2.$auto$ghdl.cc:806:import_module$12": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full2.$auto$ghdl.cc:806:import_module$13": {
+          "hide_name": 1,
+          "bits": [ 24 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full2.$auto$ghdl.cc:806:import_module$9": {
+          "hide_name": 1,
+          "bits": [ 22 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full2.\\half0.$auto$ghdl.cc:806:import_module$14": {
+          "hide_name": 1,
+          "bits": [ 22 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full2.\\half0.$auto$ghdl.cc:806:import_module$15": {
+          "hide_name": 1,
+          "bits": [ 25 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full2.\\half1.$auto$ghdl.cc:806:import_module$14": {
+          "hide_name": 1,
+          "bits": [ 23 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full2.\\half1.$auto$ghdl.cc:806:import_module$15": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full3.$auto$ghdl.cc:806:import_module$10": {
+          "hide_name": 1,
+          "bits": [ 29 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full3.$auto$ghdl.cc:806:import_module$11": {
+          "hide_name": 1,
+          "bits": [ 27 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full3.$auto$ghdl.cc:806:import_module$12": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full3.$auto$ghdl.cc:806:import_module$13": {
+          "hide_name": 1,
+          "bits": [ 28 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full3.$auto$ghdl.cc:806:import_module$9": {
+          "hide_name": 1,
+          "bits": [ 26 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full3.\\half0.$auto$ghdl.cc:806:import_module$14": {
+          "hide_name": 1,
+          "bits": [ 26 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full3.\\half0.$auto$ghdl.cc:806:import_module$15": {
+          "hide_name": 1,
+          "bits": [ 29 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full3.\\half1.$auto$ghdl.cc:806:import_module$14": {
+          "hide_name": 1,
+          "bits": [ 27 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\full3.\\half1.$auto$ghdl.cc:806:import_module$15": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+          }
+        },
+        "a": {
+          "hide_name": 0,
+          "bits": [ 2, 3, 4, 5 ],
+          "attributes": {
+          }
+        },
+        "b": {
+          "hide_name": 0,
+          "bits": [ 6, 7, 8, 9 ],
+          "attributes": {
+          }
+        },
+        "full0.a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "hdlname": "full0 a"
+          }
+        },
+        "full0.b": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "hdlname": "full0 b"
+          }
+        },
+        "full0.cin": {
+          "hide_name": 0,
+          "bits": [ "0" ],
+          "attributes": {
+            "hdlname": "full0 cin"
+          }
+        },
+        "full0.cout": {
+          "hide_name": 0,
+          "bits": [ 16 ],
+          "attributes": {
+            "hdlname": "full0 cout"
+          }
+        },
+        "full0.half0.a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "hdlname": "full0 half0 a"
+          }
+        },
+        "full0.half0.b": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "hdlname": "full0 half0 b"
+          }
+        },
+        "full0.half0.c": {
+          "hide_name": 0,
+          "bits": [ 14 ],
+          "attributes": {
+            "hdlname": "full0 half0 c"
+          }
+        },
+        "full0.half0.s": {
+          "hide_name": 0,
+          "bits": [ 17 ],
+          "attributes": {
+            "hdlname": "full0 half0 s"
+          }
+        },
+        "full0.half0c": {
+          "hide_name": 0,
+          "bits": [ 14 ],
+          "attributes": {
+            "hdlname": "full0 half0c"
+          }
+        },
+        "full0.half0s": {
+          "hide_name": 0,
+          "bits": [ 17 ],
+          "attributes": {
+            "hdlname": "full0 half0s"
+          }
+        },
+        "full0.half1.a": {
+          "hide_name": 0,
+          "bits": [ 17 ],
+          "attributes": {
+            "hdlname": "full0 half1 a"
+          }
+        },
+        "full0.half1.b": {
+          "hide_name": 0,
+          "bits": [ "0" ],
+          "attributes": {
+            "hdlname": "full0 half1 b"
+          }
+        },
+        "full0.half1.c": {
+          "hide_name": 0,
+          "bits": [ 15 ],
+          "attributes": {
+            "hdlname": "full0 half1 c"
+          }
+        },
+        "full0.half1.s": {
+          "hide_name": 0,
+          "bits": [ 10 ],
+          "attributes": {
+            "hdlname": "full0 half1 s"
+          }
+        },
+        "full0.half1c": {
+          "hide_name": 0,
+          "bits": [ 15 ],
+          "attributes": {
+            "hdlname": "full0 half1c"
+          }
+        },
+        "full0.s": {
+          "hide_name": 0,
+          "bits": [ 10 ],
+          "attributes": {
+            "hdlname": "full0 s"
+          }
+        },
+        "full0cout": {
+          "hide_name": 0,
+          "bits": [ 16 ],
+          "attributes": {
+          }
+        },
+        "full1.a": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "hdlname": "full1 a"
+          }
+        },
+        "full1.b": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "hdlname": "full1 b"
+          }
+        },
+        "full1.cin": {
+          "hide_name": 0,
+          "bits": [ 16 ],
+          "attributes": {
+            "hdlname": "full1 cin"
+          }
+        },
+        "full1.cout": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+            "hdlname": "full1 cout"
+          }
+        },
+        "full1.half0.a": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "hdlname": "full1 half0 a"
+          }
+        },
+        "full1.half0.b": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "hdlname": "full1 half0 b"
+          }
+        },
+        "full1.half0.c": {
+          "hide_name": 0,
+          "bits": [ 18 ],
+          "attributes": {
+            "hdlname": "full1 half0 c"
+          }
+        },
+        "full1.half0.s": {
+          "hide_name": 0,
+          "bits": [ 21 ],
+          "attributes": {
+            "hdlname": "full1 half0 s"
+          }
+        },
+        "full1.half0c": {
+          "hide_name": 0,
+          "bits": [ 18 ],
+          "attributes": {
+            "hdlname": "full1 half0c"
+          }
+        },
+        "full1.half0s": {
+          "hide_name": 0,
+          "bits": [ 21 ],
+          "attributes": {
+            "hdlname": "full1 half0s"
+          }
+        },
+        "full1.half1.a": {
+          "hide_name": 0,
+          "bits": [ 21 ],
+          "attributes": {
+            "hdlname": "full1 half1 a"
+          }
+        },
+        "full1.half1.b": {
+          "hide_name": 0,
+          "bits": [ 16 ],
+          "attributes": {
+            "hdlname": "full1 half1 b"
+          }
+        },
+        "full1.half1.c": {
+          "hide_name": 0,
+          "bits": [ 19 ],
+          "attributes": {
+            "hdlname": "full1 half1 c"
+          }
+        },
+        "full1.half1.s": {
+          "hide_name": 0,
+          "bits": [ 11 ],
+          "attributes": {
+            "hdlname": "full1 half1 s"
+          }
+        },
+        "full1.half1c": {
+          "hide_name": 0,
+          "bits": [ 19 ],
+          "attributes": {
+            "hdlname": "full1 half1c"
+          }
+        },
+        "full1.s": {
+          "hide_name": 0,
+          "bits": [ 11 ],
+          "attributes": {
+            "hdlname": "full1 s"
+          }
+        },
+        "full1cout": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+          }
+        },
+        "full2.a": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "hdlname": "full2 a"
+          }
+        },
+        "full2.b": {
+          "hide_name": 0,
+          "bits": [ 8 ],
+          "attributes": {
+            "hdlname": "full2 b"
+          }
+        },
+        "full2.cin": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+            "hdlname": "full2 cin"
+          }
+        },
+        "full2.cout": {
+          "hide_name": 0,
+          "bits": [ 24 ],
+          "attributes": {
+            "hdlname": "full2 cout"
+          }
+        },
+        "full2.half0.a": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "hdlname": "full2 half0 a"
+          }
+        },
+        "full2.half0.b": {
+          "hide_name": 0,
+          "bits": [ 8 ],
+          "attributes": {
+            "hdlname": "full2 half0 b"
+          }
+        },
+        "full2.half0.c": {
+          "hide_name": 0,
+          "bits": [ 22 ],
+          "attributes": {
+            "hdlname": "full2 half0 c"
+          }
+        },
+        "full2.half0.s": {
+          "hide_name": 0,
+          "bits": [ 25 ],
+          "attributes": {
+            "hdlname": "full2 half0 s"
+          }
+        },
+        "full2.half0c": {
+          "hide_name": 0,
+          "bits": [ 22 ],
+          "attributes": {
+            "hdlname": "full2 half0c"
+          }
+        },
+        "full2.half0s": {
+          "hide_name": 0,
+          "bits": [ 25 ],
+          "attributes": {
+            "hdlname": "full2 half0s"
+          }
+        },
+        "full2.half1.a": {
+          "hide_name": 0,
+          "bits": [ 25 ],
+          "attributes": {
+            "hdlname": "full2 half1 a"
+          }
+        },
+        "full2.half1.b": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+            "hdlname": "full2 half1 b"
+          }
+        },
+        "full2.half1.c": {
+          "hide_name": 0,
+          "bits": [ 23 ],
+          "attributes": {
+            "hdlname": "full2 half1 c"
+          }
+        },
+        "full2.half1.s": {
+          "hide_name": 0,
+          "bits": [ 12 ],
+          "attributes": {
+            "hdlname": "full2 half1 s"
+          }
+        },
+        "full2.half1c": {
+          "hide_name": 0,
+          "bits": [ 23 ],
+          "attributes": {
+            "hdlname": "full2 half1c"
+          }
+        },
+        "full2.s": {
+          "hide_name": 0,
+          "bits": [ 12 ],
+          "attributes": {
+            "hdlname": "full2 s"
+          }
+        },
+        "full2cout": {
+          "hide_name": 0,
+          "bits": [ 24 ],
+          "attributes": {
+          }
+        },
+        "full3.a": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "hdlname": "full3 a"
+          }
+        },
+        "full3.b": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "hdlname": "full3 b"
+          }
+        },
+        "full3.cin": {
+          "hide_name": 0,
+          "bits": [ 24 ],
+          "attributes": {
+            "hdlname": "full3 cin"
+          }
+        },
+        "full3.cout": {
+          "hide_name": 0,
+          "bits": [ 28 ],
+          "attributes": {
+            "hdlname": "full3 cout"
+          }
+        },
+        "full3.half0.a": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "hdlname": "full3 half0 a"
+          }
+        },
+        "full3.half0.b": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "hdlname": "full3 half0 b"
+          }
+        },
+        "full3.half0.c": {
+          "hide_name": 0,
+          "bits": [ 26 ],
+          "attributes": {
+            "hdlname": "full3 half0 c"
+          }
+        },
+        "full3.half0.s": {
+          "hide_name": 0,
+          "bits": [ 29 ],
+          "attributes": {
+            "hdlname": "full3 half0 s"
+          }
+        },
+        "full3.half0c": {
+          "hide_name": 0,
+          "bits": [ 26 ],
+          "attributes": {
+            "hdlname": "full3 half0c"
+          }
+        },
+        "full3.half0s": {
+          "hide_name": 0,
+          "bits": [ 29 ],
+          "attributes": {
+            "hdlname": "full3 half0s"
+          }
+        },
+        "full3.half1.a": {
+          "hide_name": 0,
+          "bits": [ 29 ],
+          "attributes": {
+            "hdlname": "full3 half1 a"
+          }
+        },
+        "full3.half1.b": {
+          "hide_name": 0,
+          "bits": [ 24 ],
+          "attributes": {
+            "hdlname": "full3 half1 b"
+          }
+        },
+        "full3.half1.c": {
+          "hide_name": 0,
+          "bits": [ 27 ],
+          "attributes": {
+            "hdlname": "full3 half1 c"
+          }
+        },
+        "full3.half1.s": {
+          "hide_name": 0,
+          "bits": [ 13 ],
+          "attributes": {
+            "hdlname": "full3 half1 s"
+          }
+        },
+        "full3.half1c": {
+          "hide_name": 0,
+          "bits": [ 27 ],
+          "attributes": {
+            "hdlname": "full3 half1c"
+          }
+        },
+        "full3.s": {
+          "hide_name": 0,
+          "bits": [ 13 ],
+          "attributes": {
+            "hdlname": "full3 s"
+          }
+        },
+        "res": {
+          "hide_name": 0,
+          "bits": [ 10, 11, 12, 13 ],
+          "attributes": {
+          }
+        }
+      }
+    },
+    "full": {
+      "attributes": {
+      },
+      "ports": {
+        "a": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "b": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "cin": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "cout": {
+          "direction": "output",
+          "bits": [ 5 ]
+        },
+        "s": {
+          "direction": "output",
+          "bits": [ 6 ]
+        }
+      },
+      "cells": {
+        "\\25": {
+          "hide_name": 0,
+          "type": "$or",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 7 ],
+            "B": [ 8 ],
+            "Y": [ 5 ]
+          }
+        },
+        "half0": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "module": "half"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "half0.28": {
+          "hide_name": 0,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "half0 28"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 2 ],
+            "B": [ 3 ],
+            "Y": [ 7 ]
+          }
+        },
+        "half0.29": {
+          "hide_name": 0,
+          "type": "$xor",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "half0 29"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 2 ],
+            "B": [ 3 ],
+            "Y": [ 9 ]
+          }
+        },
+        "half1": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "module": "half"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "half1.28": {
+          "hide_name": 0,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "half1 28"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 9 ],
+            "B": [ 4 ],
+            "Y": [ 8 ]
+          }
+        },
+        "half1.29": {
+          "hide_name": 0,
+          "type": "$xor",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+            "hdlname": "half1 29"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 9 ],
+            "B": [ 4 ],
+            "Y": [ 6 ]
+          }
+        }
+      },
+      "netnames": {
+        "$auto$ghdl.cc:806:import_module$10": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$11": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$12": {
+          "hide_name": 1,
+          "bits": [ 6 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$13": {
+          "hide_name": 1,
+          "bits": [ 5 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$9": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\half0.$auto$ghdl.cc:806:import_module$14": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\half0.$auto$ghdl.cc:806:import_module$15": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\half1.$auto$ghdl.cc:806:import_module$14": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\half1.$auto$ghdl.cc:806:import_module$15": {
+          "hide_name": 1,
+          "bits": [ 6 ],
+          "attributes": {
+          }
+        },
+        "a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+          }
+        },
+        "b": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+          }
+        },
+        "cin": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+          }
+        },
+        "cout": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+          }
+        },
+        "half0.a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "hdlname": "half0 a"
+          }
+        },
+        "half0.b": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "hdlname": "half0 b"
+          }
+        },
+        "half0.c": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "hdlname": "half0 c"
+          }
+        },
+        "half0.s": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "hdlname": "half0 s"
+          }
+        },
+        "half0c": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+          }
+        },
+        "half0s": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+          }
+        },
+        "half1.a": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "hdlname": "half1 a"
+          }
+        },
+        "half1.b": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "hdlname": "half1 b"
+          }
+        },
+        "half1.c": {
+          "hide_name": 0,
+          "bits": [ 8 ],
+          "attributes": {
+            "hdlname": "half1 c"
+          }
+        },
+        "half1.s": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "hdlname": "half1 s"
+          }
+        },
+        "half1c": {
+          "hide_name": 0,
+          "bits": [ 8 ],
+          "attributes": {
+          }
+        },
+        "s": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+          }
+        }
+      }
+    },
+    "half": {
+      "attributes": {
+      },
+      "ports": {
+        "a": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "b": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "c": {
+          "direction": "output",
+          "bits": [ 4 ]
+        },
+        "s": {
+          "direction": "output",
+          "bits": [ 5 ]
+        }
+      },
+      "cells": {
+        "\\28": {
+          "hide_name": 0,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 2 ],
+            "B": [ 3 ],
+            "Y": [ 4 ]
+          }
+        },
+        "\\29": {
+          "hide_name": 0,
+          "type": "$xor",
+          "parameters": {
+            "A_SIGNED": 0,
+            "A_WIDTH": 1,
+            "B_SIGNED": 0,
+            "B_WIDTH": 1,
+            "Y_WIDTH": 1
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 2 ],
+            "B": [ 3 ],
+            "Y": [ 5 ]
+          }
+        }
+      },
+      "netnames": {
+        "$auto$ghdl.cc:806:import_module$14": {
+          "hide_name": 1,
+          "bits": [ 4 ],
+          "attributes": {
+          }
+        },
+        "$auto$ghdl.cc:806:import_module$15": {
+          "hide_name": 1,
+          "bits": [ 5 ],
+          "attributes": {
+          }
+        },
+        "a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+          }
+        },
+        "b": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+          }
+        },
+        "c": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+          }
+        },
+        "s": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+          }
+        }
+      }
+    }
+  }
+}

--- a/intTests/test2890/test.saw
+++ b/intTests/test2890/test.saw
@@ -1,0 +1,7 @@
+// A regression test for #2890. This ensures that SAW can load a JSON file
+// that contains $scopeinfo cells, which are debugging-only cells produced by
+// Yosys's `flatten` pass.
+
+enable_experimental;
+m <- yosys_import "test.json";
+prove_print w4 {{ m.add4 === \inp -> { res = inp.a + inp.b } }};

--- a/intTests/test2890/test.sh
+++ b/intTests/test2890/test.sh
@@ -1,0 +1,1 @@
+$SAW test.saw

--- a/intTests/test2890/test.vhd
+++ b/intTests/test2890/test.vhd
@@ -1,0 +1,63 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity half is
+  port (
+    a : in std_logic;
+    b : in std_logic;
+    c : out std_logic;
+    s : out std_logic
+  );
+end half;
+
+architecture halfarch of half is
+begin
+  c <= a and b;
+  s <= a xor b;
+end halfarch;
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity full is
+  port (
+    a : in std_logic;
+    b : in std_logic;
+    cin : in std_logic;
+    cout : out std_logic;
+    s : out std_logic
+  );
+end full;
+
+architecture fullarch of full is
+  signal half0c : std_logic;
+  signal half0s : std_logic;
+  signal half1c : std_logic;
+begin
+  half0 : entity work.half port map (a => a, b => b, c => half0c, s => half0s);
+  half1 : entity work.half port map (a => half0s, b => cin, c => half1c, s => s);
+  cout <= half0c or half1c;
+end fullarch;
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity add4 is
+  port (
+    a : in std_logic_vector(3 downto 0);
+    b : in std_logic_vector(3 downto 0);
+    res : out std_logic_vector(3 downto 0)
+  );
+end add4;
+
+architecture add4arch of add4 is
+  signal full0cout : std_logic;
+  signal full1cout : std_logic;
+  signal full2cout : std_logic;
+  signal ignore : std_logic;
+begin
+  full0 : entity work.full port map (a => a(0), b => b(0), cin => '0', cout => full0cout, s => res(0));
+  full1 : entity work.full port map (a => a(1), b => b(1), cin => full0cout, cout => full1cout, s => res(1));
+  full2 : entity work.full port map (a => a(2), b => b(2), cin => full1cout, cout => full2cout, s => res(2));
+  full3 : entity work.full port map (a => a(3), b => b(3), cin => full2cout, cout => ignore, s => res(3));
+end add4arch;

--- a/saw-central/src/SAWCentral/Yosys/Cell.hs
+++ b/saw-central/src/SAWCentral/Yosys/Cell.hs
@@ -304,6 +304,9 @@ primCellToMap sc c args =
     CellTypeBUF ->
       do res <- input "A"
          output res
+    CellTypeCheck -> pure Nothing
+    CellTypePrint -> pure Nothing
+    CellTypeScopeinfo -> pure Nothing
     CellTypeUnsupportedPrimitive _ -> pure Nothing
     CellTypeUserType _ -> pure Nothing
   where

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -136,6 +136,9 @@ textToPrimitiveCellType = Map.fromList
   , ("$dff"         , CellTypeDff)
   , ("$ff"          , CellTypeFf)
   , ("$_BUF_"       , CellTypeBUF)
+  , ("$check"       , CellTypeCheck)
+  , ("$print"       , CellTypePrint)
+  , ("$scopeinfo"   , CellTypeScopeinfo)
   ]
 
 -- | Mapping from primitive cell types to textual representation
@@ -185,6 +188,9 @@ data CellType
   | CellTypeDff
   | CellTypeFf
   | CellTypeBUF
+  | CellTypeCheck
+  | CellTypePrint
+  | CellTypeScopeinfo
   | CellTypeUnsupportedPrimitive Text
   | CellTypeUserType Text
   deriving (Eq, Ord)

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -142,6 +142,11 @@ netgraphToTerms sc env ng inputs
                   do r <- lookupPatternTerm sc (YosysBitvecConsumerCell cnm "Q") ffout acc
                      ts <- deriveTermsByIndices sc ffout r
                      pure $ Map.union ts acc
+                -- $check, $print, and $scopeinfo are debugging cells (see
+                -- https://yosyshq.readthedocs.io/projects/yosys/en/latest/cell/word_debug.html),
+                -- which we simply ignore.
+              | c ^. cellType `elem` [CellTypeCheck, CellTypePrint, CellTypeScopeinfo] ->
+                  return acc
               | otherwise ->
                   do args <- fmap Map.fromList . forM (Map.assocs $ cellInputConnections c) $ \(inm, i) ->
                        -- for each input bit pattern


### PR DESCRIPTION
This allows SAW to parse files containing cells like `$check`, `$print`, or `$scopeinfo`, which can sometimes be produced by various Yosys passes. (For instance, Yosys's `flatten` pass introduces `$scopeinfo` cells by default.)

Fixes #2890.