### PR TITLE
G/C backend code for deprecated operations removed in 1.5

### DIFF
--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -1615,19 +1615,8 @@ addsimp_shallow thm ss =
 simpset_union :: SV.SAWSimpset -> SV.SAWSimpset -> SV.SAWSimpset
 simpset_union ss1 ss2 = Net.merge ss1 ss2
 
--- TODO: remove this, it implicitly adds axioms
-addsimp' :: Term -> SV.SAWSimpset -> TopLevel SV.SAWSimpset
-addsimp' t ss =
-  do  sc <- getSharedContext
-      io (ruleOfProp sc t Nothing) >>= \case
-        Nothing -> fail "addsimp': theorem not an equation"
-        Just rule -> pure (addRule rule ss)
-
 addsimps :: [Theorem] -> SV.SAWSimpset -> TopLevel SV.SAWSimpset
 addsimps thms ss = foldM (flip addsimp) ss thms
-
-addsimps' :: [Term] -> SV.SAWSimpset -> TopLevel SV.SAWSimpset
-addsimps' ts ss = foldM (flip addsimp') ss ts
 
 print_type :: Term -> TopLevel ()
 print_type t = do

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
@@ -34,7 +34,6 @@ module SAWCentral.Crucible.LLVM.Builtins
     , llvm_refine_spec
     , llvm_array_size_profile
     , llvm_setup_with_tag
-    , crucible_setup_val_to_typed_term
     , llvm_spec_size
     , llvm_spec_solvers
     , llvm_ghost_value
@@ -112,7 +111,6 @@ import qualified Data.Vector as V
 import           Prettyprinter
 import           System.IO
 import qualified Text.LLVM.AST as L
-import qualified Control.Monad.Trans.Maybe as MaybeT
 
 -- parameterized-utils
 import           Data.Parameterized.Classes
@@ -2724,17 +2722,3 @@ llvm_spec_solvers (SomeLLVM ps) =
 llvm_spec_size :: SomeLLVM MS.ProvedSpec -> Integer
 llvm_spec_size (SomeLLVM mir) =
   solverStatsGoalSize $ mir ^. MS.psSolverStats
-
-crucible_setup_val_to_typed_term ::
-  AllLLVM SetupValue ->
-  TopLevel TypedTerm
-crucible_setup_val_to_typed_term (getAllLLVM -> sval) =
-  do opts <- getOptions
-     sc <- getSharedContext
-     mtt <- io $ MaybeT.runMaybeT $ MS.setupToTypedTerm opts sc sval
-     case mtt of
-       Nothing -> do
-         opts' <- gets rwPPOpts
-         sval' <- liftIO $ MS.ppSetupValue sc opts' sval
-         throwTopLevel $ "Could not convert a setup value to a term: " ++ Text.unpack sval'
-       Just tt -> return tt


### PR DESCRIPTION
This got overlooked back in January.