### PR TITLE
Support Yosys $shift gate and fix width-mismatch bugs in cells

### DIFF
--- a/intTests/test_yosys_shift/Makefile
+++ b/intTests/test_yosys_shift/Makefile
@@ -1,0 +1,14 @@
+YOSYS?=yosys
+
+all: shift_dyn_idx.json shift_dyn_idx_signed.json
+
+shift_dyn_idx.json shift_dyn_idx_signed.json: test_shift.sv test_shift.ys
+	$(YOSYS) -s test_shift.ys
+
+.PHONY: destroy
+destroy:
+	rm -f *.json
+
+.PHONY: clean
+clean:
+	@true

--- a/intTests/test_yosys_shift/shift_dyn_idx.json
+++ b/intTests/test_yosys_shift/shift_dyn_idx.json
@@ -1,0 +1,92 @@
+{
+  "creator": "Yosys 0.60 (git sha1 5bafeb77dc71e054fa331ab9efa613e6fb0a1c49, clang++ 17.0.0 -fPIC -O3)",
+  "modules": {
+    "shift_dyn_idx": {
+      "attributes": {
+        "hdlname": "shift_dyn_idx",
+        "top": "00000000000000000000000000000001",
+        "src": "test_shift.sv:1.1-9.10"
+      },
+      "ports": {
+        "idx": {
+          "direction": "input",
+          "bits": [ 2, 3, 4, 5 ]
+        },
+        "out": {
+          "direction": "output",
+          "bits": [ 6, 7, 8, 9, 10, 11, 12, 13 ]
+        }
+      },
+      "cells": {
+        "$neg$test_shift.sv:7$8": {
+          "hide_name": 1,
+          "type": "$neg",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000100",
+            "Y_WIDTH": "00000000000000000000000000000101"
+          },
+          "attributes": {
+            "src": "test_shift.sv:7.9-7.22"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 2, 3, 4, 5 ],
+            "Y": [ 14, 15, 16, 17, 18 ]
+          }
+        },
+        "$shift$test_shift.sv:7$9": {
+          "hide_name": 1,
+          "type": "$shift",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "B_SIGNED": "00000000000000000000000000000001",
+            "B_WIDTH": "00000000000000000000000000000101",
+            "Y_WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "src": "test_shift.sv:7.9-7.22"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ "1" ],
+            "B": [ 14, 15, 16, 17, 18 ],
+            "Y": [ 6, 7, 8, 9, 10, 11, 12, 13 ]
+          }
+        }
+      },
+      "netnames": {
+        "$neg$test_shift.sv:7$8_Y": {
+          "hide_name": 1,
+          "bits": [ 14, 15, 16, 17, 18 ],
+          "signed": 1,
+          "attributes": {
+            "src": "test_shift.sv:7.9-7.22"
+          }
+        },
+        "idx": {
+          "hide_name": 0,
+          "bits": [ 2, 3, 4, 5 ],
+          "attributes": {
+            "src": "test_shift.sv:2.26-2.29"
+          }
+        },
+        "out": {
+          "hide_name": 0,
+          "bits": [ 6, 7, 8, 9, 10, 11, 12, 13 ],
+          "attributes": {
+            "src": "test_shift.sv:3.26-3.29"
+          }
+        }
+      }
+    }
+  }
+}

--- a/intTests/test_yosys_shift/shift_dyn_idx_signed.json
+++ b/intTests/test_yosys_shift/shift_dyn_idx_signed.json
@@ -1,0 +1,94 @@
+{
+  "creator": "Yosys 0.60 (git sha1 5bafeb77dc71e054fa331ab9efa613e6fb0a1c49, clang++ 17.0.0 -fPIC -O3)",
+  "modules": {
+    "shift_dyn_idx_signed": {
+      "attributes": {
+        "hdlname": "shift_dyn_idx_signed",
+        "top": "00000000000000000000000000000001",
+        "src": "test_shift.sv:11.1-19.10"
+      },
+      "ports": {
+        "idx": {
+          "direction": "input",
+          "signed": 1,
+          "bits": [ 2, 3, 4, 5 ]
+        },
+        "out": {
+          "direction": "output",
+          "bits": [ 6, 7, 8, 9, 10, 11, 12, 13 ]
+        }
+      },
+      "cells": {
+        "$neg$test_shift.sv:17$18": {
+          "hide_name": 1,
+          "type": "$neg",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000001",
+            "A_WIDTH": "00000000000000000000000000000100",
+            "Y_WIDTH": "00000000000000000000000000000101"
+          },
+          "attributes": {
+            "src": "test_shift.sv:17.9-17.22"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 2, 3, 4, 5 ],
+            "Y": [ 14, 15, 16, 17, 18 ]
+          }
+        },
+        "$shift$test_shift.sv:17$19": {
+          "hide_name": 1,
+          "type": "$shift",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "B_SIGNED": "00000000000000000000000000000001",
+            "B_WIDTH": "00000000000000000000000000000101",
+            "Y_WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "src": "test_shift.sv:17.9-17.22"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ "1" ],
+            "B": [ 14, 15, 16, 17, 18 ],
+            "Y": [ 6, 7, 8, 9, 10, 11, 12, 13 ]
+          }
+        }
+      },
+      "netnames": {
+        "$neg$test_shift.sv:17$18_Y": {
+          "hide_name": 1,
+          "bits": [ 14, 15, 16, 17, 18 ],
+          "signed": 1,
+          "attributes": {
+            "src": "test_shift.sv:17.9-17.22"
+          }
+        },
+        "idx": {
+          "hide_name": 0,
+          "bits": [ 2, 3, 4, 5 ],
+          "signed": 1,
+          "attributes": {
+            "src": "test_shift.sv:12.27-12.30"
+          }
+        },
+        "out": {
+          "hide_name": 0,
+          "bits": [ 6, 7, 8, 9, 10, 11, 12, 13 ],
+          "attributes": {
+            "src": "test_shift.sv:13.26-13.29"
+          }
+        }
+      }
+    }
+  }
+}

--- a/intTests/test_yosys_shift/shift_sshr_ext.json
+++ b/intTests/test_yosys_shift/shift_sshr_ext.json
@@ -1,0 +1,77 @@
+{
+  "creator": "Yosys 0.60 (git sha1 5bafeb77dc71e054fa331ab9efa613e6fb0a1c49, clang++ 17.0.0 -fPIC -O3)",
+  "modules": {
+    "shift_sshr_ext": {
+      "attributes": {
+        "hdlname": "shift_sshr_ext",
+        "top": "00000000000000000000000000000001",
+        "src": "test_shift.sv:29.1-35.10"
+      },
+      "ports": {
+        "a": {
+          "direction": "input",
+          "signed": 1,
+          "bits": [ 2, 3, 4, 5 ]
+        },
+        "b": {
+          "direction": "input",
+          "bits": [ 6, 7, 8, 9 ]
+        },
+        "out": {
+          "direction": "output",
+          "bits": [ 10, 11, 12, 13, 14, 15, 16, 17 ]
+        }
+      },
+      "cells": {
+        "$sshr$test_shift.sv:34$22": {
+          "hide_name": 1,
+          "type": "$sshr",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000001",
+            "A_WIDTH": "00000000000000000000000000000100",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000000100",
+            "Y_WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "src": "test_shift.sv:34.18-34.25"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 2, 3, 4, 5 ],
+            "B": [ 6, 7, 8, 9 ],
+            "Y": [ 10, 11, 12, 13, 14, 15, 16, 17 ]
+          }
+        }
+      },
+      "netnames": {
+        "a": {
+          "hide_name": 0,
+          "bits": [ 2, 3, 4, 5 ],
+          "signed": 1,
+          "attributes": {
+            "src": "test_shift.sv:30.25-30.26"
+          }
+        },
+        "b": {
+          "hide_name": 0,
+          "bits": [ 6, 7, 8, 9 ],
+          "attributes": {
+            "src": "test_shift.sv:31.18-31.19"
+          }
+        },
+        "out": {
+          "hide_name": 0,
+          "bits": [ 10, 11, 12, 13, 14, 15, 16, 17 ],
+          "attributes": {
+            "src": "test_shift.sv:32.24-32.27"
+          }
+        }
+      }
+    }
+  }
+}

--- a/intTests/test_yosys_shift/shift_sshr_trunc.json
+++ b/intTests/test_yosys_shift/shift_sshr_trunc.json
@@ -1,0 +1,77 @@
+{
+  "creator": "Yosys 0.60 (git sha1 5bafeb77dc71e054fa331ab9efa613e6fb0a1c49, clang++ 17.0.0 -fPIC -O3)",
+  "modules": {
+    "shift_sshr_trunc": {
+      "attributes": {
+        "hdlname": "shift_sshr_trunc",
+        "top": "00000000000000000000000000000001",
+        "src": "test_shift.sv:21.1-27.10"
+      },
+      "ports": {
+        "a": {
+          "direction": "input",
+          "signed": 1,
+          "bits": [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 ]
+        },
+        "b": {
+          "direction": "input",
+          "bits": [ 18, 19, 20, 21 ]
+        },
+        "out": {
+          "direction": "output",
+          "bits": [ 22, 23, 24, 25, 26, 27, 28, 29 ]
+        }
+      },
+      "cells": {
+        "$sshr$test_shift.sv:26$21": {
+          "hide_name": 1,
+          "type": "$sshr",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000001",
+            "A_WIDTH": "00000000000000000000000000010000",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000000100",
+            "Y_WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "src": "test_shift.sv:26.18-26.25"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 ],
+            "B": [ 18, 19, 20, 21 ],
+            "Y": [ 22, 23, 24, 25, 26, 27, 28, 29 ]
+          }
+        }
+      },
+      "netnames": {
+        "a": {
+          "hide_name": 0,
+          "bits": [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 ],
+          "signed": 1,
+          "attributes": {
+            "src": "test_shift.sv:22.26-22.27"
+          }
+        },
+        "b": {
+          "hide_name": 0,
+          "bits": [ 18, 19, 20, 21 ],
+          "attributes": {
+            "src": "test_shift.sv:23.18-23.19"
+          }
+        },
+        "out": {
+          "hide_name": 0,
+          "bits": [ 22, 23, 24, 25, 26, 27, 28, 29 ],
+          "attributes": {
+            "src": "test_shift.sv:24.24-24.27"
+          }
+        }
+      }
+    }
+  }
+}

--- a/intTests/test_yosys_shift/test.saw
+++ b/intTests/test_yosys_shift/test.saw
@@ -1,0 +1,22 @@
+enable_experimental;
+
+m1 <- yosys_import "shift_dyn_idx.json";
+let spec1 = {{ \(x : {idx : [4]}) -> { out = 1 << x.idx : [8] } }};
+yosys_verify {{ m1.shift_dyn_idx }} [] spec1 [] z3;
+
+m2 <- yosys_import "shift_dyn_idx_signed.json";
+// For signed 4-bit index:
+// If MSB (bit 0) is 1, it's negative -> out of bounds -> result 0.
+// If MSB is 0, it's 0..7 -> valid index -> result 1 << idx.
+let spec2 = {{ \(x : {idx : [4]}) -> { out = if x.idx @ 0 then 0 else 1 << x.idx : [8] } }};
+yosys_verify {{ m2.shift_dyn_idx_signed }} [] spec2 [] z3;
+
+m3 <- yosys_import "shift_sshr_trunc.json";
+// (small = large >>> n) should match (drop (large >>$ n))
+let spec3 = {{ \(x : {a : [16], b : [4]}) -> { out = drop`{8} (x.a >>$ x.b) } }};
+yosys_verify {{ m3.shift_sshr_trunc }} [] spec3 [] z3;
+
+m4 <- yosys_import "shift_sshr_ext.json";
+// (large = small >>> n) should match (sext small >>$ n)
+let spec4 = {{ \(x : {a : [4], b : [4]}) -> { out = (sext x.a : [8]) >>$ x.b } }};
+yosys_verify {{ m4.shift_sshr_ext }} [] spec4 [] z3;

--- a/intTests/test_yosys_shift/test.sh
+++ b/intTests/test_yosys_shift/test.sh
@@ -1,0 +1,1 @@
+$SAW test.saw

--- a/intTests/test_yosys_shift/test_shift.sv
+++ b/intTests/test_yosys_shift/test_shift.sv
@@ -1,0 +1,45 @@
+module shift_dyn_idx (
+    input  logic [3:0]   idx,
+    output logic [7:0]   out
+);
+    always_comb begin
+        out = '0;
+        out[idx] = '1;
+    end
+endmodule
+
+module shift_dyn_idx_signed (
+    input  signed [3:0]   idx,
+    output logic [7:0]   out
+);
+    always_comb begin
+        out = '0;
+        out[idx] = '1;
+    end
+endmodule
+
+module shift_sshr_trunc (
+    input  signed [15:0] a,
+    input  [3:0] b,
+    output logic [7:0] out
+);
+    assign out = a >>> b;
+endmodule
+
+module shift_sshr_ext (
+    input  signed [3:0] a,
+    input  [3:0] b,
+    output logic [7:0] out
+);
+    assign out = a >>> b;
+endmodule
+
+module shift_dyn (
+    input  signed [4:0]  idx,
+    input  logic [7:0]   inp,
+    output logic [7:0]   out
+);
+    always_comb begin
+        out = inp >>> $signed(idx);
+    end
+endmodule

--- a/intTests/test_yosys_shift/test_shift.ys
+++ b/intTests/test_yosys_shift/test_shift.ys
@@ -1,0 +1,18 @@
+read -sv test_shift.sv
+prep -top shift_dyn_idx
+write_json shift_dyn_idx.json
+
+design -reset
+read -sv test_shift.sv
+prep -top shift_dyn_idx_signed
+write_json shift_dyn_idx_signed.json
+
+design -reset
+read -sv test_shift.sv
+prep -top shift_sshr_trunc
+write_json shift_sshr_trunc.json
+
+design -reset
+read -sv test_shift.sv
+prep -top shift_sshr_ext
+write_json shift_sshr_ext.json

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -113,6 +113,7 @@ textToPrimitiveCellType = Map.fromList
   , ("$shr"         , CellTypeShr)
   , ("$sshl"        , CellTypeSshl)
   , ("$sshr"        , CellTypeSshr)
+  , ("$shift"       , CellTypeShift)
   , ("$shiftx"      , CellTypeShiftx)
   , ("$lt"          , CellTypeLt)
   , ("$le"          , CellTypeLe)
@@ -185,6 +186,7 @@ data CellType
   | CellTypeMux
   | CellTypePmux
   | CellTypeBmux
+  | CellTypeShift
   | CellTypeDff
   | CellTypeFf
   | CellTypeBUF


### PR DESCRIPTION
- Implement the $shift gate logic in SAWCentral.Yosys.Cell, supporting bidirectional and signed shifts.
- Register $shift in SAWCentral.Yosys.IR.
- Fix width-mismatch bugs in bvUnaryOp (affecting $not and $neg) and shift operators ($shl, $shr, $sshl, $sshr) where the input operand was not correctly extended to the output width before the operation.
- Add an integration test in intTests/test_yosys_shift with Verilog source and exported JSON.