### PR TITLE
Ensure download package names are clean words to avoid quoting issues.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
       - if: matrix.ghc == '9.6.7' && matrix.hpc == false
         uses: actions/upload-artifact@v5
         with:
-          name: ${{ steps.config.outputs.name }}-with-solvers (GHC ${{ matrix.ghc }})
+          name: ${{ steps.config.outputs.name }}-with-solvers
           path: "${{ steps.config.outputs.name }}-with-solvers.tar.gz*"
           if-no-files-found: error
           retention-days: ${{ needs.config.outputs.retention-days }}


### PR DESCRIPTION
When fetching packages from the bottom of the Actions page, the downloaded filenames have spaces and other awkward characters in them.  For example: `saw-1.5.0.99-ubuntu-22.04-X64-with-solvers\ \(GHC\ 9.6.7\).zip`.  It's possible to use quoting and such to immunize against filenames like this, but why generate them in the first place?