### PR TITLE
crucible-mir-comp: Don't error out if an uninterpreted name cannot be resolved

### DIFF
--- a/crucible-mir-comp/src/Mir/Compositional/State.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/State.hs
@@ -9,7 +9,6 @@ import Data.IORef
 import Data.Set(Set)
 import qualified Data.Set as Set
 import Data.Text(Text)
-import qualified Data.Text as Text
 
 import qualified SAWCentral.Builtins as SAW
 import qualified SAWCore.SharedTerm as SAW
@@ -60,8 +59,23 @@ newMirState =
     }
 
 -- | Resolve the given name and add it mark it as an uninterpreted function.
--- Throws an exception if the name does not refer to anything.  If it
--- refers to multiple things, they are all uninterpreted.
+-- If it refers to multiple things, they are all uninterpreted. If the name
+-- cannot be resolved, then do nothing.
+
+-- There is a design choice about what to do if a name cannot be resolved. An
+-- alternative approach would be to throw an exception if this happens, but we
+-- opt not do this for the following reasons:
+--
+-- 1. It is inconsistent with how SAWScript proof scripts like
+--    `w4_unint_z3 ["foo"]` work, which proceed even if the program being
+--    verified does not mention the name "foo".
+--
+-- 2. crucible-mir-comp loads Cryptol code lazily, which means that a function
+--    being marked as uninterpreted may appear in a Cryptol module that has yet
+--    to be loaded. (See the `test/symb_eval/cryptol/uninterp_multi_module.rs`
+--    test case for an example of this.) We don't want to throw an exception
+--    if this occurs, since that just means that we haven't yet loaded any code
+--    that references the function to be uninterpreted.
 resolveUninterp :: MirState t -> IO (Set SAW.VarIndex)
 resolveUninterp s =
   do
@@ -69,8 +83,6 @@ resolveUninterp s =
     let resolve done nm =
           do
             vars <- SAW.resolveNameIO (mirSharedContext s) env nm
-            case vars of
-              [] -> fail ("uninterp: undefined name `" ++ Text.unpack nm ++ "`")
-              _  -> pure (Set.union (Set.fromList vars) done)
+            pure (Set.union (Set.fromList vars) done)
     foldM resolve Set.empty =<< readIORef (mirKeepUninterp s)
-  
+

--- a/crux-mir-comp/test/symb_eval/cryptol/uninterp_multi_module.good
+++ b/crux-mir-comp/test/symb_eval/cryptol/uninterp_multi_module.good
@@ -1,0 +1,3 @@
+test uninterp_multi_module/<DISAMB>::foo_test[0]: ok
+
+[Crux] Overall status: Valid.

--- a/crux-mir-comp/test/symb_eval/cryptol/uninterp_multi_module.rs
+++ b/crux-mir-comp/test/symb_eval/cryptol/uninterp_multi_module.rs
@@ -1,0 +1,57 @@
+// A regression test for #3164. Here is the play-by-play:
+//
+// * We import two Cryptol functions `a` and `b`, each from different Cryptol
+//   modules `uninterp_multi_module_a` and `uninterp_multi_module_b`,
+//   respectively (neither of which imports the other).
+//
+// * We mark `b` as uninterpreted, so any time `crux-mir-comp` loads a Cryptol
+//   function into SAWCore, it must check to see if the Cryptol function
+//   contains `b` or not. This requires resolving the name `b` in the current
+//   Cryptol environment.
+//
+// * Because `crux-mir-comp` loads Cryptol code lazily, the first time that it
+//   tries to load any Cryptol code is when it invokes `a` in the body of
+//   `foo`. `crux-mir-comp` will load the `uninterp_multi_module_a` module (as
+//   declared by the corresponding `cryptol!` block) and then try to resolve
+//   `b` in the current Cryptol environment. Note, however, that the
+//   `uninterp_multi_module_b` module (which contains `b`) hasn't been loaded
+//   yet!
+//
+// * Due to #3164, `crux-mir-comp` used to throw an exception here, as it
+//   couldn't find `b`. After fixing #3164, however, `crux-mir-comp` simply
+//   proceeds after failing to find `b`, as there is nothing to mark
+//   uninterpreted in the definition of `a`.
+//
+// * Later, when `crux-mir-comp` invokes `b` in the body of `foo`, it will load
+//   the `uninterp_multi_module_b` module. Then, when it attempts to resolve
+//   `b` in the current Cryptol environment, it will successfully find it. This
+//   allows `crux-mir-comp` to treat `b` as uninterpreted.
+
+extern crate crucible;
+use crucible::{Symbolic, cryptol};
+use crucible::cryptol::uninterp;
+
+mod cry {
+    use super::*;
+
+    cryptol! {
+        path "test::symb_eval::cryptol::uninterp_multi_module_a";
+        pub fn a(x: u8) -> u8 = "a";
+    }
+
+    cryptol! {
+        path "test::symb_eval::cryptol::uninterp_multi_module_b";
+        pub fn b(x: u8) -> u8 = "b";
+    }
+}
+
+fn foo(x: u8) -> u8 {
+    cry::a(x).wrapping_add(cry::b(x))
+}
+
+#[crux::test]
+fn foo_test() {
+    uninterp("b");
+    let x = u8::symbolic("x");
+    foo(x);
+}

--- a/crux-mir-comp/test/symb_eval/cryptol/uninterp_multi_module_a.cry
+++ b/crux-mir-comp/test/symb_eval/cryptol/uninterp_multi_module_a.cry
@@ -1,0 +1,4 @@
+module test::symb_eval::cryptol::uninterp_multi_module_a where
+
+a : [8] -> [8]
+a x = x

--- a/crux-mir-comp/test/symb_eval/cryptol/uninterp_multi_module_b.cry
+++ b/crux-mir-comp/test/symb_eval/cryptol/uninterp_multi_module_b.cry
@@ -1,0 +1,4 @@
+module test::symb_eval::cryptol::uninterp_multi_module_b where
+
+b : [8] -> [8]
+b x = x


### PR DESCRIPTION
See the newly added comments near `resolveUninterp` for the rationale.

Fixes #3164.