### PR TITLE
Remove Template Haskell sawcore type checking

### DIFF
--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -98,13 +98,6 @@ import qualified SAWCore.QualName as QN
 import CryptolSAWCore.Panic
 import qualified CryptolSAWCore.Pretty as CryPP
 
--- Type-check the Prelude and Cryptol modules at compile time
-import Language.Haskell.TH
-import CryptolSAWCore.Prelude
-
-$(runIO (mkSharedContext >>= \sc ->
-          scLoadPreludeModule sc >> scLoadCryptolModule sc >> pure []))
-
 --------------------------------------------------------------------------------
 
 -- | Type Environments


### PR DESCRIPTION
For type checking of built-in sawcore modules during development (without requiring a full build of SAW) we can use the following two cabal test build targets instead:
```
    cabal test check-prelude-sawcore
    cabal test check-cryptol-sawcore
```
Hopefully this should speed up compilation of SAW in the common case.

EDIT:
As pointed out below, we can actually replace the TH type checking with the following two existing cabal test build targets:
```
cabal test saw-core-tests
cabal test cryptol-saw-core-tests
```