### PR TITLE
`cryptol-saw-core`: Basic `FLiteral` support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@ This release supports [version
 * SAW no longer spuriously rejects `mir_array_value`s that use a signed integer
   type (e.g., `mir_i32`) as an element type.
 
+* Using a fractional Cryptol literal (e.g., `0.5 : Rational`) no longer causes
+  SAW to emit a type error. Note that SAW does not currently support
+  _evaluating_ fractional values, however (see
+  [#1237](https://github.com/GaloisInc/saw-script/issues/1237)).
+
 # 1.5 -- 2026-01-31
 
 This release supports [version

--- a/cryptol-saw-core/saw/Cryptol.sawcore
+++ b/cryptol-saw-core/saw/Cryptol.sawcore
@@ -1203,8 +1203,8 @@ PRoundRational =
 -- Literal and LiteralLessThan classes
 
 -- Compared to Cryptol class 'Literal val a', we omit the 'val' parameter here.
--- See Note [Literal and LiteralLessThan in SAWCore] in CryptolSAWCore.Cryptol
--- more details on this design choice.
+-- See Note [Literal, LiteralLessThan, and FLiteral in SAWCore] in
+-- CryptolSAWCore.Cryptol for more details on this design choice.
 --
 -- As 'PLiteral' and 'PLiteralLessThan' are definitionally equal in saw-core,
 -- the same dictionary constructors do double duty for both type classes.
@@ -1236,8 +1236,19 @@ PLiteralIntModNum num =
 PLiteralRational : PLiteral Rational;
 PLiteralRational = \ (x : Nat) -> error Rational "Unimplemented: Literal Rational";
 
--- TODO: FLiteral class
+-- FLiteral class
 
+-- Compared to the Cryptol class 'FLiteral m n r a', we omit the 'm', 'n', and
+-- 'r' parameters here.
+-- See Note [Literal, LiteralLessThan, and FLiteral in SAWCore] in
+-- CryptolSAWCore.Cryptol for more details on this design choice.
+
+PFLiteral : (a : sort 0) -> sort 0;
+PFLiteral a = Nat -> Nat -> Nat -> a;
+
+PFLiteralRational : PFLiteral Rational;
+PFLiteralRational =
+  \ (m : Nat) (n : Nat) (r : Nat) -> ecRatio (natToInt m) (natToInt n);
 
 --------------------------------------------------------------------------------
 -- Primitive Cryptol functions
@@ -1388,8 +1399,23 @@ ecZero a pa = pa;
 
 -- FLiteral
 
-ecFraction : (a : isort 0) -> a;
-ecFraction a = error a "Unimplemented: fraction";
+ecFraction : (m : Num) -> (n : Num) -> (r : Num) -> (a : isort 0) -> PFLiteral a -> a;
+ecFraction m n r a pa =
+  Num#rec
+    (\ (_ : Num) -> a)
+    (\ (m : Nat) ->
+       Num#rec
+         (\ (_ : Num) -> a)
+         (\ (n : Nat) ->
+            Num#rec
+              (\ (_ : Num) -> a)
+              (\ (r : Nat) -> pa m n r)
+              (error a "ecFraction: r should not be infinite")
+              r)
+         (error a "ecFraction: n should not be infinite")
+         n)
+    (error a "ecFraction: m should not be infinite")
+    m;
 
 
 -- Sequences
@@ -1870,6 +1896,9 @@ PRoundFloat e p =
 
 PLiteralFloat : (e p : Num) -> PLiteral (TCFloat e p);
 PLiteralFloat e p = \ (x : Nat) -> error (TCFloat e p) "Unimplemented: Literal Float";
+
+PFLiteralFloat : (e p : Num) -> PFLiteral (TCFloat e p);
+PFLiteralFloat _ _ = \ (m : Nat) (n : Nat) (r : Nat) -> ();
 
 ecFpNaN : (e : Num) -> (p : Num) -> TCFloat e p;
 ecFpNaN e p = error (TCFloat e p) "Unimplemented: fpNaN";

--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -266,9 +266,9 @@ importPC sc pc =
     C.PSignedCmp       -> scGlobalDef sc "Cryptol.PSignedCmp"
     C.PLiteral         -> scGlobalDef sc "Cryptol.PLiteral"
     C.PLiteralLessThan -> scGlobalDef sc "Cryptol.PLiteralLessThan"
+    C.PFLiteral        -> scGlobalDef sc "Cryptol.PFLiteral"
     C.PAnd             -> panic "importPC" ["found PAnd"]
     C.PTrue            -> panic "importPC" ["found PTrue"]
-    C.PFLiteral        -> panic "importPC" ["found PFLiteral"]
     C.PValidFloat      -> panic "importPC" ["found PValidFloat"]
 
 -- | Translate size types to SAW values of type Num, value types to SAW types of sort 0.
@@ -331,15 +331,20 @@ importType sc env ty =
             C.TCTuple _n -> scTupleType sc =<< traverse go tyargs
         C.PC pc ->
           case pc of
-            -- Special cases for PLiteral and PLiteralLessThan: we
-            -- intentionally do not translate the first argument.
-            -- See Note [Literal and LiteralLessThan in SAWCore].
+            -- Special cases for PLiteral, PLiteralLessThan, and PFLiteral. For
+            -- PLiteral and PLiteralLessThan, we intentionally do not translate
+            -- the first argument, and for PFLiteral, we intentionally do not
+            -- translate the first three arguments.
+            -- See Note [Literal, LiteralLessThan, and FLiteral in SAWCore].
             C.PLiteral ->
               do a <- go (tyargs !! 1)
                  scGlobalApply sc "Cryptol.PLiteral" [a]
             C.PLiteralLessThan ->
               do a <- go (tyargs !! 1)
                  scGlobalApply sc "Cryptol.PLiteralLessThan" [a]
+            C.PFLiteral -> -- we omit the first three arguments to class FLiteral
+              do a <- go (tyargs !! 3)
+                 scGlobalApply sc "Cryptol.PFLiteral" [a]
             _ ->
               do pc' <- importPC sc pc
                  tyargs' <- traverse go tyargs
@@ -367,6 +372,7 @@ isErasedProp prop =
     C.TCon (C.PC C.PSignedCmp      ) _ -> False
     C.TCon (C.PC C.PLiteral        ) _ -> False
     C.TCon (C.PC C.PLiteralLessThan) _ -> False
+    C.TCon (C.PC C.PFLiteral       ) _ -> False
     _ -> True
 
 -- | Translate a 'Prop' containing a numeric constraint to a 'Term' that tests
@@ -726,7 +732,7 @@ provePropRec sc env prop0 prop =
 
         -- Note that in the Literal/LiteralLessThan instances below, we
         -- intentionally do not translate the first argument.
-        -- See Note [Literal and LiteralLessThan in SAWCore].
+        -- See Note [Literal, LiteralLessThan, and FLiteral in SAWCore].
 
         -- instance Literal val Bit
         (C.pIsLiteral -> Just (_, C.tIsBit -> True))
@@ -774,6 +780,19 @@ provePropRec sc env prop0 prop =
                 p' <- importType sc env p
                 scGlobalApply sc "Cryptol.PLiteralFloat" [e', p']
 
+        -- Note that in the FLiteral instances below, we intentionally do not
+        -- translate the first three arguments.
+        -- See Note [Literal, LiteralLessThan, and FLiteral in SAWCore].
+
+        -- instance (fin m, fin n, n >= 1) => FLiteral m n r Rational
+        (C.pIsFLiteral -> Just (_, _, _, C.tIsRational -> True))
+          -> do scGlobalApply sc "Cryptol.PFLiteralRational" []
+        -- instance ValidFloat e p => FLiteral m n r (Float e p) (with extra constraints)
+        (C.pIsFLiteral -> Just (_, _, _, C.tIsFloat -> Just (e, p)))
+          -> do e' <- importType sc env e
+                p' <- importType sc env p
+                scGlobalApply sc "Cryptol.PFLiteralFloat" [e', p']
+
         _ -> do
             let prop0' = "   " <> CryPP.pp prop0
                 prop' = "   " <> CryPP.pp prop
@@ -806,8 +825,8 @@ provePropRec sc env prop0 prop =
              pure (c, pc)
 
 {-
-Note [Literal and LiteralLessThan in SAWCore]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Note [Literal, LiteralLessThan, and FLiteral in SAWCore]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In Cryptol, the `Literal val a` and `LiteralLessThan val a` constraints encode
 the literal value being constructed using a numeric type `val`. Somewhat
 counterintuitively, the Cryptol-to-SAWCore translation intentionally does not
@@ -868,7 +887,10 @@ certain illicit uses of PLiteral dictionaries. See
 https://github.com/GaloisInc/saw-script/issues/3081 for more on this.
 
 The same considerations also apply to the PLiteralLessThan dictionary, which is
-given the same definition as PLiteral.
+given the same definition as PLiteral. Similar considerations also apply to the
+PFLiteral dictionary, which encodes an Cryptol `FLiteral m n r a` constraint:
+we omit the numeric types `m`, `n`, and `r` from the translation, leaving only
+`a`.
 -}
 
 importPrimitive :: SharedContext -> ImportPrimitiveOptions -> Env -> C.Name -> C.Schema -> IO Term

--- a/intTests/test3045/test.saw
+++ b/intTests/test3045/test.saw
@@ -1,0 +1,10 @@
+// A regression test for #3045. All this does is validate that
+// cryptol-saw-core's translation of the Cryptol `fraction` function
+// (implicitly used in the desugaring of fractional literals, such as `0.5`
+// below) results in a type-correct SAWCore term. Attempting to evaluate the
+// term itself will crash, however---see #1237.
+
+import Float;
+
+let x = {{ 0.5 : Rational }};
+let y = {{ 0.5 : Float32 }};

--- a/intTests/test3045/test.sh
+++ b/intTests/test3045/test.sh
@@ -1,0 +1,3 @@
+set -e
+
+$SAW test.saw

--- a/intTests/test_sawcore_qualify/test.log.good
+++ b/intTests/test_sawcore_qualify/test.log.good
@@ -20,11 +20,11 @@ While typechecking term:
 Ambiguous name: x
 Possible matches:
 A::B:|:C::x@cryptol
-x`5889@fresh
+x`5919@fresh
 
 |:C::x
 |:C::x
-x`5889
+x`5919
 == Anticipated failure message ==
 Stack trace:
    (builtin) in parse_core
@@ -64,7 +64,7 @@ x@core
 x@core
 A::x@cryptol
 |:C::x
-x`5889
+x`5919
 == Anticipated failure message ==
 Stack trace:
    (builtin) in parse_core
@@ -79,7 +79,7 @@ While typechecking term:
 Ambiguous name: x
 Possible matches:
 A::B:|:C::x@cryptol
-x`5889@fresh
+x`5919@fresh
 A::x@cryptol
 A::x@core
 B::x@core
@@ -153,8 +153,8 @@ While typechecking term:
 .:1:0:
 Ambiguous name: x@fresh
 Possible matches:
-x`5889@fresh
-x`5922@fresh
+x`5919@fresh
+x`5952@fresh
 
 z
 z
@@ -202,7 +202,7 @@ Stack trace:
    test.saw:142:1-142:25 (at top level)
 Definition body contains free variables
 Name:
-  y`5931
+  y`5961
 For term:
   let { x@free : Bool; } in x@free
 With type:

--- a/otherTests/saw-core-rocq/test_cryptol_primitives.log.good
+++ b/otherTests/saw-core-rocq/test_cryptol_primitives.log.good
@@ -595,6 +595,12 @@ Definition PLiteralIntModNum : forall (num : Num), PLiteral (IntModNum num) :=
 Definition PLiteralRational : PLiteral Rational :=
   fun (x : Init.Datatypes.nat) => SAWCoreScaffolding.error Rational "Unimplemented: Literal Rational"%string.
 
+Definition PFLiteral : forall (a : Type), Type :=
+  fun (a : Type) => forall (_1 : Init.Datatypes.nat), forall (_2 : Init.Datatypes.nat), forall (_3 : Init.Datatypes.nat), a.
+
+Definition PFLiteralRational : PFLiteral Rational :=
+  fun (m : Init.Datatypes.nat) (n : Init.Datatypes.nat) (r : Init.Datatypes.nat) => ecRatio (SAWCoreScaffolding.natToInt m) (SAWCoreScaffolding.natToInt n).
+
 Definition ecNumber : forall (val : Num), forall (a : Type), forall (_1 : PLiteral a), a :=
   fun (val : Num) (a : Type) (pa : PLiteral a) => @CryptolPrimitivesForSAWCore.Num_rect (fun (_1 : Num) => a) pa (pa SAWCoreScaffolding.Zero) val.
 
@@ -697,8 +703,8 @@ Definition ecCompl : forall (a : Type), forall (_1 : PLogic a), forall (_2 : a),
 Definition ecZero : forall (a : Type), forall (_1 : PZero a), a :=
   fun (a : Type) (pa : PZero a) => pa.
 
-Definition ecFraction : forall (a : Type), forall {Inh_a : SAWCoreScaffolding.Inhabited a}, a :=
-  fun (a : Type) (Inh_a : SAWCoreScaffolding.Inhabited a) => SAWCoreScaffolding.error a "Unimplemented: fraction"%string.
+Definition ecFraction : forall (m : Num), forall (n : Num), forall (r : Num), forall (a : Type), forall {Inh_a : SAWCoreScaffolding.Inhabited a}, forall (_1 : PFLiteral a), a :=
+  fun (m : Num) (n : Num) (r : Num) (a : Type) (Inh_a : SAWCoreScaffolding.Inhabited a) (pa : PFLiteral a) => @CryptolPrimitivesForSAWCore.Num_rect (fun (_1 : Num) => a) (fun (m1 : Init.Datatypes.nat) => @CryptolPrimitivesForSAWCore.Num_rect (fun (_1 : Num) => a) (fun (n1 : Init.Datatypes.nat) => @CryptolPrimitivesForSAWCore.Num_rect (fun (_1 : Num) => a) (fun (r1 : Init.Datatypes.nat) => pa m1 n1 r1) (SAWCoreScaffolding.error a "ecFraction: r should not be infinite"%string) r) (SAWCoreScaffolding.error a "ecFraction: n should not be infinite"%string) n) (SAWCoreScaffolding.error a "ecFraction: m should not be infinite"%string) m.
 
 Definition ecShiftL : forall (m : Num), forall (ix : Type), forall (a : Type), forall (_1 : PIntegral ix), forall (_2 : PZero a), forall (_3 : seq m a), forall (_4 : ix), seq m a :=
   fun (m : Num) => @CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : Num) => forall (ix : Type), forall (a : Type), forall (_1 : PIntegral ix), forall (_2 : PZero a), forall (_3 : seq m1 a), forall (_4 : ix), seq m1 a) (fun (m1 : Init.Datatypes.nat) (ix : Type) (a : Type) (pix : PIntegral ix) (pz : PZero a) (xs : SAWCoreVectorsAsRocqVectors.Vec m1 a) => let var__0   := ecZero a pz in
@@ -826,6 +832,9 @@ Definition PRoundFloat : forall (e : Num), forall (p : Num), PRound (TCFloat e p
 
 Definition PLiteralFloat : forall (e : Num), forall (p : Num), PLiteral (TCFloat e p) :=
   fun (e : Num) (p : Num) (x : Init.Datatypes.nat) => SAWCoreScaffolding.error (TCFloat e p) "Unimplemented: Literal Float"%string.
+
+Definition PFLiteralFloat : forall (e : Num), forall (p : Num), PFLiteral (TCFloat e p) :=
+  fun (e : Num) (p : Num) (m : Init.Datatypes.nat) (n : Init.Datatypes.nat) (r : Init.Datatypes.nat) => tt.
 
 Definition ecFpNaN : forall (e : Num), forall (p : Num), TCFloat e p :=
   fun (e : Num) (p : Num) => SAWCoreScaffolding.error (TCFloat e p) "Unimplemented: fpNaN"%string.


### PR DESCRIPTION
Fixes #3045.