### PR TITLE
Backport CI fixes to 1.5 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
     # tags only. Skip running it on forks as well, because we won't have
     # the signing key there.
     if: github.event_name == 'push' &&
-        needs.config.outputs.tag == 'true' &&
+        needs.config.outputs.event-tag == 'true' &&
         github.repository_owner == 'GaloisInc' &&
         github.actor != 'dependabot[bot]'
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
       - if: matrix.ghc == '9.6.7' && matrix.hpc == false
         uses: actions/upload-artifact@v5
         with:
-          name: ${{ steps.config.outputs.name }}-with-solvers (GHC ${{ matrix.ghc }})
+          name: ${{ steps.config.outputs.name }}-with-solvers
           path: "${{ steps.config.outputs.name }}-with-solvers.tar.gz*"
           if-no-files-found: error
           retention-days: ${{ needs.config.outputs.retention-days }}

--- a/s2nTests/scripts/blst-entrypoint.sh
+++ b/s2nTests/scripts/blst-entrypoint.sh
@@ -4,14 +4,15 @@ set -xe
 export IN_SAW_CI=yes
 
 cd /workdir
+mkdir bin
 cp /saw-bin/cryptol bin/cryptol
 cp /saw-bin/saw bin/saw
 cp /saw-bin/abc bin/abc
 cp /saw-bin/yices bin/yices
+cp /saw-bin/yices-smt2 bin/yices-smt2
 # Z3 4.8.14 has been known to nondeterministically time out with the BLST
 # proofs, so fall back to 4.8.8 instead. See #1772.
 cp /saw-bin/z3-4.8.8 bin/z3
-./scripts/install.sh
 
 export PATH=/workdir/bin:$PATH
 export CRYPTOLPATH=/workdir/cryptol-specs:/workdir/spec

--- a/s2nTests/scripts/blst-entrypoint.sh
+++ b/s2nTests/scripts/blst-entrypoint.sh
@@ -4,7 +4,6 @@ set -xe
 export IN_SAW_CI=yes
 
 cd /workdir
-./scripts/install.sh
 cp /saw-bin/cryptol bin/cryptol
 cp /saw-bin/saw bin/saw
 cp /saw-bin/abc bin/abc
@@ -12,6 +11,7 @@ cp /saw-bin/yices bin/yices
 # Z3 4.8.14 has been known to nondeterministically time out with the BLST
 # proofs, so fall back to 4.8.8 instead. See #1772.
 cp /saw-bin/z3-4.8.8 bin/z3
+./scripts/install.sh
 
 export PATH=/workdir/bin:$PATH
 export CRYPTOLPATH=/workdir/cryptol-specs:/workdir/spec


### PR DESCRIPTION
This backports #3016 (fix generation of source archives in releases) and #3067 (avoid whitespace in CI artefact names). Update: added #3065 (yices download failure workaround) as well.