### PR TITLE
saw-core: Rewriter only calls scTermF if TermF has changed.

### DIFF
--- a/saw-core/src/SAWCore/Rewriter.hs
+++ b/saw-core/src/SAWCore/Rewriter.hs
@@ -706,6 +706,7 @@ rewriteSharedTerm sc ss t0 =
       useIntCache ?cache (termIndex t) $
       do let tf = unwrapTermF t
          tf' <- rewriteTermF convertibleFlag tf
+         -- Optimization: Avoid calling scTermF to reconstruct an identical term
          let same = (fmap termIndex tf' == fmap termIndex tf)
          t' <- if same then pure t else scTermF sc tf'
          rewriteTop convertibleFlag t'


### PR DESCRIPTION
We don't use `ChangeT` to keep track of whether a term has changed; we simply test equality of the old and new `TermF`s, which according to profiling turns out to be much faster.

Fixes #2858.

Using the benchmark from #2849 (replacing solver calls with `assume_unsat`), this yields a speedup of about 15% relative to the current `master` (813b724ed7dd292f64360599db31292db6c3d6a0).
