### PR TITLE
`saw-script`: fix `:type` command argument parsing

### DIFF
--- a/intTests/test2780/test.sh
+++ b/intTests/test2780/test.sh
@@ -1,0 +1,1 @@
+exec ${TEST_SHELL:-bash} ../support/test-and-diff.sh "$@"

--- a/intTests/test2780/test01.isaw
+++ b/intTests/test2780/test01.isaw
@@ -1,0 +1,6 @@
+:type prove_print
+:type prove_print z3
+:type (prove_print z3)
+:help prove_print
+:help prove_print z3
+:help (prove_print z3)

--- a/intTests/test2780/test01.log.good
+++ b/intTests/test2780/test01.log.good
@@ -1,0 +1,13 @@
+ProofScript () -> Term -> TopLevel Theorem
+Term -> TopLevel Theorem
+Term -> TopLevel Theorem
+Description
+-----------
+
+    prove_print : ProofScript () -> Term -> TopLevel Theorem
+
+Use the given proof script to attempt to prove that a term is
+valid (true for all inputs). Returns a Theorem if successful,
+and fails if unsuccessful.
+The command :help takes only one argument
+The command :help takes only one argument

--- a/saw-script/src/SAWScript/REPL/Command.hs
+++ b/saw-script/src/SAWScript/REPL/Command.hs
@@ -316,10 +316,11 @@ instance Eq CommandDescr where
 -- XXX: should maybe also distinguish "multiple args of this type"
 -- from "one arg of this type".
 data CommandBody
-  = ExprArg     (Text     -> REPL ())
-  | TypeArgs    (Text     -> REPL ())
-  | FilenameArg (FilePath -> REPL ())
-  | NoArg       (REPL ())
+  = ExprArg       (Text     -> REPL ())
+  | SymbolNameArg (Text     -> REPL ())
+  | TypeArgs      (Text     -> REPL ())
+  | FilenameArg   (FilePath -> REPL ())
+  | NoArg         (REPL ())
 
 type CommandMap = Trie CommandDescr
 
@@ -347,9 +348,9 @@ nbCommandList  =
     "display the current sawscript type environment"
   , CommandDescr ":type" [":t"]  (ExprArg typeOfCmd)
     "check the type of an expression"
-  , CommandDescr ":?"    []      (ExprArg helpCmd)
+  , CommandDescr ":?"    []      (SymbolNameArg helpCmd)
     "display a brief description about a built-in operator"
-  , CommandDescr ":help" []      (ExprArg helpCmd)
+  , CommandDescr ":help" []      (SymbolNameArg helpCmd)
     "display a brief description about a built-in operator"
   ]
 
@@ -456,6 +457,8 @@ executeReplCommand cmd args0 =
     in
     exceptionProtect $ case cBody cmd of
         ExprArg action ->
+            action (Text.intercalate " " args0)
+        SymbolNameArg action ->
             onearg action args0
         TypeArgs action ->
             action (Text.intercalate " " args0)

--- a/saw-script/src/SAWScript/REPL/Haskeline.hs
+++ b/saw-script/src/SAWScript/REPL/Haskeline.hs
@@ -356,10 +356,11 @@ completeReplCommand text cursor =
                     -- but you can only actually give it one. Should
                     -- strengthen the argument schema.
                     case cBody cmd of
-                        ExprArg _   -> completeSAWScriptValue (last args) cursor
-                        TypeArgs _  -> completeSAWScriptType (last args) cursor
-                        FilenameArg _ -> completeFilename cursor
-                        NoArg       _ -> return (cursorLeftRaw cursor, [])
+                        ExprArg _       -> completeSAWScriptValue (last args) cursor
+                        SymbolNameArg _ -> completeSAWScriptValue (last args) cursor
+                        TypeArgs _      -> completeSAWScriptType (last args) cursor
+                        FilenameArg _   -> completeFilename cursor
+                        NoArg       _   -> return (cursorLeftRaw cursor, [])
 
 -- | Top-level completion for the REPL.
 --


### PR DESCRIPTION
Fixes #2780.