### PR TITLE
CI: fix the source-archive job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
     # tags only. Skip running it on forks as well, because we won't have
     # the signing key there.
     if: github.event_name == 'push' &&
-        needs.config.outputs.tag == 'true' &&
+        needs.config.outputs.event-tag == 'true' &&
         github.repository_owner == 'GaloisInc' &&
         github.actor != 'dependabot[bot]'
     strategy:


### PR DESCRIPTION
It never runs because it was asking a nonexistent variable whether it should.

@aschwerdfeger-galois found the problem, which was the real work...
