### PR TITLE
saw-core-coq: restore default bullet behavior after Bits import.

### DIFF
--- a/saw-core-coq/coq/handwritten/CryptolToCoq/SAWCoreVectorsAsCoqVectors.v
+++ b/saw-core-coq/coq/handwritten/CryptolToCoq/SAWCoreVectorsAsCoqVectors.v
@@ -1,5 +1,6 @@
 From Bits Require Import operations.
 From Bits Require Import spec.
+#[export] Set Bullet Behavior "Strict Subproofs". (* Bits sets this to "None". *)
 
 From Stdlib Require Import FunctionalExtensionality.
 From Stdlib Require Import Lists.List.


### PR DESCRIPTION
Fixes #1823.

I've verified this seems to work (via `Test Bullet Behavior` at various points in this file and files that import it), but not sure about the best approach to testing.