### PR TITLE
Improve `yosys_import` error message for cyclic data dependencies.

### DIFF
--- a/saw-central/src/SAWCentral/Yosys.hs
+++ b/saw-central/src/SAWCentral/Yosys.hs
@@ -92,7 +92,7 @@ convertYosysIR sc ir =
      foldM
        (\env v ->
           do let (m, nm, _) = mg ^. modgraphNodeFromVertex $ v
-             cm <- convertModule sc env m
+             cm <- convertModule sc env nm m
              n <- Nonce.freshNonce Nonce.globalNonceGenerator
              let qn = QN.fromNameIndex
                    QN.NamespaceYosys
@@ -139,7 +139,7 @@ yosysIRToSequential sc ir nm =
       [ "Could not find module: "
       , nm
       ]
-    Just m -> convertModuleInline sc m
+    Just m -> convertModuleInline sc nm m
 
 --------------------------------------------------------------------------------
 -- ** Functions visible from SAWScript REPL

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -164,16 +164,17 @@ lookupPatternTerm sc loc pat ts =
 netgraphToTerms ::
   SC.SharedContext ->
   Map CellTypeName ConvertedModule ->
+  CellTypeName ->
   Netgraph ->
   WireEnv ->
   Map CellInstName SC.Term {- ^ state inputs -} ->
   IO WireEnv
-netgraphToTerms sc env (Netgraph nodes) inputs states =
+netgraphToTerms sc env mname (Netgraph nodes) inputs states =
   foldM doVertex inputs (Graph.stronglyConnCompR nodes)
   where
     doVertex :: WireEnv -> Graph.SCC (Cell, CellInstName, [CellInstName]) -> IO WireEnv
     doVertex _ (Graph.CyclicSCC vs) =
-      yosysError $ YosysErrorCyclicDependency [ cnm | (_, cnm, _) <- vs ]
+      yosysError $ YosysErrorCyclicDependency mname [ cnm | (_, cnm, _) <- vs ]
     doVertex acc (Graph.AcyclicSCC (c, cnm, _deps)) =
       do let outputFields = Map.filter isOutput (c ^. cellPortDirections)
          let lookupConn portname =
@@ -423,9 +424,10 @@ parseNat _ = Nothing
 convertModule ::
   SC.SharedContext ->
   Map CellTypeName ConvertedModule ->
+  CellTypeName ->
   Module ->
   IO ConvertedModule
-convertModule sc env m0 =
+convertModule sc env mname m0 =
   do let m = renameDffInstances m0
      let ng = moduleNetgraph env m
 
@@ -493,7 +495,7 @@ convertModule sc env m0 =
            ]
 
      -- translate outputs of all cells in dependency order
-     terms <- netgraphToTerms sc env ng inputs oldstates
+     terms <- netgraphToTerms sc env mname ng inputs oldstates
      -- assemble the final output
      outputRecord <- cryptolRecord sc =<< mapForWithKeyM outputPorts
        (\onm out -> lookupPatternTerm sc (YosysBitvecConsumerOutputPort onm) out terms)

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -54,13 +54,9 @@ import SAWCentral.Yosys.Cell
 -- ** Building a network graph from a Yosys module
 
 -- | A 'Netgraph' represents the data dependencies between 'Cell's in
--- a module. The graph has 'Text' keys which are the cell instance
+-- a module. The graph has 'CellInstName' keys which are the cell instance
 -- names.
-data Netgraph = Netgraph
-  { _netgraphGraph :: Graph.Graph
-  , _netgraphNodeFromVertex :: Graph.Vertex -> (Cell, CellInstName, [CellInstName])
-  }
-makeLenses ''Netgraph
+newtype Netgraph = Netgraph [(Cell, CellInstName, [CellInstName])]
 
 moduleNetgraph :: Map CellTypeName ConvertedModule -> Module -> Netgraph
 moduleNetgraph env m =
@@ -112,11 +108,8 @@ moduleNetgraph env m =
 
     nodes :: [(Cell, CellInstName, [CellInstName])]
     nodes = [ (c, cname, cellDeps c) | (cname, c) <- Map.assocs (m ^. moduleCells) ]
-
-    (_netgraphGraph, _netgraphNodeFromVertex, _netgraphVertexFromKey) =
-      Graph.graphFromEdges nodes
   in
-    Netgraph{..}
+    Netgraph nodes
 
 --------------------------------------------------------------------------------
 -- ** Building a SAWCore term from a network graph
@@ -175,17 +168,14 @@ netgraphToTerms ::
   WireEnv ->
   Map CellInstName SC.Term {- ^ state inputs -} ->
   IO WireEnv
-netgraphToTerms sc env ng inputs states
-  | length (Graph.scc $ ng ^. netgraphGraph) /= length (ng ^. netgraphGraph)
-  = yosysError $ YosysError "Network graph contains a cycle after splitting on DFFs; SAW does not currently support analysis of this circuit"
-  | otherwise =
-      let sorted = reverseTopSort $ ng ^. netgraphGraph
-      in foldM doVertex inputs sorted
+netgraphToTerms sc env (Netgraph nodes) inputs states =
+  foldM doVertex inputs (Graph.stronglyConnCompR nodes)
   where
-    doVertex :: WireEnv -> Graph.Vertex -> IO WireEnv
-    doVertex acc v =
-      do let (c, cnm, _deps) = ng ^. netgraphNodeFromVertex $ v
-         let outputFields = Map.filter isOutput (c ^. cellPortDirections)
+    doVertex :: WireEnv -> Graph.SCC (Cell, CellInstName, [CellInstName]) -> IO WireEnv
+    doVertex _ (Graph.CyclicSCC vs) =
+      yosysError $ YosysErrorCyclicDependency [ cnm | (_, cnm, _) <- vs ]
+    doVertex acc (Graph.AcyclicSCC (c, cnm, _deps)) =
+      do let outputFields = Map.filter isOutput (c ^. cellPortDirections)
          let lookupConn portname =
                case Map.lookup portname (c ^. cellConnections) of
                  Nothing ->

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -164,7 +164,7 @@ lookupPatternTerm sc loc pat ts =
 netgraphToTerms ::
   SC.SharedContext ->
   Map CellTypeName ConvertedModule ->
-  CellTypeName ->
+  CellTypeName {- ^ Module type being translated, for error reporting -} ->
   Netgraph ->
   WireEnv ->
   Map CellInstName SC.Term {- ^ state inputs -} ->

--- a/saw-central/src/SAWCentral/Yosys/State.hs
+++ b/saw-central/src/SAWCentral/Yosys/State.hs
@@ -88,9 +88,10 @@ insertStateField sc stateFields fields =
 -- | Translate a stateful HDL module into SAWCore
 convertModuleInline ::
   SC.SharedContext ->
+  CellTypeName ->
   Module ->
   IO YosysSequential
-convertModuleInline sc m0 =
+convertModuleInline sc mname m0 =
   do let m = renameDffInstances m0
      let ng = moduleNetgraph Map.empty m
 
@@ -157,7 +158,7 @@ convertModuleInline sc m0 =
            , derivedInputs
            ]
 
-     terms <- netgraphToTerms sc Map.empty ng inputs prestates
+     terms <- netgraphToTerms sc Map.empty mname ng inputs prestates
 
      postStateFields <-
        mapForWithKeyM dffs $ \cnm c ->

--- a/saw-central/src/SAWCentral/Yosys/Utils.hs
+++ b/saw-central/src/SAWCentral/Yosys/Utils.hs
@@ -95,11 +95,12 @@ instance Exception YosysError
 instance Show YosysError where
   show (YosysError msg) = Text.unpack $ "Error: " <> msg <> "\n" <> reportBugText
   show (YosysErrorCyclicDependency mname cnms) =
-    Text.unpack $ mconcat $
-    [ "While translating module \"" <> mname <> "\":\n"
-    , "Network graph contains a cycle after splitting on registers;\n"
-    , "SAW does not currently support analysis of this circuit." ] ++
-    [ "\n  \"" <> cnm <> "\"" | cnm <- cnms ]
+    Text.unpack $ Text.intercalate "\n" $
+    [ "While translating module \"" <> mname <> "\":"
+    , "Network graph contains a cycle after splitting on registers;"
+    , "SAW does not currently support analysis of this circuit."
+    , "Cells participating:" ] ++
+    [ "  \"" <> cnm <> "\"" | cnm <- cnms ]
   show (YosysErrorTypeError msg err) = Text.unpack $ mconcat
     [ "Error: An internal term failed to type-check.\n"
     , "This occured while ", msg, ".\n"

--- a/saw-central/src/SAWCentral/Yosys/Utils.hs
+++ b/saw-central/src/SAWCentral/Yosys/Utils.hs
@@ -81,7 +81,7 @@ data YosysBitvecConsumer
 
 data YosysError
   = YosysError Text
-  | YosysErrorCyclicDependency [CellInstName]
+  | YosysErrorCyclicDependency CellTypeName [CellInstName]
   | YosysErrorTypeError Text Text
   | YosysErrorNoSuchOutputBitvec Text YosysBitvecConsumer
   | YosysErrorNoSuchSubmodule CellTypeName CellInstName
@@ -94,11 +94,12 @@ data YosysError
 instance Exception YosysError
 instance Show YosysError where
   show (YosysError msg) = Text.unpack $ "Error: " <> msg <> "\n" <> reportBugText
-  show (YosysErrorCyclicDependency cnms) =
+  show (YosysErrorCyclicDependency mname cnms) =
     Text.unpack $ mconcat $
-    [ "Network graph contains a cycle after splitting on registers;\n"
+    [ "While translating module \"" <> mname <> "\":\n"
+    , "Network graph contains a cycle after splitting on registers;\n"
     , "SAW does not currently support analysis of this circuit." ] ++
-    [ "\n  " <> cnm | cnm <- cnms ]
+    [ "\n  \"" <> cnm <> "\"" | cnm <- cnms ]
   show (YosysErrorTypeError msg err) = Text.unpack $ mconcat
     [ "Error: An internal term failed to type-check.\n"
     , "This occured while ", msg, ".\n"

--- a/saw-central/src/SAWCentral/Yosys/Utils.hs
+++ b/saw-central/src/SAWCentral/Yosys/Utils.hs
@@ -81,6 +81,7 @@ data YosysBitvecConsumer
 
 data YosysError
   = YosysError Text
+  | YosysErrorCyclicDependency [CellInstName]
   | YosysErrorTypeError Text Text
   | YosysErrorNoSuchOutputBitvec Text YosysBitvecConsumer
   | YosysErrorNoSuchSubmodule CellTypeName CellInstName
@@ -93,6 +94,11 @@ data YosysError
 instance Exception YosysError
 instance Show YosysError where
   show (YosysError msg) = Text.unpack $ "Error: " <> msg <> "\n" <> reportBugText
+  show (YosysErrorCyclicDependency cnms) =
+    Text.unpack $ mconcat $
+    [ "Network graph contains a cycle after splitting on registers;\n"
+    , "SAW does not currently support analysis of this circuit." ] ++
+    [ "\n  " <> cnm | cnm <- cnms ]
   show (YosysErrorTypeError msg err) = Text.unpack $ mconcat
     [ "Error: An internal term failed to type-check.\n"
     , "This occured while ", msg, ".\n"


### PR DESCRIPTION
The old error message was uninformative:
```
Network graph contains a cycle after splitting on registers; SAW does not currently support analysis of this circuit.
```

The new error message looks something like this:
```
While translating module "aes_core":
Network graph contains a cycle after splitting on registers;
SAW does not currently support analysis of this circuit.
  "gen_rounds(2)\.r_odd_inst"
  "gen_rounds(2)\.r_even_inst"
```

Fixes #3160.