### PR TITLE
new solver cache key fingerprinting algorithm

### DIFF
--- a/intTests/test_solver_cache/test_basics.saw
+++ b/intTests/test_solver_cache/test_basics.saw
@@ -10,32 +10,32 @@ test_solver_cache_stats 0 0 0 0 0;
 prove_print z3 {{ \(x:[64]) -> x == x }};
 test_solver_cache_stats 1 0 0 1 0;
 
-// Testing that cached results depend on variable names - thus, the cache
-// should now have one more entry and one more insertion, but not a new usage
+// Testing that cached results do not depend on variable names -
+// thus, the cache should have a new usage but not a new entry or insertion
 prove_print z3 {{ \(new_name:[64]) -> new_name == new_name }};
-test_solver_cache_stats 2 0 0 2 0;
+test_solver_cache_stats 1 1 0 1 0;
 
 // Testing that cached results depend on the backend used - thus, the cache
 // should now have one more entry and one more insertion, but not a new usage
 prove_print (w4_unint_z3 []) {{ \(x:[64]) -> x == x }};
-test_solver_cache_stats 3 0 0 3 0;
+test_solver_cache_stats 2 1 0 2 0;
 
 // Testing that cached results depend on the options passed to the given
 // backend - thus, the cache should now have one more entry and one more
 // insertion, but not a new usage
 prove_print (w4_unint_z3_using "qfnia" []) {{ \(x:[64]) -> x == x }};
-test_solver_cache_stats 4 0 0 4 0;
+test_solver_cache_stats 3 1 0 3 0;
 
 // Same as the above but for sat results
 
 fails (prove_print z3 {{ \(x:[64])(y:[64]) -> x == y }});
-test_solver_cache_stats 5 0 0 5 0;
+test_solver_cache_stats 4 1 0 4 0;
 
 fails (prove_print z3 {{ \(new_name_1:[64])(new_name_2:[64]) -> new_name_1 == new_name_2 }});
-test_solver_cache_stats 6 0 0 6 0;
+test_solver_cache_stats 4 2 0 4 0;
 
 fails (prove_print w4 {{ \(x:[64])(y:[64]) -> x == y }});
-test_solver_cache_stats 7 0 0 7 0;
+test_solver_cache_stats 5 2 0 5 0;
 
 fails (prove_print (w4_unint_z3_using "qfnia" []) {{ \(x:[64])(y:[64]) -> x == y }});
-test_solver_cache_stats 8 0 0 8 0;
+test_solver_cache_stats 6 2 0 6 0;

--- a/intTests/test_solver_cache/test_clean.saw
+++ b/intTests/test_solver_cache/test_clean.saw
@@ -3,14 +3,13 @@
 set_solver_cache_path "test_solver_cache.cache";
 
 // The cache still has entries from prior runs
-test_solver_cache_stats 8 0 0 0 0;
+test_solver_cache_stats 6 0 0 0 0;
 
 // After cleaning, all SBV entries should be removed (see test.sh)
 clean_mismatched_versions_solver_cache;
 test_solver_cache_stats 4 0 0 0 0;
 
-// After running test_ops, we should have all the original entries back,
-// as many insertions as there were SBV entries, and as many usages as there
-// were in test_path_second less the number of SBV entries
+// After running test_ops, we should have all the original entries back.
+// Alpha-equivalent queries hit the cache, so: 6 lookups, 2 inserts.
 include "test_ops.saw";
-test_solver_cache_stats 8 4 0 4 0;
+test_solver_cache_stats 6 6 0 2 0;

--- a/intTests/test_solver_cache/test_path_and_reuse.saw
+++ b/intTests/test_solver_cache/test_path_and_reuse.saw
@@ -3,10 +3,10 @@
 set_solver_cache_path "test_solver_cache.cache";
 
 // The cache still has entries from the last run
-test_solver_cache_stats 8 0 0 0 0;
+test_solver_cache_stats 6 0 0 0 0;
 
 // After running test_path_ops, we should have the same number of entries, but
 // no insertions and and as many usages as there were insertions plus usages
 // the first time
 include "test_ops.saw";
-test_solver_cache_stats 8 8 0 0 0;
+test_solver_cache_stats 6 8 0 0 0;

--- a/intTests/test_solver_cache_fingerprint/def_v1.cry
+++ b/intTests/test_solver_cache_fingerprint/def_v1.cry
@@ -1,0 +1,4 @@
+module DefV1 where
+
+myFunc : [32] -> [32]
+myFunc x = x + 1

--- a/intTests/test_solver_cache_fingerprint/def_v2.cry
+++ b/intTests/test_solver_cache_fingerprint/def_v2.cry
@@ -1,0 +1,4 @@
+module DefV2 where
+
+myFunc : [32] -> [32]
+myFunc x = x + 2

--- a/intTests/test_solver_cache_fingerprint/session1.saw
+++ b/intTests/test_solver_cache_fingerprint/session1.saw
@@ -1,0 +1,4 @@
+test_solver_cache_stats 0 0 0 0 0;
+
+prove_print z3 {{ \(x:[64]) -> x == x }};
+test_solver_cache_stats 1 0 0 1 0; // miss

--- a/intTests/test_solver_cache_fingerprint/session2.saw
+++ b/intTests/test_solver_cache_fingerprint/session2.saw
@@ -1,0 +1,9 @@
+// The cache should have 1 entry from part 1, and this fresh
+// session starts with 0 lookups and 0 inserts.
+test_solver_cache_stats 1 0 0 0 0;
+
+prove_print z3 {{ \(x:[64]) -> x == x }};
+test_solver_cache_stats 1 1 0 0 0; // hit
+
+prove_print z3 {{ \(y:[64]) -> y == y }};
+test_solver_cache_stats 1 2 0 0 0; // hit

--- a/intTests/test_solver_cache_fingerprint/test.saw
+++ b/intTests/test_solver_cache_fingerprint/test.saw
@@ -1,0 +1,224 @@
+enable_experimental;
+
+test_solver_cache_stats 0 0 0 0 0;
+
+// Alpha-equivalence
+
+prove_print z3 {{ \(a:[32]) -> a == a }};
+test_solver_cache_stats 1 0 0 1 0; // miss
+
+prove_print z3 {{ \(b:[32]) -> b == b }};
+test_solver_cache_stats 1 1 0 1 0; // hit
+
+prove_print z3 {{ \(x:[32]) (y:[32]) -> x + y == y + x }};
+test_solver_cache_stats 2 1 0 2 0; // miss
+
+prove_print z3 {{ \(foo:[32]) (bar:[32]) -> foo + bar == bar + foo }};
+test_solver_cache_stats 2 2 0 2 0; // hit
+
+// Stability
+
+let prop1 = {{ \(x:[32]) -> (x + 1) == (x + 1) }};
+prove_print z3 prop1;
+test_solver_cache_stats 3 2 0 3 0; // miss
+
+let prop2 = {{ \(x:[32]) -> (x + 2) == (x + 2) }};
+prove_print z3 prop2;
+test_solver_cache_stats 4 2 0 4 0; // miss
+
+m1 <- cryptol_load "def_v1.cry";
+prove_print z3 {{ \(x:[32]) -> m1::myFunc x == x + 1 }};
+test_solver_cache_stats 5 2 0 5 0; // miss
+
+m2 <- cryptol_load "def_v2.cry";
+prove_print z3 {{ \(x:[32]) -> m2::myFunc x == x + 2 }};
+test_solver_cache_stats 6 2 0 6 0; // miss
+
+prove_print z3 {{ \(x:[32]) -> m1::myFunc x == x + 1 }};
+test_solver_cache_stats 6 3 0 6 0; // hit
+
+let t1 = {{ \(x:[32]) -> x + 1 == 1 + x }};
+prove_print z3 t1;
+test_solver_cache_stats 7 3 0 7 0; // miss
+
+let t2 = {{ \(x:[32]) -> x + 2 == 2 + x }};
+prove_print z3 t2;
+test_solver_cache_stats 8 3 0 8 0; // miss
+
+prove_print z3 t1;
+test_solver_cache_stats 8 4 0 8 0; // hit
+
+// Uninterpreted functions
+
+let {{
+  f : [32] -> [32]
+  f x = x + 1
+}};
+
+prove_print (w4_unint_z3 ["f"]) {{ \(x:[32]) -> f x == f x }};
+test_solver_cache_stats 9 4 0 9 0; // miss
+
+prove_print (w4_unint_z3 ["f"]) {{ \(x:[32]) -> f x == f x }};
+test_solver_cache_stats 9 5 0 9 0; // hit
+
+prove_print z3 {{ \(x:[32]) -> f x == f x }};
+test_solver_cache_stats 10 5 0 10 0; // miss
+
+// UniversalAsserts
+
+let {{
+  g : [32] -> [32] -> [32]
+  g x y = undefined
+}};
+
+// assume_unsat not cached
+comm_v1 <- prove_print assume_unsat {{ \x y -> g x y == g y x }};
+
+prove_print
+  (do { goal_insert comm_v1; w4_unint_z3 ["g"]; })
+  {{ \a b -> g a b == g b a }};
+test_solver_cache_stats 11 5 0 11 0; // miss
+
+prove_print
+  (do { goal_insert comm_v1; w4_unint_z3 ["g"]; })
+  {{ \c d -> g c d == g d c }};
+test_solver_cache_stats 11 6 0 11 0; // hit
+
+comm_v2 <- prove_print assume_unsat {{ \a b -> g a b == g b a }};
+prove_print
+  (do { goal_insert comm_v2; w4_unint_z3 ["g"]; })
+  {{ \x y -> g x y == g y x }};
+test_solver_cache_stats 11 7 0 11 0; // hit
+
+assoc <- prove_print assume_unsat {{ \x y z -> g (g x y) z == g x (g y z) }};
+prove_print
+  (do { goal_insert assoc; w4_unint_z3 ["g"]; })
+  {{ \a b c -> g (g a b) c == g a (g b c) }};
+test_solver_cache_stats 12 7 0 12 0; // miss
+
+comm_cond <- prove_print assume_unsat
+  {{ \(x:[32]) (y:[32]) -> x < y ==> g x y == g y x }};
+prove_print
+  (do { goal_insert comm_cond; w4_unint_z3 ["g"]; })
+  {{ \a b -> a < b ==> g a b == g b a }};
+test_solver_cache_stats 13 7 0 13 0; // miss
+
+comm_cond2 <- prove_print assume_unsat
+  {{ \(p:[32]) (q:[32]) -> p < q ==> g p q == g q p }};
+prove_print
+  (do { goal_insert comm_cond2; w4_unint_z3 ["g"]; })
+  {{ \u v -> u < v ==> g u v == g v u }};
+test_solver_cache_stats 13 8 0 13 0; // hit
+
+// 1g: Different hypothesis structure -- miss
+comm_cond_neq <- prove_print assume_unsat
+  {{ \(x:[32]) (y:[32]) -> x != y ==> g x y == g y x }};
+prove_print
+  (do { goal_insert comm_cond_neq; w4_unint_z3 ["g"]; })
+  {{ \a b -> a != b ==> g a b == g b a }};
+test_solver_cache_stats 14 8 0 14 0; // miss
+
+// Counterexamples
+
+r1 <- sat z3 {{ \(x:[8]) -> x == 3 }};
+test_solver_cache_stats 15 8 0 15 0; // miss
+
+r2 <- sat z3 {{ \(y:[8]) -> y == 3 }};
+test_solver_cache_stats 15 9 0 15 0; // hit
+
+caseSatResult r2
+  (fail "Expected sat from cache (single var)")
+  (\t -> prove_print z3 {{ t == (3:[8]) }});
+test_solver_cache_stats 16 9 0 16 0; // miss
+
+r3 <- sat z3 {{ \(x:[8]) (y:[8]) -> x == 3 /\ y == 5 }};
+test_solver_cache_stats 17 9 0 17 0; // miss
+
+r4 <- sat z3 {{ \(a:[8]) (b:[8]) -> a == 3 /\ b == 5 }};
+test_solver_cache_stats 17 10 0 17 0; // hit
+
+caseSatResult r4
+  (fail "Expected sat from cache (multi var)")
+  (\t -> prove_print z3 {{ t == ((3:[8]), (5:[8])) }});
+test_solver_cache_stats 18 10 0 18 0; // hit
+
+r5 <- sat z3 {{ \(x:[8]) -> x != x }};
+test_solver_cache_stats 19 10 0 19 0; // miss
+
+r6 <- sat z3 {{ \(y:[8]) -> y != y }};
+test_solver_cache_stats 19 11 0 19 0; // hit
+
+caseSatResult r6
+  (return ())  // expected: unsat
+  (\_ -> fail "Expected unsat from cache");
+
+// Transitive definition fingerprinting
+
+// module v1 (helper x = x + 1)
+tv1 <- cryptol_load "trans_v1.cry";
+prove_print z3 {{ \(x:[32]) -> tv1::composed x == (x + 2) + 2 }};
+test_solver_cache_stats 20 11 0 20 0; // miss
+
+// module v2 (helper x = x + 2)
+tv2 <- cryptol_load "trans_v2.cry";
+prove_print z3 {{ \(x:[32]) -> tv2::composed x == (x + 2) + 2 }};
+test_solver_cache_stats 21 11 0 21 0; // miss
+
+// re-prove v1
+prove_print z3 {{ \(x:[32]) -> tv1::composed x == (x + 2) + 2 }};
+test_solver_cache_stats 21 12 0 21 0; // hit
+
+// re-prove v2 -- hit
+prove_print z3 {{ \(x:[32]) -> tv2::composed x == (x + 2) + 2 }};
+test_solver_cache_stats 21 13 0 21 0; // hit
+
+// Various types
+
+prove_print z3 {{ \(x:[8]) -> [x, x+1, x+2] == [x, x+1, x+2] }};
+test_solver_cache_stats 22 13 0 22 0; // miss
+
+prove_print z3 {{ \(y:[8]) -> [y, y+1, y+2] == [y, y+1, y+2] }};
+test_solver_cache_stats 22 14 0 22 0; // hit
+
+prove_print z3 {{ \(x:[8]) -> [x, x+1, x+3] == [x, x+1, x+3] }};
+test_solver_cache_stats 23 14 0 23 0; // miss
+
+prove_print z3 {{ \(x:[8]) -> [x, x+1] == [x, x+1] }};
+test_solver_cache_stats 24 14 0 24 0; // miss
+
+prove_print z3 {{ \(x:[8]) -> [[x, x+1], [x+2, x+3]] == [[x, x+1], [x+2, x+3]] }};
+test_solver_cache_stats 25 14 0 25 0; // miss
+
+prove_print z3 {{ \(y:[8]) -> [[y, y+1], [y+2, y+3]] == [[y, y+1], [y+2, y+3]] }};
+test_solver_cache_stats 25 15 0 25 0; // hit
+
+prove_print z3 {{ \(x:Bit) -> x == x }};
+test_solver_cache_stats 26 15 0 26 0; // miss
+
+prove_print z3 {{ \(b:Bit) -> b == b }};
+test_solver_cache_stats 26 16 0 26 0; // hit
+
+prove_print z3 {{ \(p:([32],[32])) -> p == p }};
+test_solver_cache_stats 27 16 0 27 0; // miss
+
+prove_print z3 {{ \(q:([32],[32])) -> q == q }};
+test_solver_cache_stats 27 17 0 27 0; // hit
+
+prove_print z3 {{ \(p:([32],[32],[32])) -> p == p }};
+test_solver_cache_stats 28 17 0 28 0; // miss
+
+prove_print z3 {{ \(x:[32]) (b:Bit) -> if b then x == x else x == x }};
+test_solver_cache_stats 29 17 0 29 0; // miss
+
+prove_print z3 {{ \(y:[32]) (flag:Bit) -> if flag then y == y else y == y }};
+test_solver_cache_stats 29 18 0 29 0; // hit
+
+prove_print z3 {{ \(x:Integer) -> x == x }};
+test_solver_cache_stats 30 18 0 30 0; // miss
+
+prove_print z3 {{ \(n:Integer) -> n == n }};
+test_solver_cache_stats 30 19 0 30 0; // hit
+
+print_solver_cache "";
+print_solver_cache "00";
+print_solver_cache "ff";

--- a/intTests/test_solver_cache_fingerprint/test.sh
+++ b/intTests/test_solver_cache_fingerprint/test.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+SAW=${SAW:-saw}
+set -e
+
+CACHE="test.cache"
+rm -rf "$CACHE"
+SAW_SOLVER_CACHE_PATH="$CACHE" $SAW test.saw
+
+rm -rf "$CACHE"
+SAW_SOLVER_CACHE_PATH="$CACHE" $SAW session1.saw
+SAW_SOLVER_CACHE_PATH="$CACHE" $SAW session2.saw
+rm -rf "$CACHE"

--- a/intTests/test_solver_cache_fingerprint/trans_v1.cry
+++ b/intTests/test_solver_cache_fingerprint/trans_v1.cry
@@ -1,0 +1,7 @@
+module TransV1 where
+
+helper : [32] -> [32]
+helper x = x + 1 + 1
+
+composed : [32] -> [32]
+composed x = helper (helper x)

--- a/intTests/test_solver_cache_fingerprint/trans_v2.cry
+++ b/intTests/test_solver_cache_fingerprint/trans_v2.cry
@@ -1,0 +1,7 @@
+module TransV2 where
+
+helper : [32] -> [32]
+helper x = x + 2
+
+composed : [32] -> [32]
+composed x = helper (helper x)

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -1171,7 +1171,7 @@ applyProverToGoal backends opts f unintSet sqt = do
   k    <- io $ mkSolverCacheKey sc vs opts satq
   (mb, solver_name) <- SV.onSolverCache (lookupInSolverCache k) >>= \case
     -- Use a cached result if one exists (and it's valid w.r.t our query)
-    Just v -> return $ fromSolverCacheValue satq v
+    Just v | Just res <- fromSolverCacheValue satq v -> return res
     -- Otherwise try to cache the result of the call
     _ -> f satq >>= \res -> io (toSolverCacheValue vs opts satq res) >>= \case
            Just v  -> SV.onSolverCache (insertInSolverCache k v) >>

--- a/saw-central/src/SAWCentral/SolverCache.hs
+++ b/saw-central/src/SAWCentral/SolverCache.hs
@@ -81,14 +81,14 @@ import System.Timeout (timeout)
 import GHC.Generics (Generic)
 import Data.IORef (IORef, newIORef, modifyIORef, readIORef)
 import Data.Time.Clock (UTCTime, getCurrentTime)
-import Data.Tuple.Extra (first, firstM)
-import Data.List (elemIndex, intercalate, isPrefixOf)
+import Data.List (intercalate, isPrefixOf)
 import Data.Maybe (fromMaybe, isJust)
 import Data.Functor ((<&>))
 import Numeric (readHex)
 
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import qualified Data.Vector as V
 
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -112,6 +112,7 @@ import qualified Data.SBV.Dynamic as SBV
 
 import SAWCore.FiniteValue
 import SAWCore.Fingerprint (fingerprintSATQuery)
+import SAWCore.Name (VarName)
 import SAWCore.SATQuery
 import SAWCore.SharedTerm
 
@@ -383,23 +384,35 @@ toSolverCacheValue :: SolverBackendVersions -> [SolverBackendOption] ->
                       SATQuery -> (Maybe CEX, Text) ->
                       IO (Maybe SolverCacheValue)
 toSolverCacheValue vs opts satq (cexs, solver_name) = do
-  getCurrentTime <&> \t -> case firstsMaybeM (`elemIndex` vns) cexs of
-    Just cexs' -> Just $ SolverCacheValue vs opts solver_name cexs' t
-    Nothing -> Nothing
-  where vns = Map.keys $ satVariables satq
-        firstsMaybeM :: Monad m => (a -> m b) ->
-                        Maybe [(a, c)] -> m (Maybe [(b, c)])
-        firstsMaybeM = mapM . mapM . firstM
+  getCurrentTime <&> \t ->
+    (\cachedCEXs -> SolverCacheValue vs opts solver_name cachedCEXs t) <$> cexs'
+  where
+    vnIndices :: Map VarName Int
+    vnIndices = Map.fromAscList $ zip (Map.keys $ satVariables satq) [0..]
+
+    encEntry :: (VarName, FirstOrderValue) -> Maybe (Int, FirstOrderValue)
+    encEntry (vn, val) = (, val) <$> Map.lookup vn vnIndices
+
+    cexs' :: Maybe (Maybe [(Int, FirstOrderValue)])
+    cexs' | Just xs <- cexs = Just <$> traverse encEntry xs
+          | otherwise       = Just Nothing
 
 -- | Convert a 'SolverCacheValue' to something which has the same form as the
--- result of a solver call on the given 'SATQuery'
-fromSolverCacheValue :: SATQuery -> SolverCacheValue -> (Maybe CEX, Text)
+-- result of a solver call on the given 'SATQuery'. Return 'Nothing' if the
+-- cached counterexample does not line up with the query's variable ordering.
+fromSolverCacheValue :: SATQuery -> SolverCacheValue -> Maybe (Maybe CEX, Text)
 fromSolverCacheValue satq (SolverCacheValue _ _ solver_name cexs _) =
-  (firstsMaybe (vns !!) cexs, solver_name)
-  where vns = Map.keys $ satVariables satq
-        firstsMaybe :: (a -> b) -> Maybe [(a, c)] -> Maybe [(b, c)]
-        firstsMaybe = fmap . fmap . first
+  (, solver_name) <$> cexs'
+  where
+    vns :: V.Vector VarName
+    vns = V.fromList $ Map.keys $ satVariables satq
 
+    decEntry :: (Int, FirstOrderValue) -> Maybe (VarName, FirstOrderValue)
+    decEntry (i, val) = (, val) <$> (vns V.!? i)
+
+    cexs' :: Maybe (Maybe CEX)
+    cexs' | Just xs <- cexs = Just <$> traverse decEntry xs
+          | otherwise       = Just Nothing
 
 -- The Solver Cache ------------------------------------------------------------
 
@@ -606,10 +619,10 @@ cleanMismatchedVersionsSolverCache curr_base_vs = SCOpOrFail $ \opts cache -> do
   printOutLn opts Info $
     "Removed " ++ show (length ks) ++
     " cached result" ++ s0 ++ " with mismatched version" ++ s0 ++ s1
-  forM_ (Map.toList mvs) $ \(backend, (v1, v2)) ->
+  forM_ (Map.toList mvs) $ \(backend, (curr_v, cached_v)) ->
     printOutLn opts Info $
-      "- " ++ showSolverBackendVersion backend v1 [] ++
-      " (Current: " ++ showSolverBackendVersion backend v2 [] ++ ")"
+      "- " ++ showSolverBackendVersion backend cached_v [] ++
+      " (Current: " ++ showSolverBackendVersion backend curr_v [] ++ ")"
   sz <- LMDB.readOnlyTransaction env $ LMDB.size db
   let (sz0, sz1) = if sz == 1 then ("is", "") else ("are", "s")
   printOutLn opts Info $ "There " ++ sz0 ++ " " ++ show sz ++ " result"

--- a/saw-central/src/SAWCentral/SolverCache.hs
+++ b/saw-central/src/SAWCentral/SolverCache.hs
@@ -474,12 +474,16 @@ tryTransaction :: (LMDB.Mode tmode, LMDB.SubMode LMDB.ReadWrite tmode) =>
                    LMDB.Transaction tmode a) ->
                   IO (Either String a, SolverCache)
 tryTransaction cache@SolverCache{..} t =
-  tryWithTimeout solverCacheTimeout (forceSolverCacheOpened cache) >>= \case
+  open >>= \case
     Right (env, db, cache') ->
       (,cache') <$> tryWithTimeout solverCacheTimeout
                                    (LMDB.transaction env (t db))
     Left err ->
-      return (Left $ "Failed to open LMDB database: " ++ err, cache)
+      pure (Left $ "Failed to open LMDB database: " ++ err, cache)
+  where
+    open = case (solverCacheEnv, solverCacheDB) of
+      (Just env, Just db) -> pure $ Right (env, db, cache)
+      _ -> tryWithTimeout solverCacheTimeout (forceSolverCacheOpened cache)
 
 -- | An operation on a 'SolverCache', returning a value of the given type as
 -- well as an updated 'SolverCache' ('solverCacheOp'). Additionally, in the case
@@ -545,7 +549,7 @@ setSolverCachePath path = SCOpOrFail $ \opts cache@SolverCache{..} ->
     case (solverCacheEnv, solverCacheDB) of
       (Just old_env, Just old_db) -> do
         kvs <- LMDB.readOnlyTransaction old_env $ LMDB.toList old_db
-        forM_ kvs $ \(k,v) -> LMDB.transaction new_env $ LMDB.insert k v new_db
+        LMDB.transaction new_env $ forM_ kvs $ \(k,v) -> LMDB.insert k v new_db
         printOutLn opts Info ("Saved " ++ show (length kvs) ++ " cached result" ++
                               (if length kvs == 1 then "" else "s") ++ " to disk")
         return ((), cache')
@@ -596,7 +600,7 @@ cleanMismatchedVersionsSolverCache curr_base_vs = SCOpOrFail $ \opts cache -> do
                                              else (k:ks, Map.union mvs mvs')
   (env, db, cache') <- forceSolverCacheOpened cache
   (ks, mvs) <- LMDB.readOnlyTransaction env $ LMDB.foldrWithKey flt ([], Map.empty) db
-  forM_ ks $ \k -> LMDB.transaction env $ LMDB.delete k db
+  LMDB.transaction env $ forM_ ks $ \k -> LMDB.delete k db
   let s0 = if length ks == 1 then "" else "s"
       s1 = if Map.size mvs == 0 then "" else ":"
   printOutLn opts Info $

--- a/saw-central/src/SAWCentral/SolverCache.hs
+++ b/saw-central/src/SAWCentral/SolverCache.hs
@@ -8,10 +8,10 @@ Stability   : provisional
 This file defines an interface for caching SMT/SAT solver results using an LMDB
 database. The interface, as used in 'applyProverToGoal', works as follows:
 
-1. An 'SMTQuery' is converted into a string using 'scWriteExternal', and
-   along with any relevant 'SolverBackendVersion's (obtained using
-   'getSolverBackendVersions' from @SAWCentral.SolverVersions@), is then hashed
-   using SHA256 ('mkSolverCacheKey').
+1. An 'SATQuery' is structurally fingerprinted (using 'fingerprintSATQuery' from
+   @SAWCore.Fingerprint@) and, along with any relevant 'SolverBackendVersion's
+   (obtained using 'getSolverBackendVersions' from @SAWCentral.SolverVersions@),
+   is then hashed using SHA256 ('mkSolverCacheKey').
 2. The core of the 'SolverCache' is an LMDB database mapping these hashes to
    previously obtained results ('solverCacheEnv', 'solverCacheDB'). If this is
    the first time solver caching is being used and the `SAW_SOLVER_CACHE_PATH`
@@ -79,7 +79,6 @@ import Control.Monad (when, forM_)
 import System.Timeout (timeout)
 
 import GHC.Generics (Generic)
-import qualified Data.IntMap as IntMap
 import Data.IORef (IORef, newIORef, modifyIORef, readIORef)
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import Data.Tuple.Extra (first, firstM)
@@ -93,13 +92,12 @@ import qualified Data.Map.Strict as Map
 
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Data.Text.Encoding (encodeUtf8)
+import qualified Data.Text.Lazy as TextLazy
+import Data.Text.Lazy.Encoding (encodeUtf8)
 import Text.Printf (printf)
 
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
-
-import qualified Crypto.Hash.SHA256 as SHA256
 
 import Data.Aeson ( FromJSON(..), ToJSON(..), FromJSONKey(..), ToJSONKey(..)
                   , (.:), (.:?), (.=), fromJSON )
@@ -113,9 +111,8 @@ import qualified Database.LMDB.Simple.Extra as LMDB
 import qualified Data.SBV.Dynamic as SBV
 
 import SAWCore.FiniteValue
-import SAWCore.Name (VarName(..))
+import SAWCore.Fingerprint (fingerprintSATQuery)
 import SAWCore.SATQuery
-import SAWCore.ExternalFormat
 import SAWCore.SharedTerm
 
 import SAWCentral.Options
@@ -326,36 +323,15 @@ instance Serialise SolverCacheKey where
   encode = encode . solverCacheKeyHash
   decode = solverCacheKeyFromHash <$> decode
 
--- | Hash using SHA256 a 'String' representation of a 'SATQuery' and a 'Set' of
--- 'SolverBackendVersion's to get a 'SolverCacheKey'. In particular, this
--- 'String' representation contains all the 'SolverBackendVersion's, the
--- number of 'satVariables' in the 'SATQuery', the number of 'satUninterp's in
--- the 'SATQuery, and finally the 'scWriteExternal' representation of the
--- 'satQueryAsPropTerm' of the 'SATQuery' - with two additional things:
--- 1. Before calling 'scWriteExternal', we generalize ('scGeneralizeExts') over
---    all 'satVariables' and 'satUninterp's. This ensures the hash does not
---    depend on any execution-specific 'VarIndex'es.
--- 2. After calling 'scWriteExternal', all 'LocalName's in 'Pi' and 'Lam'
---    constructors are removed. This ensures that two terms which are alpha
---    equivalent are given the same hash.
+-- | Hash a 'SATQuery' and a set of 'SolverBackendVersion's to get a
+-- 'SolverCacheKey'. Uses structural hash fingerprinting of the SAWCore term.
 mkSolverCacheKey :: SharedContext -> SolverBackendVersions ->
                     [SolverBackendOption] -> SATQuery -> IO SolverCacheKey
 mkSolverCacheKey sc vs opts satq = do
-  body <- satQueryAsPropTerm sc satq
-  let mkVar x _fot = IntMap.lookup (vnIndex x) (varTypes body)
-  let satVars = Map.mapMaybeWithKey mkVar (satVariables satq)
-  let vars = Map.toList satVars ++
-             filter (\(x, _) -> vnIndex x `elem` satUninterp satq)
-                    (getAllVars body)
-  tm <- scPiList sc vars body
-  let str_prefix = [ showBackendVersionsWithOptions "\n" vs opts
-                   , "satVariables " ++ show (Map.size (satVariables satq))
-                   , "satUninterp "  ++ show (length (satUninterp  satq)) ]
-      str_to_hash = unlines str_prefix ++ anonLocalNames (scWriteExternal tm)
-  return $ SolverCacheKey vs opts $ SHA256.hash $ encodeUtf8 $ Text.pack $ str_to_hash
-  where anonLocalNames = unlines . map (unwords . go . words) . lines
-        go (x:y:_:xs) | y `elem` ["Pi", "Lam"] = x:y:"_":xs
-        go xs = xs
+  mm <- scGetModuleMap sc
+  let prefix = encodeUtf8 $ TextLazy.pack $ showBackendVersionsWithOptions "\n" vs opts
+      fp     = fingerprintSATQuery prefix mm satq
+  pure $ SolverCacheKey vs opts fp
 
 
 -- Solver Cache Values ---------------------------------------------------------

--- a/saw-core/src/SAWCore/Fingerprint.hs
+++ b/saw-core/src/SAWCore/Fingerprint.hs
@@ -1,0 +1,289 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+
+{- |
+Module      : SAWCore.Fingerprint
+Description : SATQuery fingerprinting, intended for solver cache key.
+Copyright   : Galois, Inc. 2026
+License     : BSD3
+Stability   : experimental
+-}
+
+module SAWCore.Fingerprint
+  ( fingerprintSATQuery
+  ) where
+
+import Control.Monad.Reader (MonadReader, runReaderT, ask)
+import Control.Monad.State.Strict (state, gets, modify', evalState, MonadState)
+import qualified Crypto.Hash.SHA256 as SHA256
+import Data.Binary (encode)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BS
+import Data.ByteString.Lazy (ByteString, singleton)
+import Data.Foldable (foldl')
+import Data.IntMap.Strict (IntMap)
+import qualified Data.IntMap.Strict as IntMap
+import Data.IntSet (IntSet)
+import qualified Data.IntSet as IntSet
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8)
+import qualified Data.Vector as V
+import Data.Word (Word8)
+import GHC.Num.Natural (Natural)
+
+
+import SAWCore.FiniteValue (FirstOrderType(..))
+import SAWCore.Module (ModuleMap, ResolvedName(..), Def(..), DataType(..), Ctor(..), lookupVarIndexInMap)
+import SAWCore.Name (Name(..), VarCtx, pattern ImportedName, NameInfo, pattern ModuleIdentifier,
+                     emptyVarCtx, consVarCtx, lookupVarCtx, VarName(..), VarIndex,
+                     moduleIdentToQualName)
+import qualified SAWCore.QualName as QN
+import SAWCore.SATQuery (SATQuery, SATAssert(..), satVariables, satUninterp, satAsserts)
+import SAWCore.Term.Functor (FlatTermF(..), TermF(..), Sort(..), CompiledRecursor(..))
+import SAWCore.Term.Raw (Term, unwrapTermF, termIndex)
+
+-- | Read-only bits of state.
+data FPCfg = FPCfg
+  { fpModuleMap :: !ModuleMap
+    -- ^ The module map for looking up definitions.
+  , fpUninterp  :: !(Set VarIndex)
+    -- ^ Uninterpreted constants (only serialize name + type, not body).
+  }
+
+-- | Mutable state tracked while serializing.
+data FPSt = FPSt
+  { fpTermMemo    :: !(IntMap Int)
+    -- ^ TermIndex -> sequence number (assigned on first serialization).
+  , fpDefMemo     :: !(IntMap Int)
+    -- ^ VarIndex of global Name -> sequence number.
+  , fpDefVisiting :: !IntSet
+    -- ^ VarIndexes currently being traversed.
+  , fpNextRef     :: !Int
+    -- ^ Next available sequence number.
+  }
+
+freshRef :: MonadState FPSt m => m Int
+freshRef = state $ \s ->
+  let n = fpNextRef s in (n, s { fpNextRef = n + 1 })
+
+rememberTerm :: MonadState FPSt m => Term -> Int -> m ()
+rememberTerm t n = modify' $
+  \s -> s { fpTermMemo = IntMap.insert (termIndex t) n $ fpTermMemo s }
+
+lookupTermRef :: MonadState FPSt m => Term -> m (Maybe Int)
+lookupTermRef t = IntMap.lookup (termIndex t) <$> gets fpTermMemo
+
+rememberDef :: MonadState FPSt m => Name -> Int -> m ()
+rememberDef nm n = modify' $
+  \s -> s { fpDefMemo = IntMap.insert (nameIndex nm) n $ fpDefMemo s }
+
+lookupDefRef :: MonadState FPSt m => Name -> m (Bool, Maybe Int)
+lookupDefRef nm = do
+  visiting <- IntSet.member (nameIndex nm) <$> gets fpDefVisiting
+  def      <- IntMap.lookup (nameIndex nm) <$> gets fpDefMemo
+  pure (visiting, def)
+
+visit :: MonadState FPSt m => Name -> m ()
+visit nm = modify' $
+  \s -> s { fpDefVisiting = IntSet.insert (nameIndex nm) $ fpDefVisiting s }
+
+unvisit :: MonadState FPSt m => Name -> m ()
+unvisit nm = modify' $
+  \s -> s { fpDefVisiting = IntSet.delete (nameIndex nm) $ fpDefVisiting s }
+
+lookupName :: MonadReader FPCfg m => Name -> m (Bool, Maybe ResolvedName)
+lookupName nm = do
+  cfg <- ask
+  pure ( Set.member (nameIndex nm) $ fpUninterp cfg
+       , lookupVarIndexInMap (nameIndex nm) $ fpModuleMap cfg
+       )
+
+byte :: Word8 -> BS.Builder
+byte = BS.word8
+
+-- | Markers used to preserve structural sharing without hashing.
+tagRef, tagDef, tagCycle :: Word8
+tagRef   = 0xF1  -- Reference to a previously serialized term or definition.
+tagDef   = 0xF2  -- Introduces a new sequence number followed by its body.
+tagCycle = 0xF3  -- Placeholder emitted when a definition cycle is detected.
+
+-- | Basic serialization of small morsels.
+class Bytes a where
+  bytes :: a -> BS.Builder
+instance Bytes Int where
+  bytes = BS.int64BE . fromIntegral
+instance Bytes Natural where
+  bytes = BS.lazyByteString . encode
+instance Bytes Text where
+  bytes txt = bytes (BS.length bs) <> BS.byteString bs
+    where
+      bs = encodeUtf8 txt
+instance Bytes NameInfo where
+  bytes = \case
+    ModuleIdentifier i -> byte 0x1 <> bytes (QN.ppQualName $ moduleIdentToQualName i)
+    ImportedName qn _  -> byte 0x2 <> bytes (QN.ppQualName qn)
+instance Bytes Sort where
+  bytes = \case
+    PropSort   -> byte 0x1
+    TypeSort n -> byte 0x2 <> bytes n
+instance Bytes FirstOrderType where
+  bytes = \case
+    FOTBit       -> byte 0x1
+    FOTInt       -> byte 0x2
+    FOTRational  -> byte 0x3
+    FOTIntMod n  -> byte 0x4 <> bytes n
+    FOTVec n t   -> byte 0x5 <> bytes n <> bytes t
+    FOTArray k v -> byte 0x6 <> bytes k <> bytes v
+    FOTTuple ts  -> byte 0x7 <> bytes (length ts)
+                             <> foldMap bytes ts
+    FOTRec m     -> byte 0x8 <> bytes (Map.size m)
+                             <> foldMap (\(k, v) -> bytes k <> byte 0 <> bytes v)
+                                        (Map.toAscList m)
+
+fpTerms :: (MonadState FPSt m, MonadReader FPCfg m) => VarCtx -> [Term] -> m BS.Builder
+fpTerms ctx ts = do
+  bs <- mapM (fpTerm ctx) ts
+  pure $ bytes (length ts) <> mconcat bs
+
+fpTerm :: (MonadState FPSt m, MonadReader FPCfg m) => VarCtx -> Term -> m BS.Builder
+fpTerm ctx t = lookupTermRef t >>= \case
+  Just n  -> pure $ byte tagRef <> bytes n
+  Nothing -> do
+    n <- freshRef
+    rememberTerm t n
+    body <- fpTermF ctx (unwrapTermF t)
+    pure $ byte tagDef <> bytes n <> body
+
+fpTermF :: (MonadState FPSt m, MonadReader FPCfg m) => VarCtx -> TermF Term -> m BS.Builder
+fpTermF ctx = \case
+
+  App e1 e2 -> do
+    b1 <- fpTerm ctx e1
+    b2 <- fpTerm ctx e2
+    pure $ byte 0x1 <> b1 <> b2
+
+  Lambda x ty body -> do
+    bty   <- fpTerm ctx ty
+    bbody <- fpTerm (consVarCtx x ctx) body
+    pure $ byte 0x2 <> bty <> bbody
+
+  Pi x ty body -> do
+    bty   <- fpTerm ctx ty
+    bbody <- fpTerm (consVarCtx x ctx) body
+    pure $ byte 0x3 <> bty <> bbody
+
+  Constant nm -> do
+    bdef <- fpDef nm
+    pure $ byte 0x4 <> bdef
+
+  Variable vn ty
+    | Just dbi <- lookupVarCtx vn ctx -> -- Bound var: use index.
+      pure $ byte 0x5 <> bytes dbi
+    | otherwise -> do                    -- Free var: use name.
+      bty <- fpTerm ctx ty
+      pure $ byte 0x6 <> bytes (vnName vn) <> bty
+
+  FTermF (Sort s _) -> -- ignoring SortFlags
+    pure $ byte 0x7 <> bytes s
+
+  FTermF (StringLit txt) ->
+    pure $ byte 0x8 <> bytes txt
+
+  FTermF (ArrayValue elemTy elems) -> do
+    bty <- fpTerm ctx elemTy
+    bs  <- fpTerms ctx (V.toList elems)
+    pure $ byte 0x9 <> bty <> bs
+
+  FTermF (Recursor cr) -> do
+    dtB <- fpDef (recursorDataType cr)
+    pure $ byte 0xa
+        <> bytes (recursorSort cr)
+        <> dtB
+
+fpDef :: (MonadState FPSt m, MonadReader FPCfg m) => Name -> m BS.Builder
+fpDef nm = lookupDefRef nm >>= \case
+  (_,    Just n)  -> pure $ byte tagRef <> bytes n
+  (True, Nothing) -> pure $ byte tagCycle <> ni
+  (False, Nothing) -> do
+    visit nm
+    body <- lookupName nm >>= \case
+      (True, Just (ResolvedDef d)) -> do -- Uninterpreted.
+        bty <- fpTerm emptyVarCtx $ defType d
+        pure $ byte 0x11 <> ni <> bty
+      (_, Just (ResolvedDef d))
+        | Just b <- defBody d -> do
+          bty   <- fpTerm emptyVarCtx $ defType d
+          bbody <- fpTerm emptyVarCtx b
+          pure $ byte 0x13 <> ni <> bty <> bbody
+      (_, Just (ResolvedDef d)) -> do
+        bty <- fpTerm emptyVarCtx $ defType d
+        pure $ byte 0x12 <> ni <> bty
+      (_, Just (ResolvedDataType dt)) -> do
+        bty    <- fpTerm emptyVarCtx $ dtType dt
+        bctors <- fpTerms emptyVarCtx $ ctorType <$> dtCtors dt
+        pure $ byte 0x14 <> ni <> bty <> bctors
+      (_, Just (ResolvedCtor c)) -> do
+        bty <- fpTerm emptyVarCtx $ ctorType c
+        pure $ byte 0x15 <> ni <> bty
+      (_, Nothing) -> pure $ byte 0x16 <> ni
+    unvisit nm
+    n <- freshRef
+    rememberDef nm n
+    pure $ byte tagDef <> bytes n <> body
+  where
+    ni :: BS.Builder
+    ni = bytes $ nameInfo nm
+
+fpAssert :: (MonadState FPSt m, MonadReader FPCfg m) => VarCtx -> SATAssert -> m BS.Builder
+fpAssert ctx = \case
+  BoolAssert tm -> do
+    b <- fpTerm ctx tm
+    pure $ byte 0x21 <> b
+  UniversalAssert vars hyps concl -> do
+    let varTys = foldMap (bytes . snd) vars
+        ctx'   = foldl' (\c (v, _) -> consVarCtx v c) ctx vars
+    bhyps  <- fpTerms ctx' hyps
+    bconcl <- fpTerm ctx' concl
+    pure $ byte 0x22
+        <> bytes (length vars)
+        <> varTys
+        <> bhyps
+        <> bconcl
+
+-- | Produce a SHA256 fingerprint of a SATQuery. This fingerprint should be:
+--   * Stable across runs (has no VarIndex/TermIndex dependence).
+--   * Alpha-equivalence-respecting (uses de Bruijn indices for bound variables).
+--   * Definition-sensitive (transitively serializes constant bodies).
+--   * Relatively fast.
+fingerprintSATQuery :: ByteString -> ModuleMap -> SATQuery -> BS.ByteString
+fingerprintSATQuery prefix mm satq =
+    SHA256.hashlazy $ prefix
+                   <> singleton 0
+                   <> BS.toLazyByteString (evalState (runReaderT satq' cfg) st0)
+  where
+    cfg :: FPCfg
+    cfg = FPCfg mm $ satUninterp satq
+
+    st0 :: FPSt
+    st0 = FPSt mempty mempty mempty 0
+
+    vars :: [(VarName, FirstOrderType)]
+    vars = Map.toAscList $ satVariables satq
+
+    varTys :: BS.Builder
+    varTys = foldMap (bytes . snd) vars
+
+    queryCtx :: VarCtx
+    queryCtx = foldl' (\c (v, _) -> consVarCtx v c) emptyVarCtx vars
+
+    -- Note: asserts are not sorted here, so re-ordering the same
+    -- asserts will produce a different fingerprint.
+    satq' :: (MonadState FPSt m, MonadReader FPCfg m) => m BS.Builder
+    satq' = do
+      asserts <- mapM (fpAssert queryCtx) $ satAsserts satq
+      pure $ bytes (length vars) <> varTys <> mconcat asserts

--- a/saw-core/src/SAWCore/Fingerprint.hs
+++ b/saw-core/src/SAWCore/Fingerprint.hs
@@ -15,8 +15,8 @@ module SAWCore.Fingerprint
   ( fingerprintSATQuery
   ) where
 
-import Control.Monad.Reader (MonadReader, runReaderT, ask)
-import Control.Monad.State.Strict (state, gets, modify', evalState, MonadState)
+import Control.Monad.Reader (ReaderT, MonadReader, runReaderT, ask)
+import Control.Monad.State.Strict (State, MonadState, state, gets, modify', evalState)
 import qualified Crypto.Hash.SHA256 as SHA256
 import Data.Binary (encode)
 import qualified Data.ByteString as BS
@@ -25,8 +25,6 @@ import Data.ByteString.Lazy (ByteString, singleton)
 import Data.Foldable (foldl')
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IntMap
-import Data.IntSet (IntSet)
-import qualified Data.IntSet as IntSet
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -47,55 +45,73 @@ import SAWCore.SATQuery (SATQuery, SATAssert(..), satVariables, satUninterp, sat
 import SAWCore.Term.Functor (FlatTermF(..), TermF(..), Sort(..), CompiledRecursor(..))
 import SAWCore.Term.Raw (Term, unwrapTermF, termIndex)
 
+type FP = ReaderT FPCfg (State FPSt)
+
 -- | Read-only bits of state.
 data FPCfg = FPCfg
   { fpModuleMap :: !ModuleMap
     -- ^ The module map for looking up definitions.
   , fpUninterp  :: !(Set VarIndex)
-    -- ^ Uninterpreted constants (only serialize name + type, not body).
+    -- ^ The set of uninterpreted constants. When these are encountered, only
+    --   the name and type are included in the serialization and not a definition, if
+    --   it exists. See 'lookupName' and 'fpDef'.
   }
 
--- | Mutable state tracked while serializing.
+-- | Mutable state tracked while serializing. Sequence numbers are used to
+--   preserve structural sharing. The first time we encounter a term or definition,
+--   we create a new sequence number and emit it along with a 'tagDef' followed by
+--   the definition. Subsequent encounters just emit the sequence number along with
+--   'tagRef'.
 data FPSt = FPSt
-  { fpTermMemo    :: !(IntMap Int)
-    -- ^ TermIndex -> sequence number (assigned on first serialization).
-  , fpDefMemo     :: !(IntMap Int)
-    -- ^ VarIndex of global Name -> sequence number.
-  , fpDefVisiting :: !IntSet
-    -- ^ VarIndexes currently being traversed.
+  { fpTermMemo    :: !(IntMap BS.Builder)
+    -- ^ TermIndex -> 'tagRef' + sequence number (assigned on first serialization).
+  , fpDefMemo     :: !(IntMap BS.Builder)
+    -- ^ VarIndex of global Name -> 'tagRef' + sequence number.
   , fpNextRef     :: !Int
     -- ^ Next available sequence number.
   }
+
+-- | Markers used to preserve structural sharing without hashing.
+tagRef, tagDef :: Word8
+tagRef   = 0xF1  -- Reference to a previously serialized term or definition.
+tagDef   = 0xF2  -- Introduces a new sequence number followed by its body.
+
+ref :: Int -> BS.Builder
+ref n = byte tagRef <> bytes n
+
+def :: Int -> BS.Builder
+def n = byte tagDef <> bytes n
 
 freshRef :: MonadState FPSt m => m Int
 freshRef = state $ \s ->
   let n = fpNextRef s in (n, s { fpNextRef = n + 1 })
 
-rememberTerm :: MonadState FPSt m => Term -> Int -> m ()
-rememberTerm t n = modify' $
-  \s -> s { fpTermMemo = IntMap.insert (termIndex t) n $ fpTermMemo s }
+-- | Memoize a term, associating a `TermIndex` with a new sequence number.
+--   Returns that sequence number prepended with 'tagDef'.
+rememberTerm :: MonadState FPSt m => Term -> m BS.Builder
+rememberTerm t = do
+  n <- freshRef
+  modify' $
+    \s -> s { fpTermMemo = IntMap.insert (termIndex t) (ref n) $ fpTermMemo s }
+  pure $ def n
 
-lookupTermRef :: MonadState FPSt m => Term -> m (Maybe Int)
-lookupTermRef t = IntMap.lookup (termIndex t) <$> gets fpTermMemo
+lookupTerm :: MonadState FPSt m => Term -> m (Maybe BS.Builder)
+lookupTerm t = IntMap.lookup (termIndex t) <$> gets fpTermMemo
 
-rememberDef :: MonadState FPSt m => Name -> Int -> m ()
-rememberDef nm n = modify' $
-  \s -> s { fpDefMemo = IntMap.insert (nameIndex nm) n $ fpDefMemo s }
+-- | Memoize a name, associating a `VarIndex` with a new sequence number.
+--   Returns that sequence number prepended with 'tagDef'.
+rememberDef :: MonadState FPSt m => Name -> m BS.Builder
+rememberDef nm = do
+  n <- freshRef
+  modify' $
+    \s -> s { fpDefMemo = IntMap.insert (nameIndex nm) (ref n) $ fpDefMemo s }
+  pure $ def n
 
-lookupDefRef :: MonadState FPSt m => Name -> m (Bool, Maybe Int)
-lookupDefRef nm = do
-  visiting <- IntSet.member (nameIndex nm) <$> gets fpDefVisiting
-  def      <- IntMap.lookup (nameIndex nm) <$> gets fpDefMemo
-  pure (visiting, def)
+lookupDef :: MonadState FPSt m => Name -> m (Maybe BS.Builder)
+lookupDef nm = IntMap.lookup (nameIndex nm) <$> gets fpDefMemo
 
-visit :: MonadState FPSt m => Name -> m ()
-visit nm = modify' $
-  \s -> s { fpDefVisiting = IntSet.insert (nameIndex nm) $ fpDefVisiting s }
-
-unvisit :: MonadState FPSt m => Name -> m ()
-unvisit nm = modify' $
-  \s -> s { fpDefVisiting = IntSet.delete (nameIndex nm) $ fpDefVisiting s }
-
+-- | Lookup a name in the 'fpUninterp' set (the `Bool` result) and
+--   'fpModuleMap'.
 lookupName :: MonadReader FPCfg m => Name -> m (Bool, Maybe ResolvedName)
 lookupName nm = do
   cfg <- ask
@@ -105,12 +121,6 @@ lookupName nm = do
 
 byte :: Word8 -> BS.Builder
 byte = BS.word8
-
--- | Markers used to preserve structural sharing without hashing.
-tagRef, tagDef, tagCycle :: Word8
-tagRef   = 0xF1  -- Reference to a previously serialized term or definition.
-tagDef   = 0xF2  -- Introduces a new sequence number followed by its body.
-tagCycle = 0xF3  -- Placeholder emitted when a definition cycle is detected.
 
 -- | Basic serialization of small morsels.
 class Bytes a where
@@ -145,21 +155,20 @@ instance Bytes FirstOrderType where
                              <> foldMap (\(k, v) -> bytes k <> byte 0 <> bytes v)
                                         (Map.toAscList m)
 
-fpTerms :: (MonadState FPSt m, MonadReader FPCfg m) => VarCtx -> [Term] -> m BS.Builder
+fpTerms :: VarCtx -> [Term] -> FP BS.Builder
 fpTerms ctx ts = do
   bs <- mapM (fpTerm ctx) ts
   pure $ bytes (length ts) <> mconcat bs
 
-fpTerm :: (MonadState FPSt m, MonadReader FPCfg m) => VarCtx -> Term -> m BS.Builder
-fpTerm ctx t = lookupTermRef t >>= \case
-  Just n  -> pure $ byte tagRef <> bytes n
+fpTerm :: VarCtx -> Term -> FP BS.Builder
+fpTerm ctx t = lookupTerm t >>= \case
+  Just n  -> pure n
   Nothing -> do
-    n <- freshRef
-    rememberTerm t n
+    tag <- rememberTerm t
     body <- fpTermF ctx (unwrapTermF t)
-    pure $ byte tagDef <> bytes n <> body
+    pure $ tag <> body
 
-fpTermF :: (MonadState FPSt m, MonadReader FPCfg m) => VarCtx -> TermF Term -> m BS.Builder
+fpTermF :: VarCtx -> TermF Term -> FP BS.Builder
 fpTermF ctx = \case
 
   App e1 e2 -> do
@@ -184,7 +193,7 @@ fpTermF ctx = \case
   Variable vn ty
     | Just dbi <- lookupVarCtx vn ctx -> -- Bound var: use index.
       pure $ byte 0x5 <> bytes dbi
-    | otherwise -> do                    -- Free var: use name.
+    | otherwise -> do                    -- Free var: use name + type.
       bty <- fpTerm ctx ty
       pure $ byte 0x6 <> bytes (vnName vn) <> bty
 
@@ -196,50 +205,47 @@ fpTermF ctx = \case
 
   FTermF (ArrayValue elemTy elems) -> do
     bty <- fpTerm ctx elemTy
-    bs  <- fpTerms ctx (V.toList elems)
+    bs  <- fpTerms ctx $ V.toList elems
     pure $ byte 0x9 <> bty <> bs
 
   FTermF (Recursor cr) -> do
-    dtB <- fpDef (recursorDataType cr)
+    dtB <- fpDef $ recursorDataType cr
     pure $ byte 0xa
         <> bytes (recursorSort cr)
         <> dtB
 
-fpDef :: (MonadState FPSt m, MonadReader FPCfg m) => Name -> m BS.Builder
-fpDef nm = lookupDefRef nm >>= \case
-  (_,    Just n)  -> pure $ byte tagRef <> bytes n
-  (True, Nothing) -> pure $ byte tagCycle <> ni
-  (False, Nothing) -> do
-    visit nm
-    body <- lookupName nm >>= \case
-      (True, Just (ResolvedDef d)) -> do -- Uninterpreted.
-        bty <- fpTerm emptyVarCtx $ defType d
-        pure $ byte 0x11 <> ni <> bty
-      (_, Just (ResolvedDef d))
-        | Just b <- defBody d -> do
-          bty   <- fpTerm emptyVarCtx $ defType d
-          bbody <- fpTerm emptyVarCtx b
-          pure $ byte 0x13 <> ni <> bty <> bbody
-      (_, Just (ResolvedDef d)) -> do
-        bty <- fpTerm emptyVarCtx $ defType d
-        pure $ byte 0x12 <> ni <> bty
-      (_, Just (ResolvedDataType dt)) -> do
-        bty    <- fpTerm emptyVarCtx $ dtType dt
-        bctors <- fpTerms emptyVarCtx $ ctorType <$> dtCtors dt
-        pure $ byte 0x14 <> ni <> bty <> bctors
-      (_, Just (ResolvedCtor c)) -> do
-        bty <- fpTerm emptyVarCtx $ ctorType c
-        pure $ byte 0x15 <> ni <> bty
-      (_, Nothing) -> pure $ byte 0x16 <> ni
-    unvisit nm
-    n <- freshRef
-    rememberDef nm n
-    pure $ byte tagDef <> bytes n <> body
+fpDef :: Name -> FP BS.Builder
+fpDef nm = do
+  lookupDef nm >>= \case
+    Just v  -> pure v
+    Nothing -> do
+      tag  <- rememberDef nm
+      body <- lookupName nm >>= \case
+        (True, Just (ResolvedDef d)) -> do -- Uninterpreted.
+          bty <- fpTerm emptyVarCtx $ defType d
+          pure $ byte 0x11 <> ni <> bty
+        (_, Just (ResolvedDef d))
+          | Just b <- defBody d -> do
+            bty   <- fpTerm emptyVarCtx $ defType d
+            bbody <- fpTerm emptyVarCtx b
+            pure $ byte 0x12 <> ni <> bty <> bbody
+        (_, Just (ResolvedDef d)) -> do
+          bty <- fpTerm emptyVarCtx $ defType d
+          pure $ byte 0x13 <> ni <> bty
+        (_, Just (ResolvedDataType dt)) -> do
+          bty    <- fpTerm emptyVarCtx $ dtType dt
+          bctors <- fpTerms emptyVarCtx $ ctorType <$> dtCtors dt
+          pure $ byte 0x14 <> ni <> bty <> bctors
+        (_, Just (ResolvedCtor c)) -> do
+          bty <- fpTerm emptyVarCtx $ ctorType c
+          pure $ byte 0x15 <> ni <> bty
+        (_, Nothing) -> pure $ byte 0x16 <> ni
+      pure $ tag <> body
   where
     ni :: BS.Builder
     ni = bytes $ nameInfo nm
 
-fpAssert :: (MonadState FPSt m, MonadReader FPCfg m) => VarCtx -> SATAssert -> m BS.Builder
+fpAssert :: VarCtx -> SATAssert -> FP BS.Builder
 fpAssert ctx = \case
   BoolAssert tm -> do
     b <- fpTerm ctx tm
@@ -270,7 +276,7 @@ fingerprintSATQuery prefix mm satq =
     cfg = FPCfg mm $ satUninterp satq
 
     st0 :: FPSt
-    st0 = FPSt mempty mempty mempty 0
+    st0 = FPSt mempty mempty 0
 
     vars :: [(VarName, FirstOrderType)]
     vars = Map.toAscList $ satVariables satq
@@ -283,7 +289,7 @@ fingerprintSATQuery prefix mm satq =
 
     -- Note: asserts are not sorted here, so re-ordering the same
     -- asserts will produce a different fingerprint.
-    satq' :: (MonadState FPSt m, MonadReader FPCfg m) => m BS.Builder
+    satq' :: FP BS.Builder
     satq' = do
       asserts <- mapM (fpAssert queryCtx) $ satAsserts satq
       pure $ bytes (length vars) <> varTys <> mconcat asserts

--- a/saw.cabal
+++ b/saw.cabal
@@ -442,7 +442,6 @@ library saw-central
     cborg-json,
     containers,
     constraints >= 0.6,
-    cryptohash-sha256 >= 0.11.102.1,
     deepseq,
     directory >= 1.2.4.0,
     exceptions,

--- a/saw.cabal
+++ b/saw.cabal
@@ -116,8 +116,10 @@ library saw-core
     base >= 4.8,
     aeson >= 2.0 && < 2.3,
     array,
+    binary,
     bytestring,
     containers,
+    cryptohash-sha256 >= 0.11.102.1,
     data-inttrie,
     data-ref,
     directory,
@@ -152,6 +154,7 @@ library saw-core
   exposed-modules:
     SAWCore.SAWCore
     SAWCore.ExternalFormat
+    SAWCore.Fingerprint
     SAWCore.Conversion
     SAWCore.Cache
     SAWCore.FiniteValue


### PR DESCRIPTION
This PR:
* Implements a new fingerprinting algorithm that fixes some solver cache issues (see #2681).
* Includes some minor fixes/refactoring to the solver cache intended to improve performance (batching of some LMDB transactions).
* Makes `to/fromSolverCacheValue` into total functions and a bit more performant (no more `!!`).
* Fix order of reported cached/current versions by `cleanMismatchedVersionsSolverCache`.

The new SATQuery fingerprinter (`saw-core/src/SAWCore/Fingerprint.hs`) works by hashing a serialization of the SAWCore term, where the serialization respects alpha-equivalence, doesn't include any `Var/TermIndex`, and does include definitions of global constants.

Performance-wise, from what I can tell, I think it's comparable to the old one. Let me know if there's a particular example I should look at though -- none of the benchmarks I've tried seem to demonstrate particularly bad performance for either algorithm.

[One potentially low-hanging fruit performance-wise that this PR doesn't include: remove the cache entry timestamp update operation from [`lookupInSolverCache`](https://github.com/GaloisInc/saw-script/blob/2afa79b6d1fb8d2b699f3d56b7d1a51dc5c58582/saw-central/src/SAWCentral/SolverCache.hs#L534), which turns every cache hit into both a DB lookup and record update, in two transactions. Messing with this didn't really seem to have much impact on my benchmarks, though.]