### PR TITLE
Deprecation removals and updates for release 1.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,17 @@ This release supports [version
 
 ## Changes
 
+* The following deprecated SAWScript builtins have been removed:
+  - `addsimp'`
+  - `addsimps'`
+  - `crucible_setup_val_to_term`
+
+* The following deprecated SAWScript builtins are now hidden by default:
+  - `env`
+
+  `llvm_struct` was also scheduled to be hidden in 1.5; this has been
+  postponed to 1.6 for internal reasons.
+
 * The following solver builtins / proof tactics have been renamed for
   consistency.
   The old names remain but have been marked deprecated.

--- a/intTests/test1646/test15.log.good
+++ b/intTests/test1646/test15.log.good
@@ -105,7 +105,6 @@ enable_lax_loads_and_stores : TopLevel ()
 enable_lax_pointer_ordering : TopLevel ()
 enable_smt_array_memory_model : TopLevel ()
 enable_what4_hash_consing : TopLevel ()
-env : TopLevel ()
 eval_bool : Term -> Bool
 eval_int : Term -> Int
 eval_list : Term -> [Term]

--- a/intTests/test_search/search02.log.good
+++ b/intTests/test_search/search02.log.good
@@ -35,7 +35,6 @@ term_eval_unint : [String] -> Term -> Term
 time : {a} TopLevel a -> TopLevel a
 unfold_term : [String] -> Term -> Term
 10 more matches tagged experimental; use enable_experimental to see them
-2 more matches tagged deprecated; use enable_deprecated to see them
 --------------------------------
 -- {a} (a -> String)
 show : {a} a -> String

--- a/intTests/test_type_errors/err051.log.good
+++ b/intTests/test_type_errors/err051.log.good
@@ -1,6 +1,6 @@
 Loading file "err051.saw"
 Type errors:
-  err051.saw:8:9-8:17: Inaccessible variable: "addsimp'" (err051.saw:8:9-8:17)
-  err051.saw:8:9-8:17: This command is available only after running `enable_deprecated`.
+  err051.saw:8:9-8:12: Inaccessible variable: "env" (err051.saw:8:9-8:12)
+  err051.saw:8:9-8:12: This command is available only after running `enable_deprecated`.
 
 FAILED

--- a/intTests/test_type_errors/err051.saw
+++ b/intTests/test_type_errors/err051.saw
@@ -5,5 +5,5 @@
 // the thing I picked finally gets removed, just update the reference
 // file accordingly.
 
-let _ = addsimp';
+let _ = env;
 

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -2704,11 +2704,11 @@ primitives = Map.fromList $
 
   , prim "env"                 "TopLevel ()"
     (pureVal envCmd)
-    WarnDeprecated
+    HideDeprecated
     [ "Print all SAWScript values in scope."
     , "Deprecated; use the :env REPL command instead."
     , ""
-    , "Expected to be hidden by default in SAW 1.5."
+    , "Expected to be removed in SAW 1.6."
     ]
 
   , prim "show"                "{a} a -> String"
@@ -3874,25 +3874,6 @@ primitives = Map.fromList $
     Current
     [ "Merge two simplification sets into one." ]
 
-  , prim "addsimp'"            "Term -> Simpset -> Simpset"
-    (funVal2 addsimp')
-    HideDeprecated
-    [ "Add an arbitrary equality term to a simplification rule set."
-    , "Deprecated; use 'admit' or 'core_axiom' and 'addsimp' instead."
-    , ""
-    , "Expected to be removed in SAW 1.5."
-    ]
-
-  , prim "addsimps'"           "[Term] -> Simpset -> Simpset"
-    (funVal2 addsimps')
-    HideDeprecated
-    [ "Add multiple arbitrary equality terms to a simplification rule"
-    , "set. Deprecated; use 'admit' or 'core_axiom' and 'addsimps'"
-    , "instead."
-    , ""
-    , "Expected to be removed in SAW 1.5."
-    ]
-
   , prim "basic_ss"            "Simpset"
     (bicVal $ \bic _ -> toValue "basic_ss" $ biBasicSS bic)
     Current
@@ -5017,6 +4998,7 @@ primitives = Map.fromList $
     (pureVal do_write_rocq_term)
     WarnDeprecated
     [ "Legacy alternative name for 'write_rocq_term'."
+    , "Expected to be hidden by default in SAW 1.6."
     ]
 
   , prim "write_rocq_cryptol_module" ("String -> String -> " <>
@@ -5044,6 +5026,7 @@ primitives = Map.fromList $
     (pureVal do_write_rocq_cryptol_module)
     WarnDeprecated
     [ "Legacy alternative name for 'write_rocq_cryptol_module'."
+    , "Expected to be hidden by default in SAW 1.6."
     ]
 
   , prim "write_rocq_sawcore_prelude" ("String -> [(String, String)] -> " <>
@@ -5067,6 +5050,7 @@ primitives = Map.fromList $
     (pureVal do_write_rocq_sawcore_prelude)
     WarnDeprecated
     [ "Legacy alternative name for 'write_rocq_sawcore_prelude'."
+    , "Expected to be hidden by default in SAW 1.6."
     ]
 
   , prim "write_rocq_cryptol_primitives_for_sawcore"
@@ -5091,6 +5075,7 @@ primitives = Map.fromList $
     (pureVal do_write_rocq_cryptol_primitives_for_sawcore)
     WarnDeprecated
     [ "Legacy alternative name for 'write_rocq_cryptol_primitives_for_sawcore'."
+    , "Expected to be hidden by default in SAW 1.6."
     ]
 
   , prim "offline_rocq" "String -> ProofScript ()"
@@ -5104,6 +5089,7 @@ primitives = Map.fromList $
     (pureVal do_offline_rocq)
     WarnDeprecated
     [ "Legacy alternative name for 'offline_rocq'."
+    , "Expected to be hidden by default in SAW 1.6."
     ]
 
     ------------------------------------------------------------
@@ -5261,7 +5247,7 @@ primitives = Map.fromList $
     , "If you are trying to create a struct type from its contents, you"
     , "want llvm_struct_type."
     , ""
-    , "Expected to be hidden by default in SAW 1.5."
+    , "Expected to be hidden by default in SAW 1.6."
     ]
 
   , prim "llvm_struct_type"
@@ -5416,17 +5402,6 @@ primitives = Map.fromList $
     [ "Cast the type of the given LLVM value, which must be a pointer."
     , "The resulting value will be a pointer to the same location,"
     , "treated as a pointer to the provided type."
-    ]
-
-  , prim "crucible_setup_val_to_term"
-    " LLVMValue -> TopLevel Term"
-    (pureVal crucible_setup_val_to_typed_term)
-    HideDeprecated
-    [ "Convert from a setup value to a typed term. This can only be"
-    , "done for a subset of setup values. Fails if a setup value is a"
-    , "global, variable, or null."
-    , ""
-    , "Expected to be removed in SAW 1.5."
     ]
 
     ------------------------------------------------------------


### PR DESCRIPTION
Removed: addsimp' addsimps' crucible_setup_val_to_term
Hidden: env llvm_struct