### PR TITLE
Produce artifacts for the new Crux repository.

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -19,32 +19,21 @@ extract_exe() {
 }
 
 setup_crux_dist_bins() {
-  local dist_dir=${1:-dist}
+  local dist_dir="${1:-dist}"
   extract_exe "crux-mir-comp" "${dist_dir}/bin"
 }
 
 setup_cryptol_dist_bins() {
-  local dist_dir=${1:-dist}
+  local dist_dir="${1:-dist}"
   extract_exe "cryptol" "${dist_dir}/bin"
 }
 
-setup_saw_dist_bins() {
-  local dist_dir=${1:-dist}
-  if $IS_WIN; then
-    is_exe "dist/bin" "saw" && return
-  else
-    is_exe "dist/bin" "saw" && is_exe "dist/bin" "saw-remote-api" && return
-    extract_exe "saw-remote-api" "dist/bin"
-  fi
-  extract_exe "saw" "dist/bin"
-}
-
 setup_dist_bin_directory() {
-  local dist_dir=${1:-dist}  
+  local dist_dir="${1:-dist}"
   export PATH="$PWD/${dist_dir}/bin:$PATH"
-  echo "$PWD/dist/bin" >> "$GITHUB_PATH"
-  strip dist/bin/saw* || echo "Strip failed: Ignoring harmless error"
-  $IS_WIN || chmod +x dist/bin/*
+  echo "$PWD/${dist_dir}/bin" >> "$GITHUB_PATH"
+  strip "${dist_dir}/bin/saw*" || echo "Strip failed: Ignoring harmless error"
+  $IS_WIN || chmod +x "${dist_dir}/bin/*"
 }
 
 # Extract a subset of the compiled binaries into a location that will be
@@ -58,10 +47,18 @@ setup_dist_bin_directory() {
 #   in a given SAW release, and having a standalone Cryptol executable allows
 #   one to test it in isolation.
 setup_dist_bins() {
-  setup_saw_dist_bins
-  setup_crux_dist_bins
-  setup_cryptol_dist_bins
-  setup_dist_bin_directory
+  local dist_dir=${1:-dist}
+  if $IS_WIN; then
+    is_exe "${dist_dir}/bin" "saw" && return
+  else
+    is_exe "${dist_dir}/bin" "saw" && is_exe "${dist_dir}/bin" "saw-remote-api" && return
+    extract_exe "saw-remote-api" "${dist_dir}/bin"
+  fi
+  extract_exe "saw" "${dist_dir}/bin"
+
+  setup_crux_dist_bins "${dist_dir}"
+  setup_cryptol_dist_bins "${dist_dir}"
+  setup_dist_bin_directory "${dist_dir}"
 }
 
 build() {

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -32,8 +32,8 @@ setup_dist_bin_directory() {
   local dist_dir="${1:-dist}"
   export PATH="$PWD/${dist_dir}/bin:$PATH"
   echo "$PWD/${dist_dir}/bin" >> "$GITHUB_PATH"
-  strip "${dist_dir}/bin/saw*" || echo "Strip failed: Ignoring harmless error"
-  $IS_WIN || chmod +x "${dist_dir}/bin/*"
+  strip "${dist_dir}"/bin/saw* || echo "Strip failed: Ignoring harmless error"
+  $IS_WIN || chmod +x "${dist_dir}"/bin/*
 }
 
 # Extract a subset of the compiled binaries into a location that will be

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -18,6 +18,35 @@ extract_exe() {
   $IS_WIN || chmod +x "$2/$name"
 }
 
+setup_crux_dist_bins() {
+  local dist_dir=${1:-dist}
+  extract_exe "crux-mir-comp" "${dist_dir}/bin"
+}
+
+setup_cryptol_dist_bins() {
+  local dist_dir=${1:-dist}
+  extract_exe "cryptol" "${dist_dir}/bin"
+}
+
+setup_saw_dist_bins() {
+  local dist_dir=${1:-dist}
+  if $IS_WIN; then
+    is_exe "dist/bin" "saw" && return
+  else
+    is_exe "dist/bin" "saw" && is_exe "dist/bin" "saw-remote-api" && return
+    extract_exe "saw-remote-api" "dist/bin"
+  fi
+  extract_exe "saw" "dist/bin"
+}
+
+setup_dist_bin_directory() {
+  local dist_dir=${1:-dist}  
+  export PATH="$PWD/${dist_dir}/bin:$PATH"
+  echo "$PWD/dist/bin" >> "$GITHUB_PATH"
+  strip dist/bin/saw* || echo "Strip failed: Ignoring harmless error"
+  $IS_WIN || chmod +x dist/bin/*
+}
+
 # Extract a subset of the compiled binaries into a location that will be
 # included in a binary distribution. Currently, this subset consists of the
 # following binaries:
@@ -29,19 +58,10 @@ extract_exe() {
 #   in a given SAW release, and having a standalone Cryptol executable allows
 #   one to test it in isolation.
 setup_dist_bins() {
-  if $IS_WIN; then
-    is_exe "dist/bin" "saw" && return
-  else
-    is_exe "dist/bin" "saw" && is_exe "dist/bin" "saw-remote-api" && return
-    extract_exe "saw-remote-api" "dist/bin"
-  fi
-  extract_exe "saw" "dist/bin"
-  extract_exe "crux-mir-comp" "dist/bin"
-  extract_exe "cryptol" "dist/bin"
-  export PATH=$PWD/dist/bin:$PATH
-  echo "$PWD/dist/bin" >> "$GITHUB_PATH"
-  strip dist/bin/saw* || echo "Strip failed: Ignoring harmless error"
-  $IS_WIN || chmod +x dist/bin/*
+  setup_saw_dist_bins
+  setup_crux_dist_bins
+  setup_cryptol_dist_bins
+  setup_dist_bin_directory
 }
 
 build() {
@@ -178,7 +198,8 @@ sign() {
 
 zip_dist() {
   name="$1"
-  cp -r dist "$name"
+  dist_dir="${2:-dist}"
+  cp -r "${dist_dir}" "$name"
   tar -czf "$name".tar.gz "$name"
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,14 @@ jobs:
           if-no-files-found: error
           retention-days: ${{ needs.config.outputs.retention-days }}
 
+      - if: matrix.ghc == '9.6.7' && matrix.hpc == false
+        uses: actions/upload-artifact@v5
+        with:
+          name: ${{ steps.config.outputs.crux-name }} (GHC ${{ matrix.ghc }})
+          path: "${{ steps.config.outputs.crux-name }}.tar.gz*"
+          if-no-files-found: error
+          retention-days: ${{ needs.config.outputs.retention-days }}
+
       - if: matrix.ghc == '9.6.7' && matrix.run-tests && matrix.hpc == false
         uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
           echo "NAME=${{ needs.config.outputs.name }}-${{ matrix.os }}-${{ runner.arch }}" >> $GITHUB_ENV
           CRUX_NAME="${{ needs.config.outputs.crux-name }}-${{ matrix.os }}-${{ runner.arch }}"
           .github/ci.sh output crux-name $CRUX_NAME
-          echo "NAME=${{ needs.config.outputs.crux-name }}-${{ matrix.os }}-${{ runner.arch }}" >> $GITHUB_ENV
+          echo "CRUX_NAME=${{ needs.config.outputs.crux-name }}-${{ matrix.os }}-${{ runner.arch }}" >> $GITHUB_ENV
 
       - uses: haskell-actions/setup@v2
         id: setup-haskell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
     outputs:
       name: ${{ steps.config.outputs.name }}
       saw-version: ${{ steps.config.outputs.saw-version }}
+      crux-name: ${{ steps.config.outputs.crux-name }}
       crux-version: ${{ steps.config.outputs.crux-version }}
       event-tag: ${{ steps.config.outputs.tag }}
       event-schedule: ${{ steps.config.outputs.schedule }}
@@ -69,6 +70,7 @@ jobs:
           set -x
           .github/ci.sh output name saw-$(.github/ci.sh saw_ver)
           .github/ci.sh output saw-version $(.github/ci.sh saw_ver)
+          .github/ci.sh output crux-name crux-mir-comp-$(.github/ci.sh crux_ver)
           .github/ci.sh output crux-version $(.github/ci.sh crux_ver)
           .github/ci.sh output tag $EVENT_TAG
           .github/ci.sh output schedule $EVENT_SCHEDULE
@@ -138,6 +140,9 @@ jobs:
           NAME="${{ needs.config.outputs.name }}-${{ matrix.os }}-${{ runner.arch }}"
           .github/ci.sh output name $NAME
           echo "NAME=${{ needs.config.outputs.name }}-${{ matrix.os }}-${{ runner.arch }}" >> $GITHUB_ENV
+          CRUX_NAME="${{ needs.config.outputs.crux-name }}-${{ matrix.os }}-${{ runner.arch }}"
+          .github/ci.sh output crux-name $CRUX_NAME
+          echo "NAME=${{ needs.config.outputs.crux-name }}-${{ matrix.os }}-${{ runner.arch }}" >> $GITHUB_ENV
 
       - uses: haskell-actions/setup@v2
         id: setup-haskell
@@ -226,6 +231,12 @@ jobs:
       - shell: bash
         run: .github/ci.sh zip_dist_with_solvers $NAME-with-solvers
 
+      - shell: bash
+        run: .github/ci.sh setup_crux_dist_bins dist-crux
+
+      - shell: bash
+        run: .github/ci.sh zip_dist $CRUX_NAME dist-crux
+
       # Restrict these steps so they're only run when the secrets
       # needed are available. It's insufficient to just check whether
       # we're working on a pull request in a fork because we might be
@@ -252,6 +263,16 @@ jobs:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
         run: .github/ci.sh sign $NAME-with-solvers.tar.gz
+
+      - if: matrix.ghc == '9.6.7' &&
+            github.event.pull_request.head.repo.fork == false &&
+            github.repository_owner == 'GaloisInc' &&
+            github.actor != 'dependabot[bot]'
+        shell: bash
+        env:
+          SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+        run: .github/ci.sh sign $CRUX_NAME.tar.gz
 
       ##########################################################################
       # We upload an archive containing SAW, and also and archive containing SAW
@@ -880,14 +901,17 @@ jobs:
           - file: saw/Dockerfile
             image: ghcr.io/galoisinc/saw
             cache: ghcr.io/galoisinc/cache-saw
+            image-repo: GaloisInc/saw-script
             image-tag: ${{ needs.config.outputs.saw-version }}
           - file: saw-remote-api/Dockerfile
             image: ghcr.io/galoisinc/saw-remote-api
             cache: ghcr.io/galoisinc/cache-saw-remote-api
+            image-repo: GaloisInc/saw-script
             image-tag: ${{ needs.config.outputs.saw-version }}
           - file: crux-mir-comp/Dockerfile
             image: ghcr.io/galoisinc/crux-mir-comp
             cache: ghcr.io/galoisinc/cache-crux-mir-comp
+            image-repo: GaloisInc/crux
             image-tag: ${{ needs.config.outputs.crux-version }}
     steps:
       - uses: actions/checkout@v4
@@ -918,11 +942,13 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
-      - uses: crazy-max/ghaction-docker-meta@v1
+      - uses: docker/metadata-action@v6
         name: Labels
         id: labels
         with:
           images: ${{ matrix.image }}
+          labels: |
+             org.opencontainers.image.source=https://github.com/${{ matrix.image-repo }}
 
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
This pull requests sets the CI to produce the Crux-related binaries as a separate artifact, and to deploy the Crux-related Docker images to the Crux repository.

For the Docker images actually to deploy to the Crux repository will require further adjustments on the registry side.