### PR TITLE
`cryptol-saw-core`: Typecheck innermost expressions in record/tuple updates with known types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,9 @@ This release supports [version
   _evaluating_ fractional values, however (see
   [#1237](https://github.com/GaloisInc/saw-script/issues/1237)).
 
+* Don't raise spurious type errors when importing Cryptol record or tuple
+  update expressions.
+
 # 1.5 -- 2026-01-31
 
 This release supports [version

--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -485,7 +485,7 @@ importPC sc pc =
 -- Translates value types to SAWCore types of sort 0. Size types get
 -- imported such that they are accessible as values of type @Num@ at
 -- the SAWScript level.
--- 
+--
 importType :: HasCallStack => SharedContext -> CryptolEnv -> C.Type -> IO Term
 importType sc env ty =
   case ty of

--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -1409,41 +1409,47 @@ importExpr sc env expr =
                       ]
              scGlobalApply sc "Cryptol.eListSel" [a, n, e', i']
 
-    C.ESet _ e1 sel e2 ->
+    C.ESet t1 e1 sel e2 ->
       case sel of
         C.TupleSel i _maybeLen ->
-          do e1' <- importExpr sc env e1
-             e2' <- importExpr sc env e2
-             t1 <- scTypeOf sc e1'
-             case asTupleType t1 of
-               Nothing -> do
-                    t1' <- ppTerm sc t1
-                    panic "importExpr" [
-                        "ESet/TupleSel: not a tuple type",
-                        "Type: " <> Text.pack t1'
-                     ]
-               Just ts ->
-                 do let t2' = ts !! i
-                    f <- scGlobalApply sc "Cryptol.const" [t2', t2', e2']
-                    g <- tupleUpdate sc f i ts
-                    scApply sc g e1'
+          case C.tIsTuple t1 of
+            Nothing ->
+              panic "importExpr" [
+                  "ESet/TupleSel: not a tuple type",
+                  "Type: " <> CryPP.pp t1
+               ]
+            Just ts ->
+              do e1' <- importExpr sc env e1
+                 ts' <- mapM (importType sc env) ts
+                 let t2  = ts  !! i
+                 let t2' = ts' !! i
+                 e2' <- importExpr' sc env (C.tMono t2) e2
+                 f <- scGlobalApply sc "Cryptol.const" [t2', t2', e2']
+                 g <- tupleUpdate sc f i ts'
+                 scApply sc g e1'
         C.RecordSel x _ ->
-          do e1' <- importExpr sc env e1
-             e2' <- importExpr sc env e2
-             t1 <- scTypeOf sc e1'
-             case asRecordType t1 of
-               Nothing -> do
-                    t1' <- ppTerm sc t1
-                    panic "importExpr" [
-                        "ESet/RecordSel: not a record type",
-                        "Type: " <> Text.pack t1'
-                     ]
-               Just fields ->
-                 do let x' = C.identText x
-                    t2' <- the "field name not found" (lookup x' fields)
-                    f <- scGlobalApply sc "Cryptol.const" [t2', t2', e2']
-                    g <- recordUpdate sc f x' fields
-                    scApply sc g e1'
+          case C.tNoUser t1 of
+            C.TRec fields ->
+              importRecordUpdate sc env e1 e2 x fields
+            C.TNominal nt _ ->
+              case C.ntDef nt of
+                C.Struct con ->
+                  importRecordUpdate sc env e1 e2 x (C.ntFields con)
+                C.Enum {} ->
+                  panic "importExpr" [
+                      "ESet/RecordSel/TNominal: expected newtype, saw enum",
+                      "Type: " <> CryPP.pp t1
+                  ]
+                C.Abstract {} ->
+                  panic "importExpr" [
+                      "ESet/RecordSel/TNominal: expected newtype, saw primitive",
+                      "Type: " <> CryPP.pp t1
+                  ]
+            _ ->
+              panic "importExpr" [
+                  "ESet/RecordSel: not a record type or newtype",
+                  "Type: " <> CryPP.pp t1
+               ]
         C.ListSel _i _maybeLen ->
           let expr' = PPS.renderText PPS.defaultOpts $ PP.indent 3 $ CryPP.pretty expr in
           panic "importExpr" ("ListSel is unsupported in ESet:" : Text.lines expr')
@@ -1555,10 +1561,6 @@ importExpr sc env expr =
       importCase sc env tyResult s alts dflt
 
   where
-    -- XXX find this a better name
-    the :: Text -> Maybe a -> IO a
-    the what = maybe (panic "importExpr" ["Internal type error", what]) return
-
     -- | Translate an erased 'C.Prop' to a term and return the conjunction of the
     -- translated term and 'mt' if 'mt' is 'Just'. Otherwise, return the
     -- translated 'C.Prop'.  This function is intended to be used in a fold,
@@ -1701,6 +1703,36 @@ tupleUpdate sc f n (a : ts) =
      b <- scTupleType sc ts
      scGlobalApply sc "Cryptol.updSnd" [a, b, g]
 tupleUpdate _ _ _ [] = panic "tupleUpdate" ["empty tuple"]
+
+-- | Convert a Cryptol record update expression to a SAWCore term. This works
+-- for updating both record and newtype values.
+importRecordUpdate ::
+  SharedContext ->
+  CryptolEnv ->
+  -- | The type of the overall expression to convert.
+  C.Expr ->
+  -- | The type of the expression to update at the given field.
+  C.Expr ->
+  -- | The field name to update.
+  C.Ident ->
+  -- | The names and types of all fields in the record or newtype.
+  C.RecordMap C.Ident C.Type ->
+  IO Term
+importRecordUpdate sc env e1 e2 x fields =
+  do e1' <- importExpr sc env e1
+     fields' <- mapM (importType sc env) fields
+     t2  <- the "field name not found" (C.lookupField x fields)
+     t2' <- the "field name not found" (C.lookupField x fields')
+     e2' <- importExpr' sc env (C.tMono t2) e2
+     f <- scGlobalApply sc "Cryptol.const" [t2', t2', e2']
+     let canonicalFields = C.canonicalFields fields'
+     let canonicalFields' = map (first C.identText) canonicalFields
+     g <- recordUpdate sc f (C.identText x) canonicalFields'
+     scApply sc g e1'
+  where
+    -- XXX find this a better name
+    the :: Text -> Maybe a -> IO a
+    the what = maybe (panic "importExpr" ["Internal type error", what]) return
 
 recordUpdate :: SharedContext -> Term -> FieldName -> [(FieldName, Term)] -> IO Term
 recordUpdate _ _ _ [] = panic "recordUpdate" ["field not found"]

--- a/intTests/test3170/Test.cry
+++ b/intTests/test3170/Test.cry
@@ -1,0 +1,74 @@
+// Tuples
+
+type T = ([8], [16])
+
+tA : T
+tA = (1, 2)
+
+tB : T
+tB = { tA | 1 = 22 }
+
+tFunA : () -> T
+tFunA () = tA
+
+tFunB : () -> T
+tFunB = { tFunA | 1 = \() -> 22 }
+
+tSeqA : [2]T
+tSeqA = repeat tA
+
+tSeqB : [2]T
+tSeqB = { tSeqA | 1 = repeat 22 }
+
+tF : {n} (n <= 2) => [n][8] -> T -> T
+tF xs r = {r | 1 = join xs # 0 }
+
+// Records
+
+type R = { getR1 : [8], getR2 : [16] }
+
+rA : R
+rA = { getR1 = 1, getR2 = 2 }
+
+rB : R
+rB = { rA | getR2 = 22 }
+
+rFunA : () -> R
+rFunA () = rA
+
+rFunB : () -> R
+rFunB = { rFunA | getR2 = \() -> 22 }
+
+rSeqA : [2]R
+rSeqA = repeat rA
+
+rSeqB : [2]R
+rSeqB = { rSeqA | getR2 = repeat 22 }
+
+rF : {n} (n <= 2) => [n][8] -> R -> R
+rF xs r = {r | getR2 = join xs # 0 }
+
+// Newtypes
+
+newtype N = { getN1 : [8], getN2 : [16] }
+
+nA : N
+nA = N { getN1 = 1, getN2 = 2 }
+
+nB : N
+nB = { nA | getN2 = 22 }
+
+nFunA : () -> N
+nFunA () = nA
+
+nFunB : () -> N
+nFunB = { nFunA | getN2 = \() -> 22 }
+
+nSeqA : [2]N
+nSeqA = repeat nA
+
+nSeqB : [2]N
+nSeqB = { nSeqA | getN2 = repeat 22 }
+
+nF : {n} (n <= 2) => [n][8] -> N -> N
+nF xs r = {r | getN2 = join xs # 0 }

--- a/intTests/test3170/test.saw
+++ b/intTests/test3170/test.saw
@@ -1,0 +1,4 @@
+// A regression test for #2026. This ensures that SAW can import Cryptol code
+// involving record and tuple updates in a way that produces well-typed SAWCore
+// terms as a result.
+import "Test.cry";

--- a/intTests/test3170/test.sh
+++ b/intTests/test3170/test.sh
@@ -1,0 +1,3 @@
+set -e
+
+$SAW test.saw


### PR DESCRIPTION
When typechecking `{ e1 | x = e2 }`, where `e1 : t`, we know what the type of `e2` must be. This is because `x` must be a record type or newtype, which allows us to look up the corresponding field types to figure out `e2`'s type. Unfortunately, `cryptol-saw-core` wasn't taking advantage of this---instead, it was attempting to infer the type of `e2`, which could sometimes lead to ill-typed expressions due to a lack of necessary casts (see https://github.com/GaloisInc/saw-script/issues/3170).

(A similar problem existed for tuple update expressions as well.)

This commit fixes up the implementation in `cryptol-saw-core` to check `e2` with a known type using `importExpr'`, rather than inferring it with `importExpr`. This ensures that we cast `e2` to the appropriate type (using `coerce`) when necessary.

Fixes https://github.com/GaloisInc/saw-script/issues/3170.