### PR TITLE
Insert type coercions as needed when importing Cryptol record/tuple updates

### DIFF
--- a/cryptol-saw-core/saw/Cryptol.sawcore
+++ b/cryptol-saw-core/saw/Cryptol.sawcore
@@ -310,6 +310,11 @@ seq_cong1 : (m : Num) -> (n : Num) -> (a : sort 0) ->
 seq_cong1 m n a eq_mn =
   eq_cong Num m n eq_mn (sort 0) (\ (x:Num) -> seq x a);
 
+seq_cong2 : (n : Num) -> (a b : sort 0) ->
+  Eq (sort 0) a b -> Eq (sort 0) (seq n a) (seq n b);
+seq_cong2 n a b eq_ab =
+  eq_cong (sort 0) a b eq_ab (sort 0) (seq n);
+
 IntModNum_cong :
   (m : Num) -> (n : Num) -> Eq Num m n -> Eq (sort 0) (IntModNum m) (IntModNum n);
 IntModNum_cong m n eq_mn =

--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -1687,10 +1687,9 @@ importExpr' sc env schema expr =
 
     fallback :: IO Term
     fallback =
-      do let t1 = fastTypeOf (eAllVars env) expr
-         t2 <- the "fallback: schema is not mono" (C.isMono schema)
-         expr' <- importExpr sc env expr
-         coerceTerm sc env t1 t2 expr'
+      do expr' <- importExpr sc env expr
+         t2' <- importSchema sc env schema
+         coerceTerm sc t2' expr'
 
 tupleUpdate :: SharedContext -> Term -> Int -> [Term] -> IO Term
 tupleUpdate sc f 0 (a : ts) =
@@ -2002,18 +2001,16 @@ importDeclGroups sc = foldM (importDeclGroup NestedDeclGroup sc)
 importTopLevelDeclGroups :: SharedContext -> ImportPrimitiveOptions -> CryptolEnv -> [C.DeclGroup] -> IO CryptolEnv
 importTopLevelDeclGroups sc primOpts = foldM (importDeclGroup (TopLevelDeclGroup primOpts) sc)
 
-coerceTerm :: SharedContext -> CryptolEnv -> C.Type -> C.Type -> Term -> IO Term
-coerceTerm sc env t1 t2 e
-  | t1 == t2 = do return e
-  | otherwise =
-    do t1' <- importType sc env t1
-       t2' <- importType sc env t2
-       same <- scSubtype sc t1' t2'
-       case same of
-         True -> pure e -- ascribe type t2' to e
-         False ->
-           do q <- proveEq sc t1' t2'
-              scGlobalApply sc "Prelude.coerce" [t1', t2', q, e]
+-- | @coerceTerm sc ty t@ coerces term @t@ to have type @ty@.
+coerceTerm :: SharedContext -> Term -> Term -> IO Term
+coerceTerm sc t2 t =
+  do t1 <- scTypeOf sc t
+     same <- scSubtype sc t1 t2
+     case same of
+       True -> scAscribe sc t t2
+       False ->
+         do q <- proveEq sc t1 t2
+            scGlobalApply sc "Prelude.coerce" [t1, t2, q, t]
 
 -- | Given two SAWCore 'Term's @t1@ and @t2@ that represent Cryptol
 -- types, construct a new 'Term' of type @Eq (sort 0) t1 t2@ proving
@@ -2127,12 +2124,13 @@ importComp sc env lenT elemT expr mss =
                 do zs <- scGlobalApply sc "Cryptol.seqZip" [a, b, m, n, xs, ys]
                    mn <- scGlobalApply sc "Cryptol.tcMin" [m, n]
                    return (zs, mn, ab, args : argss, C.tMin len len')
-     (xs, n, a, argss, lenT') <- zipAll mss
+     (xs, n, a, argss, _lenT') <- zipAll mss
      f <- lambdaTuples sc env elemT expr argss
      b <- importType sc env elemT
      ys <- scGlobalApply sc "Cryptol.seqMap" [a, b, n, f, xs]
+     t2 <- importType sc env (C.tSeq lenT elemT)
      -- The resulting type might not match the annotation, so we coerce
-     coerceTerm sc env (C.tSeq lenT' elemT) (C.tSeq lenT elemT) ys
+     coerceTerm sc t2 ys
 
 lambdaTuples :: SharedContext -> CryptolEnv -> C.Type -> C.Expr -> [[(C.Name, C.Type)]] -> IO Term
 lambdaTuples sc env ty expr [] = importExpr' sc env (C.tMono ty) expr

--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -2012,130 +2012,95 @@ coerceTerm sc env t1 t2 e
        case same of
          True -> pure e -- ascribe type t2' to e
          False ->
-           do q <- proveEq sc env t1 t2
+           do q <- proveEq sc t1' t2'
               scGlobalApply sc "Prelude.coerce" [t1', t2', q, e]
 
-proveEq :: SharedContext -> CryptolEnv -> C.Type -> C.Type -> IO Term
-proveEq sc env t1 t2
-  | t1 == t2 =
-    do s <- scSort sc (mkSort 0)
-       t' <- importType sc env t1
-       scGlobalApply sc "Prelude.Refl" [s, t']
+-- | Given two SAWCore 'Term's @t1@ and @t2@ that represent Cryptol
+-- types, construct a new 'Term' of type @Eq (sort 0) t1 t2@ proving
+-- that they are equal.
+-- The proof may use @unsafeAssert@ on basic types.
+proveEq :: SharedContext -> Term -> Term -> IO Term
+proveEq sc t1 t2 =
+  do mEq <- proveEq' sc t1 t2
+     case mEq of
+       Just e -> pure e
+       Nothing ->
+         do s <- scSort sc (mkSort 0)
+            scGlobalApply sc "Prelude.Refl" [s, t1]
+
+-- | Given two SAWCore 'Term's @t1@ and @t2@ that represent Cryptol
+-- types, construct a new 'Term' of type @Eq (sort 0) t1 t2@ proving
+-- that they are equal, or return 'Nothing' if they are already equal.
+-- The proof may use @unsafeAssert@ on basic types.
+proveEq' :: SharedContext -> Term -> Term -> IO (Maybe Term)
+proveEq' sc t1 t2
+  | termIndex t1 == termIndex t2 = pure Nothing
   | otherwise =
-    case (tNoUser t1, tNoUser t2) of
-      (C.tIsSeq -> Just (n1, a1), C.tIsSeq -> Just (n2, a2)) ->
-        do n1' <- importType sc env n1
-           n2' <- importType sc env n2
-           a1' <- importType sc env a1
-           a2' <- importType sc env a2
-           num <- scGlobalApply sc "Cryptol.Num" []
-           nEq <- if n1 == n2
-                  then scGlobalApply sc "Prelude.Refl" [num, n1']
-                  else scGlobalApply sc "Prelude.unsafeAssert" [num, n1', n2']
-           aEq <- proveEq sc env a1 a2
-           if a1 == a2
-             then scGlobalApply sc "Cryptol.seq_cong1" [n1', n2', a1', nEq]
-             else scGlobalApply sc "Cryptol.seq_cong" [n1', n2', a1', a2', nEq, aEq]
-      (C.tIsIntMod -> Just n1, C.tIsIntMod -> Just n2) ->
-        do n1' <- importType sc env n1
-           n2' <- importType sc env n2
-           num <- scGlobalApply sc "Cryptol.Num" []
-           nEq <- if n1 == n2
-                  then scGlobalApply sc "Prelude.Refl" [num, n1']
-                  else scGlobalApply sc "Prelude.unsafeAssert" [num, n1', n2']
-           scGlobalApply sc "Cryptol.IntModNum_cong" [n1', n2', nEq]
-      (C.tIsFun -> Just (a1, b1), C.tIsFun -> Just (a2, b2)) ->
-        do a1' <- importType sc env a1
-           a2' <- importType sc env a2
-           b1' <- importType sc env b1
-           b2' <- importType sc env b2
-           aEq <- proveEq sc env a1 a2
-           bEq <- proveEq sc env b1 b2
-           scGlobalApply sc "Cryptol.fun_cong" [a1', a2', b1', b2', aEq, bEq]
-      (tIsPair -> Just (a1, b1), tIsPair -> Just (a2, b2)) ->
-        do a1' <- importType sc env a1
-           a2' <- importType sc env a2
-           b1' <- importType sc env b1
-           b2' <- importType sc env b2
-           aEq <- proveEq sc env a1 a2
-           bEq <- proveEq sc env b1 b2
-           if b1 == b2
-             then scGlobalApply sc "Cryptol.pair_cong1" [a1', a2', b1', aEq]
-             else if a1 == a2
-                  then scGlobalApply sc "Cryptol.pair_cong2" [a1', b1', b2', bEq]
-                  else scGlobalApply sc "Cryptol.pair_cong" [a1', a2', b1', b2', aEq, bEq]
-      (tIsRecord -> Just (s1, a1, b1), tIsRecord -> Just (s2, a2, b2)) | s1 == s2 ->
-        do a1' <- importType sc env a1
-           a2' <- importType sc env a2
-           b1' <- importType sc env b1
-           b2' <- importType sc env b2
-           aEq <- proveEq sc env a1 a2
-           bEq <- proveEq sc env b1 b2
-           s <- scString sc (C.identText s1)
-           if b1 == b2
-             then scGlobalApply sc "Cryptol.record_cong1" [s, a1', a2', b1', aEq]
-             else if a1 == a2
-                  then scGlobalApply sc "Cryptol.record_cong2" [s, a1', b1', b2', bEq]
-                  else scGlobalApply sc "Cryptol.record_cong" [s, a1', a2', b1', b2', aEq, bEq]
-
-      (C.tIsNominal -> Just (C.NominalType{C.ntDef=C.Enum _},_),
-       C.tIsNominal -> Just (C.NominalType{C.ntDef=C.Enum _},_)) ->
-        panic "proveEq" [
-            "Enum types unsupported.",
-            "Found: " <> CryPP.pp t1 <> " and " <> CryPP.pp t2
-        ]
-
-        -- XXX: add a case for `enum`
-        -- 1. Match constructors by names, and prove fields as tuples
-        -- 2. We need some way to combine the proofs of equality of
-        -- the fields, into a proof for equality of the whole type
-        -- for sums
-        --
-        -- XXX: Response to above: Not sure what purpose of `proveEq`
-        -- is, but wouldn't Enum types have name (not structural)
-        -- equality?
-
-      (_, _) ->
-        panic "proveEq" [
-            "Internal type error:",
-            "t1: " <> CryPP.pp t1,
-            "t2: " <> CryPP.pp t2
-        ]
-
-
--- | Resolve user types (type aliases and newtypes) to their simpler SAW-compatible forms.
-tNoUser :: C.Type -> C.Type
-tNoUser initialTy =
-  case C.tNoUser initialTy of
-    C.TNominal nt params
-      | C.Struct fs <- C.ntDef nt ->
-        if null params then
-            C.TRec (C.ntFields fs)
-        else
-            -- XXX: We should instantiate, see #2019
-            panic "tNoUser" [
-                "Nominal type with parameters: " <> CryPP.pp initialTy
-            ]
-    t -> t
-
-
--- | Deconstruct a Cryptol tuple type as a pair according to the
--- SAWCore tuple type encoding.
-tIsPair :: C.Type -> Maybe (C.Type, C.Type)
-tIsPair t =
-  do ts <- C.tIsTuple t
-     case ts of
-       [] -> Nothing
-       t1 : ts' -> Just (t1, C.tTuple ts')
-
--- | Deconstruct a Cryptol non-empty record type as a label, head type
--- and tail type according to the SAWCore record type encoding.
-tIsRecord :: C.Type -> Maybe (C.Ident, C.Type, C.Type)
-tIsRecord t =
-  do tm <- C.tIsRec t
-     case C.canonicalFields tm of
-       [] -> Nothing
-       ((i, t1) : more) -> Just (i, t1, C.tRec (C.recordFromFields more))
+    case (t1, t2) of
+      (asGlobalApply "Cryptol.seq" -> Just [n1, a1],
+       asGlobalApply "Cryptol.seq" -> Just [n2, a2]) ->
+        do mnEq <- proveEq' sc n1 n2
+           maEq <- proveEq' sc a1 a2
+           case mnEq of
+             Nothing ->
+               case maEq of
+                 Nothing -> pure Nothing
+                 Just aEq ->
+                   Just <$> scGlobalApply sc "Cryptol.seq_cong2" [n1, a1, a2, aEq]
+             Just nEq ->
+               case maEq of
+                 Nothing ->
+                   Just <$> scGlobalApply sc "Cryptol.seq_cong1" [n1, n2, a1, nEq]
+                 Just aEq ->
+                   Just <$> scGlobalApply sc "Cryptol.seq_cong" [n1, n2, a1, a2, nEq, aEq]
+      (asGlobalApply "Prelude.IntMod" -> Just [n1],
+       asGlobalApply "Prelude.IntMod" -> Just [n2]) ->
+        do mnEq <- proveEq' sc n1 n2
+           case mnEq of
+             Nothing -> pure Nothing
+             Just nEq ->
+               Just <$> scGlobalApply sc "Cryptol.IntModNum_cong" [n1, n2, nEq]
+      (asFun -> Just (a1, b1), asFun -> Just (a2, b2)) ->
+        do aEq <- proveEq sc a1 a2
+           bEq <- proveEq sc b1 b2
+           Just <$> scGlobalApply sc "Cryptol.fun_cong" [a1, a2, b1, b2, aEq, bEq]
+      (asPairType -> Just (a1, b1), asPairType -> Just (a2, b2)) ->
+        do maEq <- proveEq' sc a1 a2
+           mbEq <- proveEq' sc b1 b2
+           case maEq of
+             Nothing ->
+               case mbEq of
+                 Nothing -> pure Nothing
+                 Just bEq ->
+                   Just <$> scGlobalApply sc "Cryptol.pair_cong2" [a1, b1, b2, bEq]
+             Just aEq ->
+               case mbEq of
+                 Nothing ->
+                   Just <$> scGlobalApply sc "Cryptol.pair_cong1" [a1, a2, b1, aEq]
+                 Just bEq ->
+                   Just <$> scGlobalApply sc "Cryptol.pair_cong" [a1, a2, b1, b2, aEq, bEq]
+      (asGlobalApply "Prelude.RecordType" -> Just [s1, a1, b1],
+       asGlobalApply "Prelude.RecordType" -> Just [s2, a2, b2])
+        | s1 == s2 ->
+          do maEq <- proveEq' sc a1 a2
+             mbEq <- proveEq' sc b1 b2
+             case maEq of
+               Nothing ->
+                 case mbEq of
+                   Nothing -> pure Nothing
+                   Just bEq ->
+                     Just <$> scGlobalApply sc "Cryptol.record_cong2" [s1, a1, b1, b2, bEq]
+               Just aEq ->
+                 case mbEq of
+                   Nothing ->
+                     Just <$> scGlobalApply sc "Cryptol.record_cong1" [s1, a1, a2, b1, aEq]
+                   Just bEq ->
+                     Just <$> scGlobalApply sc "Cryptol.record_cong" [s1, a1, a2, b1, b2, aEq, bEq]
+      _ ->
+        do same <- scConvertible sc t1 t2
+           if same then pure Nothing else
+             do ty <- scTypeOf sc t1
+                Just <$> scGlobalApply sc "Prelude.unsafeAssert" [ty, t1, t2]
 
 
 --------------------------------------------------------------------------------

--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -1413,7 +1413,6 @@ importExpr sc env expr =
       case sel of
         C.TupleSel i _maybeLen ->
           do e1' <- importExpr sc env e1
-             e2' <- importExpr sc env e2
              t1 <- scTypeOf sc e1'
              case asTupleType t1 of
                Nothing -> do
@@ -1424,12 +1423,12 @@ importExpr sc env expr =
                      ]
                Just ts ->
                  do let t2' = ts !! i
+                    e2' <- coerceTerm sc t2' =<< importExpr sc env e2
                     f <- scGlobalApply sc "Cryptol.const" [t2', t2', e2']
                     g <- tupleUpdate sc f i ts
                     scApply sc g e1'
         C.RecordSel x _ ->
           do e1' <- importExpr sc env e1
-             e2' <- importExpr sc env e2
              t1 <- scTypeOf sc e1'
              case asRecordType t1 of
                Nothing -> do
@@ -1441,6 +1440,7 @@ importExpr sc env expr =
                Just fields ->
                  do let x' = C.identText x
                     t2' <- the "field name not found" (lookup x' fields)
+                    e2' <- coerceTerm sc t2' =<< importExpr sc env e2
                     f <- scGlobalApply sc "Cryptol.const" [t2', t2', e2']
                     g <- recordUpdate sc f x' fields
                     scApply sc g e1'

--- a/saw-core/src/SAWCore/Recognizer.hs
+++ b/saw-core/src/SAWCore/Recognizer.hs
@@ -50,6 +50,7 @@ module SAWCore.Recognizer
   , asLambdaList
   , asPi
   , asPiList
+  , asFun
   , asConstant
   , asVariable
   , asSort
@@ -78,6 +79,7 @@ import Prelude hiding (Foldable(..))
 import Control.Lens
 import Control.Monad
 import Data.Foldable (Foldable(..)) -- for foldl'
+import qualified Data.IntMap as IntMap
 import qualified Data.Vector as V
 import Data.Text (Text)
 import Numeric.Natural (Natural)
@@ -380,6 +382,14 @@ asPiList :: Term -> ([(VarName, Term)], Term)
 asPiList = go []
   where go r (asPi -> Just (nm,tp,rhs)) = go ((nm,tp):r) rhs
         go r rhs = (reverse r, rhs)
+
+-- | Recognize non-dependent function types, i.e. pi types where the
+-- result type does not use the bound variable.
+asFun :: Recognizer Term (Term, Term)
+asFun t =
+  do (x, t1, t2) <- asPi t
+     guard (not (IntMap.member (vnIndex x) (varTypes t2)))
+     pure (t1, t2)
 
 asConstant :: Recognizer Term Name
 asConstant (unwrapTermF -> Constant nm) = pure nm


### PR DESCRIPTION
Making this work involved rewriting some internals of the Cryptol-SAWCore translator (`proveEq` and `coerceTerm`, in particular).

Fixes #3170.