### PR TITLE
`crux-mir-comp-tests`: Actually use the `crux_spec_for macro` in `crux_spec_for_bool` test case

### DIFF
--- a/crux-mir-comp/test/symb_eval/comp/crux_spec_for_bool.rs
+++ b/crux-mir-comp/test/symb_eval/comp/crux_spec_for_bool.rs
@@ -40,8 +40,7 @@ mod verification {
     pub fn g_equiv() {
         uninterp("foo");
 
-        override_(f, cry::foo);
-        //f_equiv_spec().enable();
+        f_equiv_spec().enable();
 
         let x = bool::symbolic("x");
         let expected = cry::goo(x);


### PR DESCRIPTION
Due to an oversight, I accidentally copy-pasted the original code snippet from issue #2872, forgetting to enable the key `f_equiv_spec().enable()` line that is crucial for actually making use of the `crux_spec_for` macro. Oops! This commit corrects that oversight.