### PR TITLE
Implement more register cell types for Yosys import

### DIFF
--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -18,6 +18,7 @@ module SAWCentral.Yosys.IR (
     isOutput,
     Bitrep(..),
     CellTypeCombinational(..),
+    ClockEnable(..),
     CellTypeRegister(..),
     CellType(..),
     ppCellType,
@@ -140,17 +141,17 @@ textToCellTypeRegister =
 
 allCellTypeRegisters :: [CellTypeRegister]
 allCellTypeRegisters =
-  [ CellTypeAdff False
-  , CellTypeAdff True
-  , CellTypeAldff False
-  , CellTypeAldff True
-  , CellTypeDff False
-  , CellTypeDff True
-  , CellTypeDffsr False
-  , CellTypeDffsr True
+  [ CellTypeAdff WithoutClockEnable
+  , CellTypeAdff WithClockEnable
+  , CellTypeAldff WithoutClockEnable
+  , CellTypeAldff WithClockEnable
+  , CellTypeDff WithoutClockEnable
+  , CellTypeDff WithClockEnable
+  , CellTypeDffsr WithoutClockEnable
+  , CellTypeDffsr WithClockEnable
   , CellTypeFf
-  , CellTypeSdff False
-  , CellTypeSdff True
+  , CellTypeSdff WithoutClockEnable
+  , CellTypeSdff WithClockEnable
   , CellTypeSdffe
   ]
 
@@ -161,6 +162,10 @@ textToPrimitiveCellType =
   fmap CellTypeCombinational textToCellTypeCombinational
 
 -- | All supported primitive combinational cell types.
+-- See the Yosys documentation for the cell definitions:
+-- <https://yosyshq.readthedocs.io/projects/yosys/en/latest/cell/word_unary.html>
+-- <https://yosyshq.readthedocs.io/projects/yosys/en/latest/cell/word_binary.html>
+-- <https://yosyshq.readthedocs.io/projects/yosys/en/latest/cell/word_mux.html>
 data CellTypeCombinational
   = CellTypeNot
   | CellTypePos
@@ -202,15 +207,44 @@ data CellTypeCombinational
   | CellTypeBUF
   deriving (Eq, Ord, Enum, Bounded)
 
+-- | Indicates whether a primitive register cell is a variant with a
+-- clock-enable input port.
+data ClockEnable
+  = WithoutClockEnable
+  | WithClockEnable
+  deriving (Eq, Ord)
+
 -- | All supported primitive register cell types.
+-- See the Yosys documentation for the cell definitions:
+-- <https://yosyshq.readthedocs.io/projects/yosys/en/latest/cell/word_reg.html>
 data CellTypeRegister
-  = CellTypeAdff Bool -- ^ 'True' for @$adffe@, 'False' for @$adff@
-  | CellTypeAldff Bool -- ^ 'True' for @$aldffe@, 'False' for  @$aldff@
-  | CellTypeDff Bool -- ^ 'True' for @$dffe@, 'False' for  @$dff@
-  | CellTypeDffsr Bool -- ^ 'True' for @$dffsre@, 'False' for  @$dffsr@
+  = CellTypeAdff ClockEnable
+    -- ^ D-type flip-flop with asynchronous reset (@$adff@).
+    -- Also a variant with clock-enable (@$adffe@).
+  | CellTypeAldff ClockEnable
+    -- ^ D-type flip-flop with asynchronous load (@$aldff@).
+    -- Also a variant with clock-enable (@$aldffe@).
+  | CellTypeDff ClockEnable
+    -- ^ D-type flip-flop (@$dff@).
+    -- Also a variant with clock-enable (@$dffe@).
+  | CellTypeDffsr ClockEnable -- ^ 'True' for @$dffsre@, 'False' for  @$dffsr@
+    -- ^ D-type flip-flop with asynchronous per-bit set and reset (@$dffsr@).
+    -- Also a variant with clock-enable (@$dffsre@).
   | CellTypeFf
-  | CellTypeSdff Bool -- ^ 'True' for @$sdffce@, 'False' for  @$sdff@
+    -- ^ Flip-flop with implicit global clock (@$ff@).
+    -- <https://yosyshq.readthedocs.io/projects/yosys/en/latest/cell/word_formal.html#formal.$ff>
+  | CellTypeSdff ClockEnable
+    -- ^ D-type flip-flop with synchronous reset (@$sdff@).
+    -- Also a variant with clock-enable (@$sdffce@).
+    -- NOTE: Unlike @$sdffe@, @$sdffce@ requires an active
+    -- clock-enable signal for the synchronous reset signal to have
+    -- any effect.
   | CellTypeSdffe
+    -- ^ D-type flip-flop with synchronous reset and clock-enable
+    -- (@$sdffe@).
+    -- NOTE: Unlike @$sdffce$, @$sdffe@ allows the synchronous reset
+    -- signal to reset the register even on a clock edge when the
+    -- clock-enable is inactive.
   deriving (Eq, Ord)
 
 -- | All supported cell types.
@@ -291,13 +325,17 @@ instance Show CellTypeCombinational where
 ppCellTypeRegister :: CellTypeRegister -> Text
 ppCellTypeRegister ctr =
   case ctr of
-    CellTypeAdff e -> if e then "$adffe" else "$adff"
-    CellTypeAldff e -> if e then "$aldffe" else "$aldff"
-    CellTypeDff e -> if e then "$dffe" else "$dff"
-    CellTypeDffsr e -> if e then "$dffsre" else "$dffsr"
-    CellTypeFf -> "$ff"
-    CellTypeSdff e -> if e then "$sdffce" else "$sdff"
-    CellTypeSdffe -> "$sdffe"
+    CellTypeAdff e  -> ceCases e "$adff"  "$adffe"
+    CellTypeAldff e -> ceCases e "$aldff" "$aldffe"
+    CellTypeDff e   -> ceCases e "$dff"   "$dffe"
+    CellTypeDffsr e -> ceCases e "$dffsr" "$dffsre"
+    CellTypeFf      -> "$ff"
+    CellTypeSdff e  -> ceCases e "$sdff"  "$sdffce"
+    CellTypeSdffe   -> "$sdffe"
+  where
+    ceCases :: ClockEnable -> Text -> Text -> Text
+    ceCases WithoutClockEnable x _ = x
+    ceCases WithClockEnable _ y = y
 
 ppCellType :: CellType -> Text
 ppCellType ct =

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -20,6 +20,7 @@ module SAWCentral.Yosys.IR (
     CellTypeCombinational(..),
     CellTypeRegister(..),
     CellType(..),
+    ppCellType,
     ppCellTypeCombinational,
     Cell,
       cellHideName,

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -188,6 +188,7 @@ data CellTypeCombinational
 -- | All supported primitive register cell types.
 data CellTypeRegister
   = CellTypeAdff
+  | CellTypeAdffe
   | CellTypeAldff
   | CellTypeDff
   | CellTypeDffe
@@ -213,7 +214,6 @@ instance Aeson.FromJSON CellType where
   parseJSON (Aeson.String s) =
     case s of
       "$dffsr"       -> fail $ show $ YosysErrorUnsupportedFF "$dffsr"
-      "$adffe"       -> fail $ show $ YosysErrorUnsupportedFF "$adffe"
       "$sdffe"       -> fail $ show $ YosysErrorUnsupportedFF "$sdffe"
       "$sdffce"      -> fail $ show $ YosysErrorUnsupportedFF "$sdffce"
       "$aldffe"      -> fail $ show $ YosysErrorUnsupportedFF "$aldffe"
@@ -276,6 +276,7 @@ ppCellTypeRegister :: CellTypeRegister -> Text
 ppCellTypeRegister ctr =
   case ctr of
     CellTypeAdff -> "$adff"
+    CellTypeAdffe -> "$adffe"
     CellTypeAldff -> "$aldff"
     CellTypeDff -> "$dff"
     CellTypeDffe -> "$dffe"

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -194,6 +194,7 @@ data CellTypeRegister
   | CellTypeDff
   | CellTypeDffe
   | CellTypeDffsr
+  | CellTypeDffsre
   | CellTypeFf
   | CellTypeSdff
   | CellTypeSdffce
@@ -217,7 +218,6 @@ data CellType
 instance Aeson.FromJSON CellType where
   parseJSON (Aeson.String s) =
     case s of
-      "$dffsre"      -> fail $ show $ YosysErrorUnsupportedFF "$dffsre"
       _ | cellTypeIsPrimitive s ->
           case Map.lookup s textToPrimitiveCellType of
             Just cellType -> pure cellType
@@ -282,6 +282,7 @@ ppCellTypeRegister ctr =
     CellTypeDff -> "$dff"
     CellTypeDffe -> "$dffe"
     CellTypeDffsr -> "$dffsr"
+    CellTypeDffsre -> "$dffsre"
     CellTypeFf -> "$ff"
     CellTypeSdff -> "$sdff"
     CellTypeSdffce -> "$sdffce"

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -153,6 +153,10 @@ allCellTypeRegisters =
   , CellTypeSdff WithoutClockEnable
   , CellTypeSdff WithClockEnable
   , CellTypeSdffe
+  , CellTypeDlatch
+  , CellTypeAdlatch
+  , CellTypeDlatchsr
+  , CellTypeSr
   ]
 
 -- | Mapping from 'Text' to primitive cell types.
@@ -229,6 +233,7 @@ data CellTypeRegister
     -- Also a variant with clock-enable (@$dffe@).
   | CellTypeDffsr ClockEnable -- ^ 'True' for @$dffsre@, 'False' for  @$dffsr@
     -- ^ D-type flip-flop with asynchronous per-bit set and reset (@$dffsr@).
+    -- Reset takes precedence when both set and reset are active.
     -- Also a variant with clock-enable (@$dffsre@).
   | CellTypeFf
     -- ^ Flip-flop with implicit global clock (@$ff@).
@@ -245,6 +250,16 @@ data CellTypeRegister
     -- NOTE: Unlike @$sdffce$, @$sdffe@ allows the synchronous reset
     -- signal to reset the register even on a clock edge when the
     -- clock-enable is inactive.
+  | CellTypeDlatch
+    -- ^ D-type latch (@$dlatch@), transparent while EN input is active.
+  | CellTypeAdlatch
+    -- ^ D-type latch with asynchronous reset (@$adlatch@).
+  | CellTypeDlatchsr
+    -- ^ D-type latch with asynchronous per-bit set and reset (@$dlatchsr@).
+    -- Reset takes precedence when both set and reset are active.
+  | CellTypeSr
+    -- ^ SR-type latch with asynchronous per-bit set and reset (@$sr@).
+    -- Reset takes precedence when both set and reset are active.
   deriving (Eq, Ord)
 
 -- | All supported cell types.
@@ -264,10 +279,6 @@ data CellType
 instance Aeson.FromJSON CellType where
   parseJSON (Aeson.String s) =
     case s of
-      "$adlatch"     -> fail $ show $ YosysErrorUnsupportedFF "$adlatch"
-      "$dlatch"      -> fail $ show $ YosysErrorUnsupportedFF "$dlatch"
-      "$dlatchsr"    -> fail $ show $ YosysErrorUnsupportedFF "$dlatchsr"
-      "$sr"          -> fail $ show $ YosysErrorUnsupportedFF "$sr"
       _ | cellTypeIsPrimitive s ->
           case Map.lookup s textToPrimitiveCellType of
             Just cellType -> pure cellType
@@ -325,13 +336,17 @@ instance Show CellTypeCombinational where
 ppCellTypeRegister :: CellTypeRegister -> Text
 ppCellTypeRegister ctr =
   case ctr of
-    CellTypeAdff e  -> ceCases e "$adff"  "$adffe"
-    CellTypeAldff e -> ceCases e "$aldff" "$aldffe"
-    CellTypeDff e   -> ceCases e "$dff"   "$dffe"
-    CellTypeDffsr e -> ceCases e "$dffsr" "$dffsre"
-    CellTypeFf      -> "$ff"
-    CellTypeSdff e  -> ceCases e "$sdff"  "$sdffce"
-    CellTypeSdffe   -> "$sdffe"
+    CellTypeAdff e   -> ceCases e "$adff"  "$adffe"
+    CellTypeAldff e  -> ceCases e "$aldff" "$aldffe"
+    CellTypeDff e    -> ceCases e "$dff"   "$dffe"
+    CellTypeDffsr e  -> ceCases e "$dffsr" "$dffsre"
+    CellTypeFf       -> "$ff"
+    CellTypeSdff e   -> ceCases e "$sdff"  "$sdffce"
+    CellTypeSdffe    -> "$sdffe"
+    CellTypeDlatch   -> "$dlatch"
+    CellTypeAdlatch  -> "$adlatch"
+    CellTypeDlatchsr -> "$dlatchsr"
+    CellTypeSr       -> "$sr"
   where
     ceCases :: ClockEnable -> Text -> Text -> Text
     ceCases WithoutClockEnable x _ = x

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -218,6 +218,10 @@ data CellType
 instance Aeson.FromJSON CellType where
   parseJSON (Aeson.String s) =
     case s of
+      "$adlatch"     -> fail $ show $ YosysErrorUnsupportedFF "$adlatch"
+      "$dlatch"      -> fail $ show $ YosysErrorUnsupportedFF "$dlatch"
+      "$dlatchsr"    -> fail $ show $ YosysErrorUnsupportedFF "$dlatchsr"
+      "$sr"          -> fail $ show $ YosysErrorUnsupportedFF "$sr"
       _ | cellTypeIsPrimitive s ->
           case Map.lookup s textToPrimitiveCellType of
             Just cellType -> pure cellType

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -135,7 +135,23 @@ textToCellTypeCombinational =
 -- | Mapping from 'Text' to primitive register cell types.
 textToCellTypeRegister :: Map Text CellTypeRegister
 textToCellTypeRegister =
-  Map.fromList [ (ppCellTypeRegister t, t) | t <- [minBound .. maxBound] ]
+  Map.fromList [ (ppCellTypeRegister t, t) | t <- allCellTypeRegisters ]
+
+allCellTypeRegisters :: [CellTypeRegister]
+allCellTypeRegisters =
+  [ CellTypeAdff False
+  , CellTypeAdff True
+  , CellTypeAldff False
+  , CellTypeAldff True
+  , CellTypeDff
+  , CellTypeDffe
+  , CellTypeDffsr False
+  , CellTypeDffsr True
+  , CellTypeFf
+  , CellTypeSdff
+  , CellTypeSdffce
+  , CellTypeSdffe
+  ]
 
 -- | Mapping from 'Text' to primitive cell types.
 textToPrimitiveCellType :: Map Text CellType
@@ -187,19 +203,16 @@ data CellTypeCombinational
 
 -- | All supported primitive register cell types.
 data CellTypeRegister
-  = CellTypeAdff
-  | CellTypeAdffe
-  | CellTypeAldff
-  | CellTypeAldffe
+  = CellTypeAdff Bool -- ^ 'True' for @$adffe@, 'False' for @$adff@
+  | CellTypeAldff Bool -- ^ 'True' for @$aldffe@, 'False' for  @$aldff@
   | CellTypeDff
   | CellTypeDffe
-  | CellTypeDffsr
-  | CellTypeDffsre
+  | CellTypeDffsr Bool -- ^ 'True' for @$dffsre@, 'False' for  @$dffsr@
   | CellTypeFf
   | CellTypeSdff
   | CellTypeSdffce
   | CellTypeSdffe
-  deriving (Eq, Ord, Enum, Bounded)
+  deriving (Eq, Ord)
 
 -- | All supported cell types.
 -- All types are primitives except for 'CellTypeUserType' which
@@ -279,14 +292,11 @@ instance Show CellTypeCombinational where
 ppCellTypeRegister :: CellTypeRegister -> Text
 ppCellTypeRegister ctr =
   case ctr of
-    CellTypeAdff -> "$adff"
-    CellTypeAdffe -> "$adffe"
-    CellTypeAldff -> "$aldff"
-    CellTypeAldffe -> "$aldffe"
+    CellTypeAdff e -> if e then "$adffe" else "$adff"
+    CellTypeAldff e -> if e then "$aldffe" else "$aldff"
     CellTypeDff -> "$dff"
     CellTypeDffe -> "$dffe"
-    CellTypeDffsr -> "$dffsr"
-    CellTypeDffsre -> "$dffsre"
+    CellTypeDffsr e -> if e then "$dffsre" else "$dffsr"
     CellTypeFf -> "$ff"
     CellTypeSdff -> "$sdff"
     CellTypeSdffce -> "$sdffce"

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -195,6 +195,7 @@ data CellTypeRegister
   | CellTypeDffe
   | CellTypeFf
   | CellTypeSdff
+  | CellTypeSdffe
   deriving (Eq, Ord, Enum, Bounded)
 
 -- | All supported cell types.
@@ -215,7 +216,6 @@ instance Aeson.FromJSON CellType where
   parseJSON (Aeson.String s) =
     case s of
       "$dffsr"       -> fail $ show $ YosysErrorUnsupportedFF "$dffsr"
-      "$sdffe"       -> fail $ show $ YosysErrorUnsupportedFF "$sdffe"
       "$sdffce"      -> fail $ show $ YosysErrorUnsupportedFF "$sdffce"
       "$dffsre"      -> fail $ show $ YosysErrorUnsupportedFF "$dffsre"
       _ | cellTypeIsPrimitive s ->
@@ -283,6 +283,7 @@ ppCellTypeRegister ctr =
     CellTypeDffe -> "$dffe"
     CellTypeFf -> "$ff"
     CellTypeSdff -> "$sdff"
+    CellTypeSdffe -> "$sdffe"
 
 ppCellType :: CellType -> Text
 ppCellType ct =

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -190,6 +190,7 @@ data CellTypeRegister
   = CellTypeAdff
   | CellTypeAdffe
   | CellTypeAldff
+  | CellTypeAldffe
   | CellTypeDff
   | CellTypeDffe
   | CellTypeFf
@@ -216,7 +217,6 @@ instance Aeson.FromJSON CellType where
       "$dffsr"       -> fail $ show $ YosysErrorUnsupportedFF "$dffsr"
       "$sdffe"       -> fail $ show $ YosysErrorUnsupportedFF "$sdffe"
       "$sdffce"      -> fail $ show $ YosysErrorUnsupportedFF "$sdffce"
-      "$aldffe"      -> fail $ show $ YosysErrorUnsupportedFF "$aldffe"
       "$dffsre"      -> fail $ show $ YosysErrorUnsupportedFF "$dffsre"
       _ | cellTypeIsPrimitive s ->
           case Map.lookup s textToPrimitiveCellType of
@@ -278,6 +278,7 @@ ppCellTypeRegister ctr =
     CellTypeAdff -> "$adff"
     CellTypeAdffe -> "$adffe"
     CellTypeAldff -> "$aldff"
+    CellTypeAldffe -> "$aldffe"
     CellTypeDff -> "$dff"
     CellTypeDffe -> "$dffe"
     CellTypeFf -> "$ff"

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -193,6 +193,7 @@ data CellTypeRegister
   | CellTypeAldffe
   | CellTypeDff
   | CellTypeDffe
+  | CellTypeDffsr
   | CellTypeFf
   | CellTypeSdff
   | CellTypeSdffce
@@ -216,7 +217,6 @@ data CellType
 instance Aeson.FromJSON CellType where
   parseJSON (Aeson.String s) =
     case s of
-      "$dffsr"       -> fail $ show $ YosysErrorUnsupportedFF "$dffsr"
       "$dffsre"      -> fail $ show $ YosysErrorUnsupportedFF "$dffsre"
       _ | cellTypeIsPrimitive s ->
           case Map.lookup s textToPrimitiveCellType of
@@ -281,6 +281,7 @@ ppCellTypeRegister ctr =
     CellTypeAldffe -> "$aldffe"
     CellTypeDff -> "$dff"
     CellTypeDffe -> "$dffe"
+    CellTypeDffsr -> "$dffsr"
     CellTypeFf -> "$ff"
     CellTypeSdff -> "$sdff"
     CellTypeSdffce -> "$sdffce"

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -195,6 +195,7 @@ data CellTypeRegister
   | CellTypeDffe
   | CellTypeFf
   | CellTypeSdff
+  | CellTypeSdffce
   | CellTypeSdffe
   deriving (Eq, Ord, Enum, Bounded)
 
@@ -216,7 +217,6 @@ instance Aeson.FromJSON CellType where
   parseJSON (Aeson.String s) =
     case s of
       "$dffsr"       -> fail $ show $ YosysErrorUnsupportedFF "$dffsr"
-      "$sdffce"      -> fail $ show $ YosysErrorUnsupportedFF "$sdffce"
       "$dffsre"      -> fail $ show $ YosysErrorUnsupportedFF "$dffsre"
       _ | cellTypeIsPrimitive s ->
           case Map.lookup s textToPrimitiveCellType of
@@ -283,6 +283,7 @@ ppCellTypeRegister ctr =
     CellTypeDffe -> "$dffe"
     CellTypeFf -> "$ff"
     CellTypeSdff -> "$sdff"
+    CellTypeSdffce -> "$sdffce"
     CellTypeSdffe -> "$sdffe"
 
 ppCellType :: CellType -> Text

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -192,6 +192,7 @@ data CellTypeRegister
   | CellTypeDff
   | CellTypeDffe
   | CellTypeFf
+  | CellTypeSdff
   deriving (Eq, Ord, Enum, Bounded)
 
 -- | All supported cell types.
@@ -211,7 +212,6 @@ data CellType
 instance Aeson.FromJSON CellType where
   parseJSON (Aeson.String s) =
     case s of
-      "$sdff"        -> fail $ show $ YosysErrorUnsupportedFF "$sdff"
       "$dffsr"       -> fail $ show $ YosysErrorUnsupportedFF "$dffsr"
       "$adffe"       -> fail $ show $ YosysErrorUnsupportedFF "$adffe"
       "$sdffe"       -> fail $ show $ YosysErrorUnsupportedFF "$sdffe"
@@ -280,6 +280,7 @@ ppCellTypeRegister ctr =
     CellTypeDff -> "$dff"
     CellTypeDffe -> "$dffe"
     CellTypeFf -> "$ff"
+    CellTypeSdff -> "$sdff"
 
 ppCellType :: CellType -> Text
 ppCellType ct =

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -143,13 +143,13 @@ allCellTypeRegisters =
   , CellTypeAdff True
   , CellTypeAldff False
   , CellTypeAldff True
-  , CellTypeDff
-  , CellTypeDffe
+  , CellTypeDff False
+  , CellTypeDff True
   , CellTypeDffsr False
   , CellTypeDffsr True
   , CellTypeFf
-  , CellTypeSdff
-  , CellTypeSdffce
+  , CellTypeSdff False
+  , CellTypeSdff True
   , CellTypeSdffe
   ]
 
@@ -205,12 +205,10 @@ data CellTypeCombinational
 data CellTypeRegister
   = CellTypeAdff Bool -- ^ 'True' for @$adffe@, 'False' for @$adff@
   | CellTypeAldff Bool -- ^ 'True' for @$aldffe@, 'False' for  @$aldff@
-  | CellTypeDff
-  | CellTypeDffe
+  | CellTypeDff Bool -- ^ 'True' for @$dffe@, 'False' for  @$dff@
   | CellTypeDffsr Bool -- ^ 'True' for @$dffsre@, 'False' for  @$dffsr@
   | CellTypeFf
-  | CellTypeSdff
-  | CellTypeSdffce
+  | CellTypeSdff Bool -- ^ 'True' for @$sdffce@, 'False' for  @$sdff@
   | CellTypeSdffe
   deriving (Eq, Ord)
 
@@ -294,12 +292,10 @@ ppCellTypeRegister ctr =
   case ctr of
     CellTypeAdff e -> if e then "$adffe" else "$adff"
     CellTypeAldff e -> if e then "$aldffe" else "$aldff"
-    CellTypeDff -> "$dff"
-    CellTypeDffe -> "$dffe"
+    CellTypeDff e -> if e then "$dffe" else "$dff"
     CellTypeDffsr e -> if e then "$dffsre" else "$dffsr"
     CellTypeFf -> "$ff"
-    CellTypeSdff -> "$sdff"
-    CellTypeSdffce -> "$sdffce"
+    CellTypeSdff e -> if e then "$sdffce" else "$sdff"
     CellTypeSdffe -> "$sdffe"
 
 ppCellType :: CellType -> Text

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -86,6 +86,7 @@ moduleNetgraph env m =
         CellTypeAldffe -> Set.fromList ["ALOAD", "AD"]
         CellTypeDff -> Set.empty
         CellTypeDffe -> Set.empty
+        CellTypeDffsr -> Set.fromList ["SET", "CLR"]
         CellTypeFf -> Set.empty
         CellTypeSdff -> Set.empty
         CellTypeSdffce -> Set.empty
@@ -283,6 +284,20 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                              -- Set output to AD on ALOAD; else output state value
                              ty <- SC.scBitvector sc width
                              SC.scIte sc ty pos_aload ad r
+                        CellTypeDffsr ->
+                          do let set_polarity =
+                                   Maybe.fromMaybe True $
+                                   parseBool =<< Map.lookup "SET_POLARITY" (c ^. cellParameters)
+                             let clr_polarity =
+                                   Maybe.fromMaybe True $
+                                   parseBool =<< Map.lookup "CLR_POLARITY" (c ^. cellParameters)
+                             set <- input "SET"
+                             clr <- input "CLR"
+                             w <- SC.scNat sc width
+                             pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
+                             neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
+                             -- CLR takes priority over SET
+                             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set r
 
                         -- For all register cell types without
                         -- asynchronous set/reset, the output is
@@ -441,6 +456,23 @@ cellNewState sc env terms cnm (c, prevState) =
              -- update state to D on EN & CLK; otherwise hold
              trigger <- SC.scAnd sc clk pos_en
              SC.scIte sc ty trigger d q
+        CellTypeDffsr ->
+          do clk <- inputBool "CLK"
+             CellTerm d width _ <- input "D" -- new value
+             CellTerm q _ _ <- input "Q" -- old state value
+             CellTerm set _ _ <- input "SET"
+             CellTerm clr _ _ <- input "CLR"
+             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
+             -- We only support CLK_POLARITY=1, i.e. posedge CLK
+             unless clk_polarity $ yosysError $ YosysError "Unsupported $dffsr with CLK_POLARITY=0"
+             let set_polarity = Maybe.fromMaybe True (lookupBoolParam "SET_POLARITY")
+             let clr_polarity = Maybe.fromMaybe True (lookupBoolParam "CLR_POLARITY")
+             w <- SC.scNat sc width
+             ty <- SC.scBitvector sc width
+             pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
+             neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
+             -- Set each bit to 0 on CLR; else 1 on SET; else D on CLK; otherwise hold
+             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set =<< SC.scIte sc ty clk d q
         CellTypeSdff ->
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -85,6 +85,7 @@ moduleNetgraph env m =
         CellTypeDff -> Set.empty
         CellTypeDffe -> Set.empty
         CellTypeFf -> Set.empty
+        CellTypeSdff -> Set.empty
 
     cellDeps :: Cell -> [CellInstName]
     cellDeps c =
@@ -261,6 +262,7 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                         CellTypeDff -> pure r
                         CellTypeDffe -> pure r
                         CellTypeFf -> pure r
+                        CellTypeSdff -> pure r
                 ts <- deriveTermsByIndices sc bs r
                 pure $ Map.union ts acc
            CellTypeUnsupportedPrimitive nm
@@ -367,6 +369,23 @@ cellNewState sc env terms cnm (c, prevState) =
              -- update state to D on EN & CLK; otherwise hold
              trigger <- SC.scAnd sc clk pos_en
              SC.scIte sc ty trigger d q
+        CellTypeSdff ->
+          do CellTerm d width _ <- input "D" -- new value
+             CellTerm q _ _ <- input "Q" -- old state value
+             clk <- inputBool "CLK"
+             srst <- inputBool "SRST"
+             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
+             -- We only support CLK_POLARITY=1, i.e. posedge CLK
+             unless clk_polarity $ yosysError $ YosysError "Unsupported $sdff with CLK_POLARITY=0"
+             let srst_value = Maybe.fromMaybe 0 (lookupNatParam "SRST_VALUE")
+             -- complement reset signal if SRST_POLARITY=0
+             let srst_polarity = Maybe.fromMaybe True (lookupBoolParam "SRST_POLARITY")
+             pos_srst <- if srst_polarity then pure srst else SC.scNot sc srst
+             srst_value' <- SC.scBvConst sc width (fromIntegral srst_value)
+             ty <- SC.scBitvector sc width
+             -- Set state to reset value on CLK & SRST; else if CLK then D; otherwise hold
+             d' <- SC.scIte sc ty pos_srst srst_value' d
+             SC.scIte sc ty clk d' q
     CellTypeCombinational _ ->
       panic "cellNewState" ["unexpected combinational cell"]
     CellTypeUnsupportedPrimitive _ ->

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -199,6 +199,10 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                do t <- input portname
                   one <- SC.scNat sc 1
                   SC.scBvNonzero sc one t
+         let lookupBoolParam pname =
+               Maybe.fromMaybe True $ parseBool =<< Map.lookup pname (c ^. cellParameters)
+         let lookupNatParam pname =
+               Maybe.fromMaybe 0 $ parseNat =<< Map.lookup pname (c ^. cellParameters)
          case c ^. cellType of
            CellTypeCombinational ctc ->
              -- NOTE: All Yosys primitive combinational cell types
@@ -235,12 +239,8 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                           -- ARST_POLARITY should be arguments to
                           -- CellTypeAdff, so we don't have to parse
                           -- them in two places.
-                          do let arst_value =
-                                   Maybe.fromMaybe 0 $
-                                   parseNat =<< Map.lookup "ARST_VALUE" (c ^. cellParameters)
-                             let arst_polarity =
-                                   Maybe.fromMaybe True $
-                                   parseBool =<< Map.lookup "ARST_POLARITY" (c ^. cellParameters)
+                          do let arst_value = lookupNatParam "ARST_VALUE"
+                             let arst_polarity = lookupBoolParam "ARST_POLARITY"
                              arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
                              arst <- inputBool "ARST"
                              -- complement reset signal if ARST_POLARITY=0
@@ -249,12 +249,8 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                              ty <- SC.scBitvector sc width
                              SC.scIte sc ty pos_arst arst_value' r
                         CellTypeAdffe ->
-                          do let arst_value =
-                                   Maybe.fromMaybe 0 $
-                                   parseNat =<< Map.lookup "ARST_VALUE" (c ^. cellParameters)
-                             let arst_polarity =
-                                   Maybe.fromMaybe True $
-                                   parseBool =<< Map.lookup "ARST_POLARITY" (c ^. cellParameters)
+                          do let arst_value = lookupNatParam "ARST_VALUE"
+                             let arst_polarity = lookupBoolParam "ARST_POLARITY"
                              arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
                              arst <- inputBool "ARST"
                              -- complement reset signal if ARST_POLARITY=0
@@ -264,9 +260,7 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                              SC.scIte sc ty pos_arst arst_value' r
 
                         CellTypeAldff ->
-                          do let aload_polarity =
-                                   Maybe.fromMaybe True $
-                                   parseBool =<< Map.lookup "ALOAD_POLARITY" (c ^. cellParameters)
+                          do let aload_polarity = lookupBoolParam "ALOAD_POLARITY"
                              ad <- input "AD"
                              aload <- inputBool "ALOAD"
                              -- complement reset signal if ALOAD_POLARITY=0
@@ -275,9 +269,7 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                              ty <- SC.scBitvector sc width
                              SC.scIte sc ty pos_aload ad r
                         CellTypeAldffe ->
-                          do let aload_polarity =
-                                   Maybe.fromMaybe True $
-                                   parseBool =<< Map.lookup "ALOAD_POLARITY" (c ^. cellParameters)
+                          do let aload_polarity = lookupBoolParam "ALOAD_POLARITY"
                              ad <- input "AD"
                              aload <- inputBool "ALOAD"
                              -- complement reset signal if ALOAD_POLARITY=0
@@ -286,12 +278,8 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                              ty <- SC.scBitvector sc width
                              SC.scIte sc ty pos_aload ad r
                         CellTypeDffsr ->
-                          do let set_polarity =
-                                   Maybe.fromMaybe True $
-                                   parseBool =<< Map.lookup "SET_POLARITY" (c ^. cellParameters)
-                             let clr_polarity =
-                                   Maybe.fromMaybe True $
-                                   parseBool =<< Map.lookup "CLR_POLARITY" (c ^. cellParameters)
+                          do let set_polarity = lookupBoolParam "SET_POLARITY"
+                             let clr_polarity = lookupBoolParam "CLR_POLARITY"
                              set <- input "SET"
                              clr <- input "CLR"
                              w <- SC.scNat sc width
@@ -300,12 +288,8 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                              -- CLR takes priority over SET
                              SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set r
                         CellTypeDffsre ->
-                          do let set_polarity =
-                                   Maybe.fromMaybe True $
-                                   parseBool =<< Map.lookup "SET_POLARITY" (c ^. cellParameters)
-                             let clr_polarity =
-                                   Maybe.fromMaybe True $
-                                   parseBool =<< Map.lookup "CLR_POLARITY" (c ^. cellParameters)
+                          do let set_polarity = lookupBoolParam "SET_POLARITY"
+                             let clr_polarity = lookupBoolParam "CLR_POLARITY"
                              set <- input "SET"
                              clr <- input "CLR"
                              w <- SC.scNat sc width

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -80,14 +80,11 @@ moduleNetgraph env m =
     asyncInputs :: CellTypeRegister -> Set PortName
     asyncInputs ctr =
       case ctr of
-        CellTypeAdff -> Set.fromList ["ARST"]
-        CellTypeAdffe -> Set.fromList ["ARST"]
-        CellTypeAldff -> Set.fromList ["ALOAD", "AD"]
-        CellTypeAldffe -> Set.fromList ["ALOAD", "AD"]
+        CellTypeAdff _ -> Set.fromList ["ARST"]
+        CellTypeAldff _ -> Set.fromList ["ALOAD", "AD"]
         CellTypeDff -> Set.empty
         CellTypeDffe -> Set.empty
-        CellTypeDffsr -> Set.fromList ["SET", "CLR"]
-        CellTypeDffsre -> Set.fromList ["SET", "CLR"]
+        CellTypeDffsr _ -> Set.fromList ["SET", "CLR"]
         CellTypeFf -> Set.empty
         CellTypeSdff -> Set.empty
         CellTypeSdffce -> Set.empty
@@ -234,11 +231,7 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                       panic "netgraphToTerms" ["missing state for cell " <> cnm]
                     Just r ->
                       case ctr of
-                        CellTypeAdff ->
-                          -- FIXME: Parameters ARST_VALUE and
-                          -- ARST_POLARITY should be arguments to
-                          -- CellTypeAdff, so we don't have to parse
-                          -- them in two places.
+                        CellTypeAdff _ ->
                           do let arst_value = lookupNatParam "ARST_VALUE"
                              let arst_polarity = lookupBoolParam "ARST_POLARITY"
                              arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
@@ -248,18 +241,7 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                              -- Set output to reset value on ARST; else output state value
                              ty <- SC.scBitvector sc width
                              SC.scIte sc ty pos_arst arst_value' r
-                        CellTypeAdffe ->
-                          do let arst_value = lookupNatParam "ARST_VALUE"
-                             let arst_polarity = lookupBoolParam "ARST_POLARITY"
-                             arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
-                             arst <- inputBool "ARST"
-                             -- complement reset signal if ARST_POLARITY=0
-                             pos_arst <- if arst_polarity then pure arst else SC.scNot sc arst
-                             -- Set output to reset value on ARST; else output state value
-                             ty <- SC.scBitvector sc width
-                             SC.scIte sc ty pos_arst arst_value' r
-
-                        CellTypeAldff ->
+                        CellTypeAldff _ ->
                           do let aload_polarity = lookupBoolParam "ALOAD_POLARITY"
                              ad <- input "AD"
                              aload <- inputBool "ALOAD"
@@ -268,16 +250,7 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                              -- Set output to AD on ALOAD; else output state value
                              ty <- SC.scBitvector sc width
                              SC.scIte sc ty pos_aload ad r
-                        CellTypeAldffe ->
-                          do let aload_polarity = lookupBoolParam "ALOAD_POLARITY"
-                             ad <- input "AD"
-                             aload <- inputBool "ALOAD"
-                             -- complement reset signal if ALOAD_POLARITY=0
-                             pos_aload <- if aload_polarity then pure aload else SC.scNot sc aload
-                             -- Set output to AD on ALOAD; else output state value
-                             ty <- SC.scBitvector sc width
-                             SC.scIte sc ty pos_aload ad r
-                        CellTypeDffsr ->
+                        CellTypeDffsr _ ->
                           do let set_polarity = lookupBoolParam "SET_POLARITY"
                              let clr_polarity = lookupBoolParam "CLR_POLARITY"
                              set <- input "SET"
@@ -287,17 +260,6 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                              neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
                              -- CLR takes priority over SET
                              SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set r
-                        CellTypeDffsre ->
-                          do let set_polarity = lookupBoolParam "SET_POLARITY"
-                             let clr_polarity = lookupBoolParam "CLR_POLARITY"
-                             set <- input "SET"
-                             clr <- input "CLR"
-                             w <- SC.scNat sc width
-                             pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
-                             neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
-                             -- CLR takes priority over SET
-                             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set r
-
                         -- For all register cell types without
                         -- asynchronous set/reset, the output is
                         -- always identical to the stored value @r@
@@ -308,6 +270,7 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                         CellTypeSdff -> pure r
                         CellTypeSdffce -> pure r
                         CellTypeSdffe -> pure r
+
                 ts <- deriveTermsByIndices sc bs r
                 pure $ Map.union ts acc
            CellTypeUnsupportedPrimitive nm
@@ -358,51 +321,34 @@ cellNewState sc env terms cnm (c, prevState) =
   case c ^. cellType of
     CellTypeRegister ctr ->
       case ctr of
-        CellTypeAdff ->
+        CellTypeAdff e ->
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
              clk <- inputBool "CLK"
-             enforceClkPolarity "$adff"
+             enforceClkPolarity (if e then "$adffe" else "$adff")
              pos_arst <- inputBoolWithPolarity "ARST"
              let arst_value = Maybe.fromMaybe 0 (lookupNatParam "ARST_VALUE")
              arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
              ty <- SC.scBitvector sc width
+             trigger <-
+               case e of
+                 True -> SC.scAnd sc clk =<< inputBoolWithPolarity "EN"
+                 False -> pure clk
              -- Set state to reset value on ARST; else if CLK then D; otherwise hold
-             SC.scIte sc ty pos_arst arst_value' =<< SC.scIte sc ty clk d q
-        CellTypeAdffe ->
-          do CellTerm d width _ <- input "D" -- new value
-             CellTerm q _ _ <- input "Q" -- old state value
-             clk <- inputBool "CLK"
-             enforceClkPolarity "$adffe"
-             pos_arst <- inputBoolWithPolarity "ARST"
-             pos_en <- inputBoolWithPolarity "EN"
-             let arst_value = Maybe.fromMaybe 0 (lookupNatParam "ARST_VALUE")
-             arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
-             ty <- SC.scBitvector sc width
-             -- Set state to reset value on ARST; else if EN & CLK then D; otherwise hold
-             trigger <- SC.scAnd sc clk pos_en
              SC.scIte sc ty pos_arst arst_value' =<< SC.scIte sc ty trigger d q
-        CellTypeAldff ->
+        CellTypeAldff e ->
           do clk <- inputBool "CLK"
              CellTerm ad _ _ <- input "AD" -- async load value
              CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
-             enforceClkPolarity "$aldff"
+             enforceClkPolarity (if e then "$aldffe" else "$aldff")
              pos_aload <- inputBoolWithPolarity "ALOAD"
              ty <- SC.scBitvector sc width
+             trigger <-
+               case e of
+                 True -> SC.scAnd sc clk =<< inputBoolWithPolarity "EN"
+                 False -> pure clk
              -- Set state to AD on ALOAD; else if CLK then D; otherwise hold
-             SC.scIte sc ty pos_aload ad =<< SC.scIte sc ty clk d q
-        CellTypeAldffe ->
-          do clk <- inputBool "CLK"
-             CellTerm ad _ _ <- input "AD" -- async load value
-             CellTerm d width _ <- input "D" -- new value
-             CellTerm q _ _ <- input "Q" -- old state value
-             enforceClkPolarity "$aldffe"
-             pos_aload <- inputBoolWithPolarity "ALOAD"
-             pos_en <- inputBoolWithPolarity "EN"
-             ty <- SC.scBitvector sc width
-             -- Set state to AD on ALOAD; else if EN & CLK then D; otherwise hold
-             trigger <- SC.scAnd sc clk pos_en
              SC.scIte sc ty pos_aload ad =<< SC.scIte sc ty trigger d q
         CellTypeDff ->
           do CellTerm d width _ <- input "D" -- new value
@@ -425,37 +371,24 @@ cellNewState sc env terms cnm (c, prevState) =
              -- update state to D on EN & CLK; otherwise hold
              trigger <- SC.scAnd sc clk pos_en
              SC.scIte sc ty trigger d q
-        CellTypeDffsr ->
+        CellTypeDffsr e ->
           do clk <- inputBool "CLK"
              CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
              CellTerm set _ _ <- input "SET"
              CellTerm clr _ _ <- input "CLR"
-             enforceClkPolarity "$dffsr"
+             enforceClkPolarity (if e then "$dffsre" else "$dffsr")
              let set_polarity = Maybe.fromMaybe True (lookupBoolParam "SET_POLARITY")
              let clr_polarity = Maybe.fromMaybe True (lookupBoolParam "CLR_POLARITY")
              w <- SC.scNat sc width
              ty <- SC.scBitvector sc width
              pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
              neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
+             trigger <-
+               case e of
+                 True -> SC.scAnd sc clk =<< inputBoolWithPolarity "EN"
+                 False -> pure clk
              -- Set each bit to 0 on CLR; else 1 on SET; else D on CLK; otherwise hold
-             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set =<< SC.scIte sc ty clk d q
-        CellTypeDffsre ->
-          do clk <- inputBool "CLK"
-             CellTerm d width _ <- input "D" -- new value
-             CellTerm q _ _ <- input "Q" -- old state value
-             CellTerm set _ _ <- input "SET"
-             CellTerm clr _ _ <- input "CLR"
-             enforceClkPolarity "$dffsre"
-             pos_en <- inputBoolWithPolarity "EN"
-             let set_polarity = Maybe.fromMaybe True (lookupBoolParam "SET_POLARITY")
-             let clr_polarity = Maybe.fromMaybe True (lookupBoolParam "CLR_POLARITY")
-             w <- SC.scNat sc width
-             ty <- SC.scBitvector sc width
-             pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
-             neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
-             -- Set each bit to 0 on CLR; else 1 on SET; else D on EN & CLK; otherwise hold
-             trigger <- SC.scAnd sc clk pos_en
              SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set =<< SC.scIte sc ty trigger d q
         CellTypeSdff ->
           do CellTerm d width _ <- input "D" -- new value

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -77,6 +77,8 @@ moduleNetgraph env m =
             Nothing -> False
             Just (mt, _) -> mt == Moore
 
+    -- | The set of input ports that may affect the output value
+    -- of a register cell immediately, before the next clock edge.
     asyncInputs :: CellTypeRegister -> Set PortName
     asyncInputs ctr =
       case ctr of
@@ -87,6 +89,10 @@ moduleNetgraph env m =
         CellTypeFf -> Set.empty
         CellTypeSdff _ -> Set.empty
         CellTypeSdffe -> Set.empty
+        CellTypeDlatch -> Set.fromList ["EN", "D"]
+        CellTypeAdlatch -> Set.fromList ["EN", "ARST", "D"]
+        CellTypeDlatchsr -> Set.fromList ["EN", "SET", "CLR", "D"]
+        CellTypeSr -> Set.fromList ["SET", "CLR"]
 
     cellDeps :: Cell -> [CellInstName]
     cellDeps c =
@@ -258,6 +264,55 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                              neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
                              -- CLR takes priority over SET
                              SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set r
+                        CellTypeDlatch ->
+                          do d <- input "D"
+                             let en_polarity = lookupBoolParam "EN_POLARITY"
+                             en <- inputBool "EN"
+                             pos_en <- if en_polarity then pure en else SC.scNot sc en
+                             ty <- SC.scBitvector sc width
+                             SC.scIte sc ty pos_en d r
+                        CellTypeAdlatch ->
+                          do d <- input "D"
+                             let en_polarity = lookupBoolParam "EN_POLARITY"
+                             en <- inputBool "EN"
+                             pos_en <- if en_polarity then pure en else SC.scNot sc en
+                             ty <- SC.scBitvector sc width
+                             r' <- SC.scIte sc ty pos_en d r
+                             let arst_value = lookupNatParam "ARST_VALUE"
+                             let arst_polarity = lookupBoolParam "ARST_POLARITY"
+                             arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
+                             arst <- inputBool "ARST"
+                             -- complement reset signal if ARST_POLARITY=0
+                             pos_arst <- if arst_polarity then pure arst else SC.scNot sc arst
+                             -- Set output to reset value on ARST; else output state value
+                             ty <- SC.scBitvector sc width
+                             SC.scIte sc ty pos_arst arst_value' r'
+                        CellTypeDlatchsr ->
+                          do d <- input "D"
+                             let en_polarity = lookupBoolParam "EN_POLARITY"
+                             en <- inputBool "EN"
+                             pos_en <- if en_polarity then pure en else SC.scNot sc en
+                             ty <- SC.scBitvector sc width
+                             r' <- SC.scIte sc ty pos_en d r
+                             let set_polarity = lookupBoolParam "SET_POLARITY"
+                             let clr_polarity = lookupBoolParam "CLR_POLARITY"
+                             set <- input "SET"
+                             clr <- input "CLR"
+                             w <- SC.scNat sc width
+                             pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
+                             neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
+                             -- CLR takes priority over SET
+                             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set r'
+                        CellTypeSr ->
+                          do let set_polarity = lookupBoolParam "SET_POLARITY"
+                             let clr_polarity = lookupBoolParam "CLR_POLARITY"
+                             set <- input "SET"
+                             clr <- input "CLR"
+                             w <- SC.scNat sc width
+                             pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
+                             neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
+                             -- CLR takes priority over SET
+                             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set r
                         -- For all register cell types without
                         -- asynchronous set/reset, the output is
                         -- always identical to the stored value @r@
@@ -390,6 +445,13 @@ cellNewState sc env terms cnm (c, prevState) =
              rst <- SC.scAnd sc clk pos_srst
              trigger <- SC.scAnd sc clk pos_en
              SC.scIte sc ty rst srst_value' =<< SC.scIte sc ty trigger d q
+        -- For transparent latches, the new state value is always
+        -- equal to the value currently on the output port Q.
+        CellTypeDlatch   -> cellTermTerm <$> input "Q"
+        CellTypeAdlatch  -> cellTermTerm <$> input "Q"
+        CellTypeDlatchsr -> cellTermTerm <$> input "Q"
+        CellTypeSr       -> cellTermTerm <$> input "Q"
+
     CellTypeCombinational _ ->
       panic "cellNewState" ["unexpected combinational cell"]
     CellTypeUnsupportedPrimitive _ ->

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -87,6 +87,7 @@ moduleNetgraph env m =
         CellTypeDff -> Set.empty
         CellTypeDffe -> Set.empty
         CellTypeDffsr -> Set.fromList ["SET", "CLR"]
+        CellTypeDffsre -> Set.fromList ["SET", "CLR"]
         CellTypeFf -> Set.empty
         CellTypeSdff -> Set.empty
         CellTypeSdffce -> Set.empty
@@ -298,6 +299,20 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                              neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
                              -- CLR takes priority over SET
                              SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set r
+                        CellTypeDffsre ->
+                          do let set_polarity =
+                                   Maybe.fromMaybe True $
+                                   parseBool =<< Map.lookup "SET_POLARITY" (c ^. cellParameters)
+                             let clr_polarity =
+                                   Maybe.fromMaybe True $
+                                   parseBool =<< Map.lookup "CLR_POLARITY" (c ^. cellParameters)
+                             set <- input "SET"
+                             clr <- input "CLR"
+                             w <- SC.scNat sc width
+                             pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
+                             neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
+                             -- CLR takes priority over SET
+                             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set r
 
                         -- For all register cell types without
                         -- asynchronous set/reset, the output is
@@ -473,6 +488,28 @@ cellNewState sc env terms cnm (c, prevState) =
              neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
              -- Set each bit to 0 on CLR; else 1 on SET; else D on CLK; otherwise hold
              SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set =<< SC.scIte sc ty clk d q
+        CellTypeDffsre ->
+          do clk <- inputBool "CLK"
+             CellTerm d width _ <- input "D" -- new value
+             CellTerm q _ _ <- input "Q" -- old state value
+             CellTerm set _ _ <- input "SET"
+             CellTerm clr _ _ <- input "CLR"
+             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
+             -- We only support CLK_POLARITY=1, i.e. posedge CLK
+             unless clk_polarity $ yosysError $ YosysError "Unsupported $dffsre with CLK_POLARITY=0"
+             en <- inputBool "EN"
+             -- complement enable signal if EN_POLARITY=0
+             let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
+             pos_en <- if en_polarity then pure en else SC.scNot sc en
+             let set_polarity = Maybe.fromMaybe True (lookupBoolParam "SET_POLARITY")
+             let clr_polarity = Maybe.fromMaybe True (lookupBoolParam "CLR_POLARITY")
+             w <- SC.scNat sc width
+             ty <- SC.scBitvector sc width
+             pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
+             neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
+             -- Set each bit to 0 on CLR; else 1 on SET; else D on EN & CLK; otherwise hold
+             trigger <- SC.scAnd sc clk pos_en
+             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set =<< SC.scIte sc ty trigger d q
         CellTypeSdff ->
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -81,6 +81,7 @@ moduleNetgraph env m =
     asyncInputs ctr =
       case ctr of
         CellTypeAdff -> Set.fromList ["ARST"]
+        CellTypeAdffe -> Set.fromList ["ARST"]
         CellTypeAldff -> Set.fromList ["ALOAD", "AD"]
         CellTypeDff -> Set.empty
         CellTypeDffe -> Set.empty
@@ -242,6 +243,20 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                              -- Set output to reset value on ARST; else output state value
                              ty <- SC.scBitvector sc width
                              SC.scIte sc ty pos_arst arst_value' r
+                        CellTypeAdffe ->
+                          do let arst_value =
+                                   Maybe.fromMaybe 0 $
+                                   parseNat =<< Map.lookup "ARST_VALUE" (c ^. cellParameters)
+                             let arst_polarity =
+                                   Maybe.fromMaybe True $
+                                   parseBool =<< Map.lookup "ARST_POLARITY" (c ^. cellParameters)
+                             arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
+                             arst <- inputBool "ARST"
+                             -- complement reset signal if ARST_POLARITY=0
+                             pos_arst <- if arst_polarity then pure arst else SC.scNot sc arst
+                             -- Set output to reset value on ARST; else output state value
+                             ty <- SC.scBitvector sc width
+                             SC.scIte sc ty pos_arst arst_value' r
 
                         CellTypeAldff ->
                           do let aload_polarity =
@@ -329,6 +344,27 @@ cellNewState sc env terms cnm (c, prevState) =
              ty <- SC.scBitvector sc width
              -- Set state to reset value on ARST; else if CLK then D; otherwise hold
              SC.scIte sc ty pos_arst arst_value' =<< SC.scIte sc ty clk d q
+        CellTypeAdffe ->
+          do CellTerm d width _ <- input "D" -- new value
+             CellTerm q _ _ <- input "Q" -- old state value
+             clk <- inputBool "CLK"
+             arst <- inputBool "ARST"
+             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
+             -- We only support CLK_POLARITY=1, i.e. posedge CLK
+             unless clk_polarity $ yosysError $ YosysError "Unsupported $adffe with CLK_POLARITY=0"
+             en <- inputBool "EN"
+             -- complement enable signal if EN_POLARITY=0
+             let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
+             pos_en <- if en_polarity then pure en else SC.scNot sc en
+             let arst_value = Maybe.fromMaybe 0 (lookupNatParam "ARST_VALUE")
+             -- complement reset signal if ARST_POLARITY=0
+             let arst_polarity = Maybe.fromMaybe True (lookupBoolParam "ARST_POLARITY")
+             pos_arst <- if arst_polarity then pure arst else SC.scNot sc arst
+             arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
+             ty <- SC.scBitvector sc width
+             -- Set state to reset value on ARST; else if EN & CLK then D; otherwise hold
+             trigger <- SC.scAnd sc clk pos_en
+             SC.scIte sc ty pos_arst arst_value' =<< SC.scIte sc ty trigger d q
         CellTypeAldff ->
           do clk <- inputBool "CLK"
              aload <- inputBool "ALOAD"

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -380,7 +380,7 @@ cellNewState sc env terms cnm (c, prevState) =
         CellTypeSdffe ->
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
-             clk <- clockInput False -- ungated clock signal
+             clk <- clockInput WithoutClockEnable -- ungated clock signal
              pos_srst <- inputBoolWithPolarity "SRST"
              pos_en <- inputBoolWithPolarity "EN"
              let srst_value = Maybe.fromMaybe 0 (lookupNatParam "SRST_VALUE")
@@ -436,10 +436,10 @@ cellNewState sc env terms cnm (c, prevState) =
     lookupNatParam pname = parseNat =<< Map.lookup pname (c ^. cellParameters)
     lookupBoolParam :: Text.Text -> Maybe Bool
     lookupBoolParam pname = parseBool =<< Map.lookup pname (c ^. cellParameters)
-    -- | @clockInput False@ reads @CLK@ and enforces @CLK_POLARITY=1@.
-    -- @clockInput True@ additionally reads input @EN@, inverts it if
+    -- | @clockInput WithoutClockEnable@ reads @CLK@ and enforces @CLK_POLARITY=1@.
+    -- @clockInput WithClockEnable@ additionally reads input @EN@, inverts it if
     -- @EN_POLARITY=0@, then ANDs it with the clock.
-    clockInput :: Bool -> IO SC.Term
+    clockInput :: ClockEnable -> IO SC.Term
     clockInput e =
       do clk <- inputBool "CLK"
          let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
@@ -448,8 +448,8 @@ cellNewState sc env terms cnm (c, prevState) =
          unless clk_polarity $
            yosysError $ YosysError $ "Unsupported " <> ty <> " with CLK_POLARITY=0"
          case e of
-           True -> SC.scAnd sc clk =<< inputBoolWithPolarity "EN"
-           False -> pure clk
+           WithClockEnable -> SC.scAnd sc clk =<< inputBoolWithPolarity "EN"
+           WithoutClockEnable -> pure clk
 
 -- | Parse an Aeson value as a 'Bool', if possible.
 -- Note that Yosys encodes boolean parameters as either numbers like 0

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -229,22 +229,49 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
              -- single output port named "Q".
              do bs <- lookupConn "Q"
                 let width = fromIntegral (length bs)
+                let mkARST x =
+                      -- Add asynchronous reset logic to the given signal x:
+                      -- Replace signal with ARST_VALUE when ARST is active.
+                      do let arst_value = lookupNatParam "ARST_VALUE"
+                         let arst_polarity = lookupBoolParam "ARST_POLARITY"
+                         arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
+                         arst <- inputBool "ARST"
+                         -- Set output to reset value on ARST==ARST_POLARITY;
+                         -- otherwise output original value.
+                         ty <- SC.scBitvector sc width
+                         case arst_polarity of
+                           True -> SC.scIte sc ty arst arst_value' x
+                           False -> SC.scIte sc ty arst x arst_value'
+                let mkDlatch x =
+                      -- Add D-type latch logic to the given signal x:
+                      -- Replace signal with input D when EN is active.
+                      do d <- input "D"
+                         let en_polarity = lookupBoolParam "EN_POLARITY"
+                         en <- inputBool "EN"
+                         ty <- SC.scBitvector sc width
+                         -- Set output to D on EN==EN_POLARITY;
+                         -- otherwise output original value.
+                         case en_polarity of
+                           True -> SC.scIte sc ty en d x
+                           False -> SC.scIte sc ty en x d
+                let mkSR x =
+                      -- Add set/reset logic to the given signal x.
+                      do let set_polarity = lookupBoolParam "SET_POLARITY"
+                         let clr_polarity = lookupBoolParam "CLR_POLARITY"
+                         set <- input "SET"
+                         clr <- input "CLR"
+                         w <- SC.scNat sc width
+                         pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
+                         neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
+                         -- CLR takes priority over SET
+                         SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set x
                 r <-
                   case Map.lookup cnm states of
                     Nothing ->
                       panic "netgraphToTerms" ["missing state for cell " <> cnm]
                     Just r ->
                       case ctr of
-                        CellTypeAdff _ ->
-                          do let arst_value = lookupNatParam "ARST_VALUE"
-                             let arst_polarity = lookupBoolParam "ARST_POLARITY"
-                             arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
-                             arst <- inputBool "ARST"
-                             -- complement reset signal if ARST_POLARITY=0
-                             pos_arst <- if arst_polarity then pure arst else SC.scNot sc arst
-                             -- Set output to reset value on ARST; else output state value
-                             ty <- SC.scBitvector sc width
-                             SC.scIte sc ty pos_arst arst_value' r
+                        CellTypeAdff _ -> mkARST r
                         CellTypeAldff _ ->
                           do let aload_polarity = lookupBoolParam "ALOAD_POLARITY"
                              ad <- input "AD"
@@ -254,65 +281,11 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                              -- Set output to AD on ALOAD; else output state value
                              ty <- SC.scBitvector sc width
                              SC.scIte sc ty pos_aload ad r
-                        CellTypeDffsr _ ->
-                          do let set_polarity = lookupBoolParam "SET_POLARITY"
-                             let clr_polarity = lookupBoolParam "CLR_POLARITY"
-                             set <- input "SET"
-                             clr <- input "CLR"
-                             w <- SC.scNat sc width
-                             pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
-                             neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
-                             -- CLR takes priority over SET
-                             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set r
-                        CellTypeDlatch ->
-                          do d <- input "D"
-                             let en_polarity = lookupBoolParam "EN_POLARITY"
-                             en <- inputBool "EN"
-                             pos_en <- if en_polarity then pure en else SC.scNot sc en
-                             ty <- SC.scBitvector sc width
-                             SC.scIte sc ty pos_en d r
-                        CellTypeAdlatch ->
-                          do d <- input "D"
-                             let en_polarity = lookupBoolParam "EN_POLARITY"
-                             en <- inputBool "EN"
-                             pos_en <- if en_polarity then pure en else SC.scNot sc en
-                             ty <- SC.scBitvector sc width
-                             r' <- SC.scIte sc ty pos_en d r
-                             let arst_value = lookupNatParam "ARST_VALUE"
-                             let arst_polarity = lookupBoolParam "ARST_POLARITY"
-                             arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
-                             arst <- inputBool "ARST"
-                             -- complement reset signal if ARST_POLARITY=0
-                             pos_arst <- if arst_polarity then pure arst else SC.scNot sc arst
-                             -- Set output to reset value on ARST; else output state value
-                             ty <- SC.scBitvector sc width
-                             SC.scIte sc ty pos_arst arst_value' r'
-                        CellTypeDlatchsr ->
-                          do d <- input "D"
-                             let en_polarity = lookupBoolParam "EN_POLARITY"
-                             en <- inputBool "EN"
-                             pos_en <- if en_polarity then pure en else SC.scNot sc en
-                             ty <- SC.scBitvector sc width
-                             r' <- SC.scIte sc ty pos_en d r
-                             let set_polarity = lookupBoolParam "SET_POLARITY"
-                             let clr_polarity = lookupBoolParam "CLR_POLARITY"
-                             set <- input "SET"
-                             clr <- input "CLR"
-                             w <- SC.scNat sc width
-                             pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
-                             neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
-                             -- CLR takes priority over SET
-                             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set r'
-                        CellTypeSr ->
-                          do let set_polarity = lookupBoolParam "SET_POLARITY"
-                             let clr_polarity = lookupBoolParam "CLR_POLARITY"
-                             set <- input "SET"
-                             clr <- input "CLR"
-                             w <- SC.scNat sc width
-                             pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
-                             neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
-                             -- CLR takes priority over SET
-                             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set r
+                        CellTypeDffsr _ -> mkSR r
+                        CellTypeDlatch -> mkDlatch r
+                        CellTypeAdlatch -> mkARST =<< mkDlatch r -- Prioritize ARST over EN
+                        CellTypeDlatchsr -> mkSR =<< mkDlatch r -- Prioritize SET/CLR over EN
+                        CellTypeSr -> mkSR r
                         -- For all register cell types without
                         -- asynchronous set/reset, the output is
                         -- always identical to the stored value @r@

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -378,12 +378,9 @@ cellNewState sc env terms cnm (c, prevState) =
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
              clk <- inputBool "CLK"
-             arst <- inputBool "ARST"
              enforceClkPolarity "$adff"
+             pos_arst <- inputBoolWithPolarity "ARST"
              let arst_value = Maybe.fromMaybe 0 (lookupNatParam "ARST_VALUE")
-             -- complement reset signal if ARST_POLARITY=0
-             let arst_polarity = Maybe.fromMaybe True (lookupBoolParam "ARST_POLARITY")
-             pos_arst <- if arst_polarity then pure arst else SC.scNot sc arst
              arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
              ty <- SC.scBitvector sc width
              -- Set state to reset value on ARST; else if CLK then D; otherwise hold
@@ -392,16 +389,10 @@ cellNewState sc env terms cnm (c, prevState) =
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
              clk <- inputBool "CLK"
-             arst <- inputBool "ARST"
              enforceClkPolarity "$adffe"
-             en <- inputBool "EN"
-             -- complement enable signal if EN_POLARITY=0
-             let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
-             pos_en <- if en_polarity then pure en else SC.scNot sc en
+             pos_arst <- inputBoolWithPolarity "ARST"
+             pos_en <- inputBoolWithPolarity "EN"
              let arst_value = Maybe.fromMaybe 0 (lookupNatParam "ARST_VALUE")
-             -- complement reset signal if ARST_POLARITY=0
-             let arst_polarity = Maybe.fromMaybe True (lookupBoolParam "ARST_POLARITY")
-             pos_arst <- if arst_polarity then pure arst else SC.scNot sc arst
              arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
              ty <- SC.scBitvector sc width
              -- Set state to reset value on ARST; else if EN & CLK then D; otherwise hold
@@ -409,31 +400,22 @@ cellNewState sc env terms cnm (c, prevState) =
              SC.scIte sc ty pos_arst arst_value' =<< SC.scIte sc ty trigger d q
         CellTypeAldff ->
           do clk <- inputBool "CLK"
-             aload <- inputBool "ALOAD"
              CellTerm ad _ _ <- input "AD" -- async load value
              CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
              enforceClkPolarity "$aldff"
-             -- complement aload signal if ALOAD_POLARITY=0
-             let aload_polarity = Maybe.fromMaybe True (lookupBoolParam "ALOAD_POLARITY")
-             pos_aload <- if aload_polarity then pure aload else SC.scNot sc aload
+             pos_aload <- inputBoolWithPolarity "ALOAD"
              ty <- SC.scBitvector sc width
              -- Set state to AD on ALOAD; else if CLK then D; otherwise hold
              SC.scIte sc ty pos_aload ad =<< SC.scIte sc ty clk d q
         CellTypeAldffe ->
           do clk <- inputBool "CLK"
-             aload <- inputBool "ALOAD"
              CellTerm ad _ _ <- input "AD" -- async load value
              CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
              enforceClkPolarity "$aldffe"
-             en <- inputBool "EN"
-             -- complement enable signal if EN_POLARITY=0
-             let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
-             pos_en <- if en_polarity then pure en else SC.scNot sc en
-             -- complement aload signal if ALOAD_POLARITY=0
-             let aload_polarity = Maybe.fromMaybe True (lookupBoolParam "ALOAD_POLARITY")
-             pos_aload <- if aload_polarity then pure aload else SC.scNot sc aload
+             pos_aload <- inputBoolWithPolarity "ALOAD"
+             pos_en <- inputBoolWithPolarity "EN"
              ty <- SC.scBitvector sc width
              -- Set state to AD on ALOAD; else if EN & CLK then D; otherwise hold
              trigger <- SC.scAnd sc clk pos_en
@@ -452,11 +434,9 @@ cellNewState sc env terms cnm (c, prevState) =
         CellTypeDffe ->
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
-             en <- inputBool "EN"
              clk <- inputBool "CLK"
-             -- complement enable signal if EN_POLARITY=0
-             let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
-             pos_en <- if en_polarity then pure en else SC.scNot sc en
+             enforceClkPolarity "$dffe"
+             pos_en <- inputBoolWithPolarity "EN"
              ty <- SC.scBitvector sc width
              -- update state to D on EN & CLK; otherwise hold
              trigger <- SC.scAnd sc clk pos_en
@@ -483,10 +463,7 @@ cellNewState sc env terms cnm (c, prevState) =
              CellTerm set _ _ <- input "SET"
              CellTerm clr _ _ <- input "CLR"
              enforceClkPolarity "$dffsre"
-             en <- inputBool "EN"
-             -- complement enable signal if EN_POLARITY=0
-             let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
-             pos_en <- if en_polarity then pure en else SC.scNot sc en
+             pos_en <- inputBoolWithPolarity "EN"
              let set_polarity = Maybe.fromMaybe True (lookupBoolParam "SET_POLARITY")
              let clr_polarity = Maybe.fromMaybe True (lookupBoolParam "CLR_POLARITY")
              w <- SC.scNat sc width
@@ -500,12 +477,9 @@ cellNewState sc env terms cnm (c, prevState) =
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
              clk <- inputBool "CLK"
-             srst <- inputBool "SRST"
              enforceClkPolarity "$sdff"
+             pos_srst <- inputBoolWithPolarity "SRST"
              let srst_value = Maybe.fromMaybe 0 (lookupNatParam "SRST_VALUE")
-             -- complement reset signal if SRST_POLARITY=0
-             let srst_polarity = Maybe.fromMaybe True (lookupBoolParam "SRST_POLARITY")
-             pos_srst <- if srst_polarity then pure srst else SC.scNot sc srst
              srst_value' <- SC.scBvConst sc width (fromIntegral srst_value)
              ty <- SC.scBitvector sc width
              -- Set state to reset value on CLK & SRST; else if CLK then D; otherwise hold
@@ -515,16 +489,10 @@ cellNewState sc env terms cnm (c, prevState) =
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
              clk <- inputBool "CLK"
-             srst <- inputBool "SRST"
              enforceClkPolarity "$sdffce"
-             en <- inputBool "EN"
-             -- complement enable signal if EN_POLARITY=0
-             let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
-             pos_en <- if en_polarity then pure en else SC.scNot sc en
+             pos_srst <- inputBoolWithPolarity "SRST"
+             pos_en <- inputBoolWithPolarity "EN"
              let srst_value = Maybe.fromMaybe 0 (lookupNatParam "SRST_VALUE")
-             -- complement reset signal if SRST_POLARITY=0
-             let srst_polarity = Maybe.fromMaybe True (lookupBoolParam "SRST_POLARITY")
-             pos_srst <- if srst_polarity then pure srst else SC.scNot sc srst
              srst_value' <- SC.scBvConst sc width (fromIntegral srst_value)
              ty <- SC.scBitvector sc width
              -- Set state to reset value on CLK & EN & SRST; else if CLK & EN then D; otherwise hold
@@ -535,16 +503,10 @@ cellNewState sc env terms cnm (c, prevState) =
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
              clk <- inputBool "CLK"
-             srst <- inputBool "SRST"
              enforceClkPolarity "$sdffe"
-             en <- inputBool "EN"
-             -- complement enable signal if EN_POLARITY=0
-             let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
-             pos_en <- if en_polarity then pure en else SC.scNot sc en
+             pos_srst <- inputBoolWithPolarity "SRST"
+             pos_en <- inputBoolWithPolarity "EN"
              let srst_value = Maybe.fromMaybe 0 (lookupNatParam "SRST_VALUE")
-             -- complement reset signal if SRST_POLARITY=0
-             let srst_polarity = Maybe.fromMaybe True (lookupBoolParam "SRST_POLARITY")
-             pos_srst <- if srst_polarity then pure srst else SC.scNot sc srst
              srst_value' <- SC.scBvConst sc width (fromIntegral srst_value)
              ty <- SC.scBitvector sc width
              -- Set state to reset value on CLK & SRST; else if CLK & EN then D; otherwise hold
@@ -579,6 +541,12 @@ cellNewState sc env terms cnm (c, prevState) =
       do CellTerm t _ _ <- input portname
          one <- SC.scNat sc 1
          SC.scBvNonzero sc one t
+    inputBoolWithPolarity :: PortName -> IO SC.Term
+    inputBoolWithPolarity portname =
+      do t <- inputBool portname
+         let polarity = Maybe.fromMaybe True (lookupBoolParam (portname <> "_POLARITY"))
+         -- complement signal if <portname>_POLARITY=0
+         if polarity then pure t else SC.scNot sc t
     lookupConn portname =
       case Map.lookup portname (c ^. cellConnections) of
         Nothing ->

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -82,12 +82,10 @@ moduleNetgraph env m =
       case ctr of
         CellTypeAdff _ -> Set.fromList ["ARST"]
         CellTypeAldff _ -> Set.fromList ["ALOAD", "AD"]
-        CellTypeDff -> Set.empty
-        CellTypeDffe -> Set.empty
+        CellTypeDff _ -> Set.empty
         CellTypeDffsr _ -> Set.fromList ["SET", "CLR"]
         CellTypeFf -> Set.empty
-        CellTypeSdff -> Set.empty
-        CellTypeSdffce -> Set.empty
+        CellTypeSdff _ -> Set.empty
         CellTypeSdffe -> Set.empty
 
     cellDeps :: Cell -> [CellInstName]
@@ -264,11 +262,9 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                         -- asynchronous set/reset, the output is
                         -- always identical to the stored value @r@
                         -- from the state record.
-                        CellTypeDff -> pure r
-                        CellTypeDffe -> pure r
+                        CellTypeDff _ -> pure r
                         CellTypeFf -> pure r
-                        CellTypeSdff -> pure r
-                        CellTypeSdffce -> pure r
+                        CellTypeSdff _ -> pure r
                         CellTypeSdffe -> pure r
 
                 ts <- deriveTermsByIndices sc bs r
@@ -350,27 +346,22 @@ cellNewState sc env terms cnm (c, prevState) =
                  False -> pure clk
              -- Set state to AD on ALOAD; else if CLK then D; otherwise hold
              SC.scIte sc ty pos_aload ad =<< SC.scIte sc ty trigger d q
-        CellTypeDff ->
+        CellTypeDff e ->
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
              clk <- inputBool "CLK"
-             enforceClkPolarity "$dff"
+             enforceClkPolarity (if e then "$dffe" else "$dff")
              ty <- SC.scBitvector sc width
-             SC.scIte sc ty clk d q
+             trigger <-
+               case e of
+                 True -> SC.scAnd sc clk =<< inputBoolWithPolarity "EN"
+                 False -> pure clk
+             -- update state to D on CLK; otherwise hold
+             SC.scIte sc ty trigger d q
         CellTypeFf ->
           -- $ff cell has no CLK input; it uses the global clock, so
           -- it transitions every time step
           cellTermTerm <$> input "D"
-        CellTypeDffe ->
-          do CellTerm d width _ <- input "D" -- new value
-             CellTerm q _ _ <- input "Q" -- old state value
-             clk <- inputBool "CLK"
-             enforceClkPolarity "$dffe"
-             pos_en <- inputBoolWithPolarity "EN"
-             ty <- SC.scBitvector sc width
-             -- update state to D on EN & CLK; otherwise hold
-             trigger <- SC.scAnd sc clk pos_en
-             SC.scIte sc ty trigger d q
         CellTypeDffsr e ->
           do clk <- inputBool "CLK"
              CellTerm d width _ <- input "D" -- new value
@@ -390,30 +381,20 @@ cellNewState sc env terms cnm (c, prevState) =
                  False -> pure clk
              -- Set each bit to 0 on CLR; else 1 on SET; else D on CLK; otherwise hold
              SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set =<< SC.scIte sc ty trigger d q
-        CellTypeSdff ->
+        CellTypeSdff e ->
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
              clk <- inputBool "CLK"
-             enforceClkPolarity "$sdff"
+             enforceClkPolarity (if e then "$sdffce" else "$sdff")
              pos_srst <- inputBoolWithPolarity "SRST"
              let srst_value = Maybe.fromMaybe 0 (lookupNatParam "SRST_VALUE")
              srst_value' <- SC.scBvConst sc width (fromIntegral srst_value)
              ty <- SC.scBitvector sc width
+             trigger <-
+               case e of
+                 True -> SC.scAnd sc clk =<< inputBoolWithPolarity "EN"
+                 False -> pure clk
              -- Set state to reset value on CLK & SRST; else if CLK then D; otherwise hold
-             d' <- SC.scIte sc ty pos_srst srst_value' d
-             SC.scIte sc ty clk d' q
-        CellTypeSdffce ->
-          do CellTerm d width _ <- input "D" -- new value
-             CellTerm q _ _ <- input "Q" -- old state value
-             clk <- inputBool "CLK"
-             enforceClkPolarity "$sdffce"
-             pos_srst <- inputBoolWithPolarity "SRST"
-             pos_en <- inputBoolWithPolarity "EN"
-             let srst_value = Maybe.fromMaybe 0 (lookupNatParam "SRST_VALUE")
-             srst_value' <- SC.scBvConst sc width (fromIntegral srst_value)
-             ty <- SC.scBitvector sc width
-             -- Set state to reset value on CLK & EN & SRST; else if CLK & EN then D; otherwise hold
-             trigger <- SC.scAnd sc clk pos_en
              d' <- SC.scIte sc ty pos_srst srst_value' d
              SC.scIte sc ty trigger d' q
         CellTypeSdffe ->

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -317,91 +317,70 @@ cellNewState sc env terms cnm (c, prevState) =
   case c ^. cellType of
     CellTypeRegister ctr ->
       case ctr of
+        -- $adff, $adffe
         CellTypeAdff e ->
-          do CellTerm d width _ <- input "D" -- new value
+          do clk <- clockInput e
+             CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
-             clk <- inputBool "CLK"
-             enforceClkPolarity (if e then "$adffe" else "$adff")
              pos_arst <- inputBoolWithPolarity "ARST"
              let arst_value = Maybe.fromMaybe 0 (lookupNatParam "ARST_VALUE")
              arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
              ty <- SC.scBitvector sc width
-             trigger <-
-               case e of
-                 True -> SC.scAnd sc clk =<< inputBoolWithPolarity "EN"
-                 False -> pure clk
              -- Set state to reset value on ARST; else if CLK then D; otherwise hold
-             SC.scIte sc ty pos_arst arst_value' =<< SC.scIte sc ty trigger d q
+             SC.scIte sc ty pos_arst arst_value' =<< SC.scIte sc ty clk d q
+        -- $aldff, $aldffe
         CellTypeAldff e ->
-          do clk <- inputBool "CLK"
+          do clk <- clockInput e
              CellTerm ad _ _ <- input "AD" -- async load value
              CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
-             enforceClkPolarity (if e then "$aldffe" else "$aldff")
              pos_aload <- inputBoolWithPolarity "ALOAD"
              ty <- SC.scBitvector sc width
-             trigger <-
-               case e of
-                 True -> SC.scAnd sc clk =<< inputBoolWithPolarity "EN"
-                 False -> pure clk
              -- Set state to AD on ALOAD; else if CLK then D; otherwise hold
-             SC.scIte sc ty pos_aload ad =<< SC.scIte sc ty trigger d q
+             SC.scIte sc ty pos_aload ad =<< SC.scIte sc ty clk d q
+        -- $dff, $dffe
         CellTypeDff e ->
-          do CellTerm d width _ <- input "D" -- new value
+          do clk <- clockInput e
+             CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
-             clk <- inputBool "CLK"
-             enforceClkPolarity (if e then "$dffe" else "$dff")
              ty <- SC.scBitvector sc width
-             trigger <-
-               case e of
-                 True -> SC.scAnd sc clk =<< inputBoolWithPolarity "EN"
-                 False -> pure clk
              -- update state to D on CLK; otherwise hold
-             SC.scIte sc ty trigger d q
+             SC.scIte sc ty clk d q
         CellTypeFf ->
           -- $ff cell has no CLK input; it uses the global clock, so
           -- it transitions every time step
           cellTermTerm <$> input "D"
+        -- $dffsr, $dffsre
         CellTypeDffsr e ->
-          do clk <- inputBool "CLK"
+          do clk <- clockInput e
              CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
              CellTerm set _ _ <- input "SET"
              CellTerm clr _ _ <- input "CLR"
-             enforceClkPolarity (if e then "$dffsre" else "$dffsr")
              let set_polarity = Maybe.fromMaybe True (lookupBoolParam "SET_POLARITY")
              let clr_polarity = Maybe.fromMaybe True (lookupBoolParam "CLR_POLARITY")
              w <- SC.scNat sc width
              ty <- SC.scBitvector sc width
              pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
              neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
-             trigger <-
-               case e of
-                 True -> SC.scAnd sc clk =<< inputBoolWithPolarity "EN"
-                 False -> pure clk
              -- Set each bit to 0 on CLR; else 1 on SET; else D on CLK; otherwise hold
-             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set =<< SC.scIte sc ty trigger d q
+             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set =<< SC.scIte sc ty clk d q
+        -- $sdff, $sdffce
         CellTypeSdff e ->
-          do CellTerm d width _ <- input "D" -- new value
+          do clk <- clockInput e
+             CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
-             clk <- inputBool "CLK"
-             enforceClkPolarity (if e then "$sdffce" else "$sdff")
              pos_srst <- inputBoolWithPolarity "SRST"
              let srst_value = Maybe.fromMaybe 0 (lookupNatParam "SRST_VALUE")
              srst_value' <- SC.scBvConst sc width (fromIntegral srst_value)
              ty <- SC.scBitvector sc width
-             trigger <-
-               case e of
-                 True -> SC.scAnd sc clk =<< inputBoolWithPolarity "EN"
-                 False -> pure clk
              -- Set state to reset value on CLK & SRST; else if CLK then D; otherwise hold
              d' <- SC.scIte sc ty pos_srst srst_value' d
-             SC.scIte sc ty trigger d' q
+             SC.scIte sc ty clk d' q
         CellTypeSdffe ->
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
-             clk <- inputBool "CLK"
-             enforceClkPolarity "$sdffe"
+             clk <- clockInput False -- ungated clock signal
              pos_srst <- inputBoolWithPolarity "SRST"
              pos_en <- inputBoolWithPolarity "EN"
              let srst_value = Maybe.fromMaybe 0 (lookupNatParam "SRST_VALUE")
@@ -457,12 +436,20 @@ cellNewState sc env terms cnm (c, prevState) =
     lookupNatParam pname = parseNat =<< Map.lookup pname (c ^. cellParameters)
     lookupBoolParam :: Text.Text -> Maybe Bool
     lookupBoolParam pname = parseBool =<< Map.lookup pname (c ^. cellParameters)
-    enforceClkPolarity :: Text.Text -> IO ()
-    enforceClkPolarity ty =
-      do let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
+    -- | @clockInput False@ reads @CLK@ and enforces @CLK_POLARITY=1@.
+    -- @clockInput True@ additionally reads input @EN@, inverts it if
+    -- @EN_POLARITY=0@, then ANDs it with the clock.
+    clockInput :: Bool -> IO SC.Term
+    clockInput e =
+      do clk <- inputBool "CLK"
+         let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
+         let ty = ppCellType (c ^. cellType)
          -- We only support CLK_POLARITY=1, i.e. posedge CLK
          unless clk_polarity $
            yosysError $ YosysError $ "Unsupported " <> ty <> " with CLK_POLARITY=0"
+         case e of
+           True -> SC.scAnd sc clk =<< inputBoolWithPolarity "EN"
+           False -> pure clk
 
 -- | Parse an Aeson value as a 'Bool', if possible.
 -- Note that Yosys encodes boolean parameters as either numbers like 0

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -88,6 +88,7 @@ moduleNetgraph env m =
         CellTypeDffe -> Set.empty
         CellTypeFf -> Set.empty
         CellTypeSdff -> Set.empty
+        CellTypeSdffce -> Set.empty
         CellTypeSdffe -> Set.empty
 
     cellDeps :: Cell -> [CellInstName]
@@ -291,6 +292,7 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                         CellTypeDffe -> pure r
                         CellTypeFf -> pure r
                         CellTypeSdff -> pure r
+                        CellTypeSdffce -> pure r
                         CellTypeSdffe -> pure r
                 ts <- deriveTermsByIndices sc bs r
                 pure $ Map.union ts acc
@@ -456,6 +458,28 @@ cellNewState sc env terms cnm (c, prevState) =
              -- Set state to reset value on CLK & SRST; else if CLK then D; otherwise hold
              d' <- SC.scIte sc ty pos_srst srst_value' d
              SC.scIte sc ty clk d' q
+        CellTypeSdffce ->
+          do CellTerm d width _ <- input "D" -- new value
+             CellTerm q _ _ <- input "Q" -- old state value
+             clk <- inputBool "CLK"
+             srst <- inputBool "SRST"
+             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
+             -- We only support CLK_POLARITY=1, i.e. posedge CLK
+             unless clk_polarity $ yosysError $ YosysError "Unsupported $sdffce with CLK_POLARITY=0"
+             en <- inputBool "EN"
+             -- complement enable signal if EN_POLARITY=0
+             let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
+             pos_en <- if en_polarity then pure en else SC.scNot sc en
+             let srst_value = Maybe.fromMaybe 0 (lookupNatParam "SRST_VALUE")
+             -- complement reset signal if SRST_POLARITY=0
+             let srst_polarity = Maybe.fromMaybe True (lookupBoolParam "SRST_POLARITY")
+             pos_srst <- if srst_polarity then pure srst else SC.scNot sc srst
+             srst_value' <- SC.scBvConst sc width (fromIntegral srst_value)
+             ty <- SC.scBitvector sc width
+             -- Set state to reset value on CLK & EN & SRST; else if CLK & EN then D; otherwise hold
+             trigger <- SC.scAnd sc clk pos_en
+             d' <- SC.scIte sc ty pos_srst srst_value' d
+             SC.scIte sc ty trigger d' q
         CellTypeSdffe ->
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -88,6 +88,7 @@ moduleNetgraph env m =
         CellTypeDffe -> Set.empty
         CellTypeFf -> Set.empty
         CellTypeSdff -> Set.empty
+        CellTypeSdffe -> Set.empty
 
     cellDeps :: Cell -> [CellInstName]
     cellDeps c =
@@ -290,6 +291,7 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                         CellTypeDffe -> pure r
                         CellTypeFf -> pure r
                         CellTypeSdff -> pure r
+                        CellTypeSdffe -> pure r
                 ts <- deriveTermsByIndices sc bs r
                 pure $ Map.union ts acc
            CellTypeUnsupportedPrimitive nm
@@ -454,6 +456,28 @@ cellNewState sc env terms cnm (c, prevState) =
              -- Set state to reset value on CLK & SRST; else if CLK then D; otherwise hold
              d' <- SC.scIte sc ty pos_srst srst_value' d
              SC.scIte sc ty clk d' q
+        CellTypeSdffe ->
+          do CellTerm d width _ <- input "D" -- new value
+             CellTerm q _ _ <- input "Q" -- old state value
+             clk <- inputBool "CLK"
+             srst <- inputBool "SRST"
+             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
+             -- We only support CLK_POLARITY=1, i.e. posedge CLK
+             unless clk_polarity $ yosysError $ YosysError "Unsupported $sdffe with CLK_POLARITY=0"
+             en <- inputBool "EN"
+             -- complement enable signal if EN_POLARITY=0
+             let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
+             pos_en <- if en_polarity then pure en else SC.scNot sc en
+             let srst_value = Maybe.fromMaybe 0 (lookupNatParam "SRST_VALUE")
+             -- complement reset signal if SRST_POLARITY=0
+             let srst_polarity = Maybe.fromMaybe True (lookupBoolParam "SRST_POLARITY")
+             pos_srst <- if srst_polarity then pure srst else SC.scNot sc srst
+             srst_value' <- SC.scBvConst sc width (fromIntegral srst_value)
+             ty <- SC.scBitvector sc width
+             -- Set state to reset value on CLK & SRST; else if CLK & EN then D; otherwise hold
+             rst <- SC.scAnd sc clk pos_srst
+             trigger <- SC.scAnd sc clk pos_en
+             SC.scIte sc ty rst srst_value' =<< SC.scIte sc ty trigger d q
     CellTypeCombinational _ ->
       panic "cellNewState" ["unexpected combinational cell"]
     CellTypeUnsupportedPrimitive _ ->

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -379,9 +379,7 @@ cellNewState sc env terms cnm (c, prevState) =
              CellTerm q _ _ <- input "Q" -- old state value
              clk <- inputBool "CLK"
              arst <- inputBool "ARST"
-             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
-             -- We only support CLK_POLARITY=1, i.e. posedge CLK
-             unless clk_polarity $ yosysError $ YosysError "Unsupported $adff with CLK_POLARITY=0"
+             enforceClkPolarity "$adff"
              let arst_value = Maybe.fromMaybe 0 (lookupNatParam "ARST_VALUE")
              -- complement reset signal if ARST_POLARITY=0
              let arst_polarity = Maybe.fromMaybe True (lookupBoolParam "ARST_POLARITY")
@@ -395,9 +393,7 @@ cellNewState sc env terms cnm (c, prevState) =
              CellTerm q _ _ <- input "Q" -- old state value
              clk <- inputBool "CLK"
              arst <- inputBool "ARST"
-             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
-             -- We only support CLK_POLARITY=1, i.e. posedge CLK
-             unless clk_polarity $ yosysError $ YosysError "Unsupported $adffe with CLK_POLARITY=0"
+             enforceClkPolarity "$adffe"
              en <- inputBool "EN"
              -- complement enable signal if EN_POLARITY=0
              let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
@@ -417,9 +413,7 @@ cellNewState sc env terms cnm (c, prevState) =
              CellTerm ad _ _ <- input "AD" -- async load value
              CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
-             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
-             -- We only support CLK_POLARITY=1, i.e. posedge CLK
-             unless clk_polarity $ yosysError $ YosysError "Unsupported $aldff with CLK_POLARITY=0"
+             enforceClkPolarity "$aldff"
              -- complement aload signal if ALOAD_POLARITY=0
              let aload_polarity = Maybe.fromMaybe True (lookupBoolParam "ALOAD_POLARITY")
              pos_aload <- if aload_polarity then pure aload else SC.scNot sc aload
@@ -432,9 +426,7 @@ cellNewState sc env terms cnm (c, prevState) =
              CellTerm ad _ _ <- input "AD" -- async load value
              CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
-             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
-             -- We only support CLK_POLARITY=1, i.e. posedge CLK
-             unless clk_polarity $ yosysError $ YosysError "Unsupported $aldffe with CLK_POLARITY=0"
+             enforceClkPolarity "$aldffe"
              en <- inputBool "EN"
              -- complement enable signal if EN_POLARITY=0
              let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
@@ -450,9 +442,7 @@ cellNewState sc env terms cnm (c, prevState) =
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value
              clk <- inputBool "CLK"
-             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
-             -- We only support CLK_POLARITY=1, i.e. posedge CLK
-             unless clk_polarity $ yosysError $ YosysError "Unsupported $dff with CLK_POLARITY=0"
+             enforceClkPolarity "$dff"
              ty <- SC.scBitvector sc width
              SC.scIte sc ty clk d q
         CellTypeFf ->
@@ -477,9 +467,7 @@ cellNewState sc env terms cnm (c, prevState) =
              CellTerm q _ _ <- input "Q" -- old state value
              CellTerm set _ _ <- input "SET"
              CellTerm clr _ _ <- input "CLR"
-             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
-             -- We only support CLK_POLARITY=1, i.e. posedge CLK
-             unless clk_polarity $ yosysError $ YosysError "Unsupported $dffsr with CLK_POLARITY=0"
+             enforceClkPolarity "$dffsr"
              let set_polarity = Maybe.fromMaybe True (lookupBoolParam "SET_POLARITY")
              let clr_polarity = Maybe.fromMaybe True (lookupBoolParam "CLR_POLARITY")
              w <- SC.scNat sc width
@@ -494,9 +482,7 @@ cellNewState sc env terms cnm (c, prevState) =
              CellTerm q _ _ <- input "Q" -- old state value
              CellTerm set _ _ <- input "SET"
              CellTerm clr _ _ <- input "CLR"
-             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
-             -- We only support CLK_POLARITY=1, i.e. posedge CLK
-             unless clk_polarity $ yosysError $ YosysError "Unsupported $dffsre with CLK_POLARITY=0"
+             enforceClkPolarity "$dffsre"
              en <- inputBool "EN"
              -- complement enable signal if EN_POLARITY=0
              let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
@@ -515,9 +501,7 @@ cellNewState sc env terms cnm (c, prevState) =
              CellTerm q _ _ <- input "Q" -- old state value
              clk <- inputBool "CLK"
              srst <- inputBool "SRST"
-             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
-             -- We only support CLK_POLARITY=1, i.e. posedge CLK
-             unless clk_polarity $ yosysError $ YosysError "Unsupported $sdff with CLK_POLARITY=0"
+             enforceClkPolarity "$sdff"
              let srst_value = Maybe.fromMaybe 0 (lookupNatParam "SRST_VALUE")
              -- complement reset signal if SRST_POLARITY=0
              let srst_polarity = Maybe.fromMaybe True (lookupBoolParam "SRST_POLARITY")
@@ -532,9 +516,7 @@ cellNewState sc env terms cnm (c, prevState) =
              CellTerm q _ _ <- input "Q" -- old state value
              clk <- inputBool "CLK"
              srst <- inputBool "SRST"
-             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
-             -- We only support CLK_POLARITY=1, i.e. posedge CLK
-             unless clk_polarity $ yosysError $ YosysError "Unsupported $sdffce with CLK_POLARITY=0"
+             enforceClkPolarity "$sdffce"
              en <- inputBool "EN"
              -- complement enable signal if EN_POLARITY=0
              let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
@@ -554,9 +536,7 @@ cellNewState sc env terms cnm (c, prevState) =
              CellTerm q _ _ <- input "Q" -- old state value
              clk <- inputBool "CLK"
              srst <- inputBool "SRST"
-             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
-             -- We only support CLK_POLARITY=1, i.e. posedge CLK
-             unless clk_polarity $ yosysError $ YosysError "Unsupported $sdffe with CLK_POLARITY=0"
+             enforceClkPolarity "$sdffe"
              en <- inputBool "EN"
              -- complement enable signal if EN_POLARITY=0
              let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
@@ -611,6 +591,12 @@ cellNewState sc env terms cnm (c, prevState) =
     lookupNatParam pname = parseNat =<< Map.lookup pname (c ^. cellParameters)
     lookupBoolParam :: Text.Text -> Maybe Bool
     lookupBoolParam pname = parseBool =<< Map.lookup pname (c ^. cellParameters)
+    enforceClkPolarity :: Text.Text -> IO ()
+    enforceClkPolarity ty =
+      do let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
+         -- We only support CLK_POLARITY=1, i.e. posedge CLK
+         unless clk_polarity $
+           yosysError $ YosysError $ "Unsupported " <> ty <> " with CLK_POLARITY=0"
 
 -- | Parse an Aeson value as a 'Bool', if possible.
 -- Note that Yosys encodes boolean parameters as either numbers like 0

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -376,31 +376,28 @@ cellNewState sc env terms cnm (c, prevState) =
         CellTypeAdff e ->
           do clk <- clockInput e
              CellTerm d width _ <- input "D" -- new value
-             CellTerm q _ _ <- input "Q" -- old state value
              pos_arst <- inputBoolWithPolarity "ARST"
              let arst_value = Maybe.fromMaybe 0 (lookupNatParam "ARST_VALUE")
              arst_value' <- SC.scBvConst sc width (fromIntegral arst_value)
              ty <- SC.scBitvector sc width
              -- Set state to reset value on ARST; else if CLK then D; otherwise hold
-             SC.scIte sc ty pos_arst arst_value' =<< SC.scIte sc ty clk d q
+             SC.scIte sc ty pos_arst arst_value' =<< SC.scIte sc ty clk d prevState
         -- $aldff, $aldffe
         CellTypeAldff e ->
           do clk <- clockInput e
              CellTerm ad _ _ <- input "AD" -- async load value
              CellTerm d width _ <- input "D" -- new value
-             CellTerm q _ _ <- input "Q" -- old state value
              pos_aload <- inputBoolWithPolarity "ALOAD"
              ty <- SC.scBitvector sc width
              -- Set state to AD on ALOAD; else if CLK then D; otherwise hold
-             SC.scIte sc ty pos_aload ad =<< SC.scIte sc ty clk d q
+             SC.scIte sc ty pos_aload ad =<< SC.scIte sc ty clk d prevState
         -- $dff, $dffe
         CellTypeDff e ->
           do clk <- clockInput e
              CellTerm d width _ <- input "D" -- new value
-             CellTerm q _ _ <- input "Q" -- old state value
              ty <- SC.scBitvector sc width
              -- update state to D on CLK; otherwise hold
-             SC.scIte sc ty clk d q
+             SC.scIte sc ty clk d prevState
         CellTypeFf ->
           -- $ff cell has no CLK input; it uses the global clock, so
           -- it transitions every time step
@@ -409,7 +406,6 @@ cellNewState sc env terms cnm (c, prevState) =
         CellTypeDffsr e ->
           do clk <- clockInput e
              CellTerm d width _ <- input "D" -- new value
-             CellTerm q _ _ <- input "Q" -- old state value
              CellTerm set _ _ <- input "SET"
              CellTerm clr _ _ <- input "CLR"
              let set_polarity = Maybe.fromMaybe True (lookupBoolParam "SET_POLARITY")
@@ -419,22 +415,20 @@ cellNewState sc env terms cnm (c, prevState) =
              pos_set <- if set_polarity then pure set else SC.scBvNot sc w set
              neg_clr <- if clr_polarity then SC.scBvNot sc w clr else pure clr
              -- Set each bit to 0 on CLR; else 1 on SET; else D on CLK; otherwise hold
-             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set =<< SC.scIte sc ty clk d q
+             SC.scBvAnd sc w neg_clr =<< SC.scBvOr sc w pos_set =<< SC.scIte sc ty clk d prevState
         -- $sdff, $sdffce
         CellTypeSdff e ->
           do clk <- clockInput e
              CellTerm d width _ <- input "D" -- new value
-             CellTerm q _ _ <- input "Q" -- old state value
              pos_srst <- inputBoolWithPolarity "SRST"
              let srst_value = Maybe.fromMaybe 0 (lookupNatParam "SRST_VALUE")
              srst_value' <- SC.scBvConst sc width (fromIntegral srst_value)
              ty <- SC.scBitvector sc width
              -- Set state to reset value on CLK & SRST; else if CLK then D; otherwise hold
              d' <- SC.scIte sc ty pos_srst srst_value' d
-             SC.scIte sc ty clk d' q
+             SC.scIte sc ty clk d' prevState
         CellTypeSdffe ->
           do CellTerm d width _ <- input "D" -- new value
-             CellTerm q _ _ <- input "Q" -- old state value
              clk <- clockInput WithoutClockEnable -- ungated clock signal
              pos_srst <- inputBoolWithPolarity "SRST"
              pos_en <- inputBoolWithPolarity "EN"
@@ -444,7 +438,7 @@ cellNewState sc env terms cnm (c, prevState) =
              -- Set state to reset value on CLK & SRST; else if CLK & EN then D; otherwise hold
              rst <- SC.scAnd sc clk pos_srst
              trigger <- SC.scAnd sc clk pos_en
-             SC.scIte sc ty rst srst_value' =<< SC.scIte sc ty trigger d q
+             SC.scIte sc ty rst srst_value' =<< SC.scIte sc ty trigger d prevState
         -- For transparent latches, the new state value is always
         -- equal to the value currently on the output port Q.
         CellTypeDlatch   -> cellTermTerm <$> input "Q"

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -83,6 +83,7 @@ moduleNetgraph env m =
         CellTypeAdff -> Set.fromList ["ARST"]
         CellTypeAdffe -> Set.fromList ["ARST"]
         CellTypeAldff -> Set.fromList ["ALOAD", "AD"]
+        CellTypeAldffe -> Set.fromList ["ALOAD", "AD"]
         CellTypeDff -> Set.empty
         CellTypeDffe -> Set.empty
         CellTypeFf -> Set.empty
@@ -269,6 +270,17 @@ netgraphToTerms sc env mname (Netgraph nodes) inputs states =
                              -- Set output to AD on ALOAD; else output state value
                              ty <- SC.scBitvector sc width
                              SC.scIte sc ty pos_aload ad r
+                        CellTypeAldffe ->
+                          do let aload_polarity =
+                                   Maybe.fromMaybe True $
+                                   parseBool =<< Map.lookup "ALOAD_POLARITY" (c ^. cellParameters)
+                             ad <- input "AD"
+                             aload <- inputBool "ALOAD"
+                             -- complement reset signal if ALOAD_POLARITY=0
+                             pos_aload <- if aload_polarity then pure aload else SC.scNot sc aload
+                             -- Set output to AD on ALOAD; else output state value
+                             ty <- SC.scBitvector sc width
+                             SC.scIte sc ty pos_aload ad r
 
                         -- For all register cell types without
                         -- asynchronous set/reset, the output is
@@ -373,13 +385,33 @@ cellNewState sc env terms cnm (c, prevState) =
              CellTerm q _ _ <- input "Q" -- old state value
              let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
              -- We only support CLK_POLARITY=1, i.e. posedge CLK
-             unless clk_polarity $ yosysError $ YosysError "Unsupported $adff with CLK_POLARITY=0"
+             unless clk_polarity $ yosysError $ YosysError "Unsupported $aldff with CLK_POLARITY=0"
              -- complement aload signal if ALOAD_POLARITY=0
              let aload_polarity = Maybe.fromMaybe True (lookupBoolParam "ALOAD_POLARITY")
              pos_aload <- if aload_polarity then pure aload else SC.scNot sc aload
              ty <- SC.scBitvector sc width
              -- Set state to AD on ALOAD; else if CLK then D; otherwise hold
              SC.scIte sc ty pos_aload ad =<< SC.scIte sc ty clk d q
+        CellTypeAldffe ->
+          do clk <- inputBool "CLK"
+             aload <- inputBool "ALOAD"
+             CellTerm ad _ _ <- input "AD" -- async load value
+             CellTerm d width _ <- input "D" -- new value
+             CellTerm q _ _ <- input "Q" -- old state value
+             let clk_polarity = Maybe.fromMaybe True (lookupBoolParam "CLK_POLARITY")
+             -- We only support CLK_POLARITY=1, i.e. posedge CLK
+             unless clk_polarity $ yosysError $ YosysError "Unsupported $aldffe with CLK_POLARITY=0"
+             en <- inputBool "EN"
+             -- complement enable signal if EN_POLARITY=0
+             let en_polarity = Maybe.fromMaybe True (lookupBoolParam "EN_POLARITY")
+             pos_en <- if en_polarity then pure en else SC.scNot sc en
+             -- complement aload signal if ALOAD_POLARITY=0
+             let aload_polarity = Maybe.fromMaybe True (lookupBoolParam "ALOAD_POLARITY")
+             pos_aload <- if aload_polarity then pure aload else SC.scNot sc aload
+             ty <- SC.scBitvector sc width
+             -- Set state to AD on ALOAD; else if EN & CLK then D; otherwise hold
+             trigger <- SC.scAnd sc clk pos_en
+             SC.scIte sc ty pos_aload ad =<< SC.scIte sc ty trigger d q
         CellTypeDff ->
           do CellTerm d width _ <- input "D" -- new value
              CellTerm q _ _ <- input "Q" -- old state value


### PR DESCRIPTION
This PR adds support for the following Yosys register cell types:
*  `$sdff`: DFF with synchronous reset
* `$dffsr`: DFF with bitwise asynchronous set and reset
* `$adffe`: DFF with async reset and clock enable
* `$sdffe`: DFF with synchronous reset and clock enable (reset ignores enable)
* `$sdffce`: DFF with synchronous reset and clock enable (enable masks reset)
* `$aldffe`: DFF with asynchronous load and clock enable
* `$dffsre`: DFF with bitwise async set/reset and clock enable

These extend the list of already-supported register cell types:
* `$ff`
* `$dff`
* `$dffe`
* `$adff`
* `$aldff`

Fixes #3168.

The only remaining unsupported register cell types are the transparent latches:
* `$adlatch`
* `$dlatch`
* `$dlatchsr`
* `$sr`

With support for so many cell types, we now have a greater need for a comprehensive test suite to ensure that our semantics agrees with Yosys on all of them (#3114). Such a test suite is not included in this PR.

EDIT: As of 098df99, we now support *all* register cell types, including the transparent latches.