### PR TITLE
saw-core: Implement all cases of function termPat/termFPat.

### DIFF
--- a/saw-core/src/SAWCore/Conversion.hs
+++ b/saw-core/src/SAWCore/Conversion.hs
@@ -130,11 +130,11 @@ termPat t = termFPat (unwrapTermF t)
 termFPat :: TermF Term -> Net.Pat
 termFPat tf =
   case tf of
-    Constant nm  -> Net.Atom (toShortName (nameInfo nm))
-    App t1 t2    -> Net.App (termPat t1) (termPat t2)
-    Lambda{}     -> Net.Var
-    Pi{}         -> Net.Var
-    Variable{}   -> Net.Var
+    Constant nm    -> Net.Atom (toShortName (nameInfo nm))
+    App t1 t2      -> Net.App (termPat t1) (termPat t2)
+    Lambda _ t1 t2 -> Net.App (Net.App (Net.Atom "\\") (termPat t1)) (termPat t2)
+    Pi _ t1 t2     -> Net.App (Net.App (Net.Atom "->") (termPat t1)) (termPat t2)
+    Variable{}     -> Net.Var
     FTermF ftf ->
       case ftf of
         UnitValue       -> Net.Atom "()"


### PR DESCRIPTION
This ensures that rewrite rules will be filtered properly in the TermNet data structure. In particular, we avoid having so many rules being assigned a pattern of 'Net.Var', which led to them being returned from the TermNet on *every* subterm.

Fixes #1577.