### PR TITLE
Crack down on misuse of default prettyprinting options

### DIFF
--- a/crucible-mir-comp/src/Mir/Compositional/Override.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Override.hs
@@ -248,7 +248,7 @@ runSpec sc myCS mh ms = ovrWithBackend $ \bak -> do
                      , MS.conditionType = "formal argument matching"
                      , MS.conditionContext = ""
                      }
-            matchArg sym eval col (ms ^. MS.csPreState . MS.csAllocs) md shp rv sv
+            matchArg sym ppopts eval col (ms ^. MS.csPreState . MS.csAllocs) md shp rv sv
 
         -- Match PointsTo SetupValues against accessible memory.
         --
@@ -276,7 +276,7 @@ runSpec sc myCS mh ms = ovrWithBackend $ \bak -> do
                 ref' <- lift $ mirRef_offsetSim (ptr ^. mpRef) iSym elemSize
                 rv <- lift $ readMirRefSim (ptr ^. mpType) ref'
                 let shp = tyToShapeEq col ty (ptr ^. mpType)
-                matchArg sym eval col (ms ^. MS.csPreState . MS.csAllocs) md shp rv sv
+                matchArg sym ppopts eval col (ms ^. MS.csPreState . MS.csAllocs) md shp rv sv
 
         -- Validity checks
 
@@ -421,13 +421,14 @@ matchArg ::
     forall sym t fs tp0.
     (IsSymInterface sym, sym ~ MirSym t fs, HasCallStack) =>
     sym ->
+    PPS.Opts ->
     (forall tp'. W4.Expr t tp' -> IO SAW.Term) ->
     M.Collection ->
     Map MS.AllocIndex (Some MirAllocSpec) ->
     MS.ConditionMetadata ->
     TypeShape tp0 -> RegValue sym tp0 -> MS.SetupValue MIR ->
     MirOverrideMatcher sym ()
-matchArg sym eval col allocSpecs md shp0 rv0 sv0 = go shp0 rv0 sv0
+matchArg sym ppopts eval col allocSpecs md shp0 rv0 sv0 = go shp0 rv0 sv0
   where
     go :: forall tp. TypeShape tp -> RegValue sym tp -> MS.SetupValue MIR ->
         MirOverrideMatcher sym ()
@@ -438,8 +439,8 @@ matchArg sym eval col allocSpecs md shp0 rv0 sv0 = go shp0 rv0 sv0
             Just (vn, _tp) -> do
                 let var = SAW.vnIndex vn
                 sub <- use MS.termSub
-                when (IntMap.member var sub) $
-                    MS.failure loc MS.NonlinearPatternNotSupported
+                when (IntMap.member var sub) $ do
+                    MS.failure ppopts loc MS.NonlinearPatternNotSupported
                 MS.termSub %= IntMap.insert var exprTerm
             Nothing -> do
                 -- If the `TypedTerm` is a constant, we want to assert that the

--- a/crux-mir-comp/src/Mir/Cryptol.hs
+++ b/crux-mir-comp/src/Mir/Cryptol.hs
@@ -249,8 +249,9 @@ loadCryptolFunc col sig modulePath name = do
         SAW.InputText name "<string>" 1 1
     liftIO (writeIORef (mirCryEnv mirState) ce'')
 
+    ppopts <- liftIO $ SAW.scGetPPOpts sc
     args <-
-      case typecheckFnSig col sig argShps (Some retShp) (SAW.ttType tt) of
+      case typecheckFnSig ppopts col sig argShps (Some retShp) (SAW.ttType tt) of
         Left err -> fail $ "error loading " ++ show name ++ ": " ++ err
         Right ok -> pure ok
 
@@ -438,13 +439,14 @@ splitAssign n asgn
 -- | Check if the Rust type matches the Cryptol override.
 typecheckFnSig ::
     forall args.
+    PPS.Opts ->
     M.Collection ->
     M.FnSig ->
     Assignment TypeShape args ->
     Some TypeShape ->
     SAW.TypedTermType ->
     Either String (CryFunArgs args)
-typecheckFnSig col fnSig argShps0 (Some retShp) (SAW.TypedTermSchema sch@(Cry.Forall sizePs ps ty0))
+typecheckFnSig _ppopts col fnSig argShps0 (Some retShp) (SAW.TypedTermSchema sch@(Cry.Forall sizePs ps ty0))
   | not (null badTPs) =
     Left $ unlines $ [
       "Cryptol functions with non-numeric type parameters are not supported:",
@@ -579,6 +581,6 @@ typecheckFnSig col fnSig argShps0 (Some retShp) (SAW.TypedTermSchema sch@(Cry.Fo
             " does not match Rust type " ++ M.fmt (shapeMirTy shp) ++
             (if not (null extra) then ": " ++ extra else "")
 
-typecheckFnSig _ _ _ _ ttt = Left $
-    let ttt' = SAW.ppTypedTermTypePure PPS.defaultOpts ttt in
+typecheckFnSig ppopts _ _ _ _ ttt = Left $
+    let ttt' = SAW.ppTypedTermTypePure ppopts ttt in
     "internal error: unsupported TypedTermType variant: " ++ Text.unpack ttt'

--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -520,13 +520,13 @@ importType sc env ty =
              | Just prim' <- C.asPrim n
              , Just t <- Map.lookup prim' (ePrimTypes env) ->
                scApplyAllBeta sc t =<< traverse go ts
-             | Just prim' <- C.asPrim n ->
+             | Just prim' <- C.asPrim n -> do
+               ppopts <- scGetPPOpts sc
                let envNote
                      | Map.null (ePrimTypes env) =
                          " (the primitive types environment is empty)"
                      | otherwise = ""
-               in
-               fail $ PPS.render PPS.defaultOpts $ PP.vsep
+               fail $ PPS.render ppopts $ PP.vsep
                  [ "Unknown primitive type:" <+> CryPP.pretty prim' <> envNote
                  , "Full type:" <+> CryPP.pretty ty
                  ]
@@ -1451,8 +1451,9 @@ importExpr sc env expr =
                   "ESet/RecordSel: not a record type or newtype",
                   "Type: " <> CryPP.pp t1
                ]
-        C.ListSel _i _maybeLen ->
-          let expr' = PPS.renderText PPS.defaultOpts $ PP.indent 3 $ CryPP.pretty expr in
+        C.ListSel _i _maybeLen -> do
+          ppopts <- scGetPPOpts sc
+          let expr' = PPS.renderText ppopts $ PP.indent 3 $ CryPP.pretty expr
           panic "importExpr" ("ListSel is unsupported in ESet:" : Text.lines expr')
 
     C.EIf e1 e2 e3 ->
@@ -1522,7 +1523,8 @@ importExpr sc env expr =
             do e' <- importExpr sc env e
                prf <- proveProp sc env p
                scApply sc e' prf
-        s ->
+        s -> do
+            ppopts <- scGetPPOpts sc
             -- XXX: `PP.align` is probably not the nicest way to print
             -- this, but it beats failing to indent at all and it's
             -- not exactly easy to test. (Especially since I just
@@ -1532,8 +1534,7 @@ importExpr sc env expr =
                     "Expr:" <+> (PP.align $ CryPP.pretty expr),
                     "Schema:" <+> (PP.align $ CryPP.pretty s)
                  ]
-                info' = Text.lines $ PPS.renderText PPS.defaultOpts info
-            in
+                info' = Text.lines $ PPS.renderText ppopts info
             panic "importExpr" ("EProofApp: invalid type" : info')
 
     C.EWhere e dgs ->

--- a/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
@@ -82,8 +82,7 @@ import qualified SAWSupport.Pretty as PPS
 import CryptolSAWCore.Panic
 import SAWCore.Name (nameInfo)
 import SAWCore.Recognizer (asConstant)
-import SAWCore.SharedTerm (NameInfo, SharedContext, Term)
-import SAWCore.Term.Pretty (ppTermPureDefaults)
+import SAWCore.SharedTerm (NameInfo, SharedContext, Term, ppTerm)
 
 import qualified CryptolSAWCore.Cryptol as C
 -- These used to live in this file, so import them unqualified for now.
@@ -833,7 +832,7 @@ loadAndTranslateModule sc env0 src =
      env4 <- C.importTopLevelDeclGroups
                         sc C.defaultPrimitiveOptions env3 newDeclGroups
 
-     let ffiTypes' = updateFFITypes m (eAllTerms env4) (eFFITypes env4)
+     ffiTypes' <- updateFFITypes sc m (eAllTerms env4) (eFFITypes env4)
      let env5 = env4 { eFFITypes  = ffiTypes' }
 
      return (m, env5)
@@ -847,27 +846,34 @@ checkNotParameterized m =
                    ]
 
 -- | Helper for updating `eFFITypes` in `CryptolEnv`.
-updateFFITypes :: T.Module -> Map MN.Name Term -> Map NameInfo T.FFI -> Map NameInfo T.FFI
-updateFFITypes m allTerms' eFFITypes' =
-  foldr (\(nm, ty) -> Map.insert (getNameInfo nm) ty)
-                       eFFITypes'
-                       (T.findForeignDecls m)
-  where
-  getNameInfo nm =
-    case Map.lookup nm allTerms' of
-      Just tm ->
-        case asConstant tm of
-          Just n -> nameInfo n
-          Nothing ->
-            panic "updateFFITypes" [
-                "SAWCore term of Cryptol name is not Constant",
-                "Name: " <> CryPP.pp nm,
-                "Term: " <> Text.pack (ppTermPureDefaults tm)
-            ]
-      Nothing ->
-        panic "updateFFITypes" [
-            "Cannot find foreign function in term environment: " <> CryPP.pp nm
-        ]
+updateFFITypes ::
+  SharedContext ->
+  T.Module ->
+  Map MN.Name Term ->
+  Map NameInfo T.FFI ->
+  IO (Map NameInfo T.FFI)
+updateFFITypes sc m allTerms' eFFITypes' = do
+  let getNameInfo (nm, ty) = do
+        let tm = case Map.lookup nm allTerms' of
+              Just tm' -> tm'
+              Nothing ->
+                  panic "updateFFITypes" [
+                      "Cannot find foreign function in term environment: " <>
+                          CryPP.pp nm
+                  ]
+        info <- case asConstant tm of
+              Just n ->
+                pure $ nameInfo n
+              Nothing -> do
+                tm' <- ppTerm sc tm
+                panic "updateFFITypes" [
+                    "SAWCore term of Cryptol name is not a Constant",
+                    "Name: " <> CryPP.pp nm,
+                    "Term: " <> Text.pack tm'
+                 ]
+        pure $ (info, ty)
+  decls <- mapM getNameInfo (T.findForeignDecls m)
+  pure $ foldr (\(info, ty) decl -> Map.insert info ty decl) eFFITypes' decls
 
 
 ---- import --------------------------------------------------------------------

--- a/cryptol-saw-core/src/CryptolSAWCore/TypedTerm.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/TypedTerm.hs
@@ -53,7 +53,7 @@ import qualified Cryptol.TypeCheck.AST as C
 import qualified Cryptol.Utils.Ident as C (mkIdent)
 import qualified Cryptol.Utils.RecordMap as C (recordFromFields)
 
-import qualified SAWSupport.Pretty as PPS (Opts, defaultOpts, renderText)
+import qualified SAWSupport.Pretty as PPS (Opts, renderText)
 
 import qualified CryptolSAWCore.Pretty as CryPP
 import CryptolSAWCore.Cryptol (scCryptolType, CryptolEnv, importKind, translateSchema)
@@ -115,24 +115,24 @@ prettyTypedTermType sc (TypedTermOther tp) = do
 --
 --   This produces inferior output at the SAWCore level. See `prettyTermPure`.
 --
-prettyTypedTermPure :: TypedTerm -> PP.Doc ann
-prettyTypedTermPure (TypedTerm tp tm) =
-  PP.unAnnotate (prettyTermPure PPS.defaultOpts tm)
+prettyTypedTermPure :: PPS.Opts -> TypedTerm -> PP.Doc ann
+prettyTypedTermPure ppopts (TypedTerm tp tm) =
+  PP.unAnnotate (prettyTermPure ppopts tm)
   <+> ":" <+>
-  prettyTypedTermTypePure tp
+  prettyTypedTermTypePure ppopts tp
 
 -- | Print a `TypedTermType` to a `PP.Doc`, without needing the
 --   `SharedContext` or `IO`.
 --
 --   This produces inferior output at the SAWCore level. See `prettyTermPure`.
 --
-prettyTypedTermTypePure :: TypedTermType -> PP.Doc ann
-prettyTypedTermTypePure (TypedTermSchema sch) =
+prettyTypedTermTypePure :: PPS.Opts -> TypedTermType -> PP.Doc ann
+prettyTypedTermTypePure _ppopts (TypedTermSchema sch) =
   CryPP.pretty sch
-prettyTypedTermTypePure (TypedTermKind k) =
+prettyTypedTermTypePure _ppopts (TypedTermKind k) =
   CryPP.pretty k
-prettyTypedTermTypePure (TypedTermOther tp) =
-  PP.unAnnotate (prettyTermPure PPS.defaultOpts tp)
+prettyTypedTermTypePure ppopts (TypedTermOther tp) =
+  PP.unAnnotate (prettyTermPure ppopts tp)
 
 -- | Print a `TypedVariable` to a `PP.Doc`.
 prettyTypedVariable :: TypedVariable -> PP.Doc ann
@@ -154,7 +154,7 @@ ppTypedTermType sc ty = do
 --
 ppTypedTermTypePure :: PPS.Opts -> TypedTermType -> Text
 ppTypedTermTypePure opts ty =
-  PPS.renderText opts $ prettyTypedTermTypePure ty
+  PPS.renderText opts $ prettyTypedTermTypePure opts ty
 
 -- | Print a `TypedTerm` to `Text`.
 ppTypedTerm :: SharedContext -> TypedTerm -> IO Text
@@ -169,7 +169,7 @@ ppTypedTerm sc ty = do
 --
 ppTypedTermPure :: PPS.Opts -> TypedTerm -> Text
 ppTypedTermPure opts t =
-  PPS.renderText opts $ prettyTypedTermPure t
+  PPS.renderText opts $ prettyTypedTermPure opts t
 
 
 -- | Convert the 'ttType' field of a 'TypedTerm' to a SAWCore term

--- a/intTests/test_sawcore_type_errors/test.log.good
+++ b/intTests/test_sawcore_type_errors/test.log.good
@@ -306,9 +306,9 @@ Stack trace:
 core001.sawcore:5:0:
 Malformed declaration for "foo"
 More variables ["x","y","z"] than length of function type:
-Prelude::Bool
--> Prelude::Bool
--> Prelude::Bool
+Bool
+-> Bool
+-> Bool
 
 Definition without defining equation
 == Anticipated failure message ==

--- a/otherTests/saw-core-rocq/test_cryptol_module_sha512.log.good
+++ b/otherTests/saw-core-rocq/test_cryptol_module_sha512.log.good
@@ -1,59 +1,58 @@
 Loading file "test_cryptol_module_sha512.saw"
-Malformed term: let { H@free : Cryptol::seq (Cryptol::TCNum 8)
-                 (Cryptol::seq (Cryptol::TCNum 64) Prelude::Bool);
-      W@free : Cryptol::seq (Cryptol::TCNum 80)
-                 (Cryptol::seq (Cryptol::TCNum 64) Prelude::Bool);
-      x`1 = Cryptol::TCNum 0;
-      x`2 = Cryptol::TCNum 1;
-      x`3 = Cryptol::TCNum 8;
-      x`4 = Cryptol::TCNum 64;
-      x`5 = Cryptol::seq x`4 Prelude::Bool;
-      x`6 = Cryptol::TCNum 80;
-      x`7 = Cryptol::seq x`6 x`5;
-      x`8 = Cryptol::TCNum 81;
-      x`9 = Cryptol::seq x`8 x`5;
-      x`10 = #(x`5, x`5);
-      x`11 = #(x`5, x`10);
-      x`12 = Cryptol::tcMin x`8 x`6;
-      x`13 = #(x`5, x`11);
-      x`14 = Cryptol::tcMin x`8 x`12;
-      x`15 = #(x`5, x`13);
-      x`16 = Cryptol::tcMin x`8 x`14;
-      x`17 = Cryptol::tcMin x`8 x`16;
-      x`18 = Cryptol::PRingSeqBool x`4;
-      x`19 = Cryptol::seq x`17 x`5;
-      x`20 = Prelude::PairType1 x`9 x`9;
-      x`21 = Prelude::PairType1 x`9 x`20;
-      x`22 = Prelude::PairType1 x`9 x`21;
-      x`23 = Prelude::PairType1 x`9 x`22;
-      x`24 = Prelude::PairType1 x`9 x`23;
-      x`25 = Prelude::PairType1 x`9 x`24;
-      x`26 = Prelude::PairType1 x`9 x`25;
-      x`27 = Prelude::PairType1 x`9 x`26;
-      x`28 = Prelude::PairType1 x`19 x`27;
-    }
- in Prelude::fix (Prelude::PairType1 x`7 x`27)
-      (Prelude::uncurry1 x`7 x`27 x`28
+Malformed term: let { H@free : seq (TCNum 8)
+                                 (seq (TCNum 64) Bool);
+                      W@free : seq (TCNum 80) (seq (TCNum 64) Bool);
+                      x`1 = TCNum 0;
+                      x`2 = TCNum 1;
+                      x`3 = TCNum 8;
+                      x`4 = TCNum 64;
+                      x`5 = seq x`4 Bool;
+                      x`6 = TCNum 80;
+                      x`7 = seq x`6 x`5;
+                      x`8 = TCNum 81;
+                      x`9 = seq x`8 x`5;
+                      x`10 = #(x`5, x`5);
+                      x`11 = #(x`5, x`10);
+                      x`12 = tcMin x`8 x`6;
+                      x`13 = #(x`5, x`11);
+                      x`14 = tcMin x`8 x`12;
+                      x`15 = #(x`5, x`13);
+                      x`16 = tcMin x`8 x`14;
+                      x`17 = tcMin x`8 x`16;
+                      x`18 = PRingSeqBool x`4;
+                      x`19 = seq x`17 x`5;
+                      x`20 = PairType1 x`9 x`9;
+                      x`21 = PairType1 x`9 x`20;
+                      x`22 = PairType1 x`9 x`21;
+                      x`23 = PairType1 x`9 x`22;
+                      x`24 = PairType1 x`9 x`23;
+                      x`25 = PairType1 x`9 x`24;
+                      x`26 = PairType1 x`9 x`25;
+                      x`27 = PairType1 x`9 x`26;
+                      x`28 = PairType1 x`19 x`27;
+                    }
+ in fix (PairType1 x`7 x`27)
+      (uncurry1 x`7 x`27 x`28
          (\(T1 : x`7) ->
-            Prelude::uncurry1 x`9 x`26 x`28
+            uncurry1 x`9 x`26 x`28
               (\(T2 : x`9) ->
-                 Prelude::uncurry1 x`9 x`25 x`28
+                 uncurry1 x`9 x`25 x`28
                    (\(as : x`9) ->
-                      Prelude::uncurry1 x`9 x`24 x`28
+                      uncurry1 x`9 x`24 x`28
                         (\(bs : x`9) ->
-                           Prelude::uncurry1 x`9 x`23 x`28
+                           uncurry1 x`9 x`23 x`28
                              (\(cs : x`9) ->
-                                Prelude::uncurry1 x`9 x`22 x`28
+                                uncurry1 x`9 x`22 x`28
                                   (\(ds : x`9) ->
-                                     Prelude::uncurry1 x`9 x`21 x`28
+                                     uncurry1 x`9 x`21 x`28
                                        (\(es : x`9) ->
-                                          Prelude::uncurry1 x`9 x`20 x`28
+                                          uncurry1 x`9 x`20 x`28
                                             (\(fs : x`9) ->
-                                               Prelude::uncurry1 x`9 x`9 x`28
+                                               uncurry1 x`9 x`9 x`28
                                                  (\(gs : x`9) ->
                                                     \(hs : x`9) ->
-                                                      Prelude::PairValue1 x`19 x`27
-                                                        (Cryptol::seqMap #(x`5, x`15) x`5 x`17
+                                                      PairValue1 x`19 x`27
+                                                        (seqMap #(x`5, x`15) x`5 x`17
                                                            (Prelude::uncurry x`5 x`15 x`5
                                                               (\(h : x`5) ->
                                                                  Prelude::uncurry x`5 x`13 x`5
@@ -65,105 +64,74 @@ Malformed term: let { H@free : Cryptol::seq (Cryptol::TCNum 8)
                                                                                 Prelude::uncurry x`5 x`5 x`5
                                                                                   (\(k_t : x`5) ->
                                                                                      \(w_t : x`5) ->
-                                                                                       Cryptol::ecPlus x`5 x`18
-                                                                                         (Cryptol::ecPlus x`5 x`18
-                                                                                            (Cryptol::ecPlus x`5 x`18
-                                                                                               (Cryptol::ecPlus x`5 x`18 h (SHA512::S1@cryptol e))
-                                                                                               (SHA512::Ch@cryptol e f g))
+                                                                                       ecPlus x`5 x`18
+                                                                                         (ecPlus x`5 x`18
+                                                                                            (ecPlus x`5 x`18 (ecPlus x`5 x`18 h (S1 e)) (Ch e f g))
                                                                                             k_t)
                                                                                          w_t))))))
-                                                           (Cryptol::seqZip x`5 x`15 x`8 x`16 hs
-                                                              (Cryptol::seqZip x`5 x`13 x`8 x`14 es
-                                                                 (Cryptol::seqZip x`5 x`11 x`8 x`12 fs
-                                                                    (Cryptol::seqZip x`5 x`10 x`8 x`6 gs
-                                                                       (Cryptol::seqZipSame x`5 x`5 x`6
-                                                                          SHA512:|:SHA__parameter::K@cryptol
-                                                                          W@free))))))
-                                                        (Prelude::PairValue1 x`9 x`26
-                                                           (Cryptol::seqMap x`11 x`5 x`8
+                                                           (seqZip x`5 x`15 x`8 x`16 hs
+                                                              (seqZip x`5 x`13 x`8 x`14 es
+                                                                 (seqZip x`5 x`11 x`8 x`12 fs
+                                                                    (seqZip x`5 x`10 x`8 x`6 gs
+                                                                       (seqZipSame x`5 x`5 x`6 |:SHA__parameter::K W@free))))))
+                                                        (PairValue1 x`9 x`26
+                                                           (seqMap x`11 x`5 x`8
                                                               (Prelude::uncurry x`5 x`10 x`5
                                                                  (\(a : x`5) ->
                                                                     Prelude::uncurry x`5 x`5 x`5
                                                                       (\(b : x`5) ->
-                                                                         \(c : x`5) ->
-                                                                           Cryptol::ecPlus x`5 x`18 (SHA512::S0@cryptol a)
-                                                                             (SHA512::Maj@cryptol a b c))))
-                                                              (Cryptol::seqZipSame x`5 x`10 x`8 as
-                                                                 (Cryptol::seqZipSame x`5 x`5 x`8 bs cs)))
-                                                           (Prelude::PairValue1 x`9 x`25
-                                                              (Cryptol::ecTake x`8 x`1 x`5
-                                                                 (Cryptol::ecCat x`2 x`6 x`5
-                                                                    [ Cryptol::ecAt x`3 x`5 Prelude::Integer
-                                                                        Cryptol::PIntegralInteger
-                                                                        H@free
-                                                                        (Cryptol::ecNumber x`1 Prelude::Integer
-                                                                           Cryptol::PLiteralInteger) ]
-                                                                    (Cryptol::seqMap x`10 x`5 (Cryptol::tcMin x`6 x`8)
+                                                                         \(c : x`5) -> ecPlus x`5 x`18 (S0 a) (Maj a b c))))
+                                                              (seqZipSame x`5 x`10 x`8 as (seqZipSame x`5 x`5 x`8 bs cs)))
+                                                           (PairValue1 x`9 x`25
+                                                              (ecTake x`8 x`1 x`5
+                                                                 (ecCat x`2 x`6 x`5
+                                                                    [ ecAt x`3 x`5 Integer PIntegralInteger H@free
+                                                                        (ecNumber x`1 Integer PLiteralInteger) ]
+                                                                    (seqMap x`10 x`5 (tcMin x`6 x`8)
                                                                        (Prelude::uncurry x`5 x`5 x`5
-                                                                          (\(t1 : x`5) -> \(t2 : x`5) -> Cryptol::ecPlus x`5 x`18 t1 t2))
-                                                                       (Cryptol::seqZip x`5 x`5 x`6 x`8 T1 T2))))
-                                                              (Prelude::PairValue1 x`9 x`24
-                                                                 (Cryptol::ecTake x`8 x`2 x`5
-                                                                    (Cryptol::ecCat x`2 x`8 x`5
-                                                                       [ Cryptol::ecAt x`3 x`5 Prelude::Integer
-                                                                           Cryptol::PIntegralInteger
-                                                                           H@free
-                                                                           (Cryptol::ecNumber x`2 Prelude::Integer
-                                                                              Cryptol::PLiteralInteger) ]
+                                                                          (\(t1 : x`5) -> \(t2 : x`5) -> ecPlus x`5 x`18 t1 t2))
+                                                                       (seqZip x`5 x`5 x`6 x`8 T1 T2))))
+                                                              (PairValue1 x`9 x`24
+                                                                 (ecTake x`8 x`2 x`5
+                                                                    (ecCat x`2 x`8 x`5
+                                                                       [ ecAt x`3 x`5 Integer PIntegralInteger H@free
+                                                                           (ecNumber x`2 Integer PLiteralInteger) ]
                                                                        as))
-                                                                 (Prelude::PairValue1 x`9 x`23
-                                                                    (Cryptol::ecTake x`8 x`2 x`5
-                                                                       (Cryptol::ecCat x`2 x`8 x`5
-                                                                          [ Cryptol::ecAt x`3 x`5 Prelude::Integer
-                                                                              Cryptol::PIntegralInteger
-                                                                              H@free
-                                                                              (Cryptol::ecNumber (Cryptol::TCNum 2) Prelude::Integer
-                                                                                 Cryptol::PLiteralInteger) ]
+                                                                 (PairValue1 x`9 x`23
+                                                                    (ecTake x`8 x`2 x`5
+                                                                       (ecCat x`2 x`8 x`5
+                                                                          [ ecAt x`3 x`5 Integer PIntegralInteger H@free
+                                                                              (ecNumber (TCNum 2) Integer PLiteralInteger) ]
                                                                           bs))
-                                                                    (Prelude::PairValue1 x`9 x`22
-                                                                       (Cryptol::ecTake x`8 x`2 x`5
-                                                                          (Cryptol::ecCat x`2 x`8 x`5
-                                                                             [ Cryptol::ecAt x`3 x`5 Prelude::Integer
-                                                                                 Cryptol::PIntegralInteger
-                                                                                 H@free
-                                                                                 (Cryptol::ecNumber (Cryptol::TCNum 3) Prelude::Integer
-                                                                                    Cryptol::PLiteralInteger) ]
+                                                                    (PairValue1 x`9 x`22
+                                                                       (ecTake x`8 x`2 x`5
+                                                                          (ecCat x`2 x`8 x`5
+                                                                             [ ecAt x`3 x`5 Integer PIntegralInteger H@free
+                                                                                 (ecNumber (TCNum 3) Integer PLiteralInteger) ]
                                                                              cs))
-                                                                       (Prelude::PairValue1 x`9 x`21
-                                                                          (Cryptol::ecTake x`8 x`1 x`5
-                                                                             (Cryptol::ecCat x`2 x`6 x`5
-                                                                                [ Cryptol::ecAt x`3 x`5 Prelude::Integer
-                                                                                    Cryptol::PIntegralInteger
-                                                                                    H@free
-                                                                                    (Cryptol::ecNumber (Cryptol::TCNum 4) Prelude::Integer
-                                                                                       Cryptol::PLiteralInteger) ]
-                                                                                (Cryptol::seqMap x`10 x`5 x`12
+                                                                       (PairValue1 x`9 x`21
+                                                                          (ecTake x`8 x`1 x`5
+                                                                             (ecCat x`2 x`6 x`5
+                                                                                [ ecAt x`3 x`5 Integer PIntegralInteger H@free
+                                                                                    (ecNumber (TCNum 4) Integer PLiteralInteger) ]
+                                                                                (seqMap x`10 x`5 x`12
                                                                                    (Prelude::uncurry x`5 x`5 x`5
-                                                                                      (\(d : x`5) -> \(t1 : x`5) -> Cryptol::ecPlus x`5 x`18 d t1))
-                                                                                   (Cryptol::seqZip x`5 x`5 x`8 x`6 ds T1))))
-                                                                          (Prelude::PairValue1 x`9 x`20
-                                                                             (Cryptol::ecTake x`8 x`2 x`5
-                                                                                (Cryptol::ecCat x`2 x`8 x`5
-                                                                                   [ Cryptol::ecAt x`3 x`5 Prelude::Integer
-                                                                                       Cryptol::PIntegralInteger
-                                                                                       H@free
-                                                                                       (Cryptol::ecNumber (Cryptol::TCNum 5) Prelude::Integer
-                                                                                          Cryptol::PLiteralInteger) ]
+                                                                                      (\(d : x`5) -> \(t1 : x`5) -> ecPlus x`5 x`18 d t1))
+                                                                                   (seqZip x`5 x`5 x`8 x`6 ds T1))))
+                                                                          (PairValue1 x`9 x`20
+                                                                             (ecTake x`8 x`2 x`5
+                                                                                (ecCat x`2 x`8 x`5
+                                                                                   [ ecAt x`3 x`5 Integer PIntegralInteger H@free
+                                                                                       (ecNumber (TCNum 5) Integer PLiteralInteger) ]
                                                                                    es))
-                                                                             (Prelude::PairValue1 x`9 x`9
-                                                                                (Cryptol::ecTake x`8 x`2 x`5
-                                                                                   (Cryptol::ecCat x`2 x`8 x`5
-                                                                                      [ Cryptol::ecAt x`3 x`5 Prelude::Integer
-                                                                                          Cryptol::PIntegralInteger
-                                                                                          H@free
-                                                                                          (Cryptol::ecNumber (Cryptol::TCNum 6) Prelude::Integer
-                                                                                             Cryptol::PLiteralInteger) ]
+                                                                             (PairValue1 x`9 x`9
+                                                                                (ecTake x`8 x`2 x`5
+                                                                                   (ecCat x`2 x`8 x`5
+                                                                                      [ ecAt x`3 x`5 Integer PIntegralInteger H@free
+                                                                                          (ecNumber (TCNum 6) Integer PLiteralInteger) ]
                                                                                       fs))
-                                                                                (Cryptol::ecTake x`8 x`2 x`5
-                                                                                   (Cryptol::ecCat x`2 x`8 x`5
-                                                                                      [ Cryptol::ecAt x`3 x`5 Prelude::Integer
-                                                                                          Cryptol::PIntegralInteger
-                                                                                          H@free
-                                                                                          (Cryptol::ecNumber (Cryptol::TCNum 7) Prelude::Integer
-                                                                                             Cryptol::PLiteralInteger) ]
+                                                                                (ecTake x`8 x`2 x`5
+                                                                                   (ecCat x`2 x`8 x`5
+                                                                                      [ ecAt x`3 x`5 Integer PIntegralInteger H@free
+                                                                                          (ecNumber (TCNum 7) Integer PLiteralInteger) ]
                                                                                       gs))))))))))))))))))))

--- a/saw-central/src/SAWCentral/AST.hs
+++ b/saw-central/src/SAWCentral/AST.hs
@@ -421,11 +421,11 @@ prettyTyCon tc = case tc of
     BlockCon       -> "<Block>"
     ContextCon cxt -> PP.pretty $ ppContext cxt
 
-ppTyCon :: TyCon -> Text
-ppTyCon tc = PPS.renderText PPS.defaultOpts $ prettyTyCon tc
+ppTyCon :: PPS.Opts -> TyCon -> Text
+ppTyCon ppopts tc = PPS.renderText ppopts $ prettyTyCon tc
 
-prettyType :: Type -> PPS.Doc
-prettyType = PP.group . visit 0
+prettyType :: PPS.Opts -> Type -> PPS.Doc
+prettyType ppopts = PP.group . visit 0
   where
     visit :: Int -> Type -> PPS.Doc
     visit prec ty0 = case ty0 of
@@ -458,7 +458,7 @@ prettyType = PP.group . visit 0
               case args of
                   [] -> ctor'
                   _ ->
-                      let ctor'' = PPS.renderText PPS.defaultOpts ctor' in
+                      let ctor'' = PPS.renderText ppopts ctor' in
                       croak ctor'' 0 args
 
       TyRecord _ fields ->
@@ -480,7 +480,7 @@ prettyType = PP.group . visit 0
 
     croak :: Text -> Integer -> [Type] -> a
     croak what n args =
-        let ppArg arg = "   " <> (PPS.renderText PPS.defaultOpts $ visit 0 arg)
+        let ppArg arg = "   " <> (PPS.renderText ppopts $ visit 0 arg)
             args' = map ppArg args
         in
         panic "prettyType" $ [
@@ -488,13 +488,13 @@ prettyType = PP.group . visit 0
             "Expected " <> Text.pack (show n) <> " arguments, found:"
         ] ++ args'
 
-ppType :: Type -> Text
-ppType ty =
-    PPS.renderText PPS.defaultOpts $ prettyType ty
+ppType :: PPS.Opts -> Type -> Text
+ppType ppopts ty =
+    PPS.renderText ppopts $ prettyType ppopts ty
 
-prettySchema :: Schema -> PPS.Doc
-prettySchema (Forall ns t) =
-    let t' = prettyType t in
+prettySchema :: PPS.Opts -> Schema -> PPS.Doc
+prettySchema ppopts (Forall ns t) =
+    let t' = prettyType ppopts t in
     case ns of
       [] -> t'
       _  ->
@@ -503,32 +503,33 @@ prettySchema (Forall ns t) =
           in
           ns' <+> t'
 
-ppSchema :: Schema -> Text
-ppSchema ty =
-    PPS.renderText PPS.defaultOpts $ prettySchema ty
+ppSchema :: PPS.Opts -> Schema -> Text
+ppSchema ppopts ty =
+    PPS.renderText ppopts $ prettySchema ppopts ty
 
-prettyNamedType :: NamedType -> PPS.Doc
-prettyNamedType ty = case ty of
-    ConcreteType ty' -> prettyType ty'
+prettyNamedType :: PPS.Opts -> NamedType -> PPS.Doc
+prettyNamedType ppopts ty = case ty of
+    ConcreteType ty' -> prettyType ppopts ty'
     AbstractType kind -> "<opaque " <> PP.pretty (ppKind kind) <> ">"
 
 {- not used
-ppNamedType :: NamedType -> Text
-ppNamedType ty =
-    PPS.renderText PPS.defaultOpts $ prettyNamedType ty
+ppNamedType :: PPS.Opts -> NamedType -> Text
+ppNamedType ppopts ty =
+    PPS.renderText ppopts $ prettyNamedType ty
 -}
 
-prettyExpr :: Expr -> PPS.Doc
-prettyExpr expr0 = case expr0 of
+prettyExpr :: PPS.Opts -> Expr -> PPS.Doc
+prettyExpr ppopts expr0 = case expr0 of
     Bool _ b   -> PP.viaShow b
     String _ s -> PP.pretty $ PPS.ppStringLiteral s
     Int _ i    -> PP.pretty i
     Code _ s   -> PP.braces $ PP.braces $ PP.pretty s
     CType _ s  -> PP.braces $ "|" <> PP.pretty s <> "|"
-    Array _ xs -> PP.brackets $ PP.fillSep $ PP.punctuate "," (map prettyExpr xs)
+    Array _ xs ->
+        PP.brackets $ PP.fillSep $ PP.punctuate "," (map (prettyExpr ppopts) xs)
     Block _ (stmts, lastexpr) ->
-        let stmts' = map prettyStmt stmts
-            lastexpr' = prettyExpr lastexpr <> ";"
+        let stmts' = map (prettyStmt ppopts) stmts
+            lastexpr' = prettyExpr ppopts lastexpr <> ";"
             body = PP.align $ PP.vsep (stmts' ++ [lastexpr'])
             -- You would think this could unconditionally be `PP.nest 3
             -- body`. But that doesn't work. If you use `PP.nest`,
@@ -543,10 +544,10 @@ prettyExpr expr0 = case expr0 of
         in
         PP.group $ "do" <+> PP.braces (PP.line <> body' <> PP.line)
     Tuple _ exprs ->
-        PP.parens $ PP.fillSep $ PP.punctuate "," (map prettyExpr exprs)
+        PP.parens $ PP.fillSep $ PP.punctuate "," (map (prettyExpr ppopts) exprs)
     Record _ members ->
         let prettyMember (name, value) =
-                PP.pretty name <+> "=" <+> prettyExpr value
+                PP.pretty name <+> "=" <+> prettyExpr ppopts value
             members' = map prettyMember $ Map.assocs members
             body = PP.sep $ PP.punctuate PP.comma members'
             body' = PP.flatAlt (PP.indent 3 body) body
@@ -555,33 +556,33 @@ prettyExpr expr0 = case expr0 of
     Index _ _ _ ->
         panic "prettyExpr" ["There is no concrete syntax for AST node 'Index'"]
     Lookup _ expr name ->
-        let expr' = prettyExpr expr
+        let expr' = prettyExpr ppopts expr
             name' = PP.pretty name
         in
         expr' <> PP.dot <> name'
     TLookup _ expr n ->
-        let expr' = prettyExpr expr
+        let expr' = prettyExpr ppopts expr
             n' = PP.viaShow n
         in      
         expr' <> PP.dot <> n'
     Var _ name ->
         PP.pretty name
     Lambda _ _mname pat expr ->
-        let pat' = prettyPattern pat
-            expr' = prettyExpr expr
+        let pat' = prettyPattern ppopts pat
+            expr' = prettyExpr ppopts expr
             line1 = "\\" <+> pat' <+> "->"
             line2 = PP.flatAlt (PP.indent 3 expr') expr'
         in
         PP.group $ line1 <> PP.line <> line2
     Application _ f arg ->
         -- XXX FIXME: use precedence to minimize parentheses
-        let f' = prettyExpr f
-            arg' = prettyExpr arg
+        let f' = prettyExpr ppopts f
+            arg' = prettyExpr ppopts arg
         in
         PP.parens f' <+> arg'
     Let _ (NonRecursive decl) expr ->
-        let decl' = prettyDef decl
-            expr' = prettyExpr expr
+        let decl' = prettyDef ppopts decl
+            expr' = prettyExpr ppopts expr
             -- Break after the "in" when it doesn't fit. Maybe I've
             -- gotten too used to reading OCaml?
             line1 = "let" <+> decl' <+> "in"
@@ -589,22 +590,22 @@ prettyExpr expr0 = case expr0 of
         in
         PP.group $ line1 <> PP.line <> line2
     Let _ (Recursive decls) expr ->
-        let decls' = map prettyDef decls
-            expr' = prettyExpr expr
+        let decls' = map (prettyDef ppopts) decls
+            expr' = prettyExpr ppopts expr
             decls'' = case decls' of
               [] -> []  -- (not actually possible)
               first : rest -> ("rec" <+> first) : map (\d -> "and" <+> d) rest
         in
         PP.vsep decls'' <> PP.hardline <> "in" <> PP.hardline <> PP.nest 3 expr'
     TSig _ expr ty ->
-        let expr' = prettyExpr expr
-            ty' =  prettyType ty
+        let expr' = prettyExpr ppopts expr
+            ty' = prettyType ppopts ty
         in
         PP.parens (expr' <+> PP.colon <+> ty')
     IfThenElse _ e1 e2 e3 ->
-        let e1' = prettyExpr e1
-            e2' = prettyExpr e2
-            e3' = prettyExpr e3
+        let e1' = prettyExpr ppopts e1
+            e2' = prettyExpr ppopts e2
+            e3' = prettyExpr ppopts e3
             -- plan for four lines
             line1 = "if" <+> e1' <+> "then"
             line2 = PP.flatAlt (PP.indent 3 e2') e2'
@@ -614,15 +615,15 @@ prettyExpr expr0 = case expr0 of
         -- Use PP.sep so it'll fold to one line if it fits
         PP.group $ PP.sep [line1, line2, line3, line4]
 
-ppExpr :: Expr -> Text
-ppExpr e =
-    PPS.renderText PPS.defaultOpts $ prettyExpr e
+ppExpr :: PPS.Opts -> Expr -> Text
+ppExpr ppopts e =
+    PPS.renderText ppopts $ prettyExpr ppopts e
 
-prettyPattern :: Pattern -> PPS.Doc
-prettyPattern pat =
+prettyPattern :: PPS.Opts -> Pattern -> PPS.Doc
+prettyPattern ppopts pat =
     let prettyArg name' mty = case mty of
           Nothing -> name'
-          Just ty -> PP.parens $ name' <+> PP.colon <+> prettyType ty
+          Just ty -> PP.parens $ name' <+> PP.colon <+> prettyType ppopts ty
     in   
     case pat of
         PWild _ mty ->
@@ -630,20 +631,20 @@ prettyPattern pat =
         PVar _ _ name mty ->
           prettyArg (PP.pretty name) mty
         PTuple _ pats ->
-          PP.parens $ PP.fillSep $ PP.punctuate "," $ map prettyPattern pats
+          PP.parens $ PP.fillSep $ PP.punctuate "," $ map (prettyPattern ppopts) pats
 
-ppPattern :: Pattern -> Text
-ppPattern pat =
-  PPS.renderText PPS.defaultOpts $ prettyPattern pat
+ppPattern :: PPS.Opts -> Pattern -> Text
+ppPattern ppopts pat =
+  PPS.renderText ppopts $ prettyPattern ppopts pat
 
-prettyStmt :: Stmt -> PPS.Doc
-prettyStmt s0 = case s0 of
+prettyStmt :: PPS.Opts -> Stmt -> PPS.Doc
+prettyStmt ppopts s0 = case s0 of
     StmtBind _ (PWild _ _ty) expr ->
        -- Drop the _, even if it has an explicit type
-       prettyExpr expr <> ";"
+       prettyExpr ppopts expr <> ";"
     StmtBind _ pat expr ->
-       let pat' = prettyPattern pat
-           expr' = prettyExpr expr
+       let pat' = prettyPattern ppopts pat
+           expr' = prettyExpr ppopts expr
            line1 = pat' <+> "<-"
            line2 = PP.flatAlt (PP.indent 3 expr') expr'
        in
@@ -652,11 +653,11 @@ prettyStmt s0 = case s0 of
        let header = case rebindable of
              RebindableVar -> "let rebindable"
              ReadOnlyVar -> "let"
-           decl' = prettyDef decl
+           decl' = prettyDef ppopts decl
        in
        PP.group $ header <+> decl' <> ";"
     StmtLet _ _ (Recursive decls) ->
-       let decls' = map prettyDef decls
+       let decls' = map (prettyDef ppopts) decls
            decls'' = case decls' of
              [] -> []  -- (not actually possible)
              first : rest -> ("rec" <+> first) : map (\d -> "and" <+> d) rest
@@ -696,7 +697,7 @@ prettyStmt s0 = case s0 of
         inc <+> name' <> ";"
     StmtTypedef _ _ name ty ->
        let name' = PP.pretty name
-           ty' = prettyType ty
+           ty' = prettyType ppopts ty
        in
        PP.group $ "typedef" <+> name' <+> "=" <+> ty' <> ";"
     StmtPushdir _ dir ->
@@ -704,21 +705,23 @@ prettyStmt s0 = case s0 of
     StmtPopdir _ ->
        ".popdir;"
 
-prettyDef :: Decl -> PPS.Doc
-prettyDef (Decl _ pat0 _ def) =
+prettyDef :: PPS.Opts -> Decl -> PPS.Doc
+prettyDef ppopts (Decl _ pat0 _ def) =
    let dissectLambda :: Expr -> ([Pattern], Expr)
        dissectLambda = \case
           Lambda _pos _name pat (dissectLambda -> (pats, expr)) -> (pat : pats, expr)
           expr -> ([], expr)
        (args, body) = dissectLambda def
-       pats' = PP.align $ PP.sep $ map prettyPattern (pat0 : args)
-       body' = prettyExpr body
+       pats' = PP.align $ PP.sep $ map (prettyPattern ppopts) (pat0 : args)
+       body' = prettyExpr ppopts body
        body'' = PP.flatAlt (PP.indent 3 body') body'
    in
    pats' <+> "=" <> PP.line <> body''
 
-prettyWholeModule :: [Stmt] -> PPS.Doc
-prettyWholeModule stmts = (PP.vsep $ map prettyStmt stmts) <> PP.line
+prettyWholeModule :: PPS.Opts -> [Stmt] -> PPS.Doc
+prettyWholeModule ppopts stmts =
+    let stmts' = PP.vsep $ map (prettyStmt ppopts) stmts in
+    stmts' <> PP.line
 
 
 ------------------------------------------------------------

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -217,7 +217,7 @@ module SAWCentral.Builtins (
   ) where
 
 import Control.Lens (view)
-import Control.Monad (foldM, unless)
+import Control.Monad (foldM, unless, when)
 import Control.Monad.Catch (throwM)
 import Control.Monad.Except (MonadError(..))
 import Control.Monad.IO.Class (MonadIO(..))
@@ -1902,6 +1902,7 @@ generalize_term vars tt =
 envCmd :: TopLevel ()
 envCmd = do
   opts <- getOptions
+  ppopts <- SV.getPPOpts
   avail <- gets rwPrimsAvail
   SV.Environ varenv _tyenv _cryenv <- gets rwEnviron
   rbenv <- gets rwRebindables
@@ -1911,12 +1912,12 @@ envCmd = do
       io $ printOutLn opts Info $ "Rebindable globals:"
       io $ printOutLn opts Info $ ""
       let printRB (x, (_pos, ty, _v)) = do
-              let str = x <> " : rebindable " <> SAST.ppSchema ty
+              let str = x <> " : rebindable " <> SAST.ppSchema ppopts ty
               printOutLn opts Info $ Text.unpack str
       io $ mapM_ printRB $ Map.assocs rbenv
 
   let printItem (x, (_pos, _lc, ty, _v, _doc)) =
-          printOutLn opts Info $ Text.unpack (x <> " : " <> SAST.ppSchema ty)
+          printOutLn opts Info $ Text.unpack (x <> " : " <> SAST.ppSchema ppopts ty)
       -- Print only the visible objects
       keep (_x, (_pos, lc, _ty, _v, _doc)) = Set.member lc avail
       -- Insert a blank line in the output where there's a scope boundary
@@ -2098,8 +2099,10 @@ defaultTypedTerm opts sc cryenv cfg tt@(TypedTerm (TypedTermSchema schema) trm)
     Nothing -> return (TypedTerm (TypedTermSchema schema) trm)
     Just tys -> do
       let vars = C.sVars schema
-      let nms = CryPP.addTNames vars CryPP.emptyNameMap
-      mapM_ (warnDefault nms) (zip vars tys)
+      when (not $ null vars) $ do
+          ppopts <- scGetPPOpts sc
+          let nms = CryPP.addTNames vars CryPP.emptyNameMap
+          mapM_ (warnDefault ppopts nms) (zip vars tys)
       let applyType :: Term -> C.Type -> IO Term
           applyType t ty = do
             ty' <- CSC.translateType sc cryenv ty
@@ -2115,12 +2118,12 @@ defaultTypedTerm opts sc cryenv cfg tt@(TypedTerm (TypedTermSchema schema) trm)
       let schema' = C.Forall [] [] (C.apSubst su (C.sType schema))
       return (TypedTerm (TypedTermSchema schema') trm'')
   where
-    warnDefault ns (x,t) =
+    warnDefault ppopts ns (x,t) =
       let x' = CryPP.prettyWithNames ns (x :: C.TParam)
           t' = CryPP.pretty t
           msg = "Assuming" <+> x' <+> "=" <+> t'
       in
-      printOutLn opts Info $ PPS.render PPS.defaultOpts msg
+      printOutLn opts Info $ PPS.render ppopts msg
           
     -- Apply a substitution to a type *without* simplifying
     -- constraints like @Arith [n]a@ to @Arith a@. (This is in contrast to

--- a/saw-central/src/SAWCentral/Crucible/Common/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/Override.hs
@@ -39,6 +39,7 @@ module SAWCentral.Crucible.Common.Override
   --
   , OverrideFailureReason(..)
   , prettyOverrideFailureReason
+  , ppOverrideFailureReason
   , OverrideFailure(..)
   , prettyOverrideFailure
   --
@@ -48,6 +49,7 @@ module SAWCentral.Crucible.Common.Override
   , runOverrideMatcher
   , RO
   , RW
+  , omGetPPOpts
   , addTermEq
   , addAssert
   , addAssume
@@ -97,6 +99,7 @@ import           Data.Proxy (Proxy(..))
 import qualified Data.Set as Set
 import           Data.Set (Set)
 import qualified Data.Text as Text
+import           Data.Text (Text)
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic, Generic1)
 import qualified Prettyprinter as PP
@@ -106,7 +109,9 @@ import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Some (Some)
 import           Data.Parameterized.TraversableFC (toListFC)
 
-import qualified SAWSupport.Pretty as PPS (Doc, defaultOpts, limitMaxDepth, render)
+import qualified SAWSupport.Pretty as PPS (Doc, Opts, limitMaxDepth, renderText)
+
+import qualified SAWCoreWhat4.ReturnTrip as RT
 
 import           SAWCore.Name (VarName(..))
 import           SAWCore.Prelude as SAWVerifier (scEq)
@@ -127,7 +132,7 @@ import qualified What4.LabeledPred as W4
 import qualified What4.ProgramLoc as W4
 
 import           SAWCentral.Exceptions
-import           SAWCentral.Crucible.Common (Backend, OnlineSolver, Sym)
+import           SAWCentral.Crucible.Common (Backend, OnlineSolver, Sym, sawCoreState)
 import           SAWCentral.Crucible.Common.MethodSpec as MS
 import           SAWCentral.Crucible.Common.Setup.Value as MS
 import           SAWCentral.Utils (bullets)
@@ -307,12 +312,9 @@ data OverrideFailureReason ext
     -- * type of specified value
     -- * type of simulated value
 
-instance (PP.Pretty (ExtType ext)) => Show (OverrideFailureReason ext) where
-  show rsn = PPS.render PPS.defaultOpts $ prettyOverrideFailureReason rsn
-
 prettyOverrideFailureReason ::
-  (PP.Pretty (ExtType ext)) => OverrideFailureReason ext -> PPS.Doc
-prettyOverrideFailureReason rsn = case rsn of
+  (PP.Pretty (ExtType ext)) => PPS.Opts -> OverrideFailureReason ext -> PPS.Doc
+prettyOverrideFailureReason ppopts rsn = case rsn of
   AmbiguousPointsTos pts ->
     PP.vcat
     [ "LHS of points-to assertion(s) not reachable via points-tos from inputs/outputs:"
@@ -326,8 +328,8 @@ prettyOverrideFailureReason rsn = case rsn of
   BadTermMatch x y ->
     PP.vcat
     [ "Terms do not match"
-    , PP.indent 2 (PP.unAnnotate (prettyTermPure PPS.defaultOpts x))
-    , PP.indent 2 (PP.unAnnotate (prettyTermPure PPS.defaultOpts y))
+    , PP.indent 2 (PP.unAnnotate (prettyTermPure ppopts x))
+    , PP.indent 2 (PP.unAnnotate (prettyTermPure ppopts y))
     ]
   BadPointerCast ->
     "Bad pointer cast"
@@ -361,21 +363,34 @@ prettyOverrideFailureReason rsn = case rsn of
                    in maybe [] msg setupValTy)
     ]
 
+ppOverrideFailureReason ::
+  (PP.Pretty (ExtType ext)) => PPS.Opts -> OverrideFailureReason ext -> Text
+ppOverrideFailureReason ppopts rsn =
+  PPS.renderText ppopts $ prettyOverrideFailureReason ppopts rsn
+
 --------------------------------------------------------------------------------
 -- ** OverrideFailure
 
-data OverrideFailure ext = OF W4.ProgramLoc (OverrideFailureReason ext)
+-- | Exception type for an override failure.
+--
+--   We wrap in the prettyprinter options so the Show instance
+--   required by Exception can print correctly.
+data OverrideFailure ext = OF PPS.Opts W4.ProgramLoc (OverrideFailureReason ext)
 
 prettyOverrideFailure :: (PP.Pretty (ExtType ext)) => OverrideFailure ext -> PPS.Doc
-prettyOverrideFailure (OF loc rsn) =
+prettyOverrideFailure (OF ppopts loc rsn) =
   let loc' = prettyPosition (W4.plSourceLoc loc) in
   PP.vcat [
       "at" <+> loc' <> ":",
-      prettyOverrideFailureReason rsn
+      prettyOverrideFailureReason ppopts rsn
   ]
 
+ppOverrideFailure :: (PP.Pretty (ExtType ext)) => OverrideFailure ext -> Text
+ppOverrideFailure err@(OF ppopts _loc _rsn) =
+  PPS.renderText ppopts $ prettyOverrideFailure err
+
 instance (PP.Pretty (ExtType ext)) => Show (OverrideFailure ext) where
-  show err = PPS.render PPS.defaultOpts $ prettyOverrideFailure err
+  show err = Text.unpack $ ppOverrideFailure err
 
 instance (PP.Pretty (ExtType ext), Typeable ext) => X.Exception (OverrideFailure ext)
 
@@ -426,6 +441,14 @@ runOverrideMatcher ::
    m (Either (OverrideFailure ext) (a, OverrideState' sym ext))
 runOverrideMatcher sym g a t free loc (OM m) =
   runExceptT (runStateT (runReaderT m (initialEnv sym)) (initialState sym g a t free loc))
+
+-- OMG it ate the ppopts! :^)
+omGetPPOpts :: OverrideMatcher ext rorw PPS.Opts
+omGetPPOpts = do
+  sym <- getSymInterface
+  w4St <- liftIO $ sawCoreState sym
+  let sc = RT.saw_sc w4St
+  liftIO $ scGetPPOpts sc
 
 addTermEq ::
   Term {- ^ term equality -} ->
@@ -496,10 +519,11 @@ writeGlobal k v = OM (overrideGlobals %= Crucible.insertGlobal k v)
 -- exception.
 failure ::
   Monad m =>
+  PPS.Opts ->
   W4.ProgramLoc ->
   OverrideFailureReason ext ->
   OverrideMatcher' sym ext md m a
-failure loc e = OM (lift (lift (throwE (OF loc e))))
+failure ppopts loc e = OM (lift (lift (throwE (OF ppopts loc e))))
 
 getSymInterface :: Monad m => OverrideMatcher' sym ext md m sym
 getSymInterface = OM (use syminterface)
@@ -508,10 +532,11 @@ getSymInterface = OM (use syminterface)
 -- state spec have been "learned". If not, throws
 -- 'AmbiguousVars' exception.
 enforceCompleteSubstitution ::
+  PPS.Opts ->
   W4.ProgramLoc ->
   MS.StateSpec ext ->
   OverrideMatcher ext w ()
-enforceCompleteSubstitution loc ss =
+enforceCompleteSubstitution ppopts loc ss =
 
   do sub <- OM (use termSub)
 
@@ -522,7 +547,7 @@ enforceCompleteSubstitution loc ss =
          -- list of all terms not covered by substitution
          missing = filter isMissing (view MS.csFreshVars ss)
 
-     unless (null missing) (failure loc (AmbiguousVars missing))
+     unless (null missing) (failure ppopts loc (AmbiguousVars missing))
 
 -- | Allocate fresh variables for all of the "fresh" vars
 -- used in this phase and add them to the term substitution.

--- a/saw-central/src/SAWCentral/Crucible/Common/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/ResolveSetupValue.hs
@@ -109,8 +109,9 @@ resolveTerm sym unint bt rr tm =
             , intValue w == i -> pure ()
             | otherwise -> typeError (Text.unpack (CryPP.pp ty)) :: IO ()
           Nothing -> do
+            ppopts <- scGetPPOpts sc
             schema' <- prettyTypedTermType sc schema
-            typeError (PPS.render PPS.defaultOpts schema')
+            typeError (PPS.render ppopts schema')
 
   typeError :: String -> IO a
   typeError t = fail $ unlines [

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -1331,15 +1331,15 @@ generic_field_is ptr fname mval =
        case ptr of
          MS.SetupVar ptr' -> pure ptr'
          _ -> do
-             sc <- lift $ lift $ getSharedContext
-             ppopts <- lift $ lift $ getPPOpts
+             sc <- lift $ lift getSharedContext
+             ppopts <- lift $ lift getPPOpts
              ptr' <- liftIO $ MS.prettySetupValue sc ptr
              X.throwM $ JVMFieldNonReference ppopts ptr' fname
      st <- get
      let cc = st ^. Setup.csCrucibleContext
      let cb = cc ^. jccCodebase
-     sc <- lift $ lift $ getSharedContext
-     ppopts <- lift $ lift $ getPPOpts
+     sc <- lift $ lift getSharedContext
+     ppopts <- lift $ lift getPPOpts
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
      let nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
      ptrTy <- typeOfSetupValue cc sc env nameEnv ptr
@@ -1389,8 +1389,8 @@ generic_static_field_is fname mval =
      st <- get
      let cc = st ^. Setup.csCrucibleContext
      let cb = cc ^. jccCodebase
-     sc <- lift $ lift $ getSharedContext
-     ppopts <- lift $ lift $ getPPOpts
+     sc <- lift $ lift getSharedContext
+     ppopts <- lift $ lift getPPOpts
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
      let nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
      let cname =
@@ -1448,14 +1448,14 @@ generic_elem_is ptr idx mval =
        case ptr of
          MS.SetupVar ptr' -> pure ptr'
          _ -> do
-             sc <- lift $ lift $ getSharedContext
-             ppopts <- lift $ lift $ getPPOpts
+             sc <- lift $ lift getSharedContext
+             ppopts <- lift $ lift getPPOpts
              ptr' <- liftIO $ MS.prettySetupValue sc ptr
              X.throwM $ JVMElemNonReference ppopts ptr' idx
      st <- get
      let cc = st ^. Setup.csCrucibleContext
-     sc <- lift $ lift $ getSharedContext
-     ppopts <- lift $ lift $ getPPOpts
+     sc <- lift $ lift getSharedContext
+     ppopts <- lift $ lift getPPOpts
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
      let nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
      (len, elTy) <-
@@ -1509,8 +1509,8 @@ generic_array_is ptr mval =
        case ptr of
          MS.SetupVar ptr' -> pure ptr'
          _ -> do
-             sc <- lift $ lift $ getSharedContext
-             ppopts <- lift $ lift $ getPPOpts
+             sc <- lift $ lift getSharedContext
+             ppopts <- lift $ lift getPPOpts
              ptr' <- liftIO $ MS.prettySetupValue sc ptr
              X.throwM $ JVMArrayNonReference ppopts ptr'
      st <- get
@@ -1518,7 +1518,7 @@ generic_array_is ptr mval =
      (len, elTy) <-
        case snd (lookupAllocIndex env ptr') of
          AllocObject cname -> do
-             ppopts <- lift $ lift $ getPPOpts
+             ppopts <- lift $ lift getPPOpts
              X.throwM $ JVMElemNonArray ppopts (J.ClassType cname)
          AllocArray len elTy ->
              pure (len, elTy)
@@ -1528,8 +1528,8 @@ generic_array_is ptr mval =
          do schema <- case ttType val of
               TypedTermSchema sch -> pure sch
               tp -> do
-                  sc <- lift $ lift $ getSharedContext
-                  ppopts <- lift $ lift $ getPPOpts
+                  sc <- lift $ lift getSharedContext
+                  ppopts <- lift $ lift getPPOpts
                   tp' <- liftIO $ prettyTypedTermType sc tp
                   X.throwM (JVMNonValueType ppopts tp')
             let checkVal =
@@ -1540,7 +1540,7 @@ generic_array_is ptr mval =
                      guard (registerCompatible elTy jty)
             case checkVal of
               Nothing -> do
-                  ppopts <- lift $ lift $ getPPOpts
+                  ppopts <- lift $ lift getPPOpts
                   X.throwM (JVMArrayTypeMismatch ppopts len elTy schema)
               Just () -> pure ()
 
@@ -1554,13 +1554,13 @@ generic_array_is ptr mval =
      let pt = JVMPointsToArray md ptr' mval
      let pts = st ^. Setup.csMethodSpec . MS.csPreState . MS.csPointsTos
      when (st ^. Setup.csPrePost == PreState && any (overlapPointsTo pt) pts) $ do
-       sc <- lift $ lift $ getSharedContext
-       ppopts <- lift $ lift $ getPPOpts
+       sc <- lift $ lift getSharedContext
+       ppopts <- lift $ lift getPPOpts
        ptrdoc <- liftIO $ MS.prettySetupValue sc ptr
        X.throwM $ JVMArrayMultiple ppopts ptrdoc
      when (st ^. Setup.csPrePost == PreState && isNothing mval) $ do
-       sc <- lift $ lift $ getSharedContext
-       ppopts <- lift $ lift $ getPPOpts
+       sc <- lift $ lift getSharedContext
+       ppopts <- lift $ lift getPPOpts
        ptrdoc <- liftIO $ MS.prettySetupValue sc ptr
        X.throwM $ JVMArrayModifyPrestate ppopts ptrdoc
      Setup.addPointsTo pt
@@ -1592,27 +1592,27 @@ jvm_execute_func args =
   JVMSetupM $
   do st <- get
      let cc = st ^. Setup.csCrucibleContext
-     sc <- lift $ lift $ getSharedContext
+     sc <- lift $ lift getSharedContext
      let mspec = st ^. Setup.csMethodSpec
      let env = MS.csAllocations mspec
      let nameEnv = MS.csTypeNames mspec
      let argTys = mspec ^. MS.csArgs
      unless (st ^. Setup.csPrePost == PreState) $ do
-       ppopts <- lift $ lift $ getPPOpts
+       ppopts <- lift $ lift getPPOpts
        X.throwM $ JVMExecuteMultiple ppopts
      let
        checkArg i expectedTy val =
          do valTy <- typeOfSetupValue cc sc env nameEnv val
             unless (registerCompatible expectedTy valTy) $ do
-              ppopts <- lift $ lift $ getPPOpts
+              ppopts <- lift $ lift getPPOpts
               X.throwM (JVMArgTypeMismatch ppopts i expectedTy valTy)
      let
        checkArgs _ [] [] = pure ()
        checkArgs i [] vals = do
-         ppopts <- lift $ lift $ getPPOpts
+         ppopts <- lift $ lift getPPOpts
          X.throwM (JVMArgNumberWrong ppopts i (i + length vals))
        checkArgs i tys [] = do
-         ppopts <- lift $ lift $ getPPOpts
+         ppopts <- lift $ lift getPPOpts
          X.throwM (JVMArgNumberWrong ppopts (i + length tys) i)
        checkArgs i (ty : tys) (val : vals) =
          do checkArg i ty val
@@ -1625,18 +1625,18 @@ jvm_return retVal =
   JVMSetupM $
   do st <- get
      let cc = st ^. Setup.csCrucibleContext
-     sc <- lift $ lift $ getSharedContext
+     sc <- lift $ lift getSharedContext
      let mspec = st ^. Setup.csMethodSpec
      let env = MS.csAllocations mspec
      let nameEnv = MS.csTypeNames mspec
      valTy <- typeOfSetupValue cc sc env nameEnv retVal
      case mspec ^. MS.csRet of
        Nothing -> do
-         ppopts <- lift $ lift $ getPPOpts
+         ppopts <- lift $ lift getPPOpts
          X.throwM (JVMReturnUnexpected ppopts valTy)
        Just retTy ->
          unless (registerCompatible retTy valTy) $ do
-             ppopts <- lift $ lift $ getPPOpts
+             ppopts <- lift $ lift getPPOpts
              X.throwM (JVMReturnTypeMismatch ppopts retTy valTy)
      Setup.crucible_return retVal
 
@@ -1660,7 +1660,7 @@ jvm_equal val1 val2 =
   do loc <- getW4Position "jvm_equal"
      st <- get
      let cc = st ^. Setup.csCrucibleContext
-     sc <- lift $ lift $ getSharedContext
+     sc <- lift $ lift getSharedContext
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
          nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
      ty1 <- typeOfSetupValue cc sc env nameEnv val1

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -1263,7 +1263,7 @@ jvm_fresh_var ::
 jvm_fresh_var name jty =
   JVMSetupM $
   do sc <- lift $ lift getSharedContext
-     ppopts <- lift $ lift $ getPPOpts
+     ppopts <- lift $ lift getPPOpts
      cryenv <- lift $ lift getCryptolEnv
      case cryptolTypeOfActual jty of
        Nothing -> X.throwM $ JVMFreshVarInvalidType ppopts jty

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -394,6 +394,7 @@ verifyPrestate ::
 verifyPrestate cc mspec globals0 =
   jccWithBackend cc $ \bak ->
   do let sym = cc^.jccSym
+     sc <- saw_sc <$> sawCoreState sym
      let jc = cc^.jccJVMContext
      let halloc = cc^.jccHandleAllocator
      let preallocs = mspec ^. MS.csPreState . MS.csAllocs
@@ -449,7 +450,7 @@ verifyPrestate cc mspec globals0 =
                 " has void return type"
               ]
        (Just sv, Just retTy) ->
-         do retTy' <- typeOfSetupValue cc tyenv nameEnv sv
+         do retTy' <- typeOfSetupValue cc sc tyenv nameEnv sv
             unless (registerCompatible retTy retTy') $
               fail $ unlines
               [ "Incompatible types for return value when verifying " ++ mspec ^. csMethodName
@@ -506,7 +507,9 @@ resolveArguments cc mspec env = mapM resolveArg [0..(nArgs-1)]
     resolveArg i =
       case Map.lookup i (mspec ^. MS.csArgBindings) of
         Just (mt, sv) -> do
-          mt' <- typeOfSetupValue cc tyenv nameEnv sv
+          let sym = cc^.jccSym
+          sc <- saw_sc <$> sawCoreState sym
+          mt' <- typeOfSetupValue cc sc tyenv nameEnv sv
           checkArgTy i mt mt'
           v <- resolveSetupVal cc env tyenv nameEnv sv
           return (mt, v)
@@ -1219,15 +1222,17 @@ generic_field_is ptr fname mval =
              X.throwM $ JVMFieldNonReference ptr' fname
      st <- get
      let cc = st ^. Setup.csCrucibleContext
+     let sym = cc ^. jccSym
+     sc <- liftIO $ saw_sc <$> sawCoreState sym
      let cb = cc ^. jccCodebase
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
      let nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
-     ptrTy <- typeOfSetupValue cc env nameEnv ptr
+     ptrTy <- typeOfSetupValue cc sc env nameEnv ptr
      fid <- either (X.throwM . JVMFieldFailure) pure =<< (liftIO $ runExceptT $ findField cb pos ptrTy (Text.unpack fname))
      case mval of
        Nothing -> pure ()
        Just val ->
-         do valTy <- typeOfSetupValue cc env nameEnv val
+         do valTy <- typeOfSetupValue cc sc env nameEnv val
             unless (registerCompatible (J.fieldIdType fid) valTy) $
               X.throwM $ JVMFieldTypeMismatch fid valTy
      tags <- view Setup.croTags
@@ -1266,6 +1271,8 @@ generic_static_field_is fname mval =
      let loc = SS.toW4Loc "jvm_static_field_is" pos
      st <- get
      let cc = st ^. Setup.csCrucibleContext
+     let sym = cc ^. jccSym
+     sc <- liftIO $ saw_sc <$> sawCoreState sym
      let cb = cc ^. jccCodebase
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
      let nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
@@ -1279,7 +1286,7 @@ generic_static_field_is fname mval =
      case mval of
        Nothing -> pure ()
        Just val ->
-         do valTy <- typeOfSetupValue cc env nameEnv val
+         do valTy <- typeOfSetupValue cc sc env nameEnv val
             unless (registerCompatible (J.fieldIdType fid) valTy) $
               X.throwM $ JVMStaticTypeMismatch fid valTy
      -- let name = J.unClassName (J.fieldIdClass fid) ++ "." ++ J.fieldIdName fid
@@ -1329,6 +1336,8 @@ generic_elem_is ptr idx mval =
              X.throwM $ JVMElemNonReference ptr' idx
      st <- get
      let cc = st ^. Setup.csCrucibleContext
+     let sym = cc ^. jccSym
+     sc <- liftIO $ saw_sc <$> sawCoreState sym
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
      let nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
      (len, elTy) <-
@@ -1340,7 +1349,7 @@ generic_elem_is ptr idx mval =
      case mval of
        Nothing -> pure ()
        Just val ->
-         do valTy <- typeOfSetupValue cc env nameEnv val
+         do valTy <- typeOfSetupValue cc sc env nameEnv val
             unless (registerCompatible elTy valTy) $
               X.throwM $ JVMElemTypeMismatch idx elTy valTy
      tags <- view Setup.croTags
@@ -1447,6 +1456,7 @@ jvm_execute_func args =
   JVMSetupM $
   do st <- get
      let cc = st ^. Setup.csCrucibleContext
+     sc <- lift $ lift $ getSharedContext
      let mspec = st ^. Setup.csMethodSpec
      let env = MS.csAllocations mspec
      let nameEnv = MS.csTypeNames mspec
@@ -1455,7 +1465,7 @@ jvm_execute_func args =
        X.throwM JVMExecuteMultiple
      let
        checkArg i expectedTy val =
-         do valTy <- typeOfSetupValue cc env nameEnv val
+         do valTy <- typeOfSetupValue cc sc env nameEnv val
             unless (registerCompatible expectedTy valTy) $
               X.throwM (JVMArgTypeMismatch i expectedTy valTy)
      let
@@ -1475,10 +1485,11 @@ jvm_return retVal =
   JVMSetupM $
   do st <- get
      let cc = st ^. Setup.csCrucibleContext
+     sc <- lift $ lift $ getSharedContext
      let mspec = st ^. Setup.csMethodSpec
      let env = MS.csAllocations mspec
      let nameEnv = MS.csTypeNames mspec
-     valTy <- typeOfSetupValue cc env nameEnv retVal
+     valTy <- typeOfSetupValue cc sc env nameEnv retVal
      case mspec ^. MS.csRet of
        Nothing ->
          X.throwM (JVMReturnUnexpected valTy)
@@ -1507,10 +1518,11 @@ jvm_equal val1 val2 =
   do loc <- getW4Position "jvm_equal"
      st <- get
      let cc = st ^. Setup.csCrucibleContext
-         env = MS.csAllocations (st ^. Setup.csMethodSpec)
+     sc <- lift $ lift $ getSharedContext
+     let env = MS.csAllocations (st ^. Setup.csMethodSpec)
          nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
-     ty1 <- typeOfSetupValue cc env nameEnv val1
-     ty2 <- typeOfSetupValue cc env nameEnv val2
+     ty1 <- typeOfSetupValue cc sc env nameEnv val1
+     ty2 <- typeOfSetupValue cc sc env nameEnv val2
 
      let b = registerCompatible ty1 ty2
      unless b $ throwCrucibleSetup loc $ unlines

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -399,7 +399,6 @@ verifyPrestate ::
 verifyPrestate cc mspec globals0 =
   jccWithBackend cc $ \bak ->
   do let sym = cc^.jccSym
-     sc <- saw_sc <$> sawCoreState sym
      let jc = cc^.jccJVMContext
      let halloc = cc^.jccHandleAllocator
      let preallocs = mspec ^. MS.csPreState . MS.csAllocs
@@ -455,7 +454,7 @@ verifyPrestate cc mspec globals0 =
                 " has void return type"
               ]
        (Just sv, Just retTy) ->
-         do retTy' <- typeOfSetupValue cc sc tyenv nameEnv sv
+         do retTy' <- typeOfSetupValue cc tyenv nameEnv sv
             unless (registerCompatible retTy retTy') $
               fail $ unlines
               [ "Incompatible types for return value when verifying " ++ mspec ^. csMethodName
@@ -512,9 +511,7 @@ resolveArguments cc mspec env = mapM resolveArg [0..(nArgs-1)]
     resolveArg i =
       case Map.lookup i (mspec ^. MS.csArgBindings) of
         Just (mt, sv) -> do
-          let sym = cc^.jccSym
-          sc <- saw_sc <$> sawCoreState sym
-          mt' <- typeOfSetupValue cc sc tyenv nameEnv sv
+          mt' <- typeOfSetupValue cc tyenv nameEnv sv
           checkArgTy i mt mt'
           v <- resolveSetupVal cc env tyenv nameEnv sv
           return (mt, v)
@@ -1342,12 +1339,12 @@ generic_field_is ptr fname mval =
      ppopts <- lift $ lift getPPOpts
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
      let nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
-     ptrTy <- typeOfSetupValue cc sc env nameEnv ptr
+     ptrTy <- typeOfSetupValue cc env nameEnv ptr
      fid <- either (\msg -> X.throwM $ JVMFieldFailure ppopts (PP.pretty msg)) pure =<< (liftIO $ runExceptT $ findField cb pos ptrTy (Text.unpack fname))
      case mval of
        Nothing -> pure ()
        Just val ->
-         do valTy <- typeOfSetupValue cc sc env nameEnv val
+         do valTy <- typeOfSetupValue cc env nameEnv val
             unless (registerCompatible (J.fieldIdType fid) valTy) $
               X.throwM $ JVMFieldTypeMismatch ppopts fid valTy
      tags <- view Setup.croTags
@@ -1389,7 +1386,6 @@ generic_static_field_is fname mval =
      st <- get
      let cc = st ^. Setup.csCrucibleContext
      let cb = cc ^. jccCodebase
-     sc <- lift $ lift getSharedContext
      ppopts <- lift $ lift getPPOpts
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
      let nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
@@ -1403,7 +1399,7 @@ generic_static_field_is fname mval =
      case mval of
        Nothing -> pure ()
        Just val ->
-         do valTy <- typeOfSetupValue cc sc env nameEnv val
+         do valTy <- typeOfSetupValue cc env nameEnv val
             unless (registerCompatible (J.fieldIdType fid) valTy) $
               X.throwM $ JVMStaticTypeMismatch ppopts fid valTy
      -- let name = J.unClassName (J.fieldIdClass fid) ++ "." ++ J.fieldIdName fid
@@ -1467,7 +1463,7 @@ generic_elem_is ptr idx mval =
      case mval of
        Nothing -> pure ()
        Just val ->
-         do valTy <- typeOfSetupValue cc sc env nameEnv val
+         do valTy <- typeOfSetupValue cc env nameEnv val
             unless (registerCompatible elTy valTy) $
               X.throwM $ JVMElemTypeMismatch ppopts idx elTy valTy
      tags <- view Setup.croTags
@@ -1592,7 +1588,6 @@ jvm_execute_func args =
   JVMSetupM $
   do st <- get
      let cc = st ^. Setup.csCrucibleContext
-     sc <- lift $ lift getSharedContext
      let mspec = st ^. Setup.csMethodSpec
      let env = MS.csAllocations mspec
      let nameEnv = MS.csTypeNames mspec
@@ -1602,7 +1597,7 @@ jvm_execute_func args =
        X.throwM $ JVMExecuteMultiple ppopts
      let
        checkArg i expectedTy val =
-         do valTy <- typeOfSetupValue cc sc env nameEnv val
+         do valTy <- typeOfSetupValue cc env nameEnv val
             unless (registerCompatible expectedTy valTy) $ do
               ppopts <- lift $ lift getPPOpts
               X.throwM (JVMArgTypeMismatch ppopts i expectedTy valTy)
@@ -1625,11 +1620,10 @@ jvm_return retVal =
   JVMSetupM $
   do st <- get
      let cc = st ^. Setup.csCrucibleContext
-     sc <- lift $ lift getSharedContext
      let mspec = st ^. Setup.csMethodSpec
      let env = MS.csAllocations mspec
      let nameEnv = MS.csTypeNames mspec
-     valTy <- typeOfSetupValue cc sc env nameEnv retVal
+     valTy <- typeOfSetupValue cc env nameEnv retVal
      case mspec ^. MS.csRet of
        Nothing -> do
          ppopts <- lift $ lift getPPOpts
@@ -1660,11 +1654,10 @@ jvm_equal val1 val2 =
   do loc <- getW4Position "jvm_equal"
      st <- get
      let cc = st ^. Setup.csCrucibleContext
-     sc <- lift $ lift getSharedContext
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
          nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
-     ty1 <- typeOfSetupValue cc sc env nameEnv val1
-     ty2 <- typeOfSetupValue cc sc env nameEnv val2
+     ty1 <- typeOfSetupValue cc env nameEnv val1
+     ty2 <- typeOfSetupValue cc env nameEnv val2
 
      let b = registerCompatible ty1 ty2
      unless b $ throwCrucibleSetup loc $ unlines

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -62,8 +62,11 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Time.Clock (getCurrentTime, diffUTCTime)
 import qualified Data.Vector as V
-import           Prettyprinter
 import           System.IO
+
+import           Prettyprinter -- XXX legacy; remove
+import qualified Prettyprinter as PP
+--import           Prettyprinter ((<+>))
 
 -- cryptol
 import qualified Cryptol.Eval.Type as Cryptol (evalValType)
@@ -119,7 +122,7 @@ import qualified SAWCentral.Position as SS
 import SAWCentral.Options
 import SAWCentral.Crucible.JVM.BuiltinsJVM (prepareClassTopLevel)
 
-import SAWCentral.JavaExpr (JavaType(..))
+import SAWCentral.JavaExpr (JavaType(..), prettyJavaType)
 
 import qualified SAWCentral.Crucible.Common as Common
 import           SAWCentral.Crucible.Common
@@ -292,8 +295,9 @@ execJVMSetup :: JVMSetupM a -> Setup.CrucibleSetupState CJ.JVM -> TopLevel Metho
 execJVMSetup setup st0 =
   do st' <- execStateT (runReaderT (runJVMSetupM setup) Setup.makeCrucibleSetupRO) st0
      -- check for missing jvm_execute_func
-     unless (st' ^. Setup.csPrePost == PostState) $
-       X.throwM JVMExecuteMissing
+     unless (st' ^. Setup.csPrePost == PostState) $ do
+       ppopts <- getPPOpts
+       X.throwM $ JVMExecuteMissing ppopts
      -- check that jvm_return value is present if return type is non-void
      let mspec = st' ^. Setup.csMethodSpec
      case mspec ^. MS.csRet of
@@ -301,8 +305,9 @@ execJVMSetup setup st0 =
        Just retTy ->
          case mspec ^. MS.csRetValue of
            Just _ -> pure ()
-           Nothing ->
-             X.throwM $ JVMReturnMissing retTy
+           Nothing -> do
+             ppopts <- getPPOpts
+             X.throwM $ JVMReturnMissing ppopts retTy
      pure mspec
 
 verifyObligations ::
@@ -957,156 +962,264 @@ setupDynamicClassTable sym jc = foldM addClass Map.empty (Map.assocs (CJ.classTa
 --------------------------------------------------------------------------------
 -- Setup builtins
 
+-- | Errors from JVM setup.
+--
+--   We print various objects to prettyprinter docs before consing the
+--   error so that we don't have to do that printing in places that
+--   don't have the `SharedContext` and/or can't use `IO`.
+--
+--   We also embed the `PPS.Opts` so that the `Show` instance required
+--   for this to be an `X.Exception` can render the docs correctly.
+--   XXX: this is ugly. It's possible that when we manage to get the
+--   new SAW error infrastructure deployed into the Crucible code that
+--   we can make this type not need to be an `X.Exception` any more
+--   and can drop the `Show` instance.
+--
+--   (I have stuffed the `PPS.Opts` into (almost) every constructor
+--   instead of creating a wrapper type to hold it; this is to favor
+--   the readability of the call sites of the constructors, which just
+--   take an extra argument, over the printer code, which gets kind of
+--   laborious. One could fix this by writing 28 boilerplate wrapper
+--   functions instead, one for each constructor, but I don't have the
+--   patience for that and it's not better anyway.)
+--
+--   TODO: JVMFieldFailure and JVMStatic failure come with a generic
+--   failure message from upstream code that would, ideally, produce a
+--   more structured error type instead.
+--
+--   FUTURE: a number of these errors are complaining about things
+--   that have SAWScript source locations. It would be good to print
+--   those. (This will need to also be able to handle remote API
+--   positions; however, we ought to be able to manage that.)
+--
 data JVMSetupError
-  = JVMFreshVarInvalidType JavaType
-  | JVMFieldNonReference PPS.Doc Text
-  | JVMFieldMultiple AllocIndex J.FieldId
-  | JVMFieldFailure String -- TODO: switch to a more structured type
-  | JVMFieldTypeMismatch J.FieldId J.Type
-  | JVMFieldModifyPrestate AllocIndex J.FieldId
-  | JVMStaticMultiple J.FieldId
-  | JVMStaticFailure String -- TODO: switch to a more structured type
-  | JVMStaticTypeMismatch J.FieldId J.Type
-  | JVMStaticModifyPrestate J.FieldId
-  | JVMElemNonReference PPS.Doc Int
-  | JVMElemNonArray J.Type
-  | JVMElemInvalidIndex J.Type Int Int -- element type, length, index
-  | JVMElemTypeMismatch Int J.Type J.Type -- index, expected, found
-  | JVMElemMultiple AllocIndex Int -- reference and array index
-  | JVMElemModifyPrestate AllocIndex Int
-  | JVMArrayNonReference PPS.Doc
-  | JVMArrayTypeMismatch Int J.Type Cryptol.Schema
-  | JVMArrayMultiple AllocIndex
-  | JVMArrayModifyPrestate AllocIndex
-  | JVMExecuteMissing
-  | JVMExecuteMultiple
-  | JVMArgTypeMismatch Int J.Type J.Type -- argument position, expected, found
-  | JVMArgNumberWrong Int Int -- number expected, number found
-  | JVMReturnMissing J.Type -- expected
-  | JVMReturnUnexpected J.Type -- found
-  | JVMReturnTypeMismatch J.Type J.Type -- expected, found
-  | JVMNonValueType TypedTermType
+  = JVMFreshVarInvalidType PPS.Opts JavaType
+  | JVMFieldNonReference PPS.Opts PPS.Doc Text        -- pointer and field name
+  | JVMFieldMultiple PPS.Opts PPS.Doc J.FieldId       -- pointer and field
+  | JVMFieldFailure PPS.Opts PPS.Doc                  -- failure message
+  | JVMFieldTypeMismatch PPS.Opts J.FieldId J.Type    -- field id and type
+  | JVMFieldModifyPrestate PPS.Opts PPS.Doc J.FieldId -- pointer and field
+  | JVMStaticMultiple PPS.Opts J.FieldId              -- field id
+  | JVMStaticFailure PPS.Opts PPS.Doc                 -- failure message
+  | JVMStaticTypeMismatch PPS.Opts J.FieldId J.Type   -- field id and type
+  | JVMStaticModifyPrestate PPS.Opts J.FieldId        -- field id
+  | JVMElemNonReference PPS.Opts PPS.Doc Int          -- array/pointer and index
+  | JVMElemNonArray PPS.Opts J.Type                   -- type
+  | JVMElemInvalidIndex PPS.Opts J.Type Int Int       -- element type, array length, index
+  | JVMElemTypeMismatch PPS.Opts Int J.Type J.Type    -- index, expected, found
+  | JVMElemMultiple PPS.Opts PPS.Doc Int              -- array/pointer and index
+  | JVMElemModifyPrestate PPS.Opts PPS.Doc Int        -- array/pointer and index
+  | JVMArrayNonReference PPS.Opts PPS.Doc             -- array/pointer
+  | JVMArrayTypeMismatch PPS.Opts Int J.Type Cryptol.Schema -- length, expected, found
+  | JVMArrayMultiple PPS.Opts PPS.Doc                 -- array reference
+  | JVMArrayModifyPrestate PPS.Opts PPS.Doc           -- array reference
+  | JVMExecuteMissing PPS.Opts
+  | JVMExecuteMultiple PPS.Opts
+  | JVMArgTypeMismatch PPS.Opts Int J.Type J.Type     -- argument position, expected, found
+  | JVMArgNumberWrong PPS.Opts Int Int                -- number expected, number found
+  | JVMReturnMissing PPS.Opts J.Type                  -- expected type
+  | JVMReturnUnexpected PPS.Opts J.Type               -- found type
+  | JVMReturnTypeMismatch PPS.Opts J.Type J.Type      -- expected type, found type
+  | JVMNonValueType PPS.Opts PPS.Doc                  -- type
+
+-- | Print a `JVMSetupError`. For the moment we don't offer a @pretty@
+--   version to generate a `PPS.Doc` because nothing uses it downstream
+--   and the `PPS.Opts` handling makes it ugly to separate out.
+ppJVMSetupError :: JVMSetupError -> Text
+ppJVMSetupError err =
+  let (ppopts_, msg_) = case err of
+        JVMFreshVarInvalidType ppopts jty ->
+            let jty' = prettyJavaType ppopts jty in
+            (ppopts, "jvm_fresh_var: Invalid type:" <+> jty')
+        JVMFieldNonReference ppopts ptr fname ->
+            (ppopts, PP.vsep [
+                "jvm_field_is: Left-hand side is not a valid object reference",
+                "Left-hand side:" <+> ptr,
+                "Field name:" <+> PP.pretty fname
+            ])
+        JVMFieldMultiple ppopts ptr fid ->
+            let fid' = PP.pretty fid in
+            (ppopts, PP.vsep [
+                "jvm_field_is: Multiple specifications for the same instance field",
+                "Object reference:" <+> ptr,
+                "Field: " <+> fid'
+            ])
+        JVMFieldFailure ppopts msg ->
+            (ppopts, PP.vsep [
+                "jvm_field_is: JVM field resolution failed:",
+                msg
+            ])
+        JVMFieldTypeMismatch ppopts fid found ->
+            let fid' = PP.pretty fid
+                exp' = PP.pretty $ J.fieldIdType fid
+                found' = PP.pretty found
+            in
+            (ppopts, PP.vsep [
+                "jvm_field_is: Incompatible types for field" <+> fid',
+                "Expected:" <+> exp',
+                "Found:" <+> found'
+            ])
+        JVMFieldModifyPrestate ppopts ptr fid ->
+            let fid' = PP.pretty fid in
+            (ppopts, PP.vsep [
+                "jvm_modifies_field: Invalid use before jvm_execute_func",
+                "Object reference:" <+> ptr,
+                "Field:" <+> fid'
+            ])
+        JVMStaticMultiple ppopts fid ->
+            let fid' = PP.pretty fid in
+            (ppopts, PP.vsep [
+                "jvm_static_field_is: Multiple specifications for the same static field",
+                "Field:" <+> fid'
+            ])
+        JVMStaticFailure ppopts msg ->
+            (ppopts, PP.vsep [
+                "jvm_static_field_is: JVM field resolution failed:",
+                msg
+            ])
+        JVMStaticTypeMismatch ppopts fid found ->
+            let fid' = PP.pretty fid
+                exp' = PP.pretty $ J.fieldIdType fid
+                found' = PP.pretty found
+            in
+            (ppopts, PP.vsep [
+                "jvm_static_field_is: Incompatible types for field" <+> fid',
+                "Expected:" <+> exp',
+                "Found:" <+> found'
+            ])
+        JVMStaticModifyPrestate ppopts fid ->
+            let fid' = PP.pretty fid in
+            (ppopts, PP.vsep [
+                "jvm_modifies_static_field: Invalid use before jvm_execute_func",
+                "Field:" <+> fid'
+            ])
+        JVMElemNonReference ppopts ptr idx ->
+            let idx' = PPS.prettyInt ppopts idx in
+            (ppopts, PP.vsep [
+                "jvm_elem_is: Left-hand side is not a valid object reference",
+                "Left-hand side:" <+> ptr,
+                "Index:" <+> idx'
+            ])
+        JVMElemNonArray ppopts jty ->
+            let jty' = PP.pretty jty in
+            (ppopts, "jvm_elem_is: Not an array type:" <+> jty')
+        JVMElemInvalidIndex ppopts ty len idx ->
+            let ty' = PP.pretty ty
+                len' = PPS.prettyInt ppopts len
+                idx' = PPS.prettyInt ppopts idx
+            in
+            (ppopts, PP.vsep [
+                "jvm_elem_is: Array index out of bounds",
+                "Element type:" <+> ty',
+                "Array length:" <+> len',
+                "Given index:" <+> idx'
+            ])
+        JVMElemTypeMismatch ppopts idx expected found ->
+            let idx' = PPS.prettyInt ppopts idx
+                exp' = PP.pretty expected
+                found' = PP.pretty found
+            in
+            (ppopts, PP.vsep [
+                "jvm_elem_is: Incompatible types for array index" <+> idx',
+                "Expected type:" <+> exp',
+                "Type found:" <+> found'
+            ])
+        JVMElemMultiple ppopts ptr idx ->
+            let idx' = PPS.prettyInt ppopts idx in
+            (ppopts, PP.vsep [
+                "jvm_elem_is: Multiple specifications for the same array index",
+                "Array:" <+> ptr,
+                "Index:" <+> idx'
+            ])
+        JVMElemModifyPrestate ppopts ptr idx ->
+            let idx' = PPS.prettyInt ppopts idx in
+            (ppopts, PP.vsep [
+                "jvm_modifies_elem: Invalid use before jvm_execute_func",
+                "Aray:" <+> ptr,
+                "Index:" <+> idx'
+            ])
+        JVMArrayNonReference ppopts ptr ->
+            (ppopts, PP.vsep [
+                "jvm_array_is: Left-hand side is not a valid object reference",
+                "Left-hand side:" <+> ptr
+            ])
+        JVMArrayTypeMismatch ppopts len ty schema ->
+            let len' = PPS.prettyInt ppopts len
+                ty' = PP.pretty ty
+                schema' = CryPP.pretty schema
+            in
+            (ppopts, PP.vsep [
+                "jvm_array_is: Specified value does not have the expected type",
+                "Expected array length:" <+> len',
+                "Expected element type:" <+> ty',
+                "Given type:" <+> schema'
+            ])
+        JVMArrayMultiple ppopts ptr ->
+            (ppopts, PP.vsep [
+                "jvm_array_is: Multiple specifications for the same array reference",
+                "Array is:" <+> ptr
+            ])
+        JVMArrayModifyPrestate ppopts ptr ->
+            (ppopts, PP.vsep [
+                "jvm_modifies_array: Invalid use before jvm_execute_func",
+                "Array is:" <+> ptr
+            ])
+        JVMExecuteMissing ppopts ->
+            (ppopts, "JVMSetup: Missing jvm_execute_func specification")
+        JVMExecuteMultiple ppopts ->
+            (ppopts, "jvm_execute_func: Multiple jvm_execute_func specifications")
+        JVMArgTypeMismatch ppopts i expected found ->
+            let i' = PPS.prettyInt ppopts i
+                expected' = PP.pretty expected
+                found' = PP.pretty found
+            in
+            (ppopts, PP.vsep [
+                "jvm_execute_func: Argument type mismatch",
+                "Argument position:" <+> i',
+                "Expected:" <+> expected',
+                "Found:" <+> found'
+            ])
+        JVMArgNumberWrong ppopts expected found ->
+            let expected' = PPS.prettyInt ppopts expected
+                found' = PPS.prettyInt ppopts found
+            in
+            (ppopts, PP.vsep [
+                "jvm_execute_func: Wrong number of arguments",
+                "Expected:" <+> expected',
+                "Found:" <+> found'
+            ])
+        JVMReturnMissing ppopts expected ->
+            let expected' = PP.pretty expected in
+            (ppopts, PP.vsep [
+                "JVMSetup: Missing jvm_return specification",
+                "Expected a return value of type:" <+> expected'
+            ])
+        JVMReturnUnexpected ppopts found ->
+            let found' = PP.pretty found in
+            (ppopts, PP.vsep [
+                "jvm_return: Unexpected return value specification for void method",
+                "Type of return value found:" <+> found'
+            ])
+        JVMReturnTypeMismatch ppopts expected found ->
+            let expected' = PP.pretty expected
+                found' = PP.pretty found
+            in
+            (ppopts, PP.vsep [
+                "jvm_return: Return type mismatch",
+                "Expected:" <+> expected',
+                "Found:" <+> found'
+            ])
+        JVMNonValueType ppopts ty ->
+            (ppopts, "Expected term with value type, but got" <+> ty)
+  in
+  PPS.renderText ppopts_ msg_
 
 instance X.Exception JVMSetupError where
   toException = topLevelExceptionToException
   fromException = topLevelExceptionFromException
 
 instance Show JVMSetupError where
-  show err =
-    case err of
-      JVMFreshVarInvalidType jty ->
-        "jvm_fresh_var: Invalid type: " ++ show jty
-      JVMFieldNonReference ptr fname ->
-        unlines
-        [ "jvm_field_is: Left-hand side is not a valid object reference"
-        , "Left-hand side: " ++ show ptr
-        , "Field name: " ++ Text.unpack fname
-        ]
-      JVMFieldMultiple _ptr fid ->
-        "jvm_field_is: Multiple specifications for the same instance field (" ++ J.fieldIdName fid ++ ")"
-      JVMFieldFailure msg ->
-        "jvm_field_is: JVM field resolution failed:\n" ++ msg
-      JVMFieldTypeMismatch fid found ->
-         -- FIXME: use a pretty printing function for J.Type instead of show
-        unlines
-        [ "jvm_field_is: Incompatible types for field " ++ show (J.fieldIdName fid)
-        , "Expected type: " ++ show (J.fieldIdType fid)
-        , "Given type: " ++ show found
-        ]
-      JVMFieldModifyPrestate _ptr fid ->
-        "jvm_modifies_field: Invalid use before jvm_execute_func (" ++ J.fieldIdName fid ++ ")"
-      JVMStaticMultiple fid ->
-        "jvm_static_field_is: Multiple specifications for the same static field (" ++ J.fieldIdName fid ++ ")"
-      JVMStaticFailure msg ->
-        "jvm_static_field_is: JVM field resolution failed:\n" ++ msg
-      JVMStaticTypeMismatch fid found ->
-         -- FIXME: use a pretty printing function for J.Type instead of show
-        unlines
-        [ "jvm_static_field_is: Incompatible types for field " ++ show (J.fieldIdName fid)
-        , "Expected type: " ++ show (J.fieldIdType fid)
-        , "Given type: " ++ show found
-        ]
-      JVMStaticModifyPrestate fid ->
-        "jvm_modifies_static_field: Invalid use before jvm_execute_func (" ++ J.fieldIdName fid ++ ")"
-      JVMElemNonReference ptr idx ->
-        unlines
-        [ "jvm_elem_is: Left-hand side is not a valid object reference"
-        , "Left-hand side: " ++ show ptr
-        , "Index: " ++ show idx
-        ]
-      JVMElemNonArray jty ->
-        "jvm_elem_is: Not an array type: " ++ show jty
-      JVMElemInvalidIndex ty len idx ->
-        unlines
-        [ "jvm_elem_is: Array index out of bounds"
-        , "Element type: " ++ show ty
-        , "Array length: " ++ show len
-        , "Given index: " ++ show idx
-        ]
-      JVMElemTypeMismatch idx expected found ->
-        unlines
-        [ "jvm_elem_is: Incompatible types for array index " ++ show idx
-        , "Expected type: " ++ show expected
-        , "Given type: " ++ show found
-        ]
-      JVMElemMultiple _ptr idx ->
-        "jvm_elem_is: Multiple specifications for the same array index (" ++ show idx ++ ")"
-      JVMElemModifyPrestate _ptr idx ->
-        "jvm_modifies_elem: Invalid use before jvm_execute_func (" ++ show idx ++ ")"
-      JVMArrayNonReference ptr ->
-        unlines
-        [ "jvm_array_is: Left-hand side is not a valid object reference"
-        , "Left-hand side: " ++ show ptr
-        ]
-      JVMArrayTypeMismatch len ty schema ->
-        unlines
-        [ "jvm_array_is: Specified value does not have the expected type"
-        , "Expected array length: " ++ show len
-        , "Expected element type: " ++ show ty
-        , "Given type: " ++ Text.unpack (CryPP.pp schema)
-        ]
-      JVMArrayMultiple _ptr ->
-        "jvm_array_is: Multiple specifications for the same array reference"
-      JVMArrayModifyPrestate _ptr ->
-        "jvm_modifies_array: Invalid use before jvm_execute_func"
-      JVMExecuteMissing ->
-        "JVMSetup: Missing jvm_execute_func specification"
-      JVMExecuteMultiple ->
-        "jvm_execute_func: Multiple jvm_execute_func specifications"
-      JVMArgTypeMismatch i expected found ->
-        unlines
-        [ "jvm_execute_func: Argument type mismatch"
-        , "Argument position: " ++ show i
-        , "Expected type: " ++ show expected
-        , "Given type: " ++ show found
-        ]
-      JVMArgNumberWrong expected found ->
-        unlines
-        [ "jvm_execute_func: Wrong number of arguments"
-        , "Expected: " ++ show expected
-        , "Given: " ++ show found
-        ]
-      JVMReturnMissing expected ->
-        unlines
-        [ "JVMSetup: Missing jvm_return specification"
-        , "Expected type: " ++ show expected
-        ]
-      JVMReturnUnexpected found ->
-        unlines
-        [ "jvm_return: Unexpected return value for void method"
-        , "Given type: " ++ show found
-        ]
-      JVMReturnTypeMismatch expected found ->
-        unlines
-        [ "jvm_return: Return type mismatch"
-        , "Expected type: " ++ show expected
-        , "Given type: " ++ show found
-        ]
-      JVMNonValueType tp ->
-        unlines
-        [ "Expected term with value type, but got"
-        , show (prettyTypedTermTypePure PPS.defaultOpts tp)
-        ]
+  show err = Text.unpack $ ppJVMSetupError err
 
 -- | Returns Cryptol type of actual type if it is an array or
 -- primitive type.
@@ -1150,9 +1263,10 @@ jvm_fresh_var ::
 jvm_fresh_var name jty =
   JVMSetupM $
   do sc <- lift $ lift getSharedContext
+     ppopts <- lift $ lift $ getPPOpts
      cryenv <- lift $ lift getCryptolEnv
      case cryptolTypeOfActual jty of
-       Nothing -> X.throwM $ JVMFreshVarInvalidType jty
+       Nothing -> X.throwM $ JVMFreshVarInvalidType ppopts jty
        Just cty -> Setup.freshVariable sc cryenv name cty
 
 jvm_alloc_object ::
@@ -1218,23 +1332,24 @@ generic_field_is ptr fname mval =
          MS.SetupVar ptr' -> pure ptr'
          _ -> do
              sc <- lift $ lift $ getSharedContext
+             ppopts <- lift $ lift $ getPPOpts
              ptr' <- liftIO $ MS.prettySetupValue sc ptr
-             X.throwM $ JVMFieldNonReference ptr' fname
+             X.throwM $ JVMFieldNonReference ppopts ptr' fname
      st <- get
      let cc = st ^. Setup.csCrucibleContext
-     let sym = cc ^. jccSym
-     sc <- liftIO $ saw_sc <$> sawCoreState sym
      let cb = cc ^. jccCodebase
+     sc <- lift $ lift $ getSharedContext
+     ppopts <- lift $ lift $ getPPOpts
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
      let nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
      ptrTy <- typeOfSetupValue cc sc env nameEnv ptr
-     fid <- either (X.throwM . JVMFieldFailure) pure =<< (liftIO $ runExceptT $ findField cb pos ptrTy (Text.unpack fname))
+     fid <- either (\msg -> X.throwM $ JVMFieldFailure ppopts (PP.pretty msg)) pure =<< (liftIO $ runExceptT $ findField cb pos ptrTy (Text.unpack fname))
      case mval of
        Nothing -> pure ()
        Just val ->
          do valTy <- typeOfSetupValue cc sc env nameEnv val
             unless (registerCompatible (J.fieldIdType fid) valTy) $
-              X.throwM $ JVMFieldTypeMismatch fid valTy
+              X.throwM $ JVMFieldTypeMismatch ppopts fid valTy
      tags <- view Setup.croTags
      let md = MS.ConditionMetadata
               { MS.conditionLoc = loc
@@ -1244,10 +1359,12 @@ generic_field_is ptr fname mval =
               }
      let pt = JVMPointsToField md ptr' fid mval
      let pts = st ^. Setup.csMethodSpec . MS.csPreState . MS.csPointsTos
-     when (st ^. Setup.csPrePost == PreState && any (overlapPointsTo pt) pts) $
-       X.throwM $ JVMFieldMultiple ptr' fid
-     when (st ^. Setup.csPrePost == PreState && isNothing mval) $
-       X.throwM $ JVMFieldModifyPrestate ptr' fid
+     when (st ^. Setup.csPrePost == PreState && any (overlapPointsTo pt) pts) $ do
+       ptrdoc <- liftIO $ MS.prettySetupValue sc ptr
+       X.throwM $ JVMFieldMultiple ppopts ptrdoc fid
+     when (st ^. Setup.csPrePost == PreState && isNothing mval) $ do
+       ptrdoc <- liftIO $ MS.prettySetupValue sc ptr
+       X.throwM $ JVMFieldModifyPrestate ppopts ptrdoc fid
      Setup.addPointsTo pt
 
 jvm_modifies_static_field ::
@@ -1271,9 +1388,9 @@ generic_static_field_is fname mval =
      let loc = SS.toW4Loc "jvm_static_field_is" pos
      st <- get
      let cc = st ^. Setup.csCrucibleContext
-     let sym = cc ^. jccSym
-     sc <- liftIO $ saw_sc <$> sawCoreState sym
      let cb = cc ^. jccCodebase
+     sc <- lift $ lift $ getSharedContext
+     ppopts <- lift $ lift $ getPPOpts
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
      let nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
      let cname =
@@ -1282,13 +1399,13 @@ generic_static_field_is fname mval =
                Just (fname', _) -> J.mkClassName (Text.unpack fname')
      -- liftIO $ putStrLn $ "jvm_static_field_is " ++ J.unClassName cname ++ " " ++ fname
      let ptrTy = J.ClassType cname
-     fid <- either (X.throwM . JVMStaticFailure) pure =<< (liftIO $ runExceptT $ findField cb pos ptrTy (Text.unpack fname))
+     fid <- either (\msg -> X.throwM $ JVMStaticFailure ppopts (PP.pretty msg)) pure =<< (liftIO $ runExceptT $ findField cb pos ptrTy (Text.unpack fname))
      case mval of
        Nothing -> pure ()
        Just val ->
          do valTy <- typeOfSetupValue cc sc env nameEnv val
             unless (registerCompatible (J.fieldIdType fid) valTy) $
-              X.throwM $ JVMStaticTypeMismatch fid valTy
+              X.throwM $ JVMStaticTypeMismatch ppopts fid valTy
      -- let name = J.unClassName (J.fieldIdClass fid) ++ "." ++ J.fieldIdName fid
      -- liftIO $ putStrLn $ "resolved to: " ++ name
      tags <- view Setup.croTags
@@ -1301,9 +1418,9 @@ generic_static_field_is fname mval =
      let pt = JVMPointsToStatic md fid mval
      let pts = st ^. Setup.csMethodSpec . MS.csPreState . MS.csPointsTos
      when (st ^. Setup.csPrePost == PreState && any (overlapPointsTo pt) pts) $
-       X.throwM $ JVMStaticMultiple fid
+       X.throwM $ JVMStaticMultiple ppopts fid
      when (st ^. Setup.csPrePost == PreState && isNothing mval) $
-       X.throwM $ JVMStaticModifyPrestate fid
+       X.throwM $ JVMStaticModifyPrestate ppopts fid
      Setup.addPointsTo pt
 
 jvm_modifies_elem ::
@@ -1332,26 +1449,27 @@ generic_elem_is ptr idx mval =
          MS.SetupVar ptr' -> pure ptr'
          _ -> do
              sc <- lift $ lift $ getSharedContext
+             ppopts <- lift $ lift $ getPPOpts
              ptr' <- liftIO $ MS.prettySetupValue sc ptr
-             X.throwM $ JVMElemNonReference ptr' idx
+             X.throwM $ JVMElemNonReference ppopts ptr' idx
      st <- get
      let cc = st ^. Setup.csCrucibleContext
-     let sym = cc ^. jccSym
-     sc <- liftIO $ saw_sc <$> sawCoreState sym
+     sc <- lift $ lift $ getSharedContext
+     ppopts <- lift $ lift $ getPPOpts
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
      let nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
      (len, elTy) <-
        case snd (lookupAllocIndex env ptr') of
-         AllocObject cname -> X.throwM $ JVMElemNonArray (J.ClassType cname)
+         AllocObject cname -> X.throwM $ JVMElemNonArray ppopts (J.ClassType cname)
          AllocArray len elTy -> pure (len, elTy)
      unless (0 <= idx && idx < len) $
-       X.throwM $ JVMElemInvalidIndex elTy len idx
+       X.throwM $ JVMElemInvalidIndex ppopts elTy len idx
      case mval of
        Nothing -> pure ()
        Just val ->
          do valTy <- typeOfSetupValue cc sc env nameEnv val
             unless (registerCompatible elTy valTy) $
-              X.throwM $ JVMElemTypeMismatch idx elTy valTy
+              X.throwM $ JVMElemTypeMismatch ppopts idx elTy valTy
      tags <- view Setup.croTags
      let md = MS.ConditionMetadata
               { MS.conditionLoc = loc
@@ -1361,10 +1479,12 @@ generic_elem_is ptr idx mval =
               }
      let pt = JVMPointsToElem md ptr' idx mval
      let pts = st ^. Setup.csMethodSpec . MS.csPreState . MS.csPointsTos
-     when (st ^. Setup.csPrePost == PreState && any (overlapPointsTo pt) pts) $
-       X.throwM $ JVMElemMultiple ptr' idx
-     when (st ^. Setup.csPrePost == PreState && isNothing mval) $
-       X.throwM $ JVMElemModifyPrestate ptr' idx
+     when (st ^. Setup.csPrePost == PreState && any (overlapPointsTo pt) pts) $ do
+       ptrdoc <- liftIO $ MS.prettySetupValue sc ptr
+       X.throwM $ JVMElemMultiple ppopts ptrdoc idx
+     when (st ^. Setup.csPrePost == PreState && isNothing mval) $ do
+       ptrdoc <- liftIO $ MS.prettySetupValue sc ptr
+       X.throwM $ JVMElemModifyPrestate ppopts ptrdoc idx
      Setup.addPointsTo pt
 
 jvm_modifies_array ::
@@ -1390,20 +1510,28 @@ generic_array_is ptr mval =
          MS.SetupVar ptr' -> pure ptr'
          _ -> do
              sc <- lift $ lift $ getSharedContext
+             ppopts <- lift $ lift $ getPPOpts
              ptr' <- liftIO $ MS.prettySetupValue sc ptr
-             X.throwM $ JVMArrayNonReference ptr'
+             X.throwM $ JVMArrayNonReference ppopts ptr'
      st <- get
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
      (len, elTy) <-
        case snd (lookupAllocIndex env ptr') of
-         AllocObject cname -> X.throwM $ JVMElemNonArray (J.ClassType cname)
-         AllocArray len elTy -> pure (len, elTy)
+         AllocObject cname -> do
+             ppopts <- lift $ lift $ getPPOpts
+             X.throwM $ JVMElemNonArray ppopts (J.ClassType cname)
+         AllocArray len elTy ->
+             pure (len, elTy)
      case mval of
        Nothing -> pure ()
        Just val ->
          do schema <- case ttType val of
               TypedTermSchema sch -> pure sch
-              tp -> X.throwM (JVMNonValueType tp)
+              tp -> do
+                  sc <- lift $ lift $ getSharedContext
+                  ppopts <- lift $ lift $ getPPOpts
+                  tp' <- liftIO $ prettyTypedTermType sc tp
+                  X.throwM (JVMNonValueType ppopts tp')
             let checkVal =
                   do ty <- Cryptol.isMono schema
                      (n, a) <- Cryptol.tIsSeq ty
@@ -1411,7 +1539,9 @@ generic_array_is ptr mval =
                      jty <- toJVMType (Cryptol.evalValType mempty a)
                      guard (registerCompatible elTy jty)
             case checkVal of
-              Nothing -> X.throwM (JVMArrayTypeMismatch len elTy schema)
+              Nothing -> do
+                  ppopts <- lift $ lift $ getPPOpts
+                  X.throwM (JVMArrayTypeMismatch ppopts len elTy schema)
               Just () -> pure ()
 
      tags <- view Setup.croTags
@@ -1423,10 +1553,16 @@ generic_array_is ptr mval =
               }
      let pt = JVMPointsToArray md ptr' mval
      let pts = st ^. Setup.csMethodSpec . MS.csPreState . MS.csPointsTos
-     when (st ^. Setup.csPrePost == PreState && any (overlapPointsTo pt) pts) $
-       X.throwM $ JVMArrayMultiple ptr'
-     when (st ^. Setup.csPrePost == PreState && isNothing mval) $
-       X.throwM $ JVMArrayModifyPrestate ptr'
+     when (st ^. Setup.csPrePost == PreState && any (overlapPointsTo pt) pts) $ do
+       sc <- lift $ lift $ getSharedContext
+       ppopts <- lift $ lift $ getPPOpts
+       ptrdoc <- liftIO $ MS.prettySetupValue sc ptr
+       X.throwM $ JVMArrayMultiple ppopts ptrdoc
+     when (st ^. Setup.csPrePost == PreState && isNothing mval) $ do
+       sc <- lift $ lift $ getSharedContext
+       ppopts <- lift $ lift $ getPPOpts
+       ptrdoc <- liftIO $ MS.prettySetupValue sc ptr
+       X.throwM $ JVMArrayModifyPrestate ppopts ptrdoc
      Setup.addPointsTo pt
 
 jvm_assert :: TypedTerm -> JVMSetupM ()
@@ -1461,19 +1597,23 @@ jvm_execute_func args =
      let env = MS.csAllocations mspec
      let nameEnv = MS.csTypeNames mspec
      let argTys = mspec ^. MS.csArgs
-     unless (st ^. Setup.csPrePost == PreState) $
-       X.throwM JVMExecuteMultiple
+     unless (st ^. Setup.csPrePost == PreState) $ do
+       ppopts <- lift $ lift $ getPPOpts
+       X.throwM $ JVMExecuteMultiple ppopts
      let
        checkArg i expectedTy val =
          do valTy <- typeOfSetupValue cc sc env nameEnv val
-            unless (registerCompatible expectedTy valTy) $
-              X.throwM (JVMArgTypeMismatch i expectedTy valTy)
+            unless (registerCompatible expectedTy valTy) $ do
+              ppopts <- lift $ lift $ getPPOpts
+              X.throwM (JVMArgTypeMismatch ppopts i expectedTy valTy)
      let
        checkArgs _ [] [] = pure ()
-       checkArgs i [] vals =
-         X.throwM (JVMArgNumberWrong i (i + length vals))
-       checkArgs i tys [] =
-         X.throwM (JVMArgNumberWrong (i + length tys) i)
+       checkArgs i [] vals = do
+         ppopts <- lift $ lift $ getPPOpts
+         X.throwM (JVMArgNumberWrong ppopts i (i + length vals))
+       checkArgs i tys [] = do
+         ppopts <- lift $ lift $ getPPOpts
+         X.throwM (JVMArgNumberWrong ppopts (i + length tys) i)
        checkArgs i (ty : tys) (val : vals) =
          do checkArg i ty val
             checkArgs (i + 1) tys vals
@@ -1491,11 +1631,13 @@ jvm_return retVal =
      let nameEnv = MS.csTypeNames mspec
      valTy <- typeOfSetupValue cc sc env nameEnv retVal
      case mspec ^. MS.csRet of
-       Nothing ->
-         X.throwM (JVMReturnUnexpected valTy)
+       Nothing -> do
+         ppopts <- lift $ lift $ getPPOpts
+         X.throwM (JVMReturnUnexpected ppopts valTy)
        Just retTy ->
-         unless (registerCompatible retTy valTy) $
-         X.throwM (JVMReturnTypeMismatch retTy valTy)
+         unless (registerCompatible retTy valTy) $ do
+             ppopts <- lift $ lift $ getPPOpts
+             X.throwM (JVMReturnTypeMismatch ppopts retTy valTy)
      Setup.crucible_return retVal
 
 jvm_setup_with_tag ::

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -596,11 +596,14 @@ setupPrestateConditions mspec cc env = aux []
       case val of
         TypedTerm (TypedTermSchema sch) tm ->
           aux acc (Crucible.insertGlobal var (sch,tm) globals) xs
-        TypedTerm tp _ ->
-          fail $ unlines
-            [ "Setup term for global variable expected to have Cryptol schema type, but got"
-            , show (prettyTypedTermTypePure tp)
-            ]
+        TypedTerm tp _ -> do
+          let sym = cc ^. jccSym
+          st <- sawCoreState sym
+          let sc = saw_sc st
+          ppopts <- scGetPPOpts sc
+          tp' <- prettyTypedTermType sc tp
+          fail $ PPS.render ppopts $ "Setup term for global variable" <+>
+              "should have Cryptol schema type, but got" <+> tp'
 
 --------------------------------------------------------------------------------
 
@@ -1099,7 +1102,7 @@ instance Show JVMSetupError where
       JVMNonValueType tp ->
         unlines
         [ "Expected term with value type, but got"
-        , show (prettyTypedTermTypePure tp)
+        , show (prettyTypedTermTypePure PPS.defaultOpts tp)
         ]
 
 -- | Returns Cryptol type of actual type if it is an array or

--- a/saw-central/src/SAWCentral/Crucible/JVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Override.hs
@@ -134,7 +134,7 @@ mkStructuralMismatch ::
   J.Type     {- ^ the expected type -} ->
   OverrideMatcher CJ.JVM w (OverrideFailureReason CJ.JVM)
 mkStructuralMismatch opts cc sc spec jvmval setupval jty = do
-  setupTy <- typeOfSetupValueJVM cc spec setupval
+  setupTy <- typeOfSetupValueJVM cc sc spec setupval
   setupJVal <- resolveSetupValueJVM opts cc sc spec setupval
   pure $ StructuralMismatch
             (ppJVMVal jvmval)
@@ -646,20 +646,20 @@ learnPointsTo opts sc cc spec prepost pt =
   case pt of
 
     JVMPointsToField md ptr fid (Just val) ->
-      do ty <- typeOfSetupValue cc tyenv nameEnv val
+      do ty <- typeOfSetupValue cc sc tyenv nameEnv val
          rval <- resolveAllocIndexJVM ptr
          dyn <- liftIO $ CJ.doFieldLoad bak globals rval fid
          v <- liftIO $ projectJVMVal bak ty ("field load " ++ J.fieldIdName fid ++ ", " ++ show (MS.conditionLoc md)) dyn
          matchArg opts sc cc spec prepost md v ty val
 
     JVMPointsToStatic md fid (Just val) ->
-      do ty <- typeOfSetupValue cc tyenv nameEnv val
+      do ty <- typeOfSetupValue cc sc tyenv nameEnv val
          dyn <- liftIO $ CJ.doStaticFieldLoad bak jc globals fid
          v <- liftIO $ projectJVMVal bak ty ("static field load " ++ J.fieldIdName fid ++ ", " ++ show (MS.conditionLoc md)) dyn
          matchArg opts sc cc spec prepost md v ty val
 
     JVMPointsToElem md ptr idx (Just val) ->
-      do ty <- typeOfSetupValue cc tyenv nameEnv val
+      do ty <- typeOfSetupValue cc sc tyenv nameEnv val
          rval <- resolveAllocIndexJVM ptr
          dyn <- liftIO $ CJ.doArrayLoad bak globals rval idx
          v <- liftIO $ projectJVMVal bak ty ("array load " ++ show idx ++ ", " ++ show (MS.conditionLoc md)) dyn
@@ -985,13 +985,14 @@ resolveSetupValueJVM opts cc sc spec sval =
 
 typeOfSetupValueJVM ::
   JVMCrucibleContext   ->
+  SharedContext ->
   CrucibleMethodSpecIR ->
   SetupValue           ->
   OverrideMatcher CJ.JVM w J.Type
-typeOfSetupValueJVM cc spec sval =
+typeOfSetupValueJVM cc sc spec sval =
   do let tyenv = MS.csAllocations spec
          nameEnv = MS.csTypeNames spec
-     liftIO $ typeOfSetupValue cc tyenv nameEnv sval
+     liftIO $ typeOfSetupValue cc sc tyenv nameEnv sval
 
 injectJVMVal :: Sym -> JVMVal -> Crucible.RegValue Sym CJ.JVMValueType
 injectJVMVal sym jv =

--- a/saw-central/src/SAWCentral/Crucible/JVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Override.hs
@@ -83,15 +83,12 @@ import           Data.Parameterized.Classes ((:~:)(..), testEquality)
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Some (Some(Some))
 
--- saw-support
-import qualified SAWSupport.Pretty as PPS
-
 -- saw-core
 import           SAWCore.Name (VarName(..))
 import           SAWCore.SharedTerm
 import           CryptolSAWCore.TypedTerm
 
-import           SAWCoreWhat4.ReturnTrip (toSC)
+import           SAWCoreWhat4.ReturnTrip (toSC, saw_sc)
 
 -- cryptol-saw-core
 import qualified CryptolSAWCore.Cryptol as Cryptol
@@ -243,16 +240,14 @@ methodSpecHandler opts sc cc top_loc _mdMap css h =
                    (st^.osLocation)
                    (methodSpecHandler_poststate opts sc cc retTy cs)
                 case res of
-                  Left (OF loc rsn)  -> do
-                    ppopts <- liftIO $ scGetPPOpts sc
+                  Left (OF ppopts loc rsn)  -> do
                     -- TODO, better pretty printing for reasons
-                    let rsn' = prettyOverrideFailureReason rsn
-                        rsn'' = PPS.render ppopts rsn'
+                    let rsn' = ppOverrideFailureReason ppopts rsn
                     liftIO
                       $ Crucible.abortExecBecause
                       $ Crucible.AssertionFailure
                       $ Crucible.SimError loc
-                      $ Crucible.AssertFailureSimError "assumed false" rsn''
+                      $ Crucible.AssertFailureSimError "assumed false" (Text.unpack rsn')
                   Right (ret,st') ->
                     do liftIO $ forM_ (st'^.osAssumes) $ \(_md,asum) ->
                          Crucible.addAssumption bak
@@ -344,12 +339,13 @@ learnCond ::
   StateSpec ->
   OverrideMatcher CJ.JVM w ()
 learnCond opts sc cc cs prepost ss =
-  do let loc = cs ^. MS.csLoc
+  do ppopts <- liftIO $ scGetPPOpts sc
+     let loc = cs ^. MS.csLoc
      matchPointsTos opts sc cc cs prepost (ss ^. MS.csPointsTos)
      traverse_ (learnSetupCondition opts sc cc cs prepost) (ss ^. MS.csConditions)
      assertTermEqualities sc cc
      enforceDisjointness cc loc ss
-     enforceCompleteSubstitution loc ss
+     enforceCompleteSubstitution ppopts loc ss
 
 
 assertTermEqualities ::
@@ -437,7 +433,8 @@ matchPointsTos opts sc cc spec prepost = go False []
     -- not all conditions processed, no progress, failure
     go False delayed [] = do
         delayed' <- liftIO $ mapM (prettyJVMPointsTo sc) delayed
-        failure (spec ^. MS.csLoc) (AmbiguousPointsTos delayed')
+        ppopts <- liftIO $ scGetPPOpts sc
+        failure ppopts (spec ^. MS.csLoc) (AmbiguousPointsTos delayed')
 
     -- not all conditions processed, progress made, resume delayed conditions
     go True delayed [] = go False [] delayed
@@ -476,14 +473,17 @@ computeReturnValue ::
   OverrideMatcher CJ.JVM w (Crucible.RegValue Sym ret)
                         {- ^ concrete return value                  -}
 
-computeReturnValue _opts _cc _sc spec ty Nothing =
+computeReturnValue _opts _cc sc spec ty Nothing =
   case ty of
     Crucible.UnitRepr -> return ()
-    _ -> failure (spec ^. MS.csLoc) (BadReturnSpecification (Some ty))
+    _ -> do
+        ppopts <- liftIO $ scGetPPOpts sc
+        failure ppopts (spec ^. MS.csLoc) (BadReturnSpecification (Some ty))
 
 computeReturnValue opts cc sc spec ty (Just val) =
   do val' <- resolveSetupValueJVM opts cc sc spec val
-     let fail_ = failure (spec ^. MS.csLoc) (BadReturnSpecification (Some ty))
+     ppopts <- liftIO $ scGetPPOpts sc
+     let fail_ = failure ppopts (spec ^. MS.csLoc) (BadReturnSpecification (Some ty))
      case val' of
        IVal i ->
          case testEquality ty CJ.intRepr of
@@ -557,12 +557,16 @@ matchArg opts sc cc cs prepost md actual@(RVal ref) expectedTy setupval =
     MS.SetupTuple  empty _ -> absurd empty
     MS.SetupSlice  empty   -> absurd empty
 
-    _ -> failure (cs ^. MS.csLoc) =<<
+    _ -> do
+        ppopts <- liftIO $ scGetPPOpts sc
+        failure ppopts (cs ^. MS.csLoc) =<<
            mkStructuralMismatch opts cc sc cs actual setupval expectedTy
 
-matchArg opts sc cc cs _prepost md actual expectedTy expected =
-  failure (MS.conditionLoc md) =<<
-    mkStructuralMismatch opts cc sc cs actual expected expectedTy
+matchArg opts sc cc cs _prepost md actual expectedTy expected = do
+  ppopts <-  liftIO $ scGetPPOpts sc
+  err <- mkStructuralMismatch opts cc sc cs actual expected expectedTy
+  failure ppopts (MS.conditionLoc md) err
+
 
 ------------------------------------------------------------------------
 
@@ -595,8 +599,11 @@ valueToSC sym _ _ (Cryptol.TVSeq 64 Cryptol.TVBit) (LVal x) =
   do st <- liftIO (sawCoreState sym)
      liftIO (toSC sym st x)
 
-valueToSC _sym md failMsg _tval _val =
-  failure (MS.conditionLoc md) failMsg
+valueToSC sym md failMsg _tval _val =
+  do st <- liftIO (sawCoreState sym)
+     let sc = saw_sc st
+     ppopts <- liftIO $ scGetPPOpts sc
+     failure ppopts (MS.conditionLoc md) failMsg
 
 ------------------------------------------------------------------------
 

--- a/saw-central/src/SAWCentral/Crucible/JVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Override.hs
@@ -244,9 +244,10 @@ methodSpecHandler opts sc cc top_loc _mdMap css h =
                    (methodSpecHandler_poststate opts sc cc retTy cs)
                 case res of
                   Left (OF loc rsn)  -> do
+                    ppopts <- liftIO $ scGetPPOpts sc
                     -- TODO, better pretty printing for reasons
                     let rsn' = prettyOverrideFailureReason rsn
-                        rsn'' = PPS.render PPS.defaultOpts rsn'
+                        rsn'' = PPS.render ppopts rsn'
                     liftIO
                       $ Crucible.abortExecBecause
                       $ Crucible.AssertionFailure

--- a/saw-central/src/SAWCentral/Crucible/JVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Override.hs
@@ -127,15 +127,14 @@ instance PP.Pretty JVMVal where
 mkStructuralMismatch ::
   Options              {- ^ output/verbosity options -} ->
   JVMCrucibleContext ->
-  SharedContext {- ^ context for constructing SAW terms -} ->
   CrucibleMethodSpecIR {- ^ for name and typing environments -} ->
   JVMVal {- ^ the value from the simulator -} ->
   SetupValue {- ^ the value from the spec -} ->
   J.Type     {- ^ the expected type -} ->
   OverrideMatcher CJ.JVM w (OverrideFailureReason CJ.JVM)
-mkStructuralMismatch opts cc sc spec jvmval setupval jty = do
-  setupTy <- typeOfSetupValueJVM cc sc spec setupval
-  setupJVal <- resolveSetupValueJVM opts cc sc spec setupval
+mkStructuralMismatch opts cc spec jvmval setupval jty = do
+  setupTy <- typeOfSetupValueJVM cc spec setupval
+  setupJVal <- resolveSetupValueJVM opts cc spec setupval
   pure $ StructuralMismatch
             (ppJVMVal jvmval)
             (ppJVMVal setupJVal)
@@ -481,7 +480,7 @@ computeReturnValue _opts _cc sc spec ty Nothing =
         failure ppopts (spec ^. MS.csLoc) (BadReturnSpecification (Some ty))
 
 computeReturnValue opts cc sc spec ty (Just val) =
-  do val' <- resolveSetupValueJVM opts cc sc spec val
+  do val' <- resolveSetupValueJVM opts cc spec val
      ppopts <- liftIO $ scGetPPOpts sc
      let fail_ = failure ppopts (spec ^. MS.csLoc) (BadReturnSpecification (Some ty))
      case val' of
@@ -538,7 +537,7 @@ matchArg opts sc cc cs prepost md actual expectedTy expected@(MS.SetupTerm expec
   | TypedTermSchema (Cryptol.Forall [] [] tyexpr) <- ttType expectedTT
   , Right tval <- Cryptol.evalType mempty tyexpr
   = do sym <- Ov.getSymInterface
-       failMsg  <- mkStructuralMismatch opts cc sc cs actual expected expectedTy
+       failMsg  <- mkStructuralMismatch opts cc cs actual expected expectedTy
        realTerm <- valueToSC sym md failMsg tval actual
        matchTerm sc md prepost realTerm (ttTerm expectedTT)
 
@@ -560,11 +559,11 @@ matchArg opts sc cc cs prepost md actual@(RVal ref) expectedTy setupval =
     _ -> do
         ppopts <- liftIO $ scGetPPOpts sc
         failure ppopts (cs ^. MS.csLoc) =<<
-           mkStructuralMismatch opts cc sc cs actual setupval expectedTy
+           mkStructuralMismatch opts cc cs actual setupval expectedTy
 
 matchArg opts sc cc cs _prepost md actual expectedTy expected = do
   ppopts <-  liftIO $ scGetPPOpts sc
-  err <- mkStructuralMismatch opts cc sc cs actual expected expectedTy
+  err <- mkStructuralMismatch opts cc cs actual expected expectedTy
   failure ppopts (MS.conditionLoc md) err
 
 
@@ -619,7 +618,7 @@ learnSetupCondition ::
   OverrideMatcher CJ.JVM w ()
 learnSetupCondition opts sc cc spec prepost cond =
   case cond of
-    MS.SetupCond_Equal md val1 val2 -> learnEqual opts sc cc spec md prepost val1 val2
+    MS.SetupCond_Equal md val1 val2 -> learnEqual opts cc spec md prepost val1 val2
     MS.SetupCond_Pred md tm         -> learnPred sc cc md prepost (ttTerm tm)
     MS.SetupCond_Ghost md var val   -> learnGhost sc md prepost var val
 
@@ -646,20 +645,20 @@ learnPointsTo opts sc cc spec prepost pt =
   case pt of
 
     JVMPointsToField md ptr fid (Just val) ->
-      do ty <- typeOfSetupValue cc sc tyenv nameEnv val
+      do ty <- typeOfSetupValue cc tyenv nameEnv val
          rval <- resolveAllocIndexJVM ptr
          dyn <- liftIO $ CJ.doFieldLoad bak globals rval fid
          v <- liftIO $ projectJVMVal bak ty ("field load " ++ J.fieldIdName fid ++ ", " ++ show (MS.conditionLoc md)) dyn
          matchArg opts sc cc spec prepost md v ty val
 
     JVMPointsToStatic md fid (Just val) ->
-      do ty <- typeOfSetupValue cc sc tyenv nameEnv val
+      do ty <- typeOfSetupValue cc tyenv nameEnv val
          dyn <- liftIO $ CJ.doStaticFieldLoad bak jc globals fid
          v <- liftIO $ projectJVMVal bak ty ("static field load " ++ J.fieldIdName fid ++ ", " ++ show (MS.conditionLoc md)) dyn
          matchArg opts sc cc spec prepost md v ty val
 
     JVMPointsToElem md ptr idx (Just val) ->
-      do ty <- typeOfSetupValue cc sc tyenv nameEnv val
+      do ty <- typeOfSetupValue cc tyenv nameEnv val
          rval <- resolveAllocIndexJVM ptr
          dyn <- liftIO $ CJ.doArrayLoad bak globals rval idx
          v <- liftIO $ projectJVMVal bak ty ("array load " ++ show idx ++ ", " ++ show (MS.conditionLoc md)) dyn
@@ -707,7 +706,6 @@ learnPointsTo opts sc cc spec prepost pt =
 -- section of the CrucibleSetup block.
 learnEqual ::
   Options                                          ->
-  SharedContext                                    ->
   JVMCrucibleContext                                  ->
   CrucibleMethodSpecIR                             ->
   MS.ConditionMetadata                             ->
@@ -715,9 +713,9 @@ learnEqual ::
   SetupValue       {- ^ first value to compare  -} ->
   SetupValue       {- ^ second value to compare -} ->
   OverrideMatcher CJ.JVM w ()
-learnEqual opts sc cc spec md prepost v1 v2 =
-  do val1 <- resolveSetupValueJVM opts cc sc spec v1
-     val2 <- resolveSetupValueJVM opts cc sc spec v2
+learnEqual opts cc spec md prepost v1 v2 =
+  do val1 <- resolveSetupValueJVM opts cc spec v1
+     val2 <- resolveSetupValueJVM opts cc spec v2
      p <- liftIO (equalValsPred cc val1 val2)
      let name = "equality " ++ MS.stateCond prepost
      let loc = MS.conditionLoc md
@@ -791,7 +789,7 @@ executeSetupCondition ::
 executeSetupCondition opts sc cc spec =
   \case
     MS.SetupCond_Equal md val1 val2 ->
-      executeEqual opts sc cc spec md val1 val2
+      executeEqual opts cc spec md val1 val2
     MS.SetupCond_Pred md tm -> executePred sc cc md tm
     MS.SetupCond_Ghost md var val -> executeGhost sc md var val
 
@@ -815,18 +813,18 @@ executePointsTo opts sc cc spec pt =
   case pt of
 
     JVMPointsToField _loc ptr fid val ->
-      do dyn <- maybe (pure CJ.unassignedJVMValue) (injectSetupValueJVM sym opts cc sc spec) val
+      do dyn <- maybe (pure CJ.unassignedJVMValue) (injectSetupValueJVM sym opts cc spec) val
          rval <- resolveAllocIndexJVM ptr
          globals' <- liftIO $ CJ.doFieldStore bak globals rval fid dyn
          OM (overrideGlobals .= globals')
 
     JVMPointsToStatic _loc fid val ->
-      do dyn <- maybe (pure CJ.unassignedJVMValue) (injectSetupValueJVM sym opts cc sc spec) val
+      do dyn <- maybe (pure CJ.unassignedJVMValue) (injectSetupValueJVM sym opts cc spec) val
          globals' <- liftIO $ CJ.doStaticFieldStore bak jc globals fid dyn
          OM (overrideGlobals .= globals')
 
     JVMPointsToElem _loc ptr idx val ->
-      do dyn <- maybe (pure CJ.unassignedJVMValue) (injectSetupValueJVM sym opts cc sc spec) val
+      do dyn <- maybe (pure CJ.unassignedJVMValue) (injectSetupValueJVM sym opts cc spec) val
          rval <- resolveAllocIndexJVM ptr
          globals' <- liftIO $ CJ.doArrayStore bak globals rval idx dyn
          OM (overrideGlobals .= globals')
@@ -839,7 +837,7 @@ executePointsTo opts sc cc spec pt =
              Nothing -> fail "jvm_array_is: not a monomorphic sequence type"
              Just x -> pure x
          rval <- resolveAllocIndexJVM ptr
-         vs <- traverse (injectSetupValueJVM sym opts cc sc spec . MS.SetupTerm) tts
+         vs <- traverse (injectSetupValueJVM sym opts cc spec . MS.SetupTerm) tts
          globals' <- liftIO $ doEntireArrayStore bak globals rval vs
          OM (overrideGlobals .= globals')
 
@@ -856,12 +854,11 @@ injectSetupValueJVM ::
   Sym                  ->
   Options              ->
   JVMCrucibleContext   ->
-  SharedContext        ->
   CrucibleMethodSpecIR ->
   SetupValue           ->
   OverrideMatcher CJ.JVM w (Crucible.RegValue Sym CJ.JVMValueType)
-injectSetupValueJVM sym opts cc sc spec val =
-  injectJVMVal sym <$> resolveSetupValueJVM opts cc sc spec val
+injectSetupValueJVM sym opts cc spec val =
+  injectJVMVal sym <$> resolveSetupValueJVM opts cc spec val
 
 doEntireArrayStore ::
   (Crucible.IsSymBackend sym bak) =>
@@ -900,16 +897,15 @@ destVecTypedTerm sc env (TypedTerm ttp t) =
 -- section of the CrucibleSetup block.
 executeEqual ::
   Options                                          ->
-  SharedContext                                    ->
   JVMCrucibleContext                                  ->
   CrucibleMethodSpecIR                             ->
   MS.ConditionMetadata ->
   SetupValue       {- ^ first value to compare  -} ->
   SetupValue       {- ^ second value to compare -} ->
   OverrideMatcher CJ.JVM w ()
-executeEqual opts sc cc spec md v1 v2 =
-  do val1 <- resolveSetupValueJVM opts cc sc spec v1
-     val2 <- resolveSetupValueJVM opts cc sc spec v2
+executeEqual opts cc spec md v1 v2 =
+  do val1 <- resolveSetupValueJVM opts cc spec v1
+     val2 <- resolveSetupValueJVM opts cc spec v2
      p <- liftIO (equalValsPred cc val1 val2)
      addAssume p md
 
@@ -971,12 +967,12 @@ resolveAllocIndexJVM i =
 resolveSetupValueJVM ::
   Options              ->
   JVMCrucibleContext   ->
-  SharedContext        ->
   CrucibleMethodSpecIR ->
   SetupValue           ->
   OverrideMatcher CJ.JVM w JVMVal
-resolveSetupValueJVM opts cc sc spec sval =
-  do m <- OM (use setupValueSub)
+resolveSetupValueJVM opts cc spec sval =
+  do sc <- liftIO $ saw_sc <$> sawCoreState (cc ^. jccSym)
+     m <- OM (use setupValueSub)
      s <- OM (use termSub)
      let tyenv = MS.csAllocations spec
          nameEnv = MS.csTypeNames spec
@@ -985,14 +981,13 @@ resolveSetupValueJVM opts cc sc spec sval =
 
 typeOfSetupValueJVM ::
   JVMCrucibleContext   ->
-  SharedContext ->
   CrucibleMethodSpecIR ->
   SetupValue           ->
   OverrideMatcher CJ.JVM w J.Type
-typeOfSetupValueJVM cc sc spec sval =
+typeOfSetupValueJVM cc spec sval =
   do let tyenv = MS.csAllocations spec
          nameEnv = MS.csTypeNames spec
-     liftIO $ typeOfSetupValue cc sc tyenv nameEnv sval
+     liftIO $ typeOfSetupValue cc tyenv nameEnv sval
 
 injectJVMVal :: Sym -> JVMVal -> Crucible.RegValue Sym CJ.JVMValueType
 injectJVMVal sym jv =

--- a/saw-central/src/SAWCentral/Crucible/JVM/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/ResolveSetupValue.hs
@@ -39,9 +39,14 @@ import qualified Cryptol.TypeCheck.AST as Cryptol (Type, Schema(..))
 import qualified What4.BaseTypes as W4
 import qualified What4.Interface as W4
 
+import Prettyprinter ((<+>))
+
+import qualified SAWSupport.Pretty as PPS
+
 import SAWCore.SharedTerm
 import qualified CryptolSAWCore.Pretty as CryPP
 import CryptolSAWCore.TypedTerm
+import SAWCoreWhat4.ReturnTrip (saw_sc)
 
 -- crucible
 
@@ -98,7 +103,7 @@ instance Show JVMTypeOfError where
   show (JVMInvalidTypedTerm tp) =
     unlines
     [ "Expected typed term with Cryptol representable type, but got"
-    , show (prettyTypedTermTypePure tp)
+    , show (prettyTypedTermTypePure PPS.defaultOpts tp)
     ]
 
 instance X.Exception JVMTypeOfError
@@ -195,11 +200,14 @@ resolveTypedTerm cc tm =
   case ttType tm of
     TypedTermSchema (Cryptol.Forall [] [] ty) ->
       resolveSAWTerm cc (Cryptol.evalValType mempty ty) (ttTerm tm)
-    tp -> fail $ unlines
-            [ "resolveSetupVal: expected monomorphic term"
-            , "but got a term of type"
-            , show (prettyTypedTermTypePure tp)
-            ]
+    tp -> do
+        let sym = cc ^. jccSym
+        st <- sawCoreState sym
+        let sc = saw_sc st
+        ppopts <- scGetPPOpts sc
+        tp' <- prettyTypedTermType sc tp
+        fail $ PPS.render ppopts $ "resolveSetupVal: expected monomorphic" <+>
+            "term, but got a term of type" <+> tp'
 
 resolveSAWPred ::
   JVMCrucibleContext ->

--- a/saw-central/src/SAWCentral/Crucible/JVM/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/ResolveSetupValue.hs
@@ -35,13 +35,13 @@ import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Void (absurd)
 
+import Prettyprinter ((<+>))
+
 import qualified Cryptol.Eval.Type as Cryptol (TValue(..), evalValType)
 import qualified Cryptol.TypeCheck.AST as Cryptol (Schema(..))
 
 import qualified What4.BaseTypes as W4
 import qualified What4.Interface as W4
-
-import Prettyprinter ((<+>))
 
 import qualified SAWSupport.Pretty as PPS
 

--- a/saw-central/src/SAWCentral/Crucible/JVM/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/ResolveSetupValue.hs
@@ -27,14 +27,16 @@ module SAWCentral.Crucible.JVM.ResolveSetupValue
 
 import           Control.Lens
 import qualified Control.Monad.Catch as X
+import           Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Data.BitVector.Sized as BV
 import qualified Data.Text as Text
+import           Data.Text (Text)
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Void (absurd)
 
 import qualified Cryptol.Eval.Type as Cryptol (TValue(..), evalValType)
-import qualified Cryptol.TypeCheck.AST as Cryptol (Type, Schema(..))
+import qualified Cryptol.TypeCheck.AST as Cryptol (Schema(..))
 
 import qualified What4.BaseTypes as W4
 import qualified What4.Interface as W4
@@ -83,39 +85,45 @@ instance Show JVMVal where
 
 type SetupValue = MS.SetupValue CJ.JVM
 
+-- | This contains the prettyprinter options plus already-printed
+--   values to allow the `Show` instance required by `X.Exception` to
+--   print correctly.
 data JVMTypeOfError
-  = JVMPolymorphicType Cryptol.Schema
-  | JVMNonRepresentableType Cryptol.Type
-  | JVMInvalidTypedTerm TypedTermType
+  = JVMPolymorphicType PPS.Opts PPS.Doc -- Cryptol.Schema
+  | JVMNonRepresentableType PPS.Opts PPS.Doc -- Cryptol.Type
+  | JVMInvalidTypedTerm PPS.Opts PPS.Doc -- TypedTermType
+
+ppJVMTypeOfError :: JVMTypeOfError -> Text
+ppJVMTypeOfError err =
+  let (ppopts_, msg_) = case err of
+        JVMPolymorphicType ppopts s ->
+            let msg = "Expected monomorphic term; instead got" <+> s in
+            (ppopts, msg)
+        JVMNonRepresentableType ppopts ty ->
+            let msg = "Type not representable in JVM:" <+> ty in
+            (ppopts, msg)
+        JVMInvalidTypedTerm ppopts tp ->
+            let msg = "Expected typed term with Cryptol representable type," <+>
+                      "but got" <+> tp
+            in
+            (ppopts, msg)
+  in
+  PPS.renderText ppopts_ msg_
 
 instance Show JVMTypeOfError where
-  show (JVMPolymorphicType s) =
-    unlines
-    [ "Expected monomorphic term"
-    , "instead got:"
-    , Text.unpack (CryPP.pp s)
-    ]
-  show (JVMNonRepresentableType ty) =
-    unlines
-    [ "Type not representable in JVM:"
-    , Text.unpack (CryPP.pp ty)
-    ]
-  show (JVMInvalidTypedTerm tp) =
-    unlines
-    [ "Expected typed term with Cryptol representable type, but got"
-    , show (prettyTypedTermTypePure PPS.defaultOpts tp)
-    ]
+  show err = Text.unpack $ ppJVMTypeOfError err
 
 instance X.Exception JVMTypeOfError
 
 typeOfSetupValue ::
-  X.MonadThrow m =>
+  (X.MonadThrow m, MonadIO m) =>
   JVMCrucibleContext ->
+  SharedContext ->
   Map AllocIndex (MS.ConditionMetadata, Allocation) ->
   Map AllocIndex JIdent ->
   SetupValue ->
   m J.Type
-typeOfSetupValue _cc env _nameEnv val =
+typeOfSetupValue _cc sc env _nameEnv val =
   case val of
     MS.SetupVar i ->
       case Map.lookup i env of
@@ -128,10 +136,19 @@ typeOfSetupValue _cc env _nameEnv val =
       case ttType tt of
         TypedTermSchema (Cryptol.Forall [] [] ty) ->
           case toJVMType (Cryptol.evalValType mempty ty) of
-            Nothing -> X.throwM (JVMNonRepresentableType ty)
+            Nothing -> do
+              ppopts <- liftIO $ scGetPPOpts sc
+              let ty' = CryPP.pretty ty
+              X.throwM (JVMNonRepresentableType ppopts ty')
             Just jty -> return jty
-        TypedTermSchema s -> X.throwM (JVMPolymorphicType s)
-        tp -> X.throwM (JVMInvalidTypedTerm tp)
+        TypedTermSchema s -> do
+          ppopts <- liftIO $ scGetPPOpts sc
+          let s' = CryPP.pretty s
+          X.throwM (JVMPolymorphicType ppopts s')
+        tp -> do
+          ppopts <- liftIO $ scGetPPOpts sc
+          tp' <- liftIO $ prettyTypedTermType sc tp
+          X.throwM (JVMInvalidTypedTerm ppopts tp')
 
     MS.SetupNull () ->
       -- We arbitrarily set the type of NULL to java.lang.Object,

--- a/saw-central/src/SAWCentral/Crucible/JVM/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/ResolveSetupValue.hs
@@ -118,12 +118,11 @@ instance X.Exception JVMTypeOfError
 typeOfSetupValue ::
   (X.MonadThrow m, MonadIO m) =>
   JVMCrucibleContext ->
-  SharedContext ->
   Map AllocIndex (MS.ConditionMetadata, Allocation) ->
   Map AllocIndex JIdent ->
   SetupValue ->
   m J.Type
-typeOfSetupValue _cc sc env _nameEnv val =
+typeOfSetupValue cc env _nameEnv val =
   case val of
     MS.SetupVar i ->
       case Map.lookup i env of
@@ -137,15 +136,21 @@ typeOfSetupValue _cc sc env _nameEnv val =
         TypedTermSchema (Cryptol.Forall [] [] ty) ->
           case toJVMType (Cryptol.evalValType mempty ty) of
             Nothing -> do
+              let sym = cc ^. jccSym
+              sc <- liftIO $ saw_sc <$> sawCoreState sym
               ppopts <- liftIO $ scGetPPOpts sc
               let ty' = CryPP.pretty ty
               X.throwM (JVMNonRepresentableType ppopts ty')
             Just jty -> return jty
         TypedTermSchema s -> do
+          let sym = cc ^. jccSym
+          sc <- liftIO $ saw_sc <$> sawCoreState sym
           ppopts <- liftIO $ scGetPPOpts sc
           let s' = CryPP.pretty s
           X.throwM (JVMPolymorphicType ppopts s')
         tp -> do
+          let sym = cc ^. jccSym
+          sc <- liftIO $ saw_sc <$> sawCoreState sym
           ppopts <- liftIO $ scGetPPOpts sc
           tp' <- liftIO $ prettyTypedTermType sc tp
           X.throwM (JVMInvalidTypedTerm ppopts tp')

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
@@ -2139,7 +2139,7 @@ constructExpandedSetupValue cc sc loc t =
   case t of
     Crucible.IntType w ->
       do let cty = Cryptol.tWord (Cryptol.tNum w)
-         cryenv <- lift $ lift $ getCryptolEnv
+         cryenv <- lift $ lift getCryptolEnv
          fv <- Setup.freshVariable sc cryenv "" cty
          pure $ mkAllLLVM (SetupTerm fv)
 
@@ -2581,7 +2581,7 @@ llvm_points_to_bitfield (getAllLLVM -> ptr) fieldName (getAllLLVM -> val) =
           let path = [ResolvedField fieldName]
           _ <- llvm_points_to_check_lhs_validity ptr loc path
 
-          sc <- lift $ lift $ getSharedContext
+          sc <- lift $ lift getSharedContext
           bfIndex <- exceptToFail sc $ resolveSetupBitfield cc env nameEnv ptr fieldName'
           let lhsFieldTy = Crucible.IntType $ fromIntegral $ biFieldSize bfIndex
           valTy <- exceptToFail sc $ typeOfSetupValue cc env nameEnv val
@@ -2625,7 +2625,7 @@ llvm_points_to_check_lhs_validity ptr loc path =
        else Setup.csResolvedState %= markResolved ptr path
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
          nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
-     sc <- lift $ lift $ getSharedContext
+     sc <- lift $ lift getSharedContext
      ptrTy <- exceptToFail sc $ typeOfSetupValue cc env nameEnv ptr
      case ptrTy of
        Crucible.PtrType symTy ->
@@ -2666,7 +2666,7 @@ llvm_points_to_array_prefix (getAllLLVM -> ptr) arr sz =
               , Cryptol.pretty ty
               ]
        _ -> do
-           sc <- lift $ lift $ getSharedContext
+           sc <- lift $ lift getSharedContext
            sz' <- liftIO $ ppTerm sc (ttTerm sz)
            throwCrucibleSetup loc $ unwords
               [ "llvm_points_to_array_prefix:"
@@ -2683,7 +2683,7 @@ llvm_points_to_array_prefix (getAllLLVM -> ptr) arr sz =
             else Setup.csResolvedState %= markResolved ptr []
           let env = MS.csAllocations (st ^. Setup.csMethodSpec)
               nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
-          sc <- lift $ lift $ getSharedContext
+          sc <- lift $ lift getSharedContext
           ptrTy <- exceptToFail sc $ typeOfSetupValue cc env nameEnv ptr
           _ <- case ptrTy of
             Crucible.PtrType symTy ->
@@ -2716,7 +2716,7 @@ llvm_equal (getAllLLVM -> val1) (getAllLLVM -> val2) =
      st <- get
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
          nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
-     sc <- lift $ lift $ getSharedContext
+     sc <- lift $ lift getSharedContext
      ty1 <- exceptToFail sc $ typeOfSetupValue cc env nameEnv val1
      ty2 <- exceptToFail sc $ typeOfSetupValue cc env nameEnv val2
 

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
@@ -582,8 +582,9 @@ withMethodSpec pathSat lm nm setup action =
                 "Missing llvm_execute_func specification when verifying " <>
                 methodSpec^.csName
 
-              io $ checkSpecArgumentTypes cc1 methodSpec
-              io $ checkSpecReturnType cc1 methodSpec
+              sc <- getSharedContext
+              io $ checkSpecArgumentTypes sc cc1 methodSpec
+              io $ checkSpecReturnType sc cc1 methodSpec
 
               action cc1 methodSpec
 
@@ -849,10 +850,11 @@ throwMethodSpec mspec msg = X.throw $ LLVMMethodSpecException (mspec ^. MS.csLoc
 -- The expected types are inferred from the LLVM module.
 checkSpecArgumentTypes ::
   Crucible.HasPtrWidth (Crucible.ArchWidth arch) =>
+  SharedContext ->
   LLVMCrucibleContext arch ->
   MS.CrucibleMethodSpecIR (LLVM arch) ->
   IO ()
-checkSpecArgumentTypes cc mspec = mapM_ resolveArg [0..(nArgs-1)]
+checkSpecArgumentTypes sc cc mspec = mapM_ resolveArg [0..(nArgs-1)]
   where
     nArgs = toInteger (length (mspec ^. MS.csArgs))
     tyenv = MS.csAllocations mspec
@@ -874,7 +876,7 @@ checkSpecArgumentTypes cc mspec = mapM_ resolveArg [0..(nArgs-1)]
     resolveArg i =
       case Map.lookup i (mspec ^. MS.csArgBindings) of
         Just (mt, sv) -> do
-          mt' <- exceptToFail (typeOfSetupValue cc tyenv nameEnv sv)
+          mt' <- exceptToFail sc (typeOfSetupValue cc tyenv nameEnv sv)
           checkArgTy i mt mt'
         Nothing -> throwMethodSpec mspec $ unwords
           ["Argument", show i, "unspecified when verifying", show nm]
@@ -887,17 +889,18 @@ checkSpecArgumentTypes cc mspec = mapM_ resolveArg [0..(nArgs-1)]
 -- TODO: generalize, put in Setup.Builtins
 checkSpecReturnType ::
   Crucible.HasPtrWidth (Crucible.ArchWidth arch) =>
+  SharedContext ->
   LLVMCrucibleContext arch ->
   MS.CrucibleMethodSpecIR (LLVM arch) ->
   IO ()
-checkSpecReturnType cc mspec =
+checkSpecReturnType sc cc mspec =
   case (mspec ^. MS.csRetValue, mspec ^. MS.csRet) of
     (Just _, Nothing) ->
          throwMethodSpec mspec $ Text.unpack $
              "Return value specified, but function " <> mspec ^. csName <>
              " has void return type"
     (Just sv, Just retTy) ->
-      do retTy' <- exceptToFail $
+      do retTy' <- exceptToFail sc $
            typeOfSetupValue cc
              (MS.csAllocations mspec) -- map allocation indices to allocations
              (mspec ^. MS.csPreState . MS.csVarTypeNames) -- map alloc indices to var names
@@ -2532,7 +2535,8 @@ llvm_points_to_internal mbCheckType cond (getAllLLVM -> ptr) (getAllLLVM -> val)
           let path = []
           lhsTy <- llvm_points_to_check_lhs_validity ptr loc path
 
-          valTy <- exceptToFail $ typeOfSetupValue cc env nameEnv val
+          sc <- lift $ lift $ getSharedContext
+          valTy <- exceptToFail sc $ typeOfSetupValue cc env nameEnv val
           case mbCheckType of
             Nothing                                -> pure ()
             Just Setup.CheckAgainstPointerType     -> checkMemTypeCompatibility loc lhsTy valTy
@@ -2577,9 +2581,10 @@ llvm_points_to_bitfield (getAllLLVM -> ptr) fieldName (getAllLLVM -> val) =
           let path = [ResolvedField fieldName]
           _ <- llvm_points_to_check_lhs_validity ptr loc path
 
-          bfIndex <- exceptToFail $ resolveSetupBitfield cc env nameEnv ptr fieldName'
+          sc <- lift $ lift $ getSharedContext
+          bfIndex <- exceptToFail sc $ resolveSetupBitfield cc env nameEnv ptr fieldName'
           let lhsFieldTy = Crucible.IntType $ fromIntegral $ biFieldSize bfIndex
-          valTy <- exceptToFail $ typeOfSetupValue cc env nameEnv val
+          valTy <- exceptToFail sc $ typeOfSetupValue cc env nameEnv val
           -- Currently, we require the type of the RHS value to precisely match
           -- the type of the field within the bitfield. One could imagine
           -- having finer-grained control over this (e.g.,
@@ -2620,7 +2625,8 @@ llvm_points_to_check_lhs_validity ptr loc path =
        else Setup.csResolvedState %= markResolved ptr path
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
          nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
-     ptrTy <- exceptToFail $ typeOfSetupValue cc env nameEnv ptr
+     sc <- lift $ lift $ getSharedContext
+     ptrTy <- exceptToFail sc $ typeOfSetupValue cc env nameEnv ptr
      case ptrTy of
        Crucible.PtrType symTy ->
          case Crucible.asMemType symTy of
@@ -2677,7 +2683,8 @@ llvm_points_to_array_prefix (getAllLLVM -> ptr) arr sz =
             else Setup.csResolvedState %= markResolved ptr []
           let env = MS.csAllocations (st ^. Setup.csMethodSpec)
               nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
-          ptrTy <- exceptToFail $ typeOfSetupValue cc env nameEnv ptr
+          sc <- lift $ lift $ getSharedContext
+          ptrTy <- exceptToFail sc $ typeOfSetupValue cc env nameEnv ptr
           _ <- case ptrTy of
             Crucible.PtrType symTy ->
               case Crucible.asMemType symTy of
@@ -2709,8 +2716,9 @@ llvm_equal (getAllLLVM -> val1) (getAllLLVM -> val2) =
      st <- get
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
          nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
-     ty1 <- exceptToFail $ typeOfSetupValue cc env nameEnv val1
-     ty2 <- exceptToFail $ typeOfSetupValue cc env nameEnv val2
+     sc <- lift $ lift $ getSharedContext
+     ty1 <- exceptToFail sc $ typeOfSetupValue cc env nameEnv val1
+     ty2 <- exceptToFail sc $ typeOfSetupValue cc env nameEnv val2
 
      b <- liftIO $ checkRegisterCompatibility ty1 ty2
      unless b $ throwCrucibleSetup loc $ unlines

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
@@ -876,7 +876,7 @@ checkSpecArgumentTypes sc cc mspec = mapM_ resolveArg [0..(nArgs-1)]
     resolveArg i =
       case Map.lookup i (mspec ^. MS.csArgBindings) of
         Just (mt, sv) -> do
-          mt' <- exceptToFail sc (typeOfSetupValue cc tyenv nameEnv sv)
+          mt' <- llvmExceptToFail sc (typeOfSetupValue cc tyenv nameEnv sv)
           checkArgTy i mt mt'
         Nothing -> throwMethodSpec mspec $ unwords
           ["Argument", show i, "unspecified when verifying", show nm]
@@ -900,7 +900,7 @@ checkSpecReturnType sc cc mspec =
              "Return value specified, but function " <> mspec ^. csName <>
              " has void return type"
     (Just sv, Just retTy) ->
-      do retTy' <- exceptToFail sc $
+      do retTy' <- llvmExceptToFail sc $
            typeOfSetupValue cc
              (MS.csAllocations mspec) -- map allocation indices to allocations
              (mspec ^. MS.csPreState . MS.csVarTypeNames) -- map alloc indices to var names
@@ -2536,7 +2536,7 @@ llvm_points_to_internal mbCheckType cond (getAllLLVM -> ptr) (getAllLLVM -> val)
           lhsTy <- llvm_points_to_check_lhs_validity ptr loc path
 
           sc <- lift $ lift getSharedContext
-          valTy <- exceptToFail sc $ typeOfSetupValue cc env nameEnv val
+          valTy <- llvmExceptToFail sc $ typeOfSetupValue cc env nameEnv val
           case mbCheckType of
             Nothing                                -> pure ()
             Just Setup.CheckAgainstPointerType     -> checkMemTypeCompatibility loc lhsTy valTy
@@ -2582,9 +2582,9 @@ llvm_points_to_bitfield (getAllLLVM -> ptr) fieldName (getAllLLVM -> val) =
           _ <- llvm_points_to_check_lhs_validity ptr loc path
 
           sc <- lift $ lift getSharedContext
-          bfIndex <- exceptToFail sc $ resolveSetupBitfield cc env nameEnv ptr fieldName'
+          bfIndex <- llvmExceptToFail sc $ resolveSetupBitfield cc env nameEnv ptr fieldName'
           let lhsFieldTy = Crucible.IntType $ fromIntegral $ biFieldSize bfIndex
-          valTy <- exceptToFail sc $ typeOfSetupValue cc env nameEnv val
+          valTy <- llvmExceptToFail sc $ typeOfSetupValue cc env nameEnv val
           -- Currently, we require the type of the RHS value to precisely match
           -- the type of the field within the bitfield. One could imagine
           -- having finer-grained control over this (e.g.,
@@ -2626,7 +2626,7 @@ llvm_points_to_check_lhs_validity ptr loc path =
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
          nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
      sc <- lift $ lift getSharedContext
-     ptrTy <- exceptToFail sc $ typeOfSetupValue cc env nameEnv ptr
+     ptrTy <- llvmExceptToFail sc $ typeOfSetupValue cc env nameEnv ptr
      case ptrTy of
        Crucible.PtrType symTy ->
          case Crucible.asMemType symTy of
@@ -2684,7 +2684,7 @@ llvm_points_to_array_prefix (getAllLLVM -> ptr) arr sz =
           let env = MS.csAllocations (st ^. Setup.csMethodSpec)
               nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
           sc <- lift $ lift getSharedContext
-          ptrTy <- exceptToFail sc $ typeOfSetupValue cc env nameEnv ptr
+          ptrTy <- llvmExceptToFail sc $ typeOfSetupValue cc env nameEnv ptr
           _ <- case ptrTy of
             Crucible.PtrType symTy ->
               case Crucible.asMemType symTy of
@@ -2717,8 +2717,8 @@ llvm_equal (getAllLLVM -> val1) (getAllLLVM -> val2) =
      let env = MS.csAllocations (st ^. Setup.csMethodSpec)
          nameEnv = MS.csTypeNames (st ^. Setup.csMethodSpec)
      sc <- lift $ lift getSharedContext
-     ty1 <- exceptToFail sc $ typeOfSetupValue cc env nameEnv val1
-     ty2 <- exceptToFail sc $ typeOfSetupValue cc env nameEnv val2
+     ty1 <- llvmExceptToFail sc $ typeOfSetupValue cc env nameEnv val1
+     ty2 <- llvmExceptToFail sc $ typeOfSetupValue cc env nameEnv val2
 
      b <- liftIO $ checkRegisterCompatibility ty1 ty2
      unless b $ throwCrucibleSetup loc $ unlines

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
@@ -161,6 +161,9 @@ import qualified Lang.Crucible.LLVM.Translation as Crucible
 
 import qualified SAWCentral.Crucible.LLVM.CrucibleLLVM as Crucible
 
+-- saw-support
+import qualified SAWSupport.Pretty as PPS
+
 -- saw-core
 import SAWCore.FiniteValue (prettyFirstOrderValue)
 import SAWCore.Name (VarName(..))
@@ -1132,11 +1135,14 @@ setupPrestateConditions mspec cc mem env = aux []
       case val of
         TypedTerm (TypedTermSchema sch) tm ->
           aux acc (Crucible.insertGlobal var (sch,tm) globals) xs
-        TypedTerm tp _ ->
-          fail $ unlines
-            [ "Setup term for global variable expected to have Cryptol schema type, but got"
-            , show (prettyTypedTermTypePure tp)
-            ]
+        TypedTerm tp _ -> do
+          let sym = cc ^. ccSym
+          st <- Common.sawCoreState sym
+          let sc = saw_sc st
+          ppopts <- scGetPPOpts sc
+          tp' <- prettyTypedTermType sc tp
+          fail $ PPS.render ppopts $ "Setup term for global variable should" <+>
+              "have Cryptol schema type, but got" <+> tp'
 
 --------------------------------------------------------------------------------
 

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
@@ -2535,7 +2535,7 @@ llvm_points_to_internal mbCheckType cond (getAllLLVM -> ptr) (getAllLLVM -> val)
           let path = []
           lhsTy <- llvm_points_to_check_lhs_validity ptr loc path
 
-          sc <- lift $ lift $ getSharedContext
+          sc <- lift $ lift getSharedContext
           valTy <- exceptToFail sc $ typeOfSetupValue cc env nameEnv val
           case mbCheckType of
             Nothing                                -> pure ()

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
@@ -1204,7 +1204,7 @@ matchArg opts sc cc cs prepost md actual expectedTy expected =
     (Crucible.LLVMValInt blk off, _, SetupElem () v i) | Crucible.isPointerMemType expectedTy ->
       do let tyenv = MS.csAllocations cs
              nameEnv = MS.csTypeNames cs
-         delta <- exceptToFail sc $ resolveSetupElemOffset cc tyenv nameEnv v i
+         delta <- llvmExceptToFail sc $ resolveSetupElemOffset cc tyenv nameEnv v i
          off' <- liftIO $ W4.bvSub sym off
            =<< W4.bvLit sym (W4.bvWidth off) (Crucible.bytesToBV (W4.bvWidth off) delta)
          matchArg opts sc cc cs prepost md (Crucible.LLVMValInt blk off') expectedTy v
@@ -1212,7 +1212,7 @@ matchArg opts sc cc cs prepost md actual expectedTy expected =
     (Crucible.LLVMValInt blk off, _, SetupField () v n) | Crucible.isPointerMemType expectedTy ->
       do let tyenv = MS.csAllocations cs
              nameEnv = MS.csTypeNames cs
-         fld <- exceptToFail sc $
+         fld <- llvmExceptToFail sc $
                   do info <- resolveSetupValueInfo cc tyenv nameEnv v
                      recoverStructFieldInfo cc tyenv nameEnv v info n
          let delta = fromIntegral $ Crucible.fiOffset fld
@@ -1454,7 +1454,7 @@ matchPointsToValue opts sc cc spec prepost md maybe_cond ptr val =
 
      case val of
        ConcreteSizeValue val' ->
-         do memTy <- exceptToFail sc $ typeOfSetupValue cc tyenv nameEnv val'
+         do memTy <- llvmExceptToFail sc $ typeOfSetupValue cc tyenv nameEnv val'
             -- In case the types are different (from llvm_points_to_untyped)
             -- then the load type should be determined by the rhs.
             storTy <- Crucible.toStorableType memTy
@@ -1863,7 +1863,7 @@ invalidateMutableAllocs opts sc cc cs =
       LLVMPointsTo _loc _cond ptr val -> case val of
         ConcreteSizeValue val' -> do
           (_, Crucible.LLVMPointer blk _) <- resolveSetupValue opts cc cs Crucible.PtrRepr ptr
-          memTy <- exceptToFail sc $
+          memTy <- llvmExceptToFail sc $
                      typeOfSetupValue cc (MS.csAllocations cs) (MS.csTypeNames cs) val'
           sz <- Crucible.storageTypeSize <$> Crucible.toStorableType memTy
           return $ Just (W4.asNat blk, sz)
@@ -2064,7 +2064,7 @@ storePointsToValue sc opts cc env tyenv nameEnv base_mem maybe_cond ptr val mayb
 
   let store_op = \mem -> case val of
         ConcreteSizeValue val' -> do
-          memTy <- exceptToFail sc $ typeOfSetupValue cc tyenv nameEnv val'
+          memTy <- llvmExceptToFail sc $ typeOfSetupValue cc tyenv nameEnv val'
           storTy <- Crucible.toStorableType memTy
           case val' of
             SetupTerm tm
@@ -2104,7 +2104,7 @@ storePointsToValue sc opts cc env tyenv nameEnv base_mem maybe_cond ptr val mayb
         let invalidate_op = \mem -> do
               sz <- case val of
                 ConcreteSizeValue val' -> do
-                  memTy <- exceptToFail sc $ typeOfSetupValue cc tyenv nameEnv val'
+                  memTy <- llvmExceptToFail sc $ typeOfSetupValue cc tyenv nameEnv val'
                   storTy <- Crucible.toStorableType memTy
                   W4.bvLit
                     sym
@@ -2389,7 +2389,7 @@ resolveSetupValueLLVM opts cc spec sval =
      mem <- readGlobal (Crucible.llvmMemVar (ccLLVMContext cc))
      let tyenv = MS.csAllocations spec
          nameEnv = MS.csTypeNames spec
-     memTy <- exceptToFail sc $ typeOfSetupValue cc tyenv nameEnv sval
+     memTy <- llvmExceptToFail sc $ typeOfSetupValue cc tyenv nameEnv sval
      sval' <- liftIO $ instantiateSetupValue sc s sval
      lval  <- liftIO $ resolveSetupVal cc mem m tyenv nameEnv sval' `X.catch` handleException opts
      return (memTy, lval)

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
@@ -153,12 +153,11 @@ prettySetupValueAsLLVMVal ::
   (?w4EvalTactic :: W4EvalTactic, Crucible.HasPtrWidth (Crucible.ArchWidth arch)) =>
   Options              {- ^ output/verbosity options -} ->
   LLVMCrucibleContext arch ->
-  SharedContext {- ^ context for constructing SAW terms -} ->
   MS.CrucibleMethodSpecIR (LLVM arch) {- ^ for name and typing environments -} ->
   SetupValue (LLVM arch) ->
   OverrideMatcher (LLVM arch) w (PP.Doc ann)
-prettySetupValueAsLLVMVal opts cc sc spec setupval = do
-  (_memTy, llvmval) <- resolveSetupValueLLVM opts cc sc spec setupval
+prettySetupValueAsLLVMVal opts cc spec setupval = do
+  (_memTy, llvmval) <- resolveSetupValueLLVM opts cc spec setupval
   prettyLLVMVal cc llvmval
 
 -- | Try to translate the spec\'s 'SetupValue' into an 'LLVMVal', pretty-print
@@ -195,7 +194,7 @@ prettyPointsToAsLLVMVal ::
   PointsTo (LLVM arch) ->
   OverrideMatcher (LLVM arch) w PPS.Doc
 prettyPointsToAsLLVMVal opts cc sc spec (LLVMPointsTo md cond ptr val) = do
-  pretty1 <- prettySetupValueAsLLVMVal opts cc sc spec ptr
+  pretty1 <- prettySetupValueAsLLVMVal opts cc spec ptr
   pretty2 <- liftIO $ prettyLLVMPointsToValue sc val
   cond' <- case cond of
       Nothing ->
@@ -211,7 +210,7 @@ prettyPointsToAsLLVMVal opts cc sc spec (LLVMPointsTo md cond ptr val) = do
                  ]
 prettyPointsToAsLLVMVal opts cc sc spec (LLVMPointsToBitfield md ptr fieldName val) = do
   let loc = PP.pretty $ W4.plSourceLoc $ MS.conditionLoc md
-  pretty1 <- prettySetupValueAsLLVMVal opts cc sc spec ptr
+  pretty1 <- prettySetupValueAsLLVMVal opts cc spec ptr
   pretty2 <- liftIO $ MS.prettySetupValue sc val
   pure $ PP.vcat [ "Pointer (bitfield):" <+> pretty1 <> "." <> PP.pretty fieldName
                  , "Pointee:" <+> pretty2
@@ -235,7 +234,7 @@ notEqual cond opts loc cc sc spec expected actual = do
   let cond'     = PP.pretty $ MS.stateCond cond
   expected'    <- liftIO $ MS.prettySetupValue sc expected
   lv'actual    <- prettyLLVMVal cc actual
-  slv'actual   <- prettySetupValueAsLLVMVal opts cc sc spec expected
+  slv'actual   <- prettySetupValueAsLLVMVal opts cc spec expected
   let msg = PP.vcat
         [ "Equality" <+> cond'
         , "Expected value (as a SAW value): "
@@ -1059,8 +1058,8 @@ computeReturnValue _opts _cc sc spec ty Nothing =
         ppopts <- liftIO $ scGetPPOpts sc
         failure ppopts (spec ^. MS.csLoc) (BadReturnSpecification (Some ty))
 
-computeReturnValue opts cc sc spec ty (Just val) =
-  do (_memTy, xval) <- resolveSetupValue opts cc sc spec ty val
+computeReturnValue opts cc _sc spec ty (Just val) =
+  do (_memTy, xval) <- resolveSetupValue opts cc spec ty val
      return xval
 
 
@@ -1256,7 +1255,7 @@ matchArg opts sc cc cs prepost md actual expectedTy expected =
     loc = MS.conditionLoc md
 
     resolveAndMatch = do
-      (ty, val) <- resolveSetupValueLLVM opts cc sc cs expected
+      (ty, val) <- resolveSetupValueLLVM opts cc cs expected
       sym  <- Ov.getSymInterface
       if diffMemTypes expectedTy ty /= []
       then do
@@ -1390,7 +1389,7 @@ learnSetupCondition ::
   OverrideMatcher (LLVM arch) md ()
 learnSetupCondition opts sc cc spec prepost cond =
   case cond of
-    MS.SetupCond_Equal md val1 val2 -> learnEqual opts sc cc spec md prepost val1 val2
+    MS.SetupCond_Equal md val1 val2 -> learnEqual opts cc spec md prepost val1 val2
     MS.SetupCond_Pred md tm         -> learnPred sc cc md prepost (ttTerm tm)
     MS.SetupCond_Ghost md var val   -> learnGhost sc md prepost var val
 
@@ -1418,10 +1417,10 @@ learnPointsTo ::
   PointsTo (LLVM arch) ->
   OverrideMatcher (LLVM arch) md (Maybe (PP.Doc ann))
 learnPointsTo opts sc cc spec prepost (LLVMPointsTo md maybe_cond ptr val) =
-  do (_memTy, ptr1) <- resolveSetupValue opts cc sc spec Crucible.PtrRepr ptr
+  do (_memTy, ptr1) <- resolveSetupValue opts cc spec Crucible.PtrRepr ptr
      matchPointsToValue opts sc cc spec prepost md maybe_cond ptr1 val
 learnPointsTo opts sc cc spec prepost (LLVMPointsToBitfield md ptr fieldName val) =
-  do (bfIndex, ptr1) <- resolveSetupValueBitfield opts cc sc spec ptr fieldName
+  do (bfIndex, ptr1) <- resolveSetupValueBitfield opts cc spec ptr fieldName
      matchPointsToBitfieldValue opts sc cc spec prepost md ptr1 bfIndex val
 
 matchPointsToValue ::
@@ -1741,7 +1740,6 @@ describeConcreteMemoryLoadFailure mem badLoadSummary ptr = do
 learnEqual ::
   (?w4EvalTactic :: W4EvalTactic, Crucible.HasPtrWidth (Crucible.ArchWidth arch)) =>
   Options                                          ->
-  SharedContext                                    ->
   LLVMCrucibleContext arch                            ->
   MS.CrucibleMethodSpecIR (LLVM arch)                             ->
   MS.ConditionMetadata                             ->
@@ -1749,9 +1747,9 @@ learnEqual ::
   SetupValue (LLVM arch)       {- ^ first value to compare  -} ->
   SetupValue (LLVM arch)       {- ^ second value to compare -} ->
   OverrideMatcher (LLVM arch) md ()
-learnEqual opts sc cc spec md prepost v1 v2 = do
-  (_, val1) <- resolveSetupValueLLVM opts cc sc spec v1
-  (_, val2) <- resolveSetupValueLLVM opts cc sc spec v2
+learnEqual opts cc spec md prepost v1 v2 = do
+  (_, val1) <- resolveSetupValueLLVM opts cc spec v1
+  (_, val2) <- resolveSetupValueLLVM opts cc spec v2
   p         <- liftIO (equalValsPred cc val1 val2)
   let name = "equality " ++ MS.stateCond prepost
   let loc = MS.conditionLoc md
@@ -1864,7 +1862,7 @@ invalidateMutableAllocs opts sc cc cs =
     (\case
       LLVMPointsTo _loc _cond ptr val -> case val of
         ConcreteSizeValue val' -> do
-          (_, Crucible.LLVMPointer blk _) <- resolveSetupValue opts cc sc cs Crucible.PtrRepr ptr
+          (_, Crucible.LLVMPointer blk _) <- resolveSetupValue opts cc cs Crucible.PtrRepr ptr
           memTy <- exceptToFail sc $
                      typeOfSetupValue cc (MS.csAllocations cs) (MS.csTypeNames cs) val'
           sz <- Crucible.storageTypeSize <$> Crucible.toStorableType memTy
@@ -1872,7 +1870,7 @@ invalidateMutableAllocs opts sc cc cs =
         SymbolicSizeValue{} -> return Nothing
       LLVMPointsToBitfield _loc ptr fieldName _val -> do
         (bfIndex, Crucible.LLVMPointer blk _) <-
-          resolveSetupValueBitfield opts cc sc cs ptr fieldName
+          resolveSetupValueBitfield opts cc cs ptr fieldName
         let memTy = biBitfieldType bfIndex
         storTy <- Crucible.toStorableType memTy
         let sz = Crucible.storageTypeSize storTy
@@ -1979,7 +1977,7 @@ executeSetupCondition ::
 executeSetupCondition opts sc cc spec =
   \case
     MS.SetupCond_Equal md val1 val2 ->
-      executeEqual opts sc cc spec md val1 val2
+      executeEqual opts cc spec md val1 val2
     MS.SetupCond_Pred md tm -> executePred sc cc md tm
     MS.SetupCond_Ghost md var val -> executeGhost sc md var val
 
@@ -2003,7 +2001,7 @@ executePointsTo ::
   PointsTo (LLVM arch)       ->
   OverrideMatcher (LLVM arch) RW ()
 executePointsTo opts sc cc spec overwritten_allocs (LLVMPointsTo _loc cond ptr val) =
-  do (_, ptr') <- resolveSetupValue opts cc sc spec Crucible.PtrRepr ptr
+  do (_, ptr') <- resolveSetupValue opts cc spec Crucible.PtrRepr ptr
      let memVar = Crucible.llvmMemVar (ccLLVMContext cc)
      mem <- readGlobal memVar
 
@@ -2024,7 +2022,7 @@ executePointsTo opts sc cc spec overwritten_allocs (LLVMPointsTo _loc cond ptr v
      mem' <- liftIO $ storePointsToValue sc opts cc m tyenv nameEnv mem cond' ptr' val' invalidate_msg
      writeGlobal memVar mem'
 executePointsTo opts sc cc spec _overwritten_allocs (LLVMPointsToBitfield _loc ptr fieldName val) =
-  do (bfIndex, ptr') <- resolveSetupValueBitfield opts cc sc spec ptr fieldName
+  do (bfIndex, ptr') <- resolveSetupValueBitfield opts cc spec ptr fieldName
      let memVar = Crucible.llvmMemVar (ccLLVMContext cc)
      mem <- readGlobal memVar
 
@@ -2305,16 +2303,15 @@ storePointsToBitfieldValue sc opts cc env tyenv nameEnv base_mem ptr bfIndex val
 executeEqual ::
   (?w4EvalTactic :: W4EvalTactic, Crucible.HasPtrWidth (Crucible.ArchWidth arch)) =>
   Options                                          ->
-  SharedContext                                    ->
   LLVMCrucibleContext arch                           ->
   MS.CrucibleMethodSpecIR (LLVM arch)                             ->
   MS.ConditionMetadata ->
   SetupValue (LLVM arch)       {- ^ first value to compare  -} ->
   SetupValue (LLVM arch)       {- ^ second value to compare -} ->
   OverrideMatcher (LLVM arch) md ()
-executeEqual opts sc cc spec md v1 v2 = do
-  (_, val1) <- resolveSetupValueLLVM opts cc sc spec v1
-  (_, val2) <- resolveSetupValueLLVM opts cc sc spec v2
+executeEqual opts cc spec md v1 v2 = do
+  (_, val1) <- resolveSetupValueLLVM opts cc spec v1
+  (_, val2) <- resolveSetupValueLLVM opts cc spec v2
   p         <- liftIO (equalValsPred cc val1 val2)
   addAssume p md
 
@@ -2382,12 +2379,12 @@ resolveSetupValueLLVM ::
   (?w4EvalTactic :: W4EvalTactic, Crucible.HasPtrWidth (Crucible.ArchWidth arch)) =>
   Options ->
   LLVMCrucibleContext arch ->
-  SharedContext ->
   MS.CrucibleMethodSpecIR (LLVM arch) ->
   SetupValue (LLVM arch) ->
   OverrideMatcher (LLVM arch) md (Crucible.MemType, LLVMVal)
-resolveSetupValueLLVM opts cc sc spec sval =
-  do m <- OM (use setupValueSub)
+resolveSetupValueLLVM opts cc spec sval =
+  do sc <- liftIO $ saw_sc <$> sawCoreState (cc ^. ccSym)
+     m <- OM (use setupValueSub)
      s <- OM (use termSub)
      mem <- readGlobal (Crucible.llvmMemVar (ccLLVMContext cc))
      let tyenv = MS.csAllocations spec
@@ -2401,13 +2398,12 @@ resolveSetupValue ::
   (?w4EvalTactic :: W4EvalTactic, Crucible.HasPtrWidth (Crucible.ArchWidth arch)) =>
   Options ->
   LLVMCrucibleContext arch ->
-  SharedContext ->
   MS.CrucibleMethodSpecIR (LLVM arch) ->
   Crucible.TypeRepr tp ->
   SetupValue (LLVM arch) ->
   OverrideMatcher (LLVM arch) md (Crucible.MemType, Crucible.RegValue Sym tp)
-resolveSetupValue opts cc sc spec tp sval =
-  do (memTy, lval) <- resolveSetupValueLLVM opts cc sc spec sval
+resolveSetupValue opts cc spec tp sval =
+  do (memTy, lval) <- resolveSetupValueLLVM opts cc spec sval
      sym <- Ov.getSymInterface
      val <- liftIO $ Crucible.unpackMemValue sym tp lval
      return (memTy, val)
@@ -2419,13 +2415,13 @@ resolveSetupValueBitfieldLLVM ::
   (?w4EvalTactic :: W4EvalTactic, Crucible.HasPtrWidth (Crucible.ArchWidth arch)) =>
   Options ->
   LLVMCrucibleContext arch ->
-  SharedContext ->
   MS.CrucibleMethodSpecIR (LLVM arch) ->
   SetupValue (LLVM arch) ->
   String ->
   OverrideMatcher (LLVM arch) md (BitfieldIndex, LLVMVal)
-resolveSetupValueBitfieldLLVM opts cc sc spec sval fieldName =
-  do m <- OM (use setupValueSub)
+resolveSetupValueBitfieldLLVM opts cc spec sval fieldName =
+  do sc <- liftIO $ saw_sc <$> sawCoreState (cc ^. ccSym)
+     m <- OM (use setupValueSub)
      s <- OM (use termSub)
      mem <- readGlobal (Crucible.llvmMemVar (ccLLVMContext cc))
      let tyenv = MS.csAllocations spec
@@ -2442,13 +2438,12 @@ resolveSetupValueBitfield ::
   (?w4EvalTactic :: W4EvalTactic, Crucible.HasPtrWidth (Crucible.ArchWidth arch)) =>
   Options ->
   LLVMCrucibleContext arch ->
-  SharedContext ->
   MS.CrucibleMethodSpecIR (LLVM arch) ->
   SetupValue (LLVM arch) ->
   String ->
   OverrideMatcher (LLVM arch) md (BitfieldIndex, LLVMPtr (Crucible.ArchWidth arch))
-resolveSetupValueBitfield opts cc sc spec sval fieldName =
-  do (bfIndex, lval) <- resolveSetupValueBitfieldLLVM opts cc sc spec sval fieldName
+resolveSetupValueBitfield opts cc spec sval fieldName =
+  do (bfIndex, lval) <- resolveSetupValueBitfieldLLVM opts cc spec sval fieldName
      sym <- Ov.getSymInterface
      val <- liftIO $ Crucible.unpackMemValue sym Crucible.PtrRepr lval
      pure (bfIndex, val)

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
@@ -427,13 +427,14 @@ handleSingleOverrideBranch opts sc cc call_loc mdMap h (OverrideWithPrecondition
      (st^.osLocation)
      (methodSpecHandler_poststate opts sc cc retTy cs)
   case res of
-    Left (OF loc rsn)  ->
+    Left (OF ppopts loc rsn)  -> do
       -- TODO, better pretty printing for reasons
+      let rsn' = ppOverrideFailureReason ppopts rsn
       liftIO
         $ Crucible.abortExecBecause
         $ Crucible.AssertionFailure
         $ Crucible.SimError loc
-        $ Crucible.AssertFailureSimError "assumed false" (show rsn)
+        $ Crucible.AssertFailureSimError "assumed false" (Text.unpack rsn')
     Right (ret,st') ->
       do liftIO $ forM_ (st'^.osAssumes) $ \(_md,asum) ->
            Crucible.addAssumption bak
@@ -502,13 +503,14 @@ handleOverrideBranches opts sc cc call_loc css h branches (true, false, unknown)
                    (st^.osLocation)
                    (methodSpecHandler_poststate opts sc cc retTy cs)
                 case res of
-                  Left (OF loc rsn)  ->
+                  Left (OF ppopts loc rsn)  -> do
                     -- TODO, better pretty printing for reasons
+                    let rsn' = ppOverrideFailureReason ppopts rsn
                     liftIO
                       $ Crucible.abortExecBecause
                       $ Crucible.AssertionFailure
                       $ Crucible.SimError loc
-                      $ Crucible.AssertFailureSimError "assumed false" (show rsn)
+                      $ Crucible.AssertFailureSimError "assumed false" (Text.unpack rsn')
                   Right (ret,st') ->
                     do liftIO $ forM_ (st'^.osAssumes) $ \(_md,asum) ->
                          Crucible.addAssumption bak
@@ -694,13 +696,14 @@ learnCond ::
   MS.StateSpec (LLVM arch) ->
   OverrideMatcher (LLVM arch) md ()
 learnCond opts sc cc cs prepost globals extras ss =
-  do let loc = cs ^. MS.csLoc
+  do ppopts <- liftIO $ scGetPPOpts sc
+     let loc = cs ^. MS.csLoc
      matchPointsTos opts sc cc cs prepost (ss ^. MS.csPointsTos)
      traverse_ (learnSetupCondition opts sc cc cs prepost) (ss ^. MS.csConditions)
      assertTermEqualities sc cc
      enforcePointerValidity sc cc ss
      enforceDisjointness sc cc loc globals extras ss
-     enforceCompleteSubstitution loc ss
+     enforceCompleteSubstitution ppopts loc ss
 
 
 assertTermEqualities ::
@@ -790,7 +793,9 @@ enforcePointerValidity sc cc ss =
                        Just ok ->
                          addAssert ok allocMd $ Crucible.SimError (MS.conditionLoc allocMd) $
                            Crucible.AssertFailureSimError (show msg') ""
-                       Nothing -> failure ploc (BadPointerLoad msg' "")
+                       Nothing -> do
+                         ppopts <- liftIO $ scGetPPOpts sc
+                         failure ppopts ploc (BadPointerLoad msg' "")
               _ -> return ()
 
        | (LLVMAllocSpec mut _pty alignment psz allocMd fresh initialization, ptr) <- mems
@@ -982,8 +987,9 @@ matchPointsTos opts sc cc spec prepost = go False []
 
     -- not all conditions processed, no progress, failure
     go False delayed [] = do
+        ppopts <- liftIO $ scGetPPOpts sc
         delayed' <- liftIO $ mapM (prettyLLVMPointsTo sc) delayed
-        failure (spec ^. MS.csLoc) (AmbiguousPointsTos delayed')
+        failure ppopts (spec ^. MS.csLoc) (AmbiguousPointsTos delayed')
 
     -- not all conditions processed, progress made, resume delayed conditions
     go True delayed [] = go False [] delayed
@@ -995,8 +1001,9 @@ matchPointsTos opts sc cc spec prepost = go False []
            do err <- learnPointsTo opts sc cc spec prepost c
               case err of
                 Just msg -> do
+                  ppopts <- liftIO $ scGetPPOpts sc
                   doc <- prettyPointsToAsLLVMVal opts cc sc spec c
-                  failure (llvmPointsToProgramLoc c) (BadPointerLoad doc msg)
+                  failure ppopts (llvmPointsToProgramLoc c) (BadPointerLoad doc msg)
                 Nothing  -> go True delayed cs
          else
            do go progress (c:delayed) cs
@@ -1045,10 +1052,12 @@ computeReturnValue ::
   OverrideMatcher (LLVM arch) md (Crucible.RegValue Sym ret)
                         {- ^ concrete return value                  -}
 
-computeReturnValue _opts _cc _sc spec ty Nothing =
+computeReturnValue _opts _cc sc spec ty Nothing =
   case ty of
     Crucible.UnitRepr -> return ()
-    _ -> failure (spec ^. MS.csLoc) (BadReturnSpecification (Some ty))
+    _ -> do
+        ppopts <- liftIO $ scGetPPOpts sc
+        failure ppopts (spec ^. MS.csLoc) (BadReturnSpecification (Some ty))
 
 computeReturnValue opts cc sc spec ty (Just val) =
   do (_memTy, xval) <- resolveSetupValue opts cc sc spec ty val
@@ -1232,11 +1241,16 @@ matchArg opts sc cc cs prepost md actual expectedTy expected =
              addAssert pred_ md =<<
                notEqual prepost opts loc cc sc cs expected actual
 
-        _ -> failure loc =<<
-              mkStructuralMismatch opts cc sc cs actual expected expectedTy
+        _ -> do
+            ppopts <- liftIO $ scGetPPOpts sc
+            err <- mkStructuralMismatch opts cc sc cs actual expected expectedTy
+            failure ppopts loc err
+              
 
-    _ -> failure loc =<<
-           mkStructuralMismatch opts cc sc cs actual expected expectedTy
+    _ -> do
+        ppopts <- liftIO $ scGetPPOpts sc
+        err <- mkStructuralMismatch opts cc sc cs actual expected expectedTy
+        failure ppopts loc err
 
   where
     loc = MS.conditionLoc md
@@ -1245,11 +1259,15 @@ matchArg opts sc cc cs prepost md actual expectedTy expected =
       (ty, val) <- resolveSetupValueLLVM opts cc sc cs expected
       sym  <- Ov.getSymInterface
       if diffMemTypes expectedTy ty /= []
-      then failure loc =<<
-            mkStructuralMismatch opts cc sc cs actual expected expectedTy
+      then do
+          ppopts <- liftIO $ scGetPPOpts sc
+          err <- mkStructuralMismatch opts cc sc cs actual expected expectedTy
+          failure ppopts loc err
       else liftIO (Crucible.testEqual sym val actual) >>=
         \case
-          Nothing -> failure loc BadEqualityComparison
+          Nothing -> do
+            ppopts <- liftIO $ scGetPPOpts sc
+            failure ppopts loc BadEqualityComparison
           Just pred_ ->
             addAssert pred_ md =<<
               notEqual prepost opts loc cc sc cs expected actual
@@ -1299,10 +1317,15 @@ valueToSC sym md failMsg (Cryptol.TVSeq _n Cryptol.TVBit) (Crucible.LLVMValInt b
      st <- liftIO (sawCoreState sym)
      offTm <- liftIO (toSC sym st off)
      case W4.asConstantPred baseZero of
-       Just True  -> return offTm
-       Just False -> failure loc failMsg
-       _ -> do addAssert baseZero md (Crucible.SimError loc (Crucible.GenericSimError "Expected bitvector value, but found pointer"))
-               return offTm
+       Just True  ->
+           return offTm
+       Just False -> do
+           ppopts <- omGetPPOpts
+           failure ppopts loc failMsg
+       _ -> do
+           let err = Crucible.GenericSimError "Expected bitvector value, but found pointer"
+           addAssert baseZero md (Crucible.SimError loc err)
+           return offTm
 
 -- This is a case for pointers, when we opaque types in Cryptol to represent them...
 -- valueToSC sym _tval (Crucible.LLVMValInt base off) =
@@ -1329,8 +1352,11 @@ valueToSC sym md failMsg tval@(Cryptol.TVSeq n (Cryptol.TVSeq 8 Cryptol.TVBit)) 
 valueToSC _ _ _ _ Crucible.LLVMValFloat{} =
   fail  "valueToSC: Real not supported"
 
-valueToSC _sym md failMsg _tval _val =
-  failure (MS.conditionLoc md) failMsg
+valueToSC sym md failMsg _tval _val = do
+  st <- liftIO $ sawCoreState sym
+  let sc = saw_sc st
+  ppopts <- liftIO $ scGetPPOpts sc
+  failure ppopts (MS.conditionLoc md) failMsg
 
 ------------------------------------------------------------------------
 

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
@@ -1205,7 +1205,7 @@ matchArg opts sc cc cs prepost md actual expectedTy expected =
     (Crucible.LLVMValInt blk off, _, SetupElem () v i) | Crucible.isPointerMemType expectedTy ->
       do let tyenv = MS.csAllocations cs
              nameEnv = MS.csTypeNames cs
-         delta <- exceptToFail $ resolveSetupElemOffset cc tyenv nameEnv v i
+         delta <- exceptToFail sc $ resolveSetupElemOffset cc tyenv nameEnv v i
          off' <- liftIO $ W4.bvSub sym off
            =<< W4.bvLit sym (W4.bvWidth off) (Crucible.bytesToBV (W4.bvWidth off) delta)
          matchArg opts sc cc cs prepost md (Crucible.LLVMValInt blk off') expectedTy v
@@ -1213,7 +1213,7 @@ matchArg opts sc cc cs prepost md actual expectedTy expected =
     (Crucible.LLVMValInt blk off, _, SetupField () v n) | Crucible.isPointerMemType expectedTy ->
       do let tyenv = MS.csAllocations cs
              nameEnv = MS.csTypeNames cs
-         fld <- exceptToFail $
+         fld <- exceptToFail sc $
                   do info <- resolveSetupValueInfo cc tyenv nameEnv v
                      recoverStructFieldInfo cc tyenv nameEnv v info n
          let delta = fromIntegral $ Crucible.fiOffset fld
@@ -1455,7 +1455,7 @@ matchPointsToValue opts sc cc spec prepost md maybe_cond ptr val =
 
      case val of
        ConcreteSizeValue val' ->
-         do memTy <- exceptToFail $ typeOfSetupValue cc tyenv nameEnv val'
+         do memTy <- exceptToFail sc $ typeOfSetupValue cc tyenv nameEnv val'
             -- In case the types are different (from llvm_points_to_untyped)
             -- then the load type should be determined by the rhs.
             storTy <- Crucible.toStorableType memTy
@@ -1865,7 +1865,7 @@ invalidateMutableAllocs opts sc cc cs =
       LLVMPointsTo _loc _cond ptr val -> case val of
         ConcreteSizeValue val' -> do
           (_, Crucible.LLVMPointer blk _) <- resolveSetupValue opts cc sc cs Crucible.PtrRepr ptr
-          memTy <- exceptToFail $
+          memTy <- exceptToFail sc $
                      typeOfSetupValue cc (MS.csAllocations cs) (MS.csTypeNames cs) val'
           sz <- Crucible.storageTypeSize <$> Crucible.toStorableType memTy
           return $ Just (W4.asNat blk, sz)
@@ -2066,7 +2066,7 @@ storePointsToValue sc opts cc env tyenv nameEnv base_mem maybe_cond ptr val mayb
 
   let store_op = \mem -> case val of
         ConcreteSizeValue val' -> do
-          memTy <- exceptToFail $ typeOfSetupValue cc tyenv nameEnv val'
+          memTy <- exceptToFail sc $ typeOfSetupValue cc tyenv nameEnv val'
           storTy <- Crucible.toStorableType memTy
           case val' of
             SetupTerm tm
@@ -2106,7 +2106,7 @@ storePointsToValue sc opts cc env tyenv nameEnv base_mem maybe_cond ptr val mayb
         let invalidate_op = \mem -> do
               sz <- case val of
                 ConcreteSizeValue val' -> do
-                  memTy <- exceptToFail $ typeOfSetupValue cc tyenv nameEnv val'
+                  memTy <- exceptToFail sc $ typeOfSetupValue cc tyenv nameEnv val'
                   storTy <- Crucible.toStorableType memTy
                   W4.bvLit
                     sym
@@ -2392,7 +2392,7 @@ resolveSetupValueLLVM opts cc sc spec sval =
      mem <- readGlobal (Crucible.llvmMemVar (ccLLVMContext cc))
      let tyenv = MS.csAllocations spec
          nameEnv = MS.csTypeNames spec
-     memTy <- exceptToFail $ typeOfSetupValue cc tyenv nameEnv sval
+     memTy <- exceptToFail sc $ typeOfSetupValue cc tyenv nameEnv sval
      sval' <- liftIO $ instantiateSetupValue sc s sval
      lval  <- liftIO $ resolveSetupVal cc mem m tyenv nameEnv sval' `X.catch` handleException opts
      return (memTy, lval)

--- a/saw-central/src/SAWCentral/Crucible/LLVM/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/ResolveSetupValue.hs
@@ -50,6 +50,8 @@ import qualified Data.Vector as V
 import           Data.Word (Word64)
 import           Numeric.Natural
 
+import Prettyprinter ((<+>))
+
 import qualified Text.LLVM.AST as L
 
 import qualified Cryptol.Eval.Type as Cryptol (TValue(..), tValTy, evalValType)
@@ -76,7 +78,7 @@ import SAWCoreWhat4.ReturnTrip
 import qualified Text.LLVM.DebugUtils as L
 
 import           SAWCentral.Crucible.Common (Sym, sawCoreState, HasSymInterface(..))
-import           SAWCentral.Crucible.Common.MethodSpec (AllocIndex(..), SetupValue(..))
+import           SAWCentral.Crucible.Common.MethodSpec (AllocIndex(..), SetupValue(..), prettyAllocIndex)
 import qualified SAWCentral.Crucible.Common.ResolveSetupValue as Common
 
 import SAWCentral.Crucible.LLVM.MethodSpecIR
@@ -430,10 +432,17 @@ typeOfSetupValue :: forall arch.
   SetupValue (LLVM arch)        {- ^ value to compute the type of -} ->
   Except String Crucible.MemType
 typeOfSetupValue cc env nameEnv val =
+  -- XXX: convert this code to use structured errors so we can print them
+  -- downstream where we can use IO.
+  let ppopts = PPS.defaultOpts in
+
   case val of
     SetupVar i ->
       case Map.lookup i env of
-        Nothing -> throwError ("typeOfSetupValue: Unresolved prestate variable:" ++ show i)
+        Nothing ->
+          let i' = prettyAllocIndex i in
+          throwError $ PPS.render ppopts $ "typeOfSetupValue: Unresolved" <+>
+              "prestate variable:" <+> i'
         Just spec ->
           return (Crucible.PtrType (Crucible.MemType (spec ^. allocSpecType)))
 
@@ -443,11 +452,10 @@ typeOfSetupValue cc env nameEnv val =
           case toLLVMType dl (Cryptol.evalValType mempty ty) of
             Left err -> throwError (toLLVMTypeErrToString err)
             Right memTy -> return memTy
-        tp -> throwError $ unlines
-                [ "typeOfSetupValue: expected monomorphic term"
-                , "instead got:"
-                , show (prettyTypedTermTypePure tp)
-                ]
+        tp ->
+          let tp' = prettyTypedTermTypePure ppopts tp in
+          throwError $ PPS.render ppopts $ "typeOfSetupValue: expected" <+>
+              "monomorphic term; instead got " <+> tp'
 
     SetupStruct packed vs ->
       do memTys <- traverse (typeOfSetupValue cc env nameEnv) vs
@@ -739,11 +747,14 @@ resolveTypedTerm cc tm =
   case ttType tm of
     TypedTermSchema (Cryptol.Forall [] [] ty) ->
       resolveSAWTerm cc (Cryptol.evalValType mempty ty) (ttTerm tm)
-    tp -> fail $ unlines
-            [ "resolveSetupVal: expected monomorphic term"
-            , "instead got term with type"
-            , show (prettyTypedTermTypePure tp)
-            ]
+    tp -> do
+      let sym = cc ^. ccSym
+      st <- sawCoreState sym
+      let sc = saw_sc st
+      ppOpts <- scGetPPOpts sc
+      tp' <- prettyTypedTermType sc tp
+      fail $ PPS.render ppOpts $ "resolveSetupVal: expected monomorphic" <+>
+          "term; instead got term with type" <+> tp'
 
 resolveSAWPred ::
   (?w4EvalTactic :: W4EvalTactic) =>
@@ -1057,5 +1068,5 @@ memArrayToSawCoreTerm crucible_context endianess typed_term = do
         fresh_array_const
 
     _ -> do
-      typed_term' <- prettyTypedTerm sc typed_term
-      fail $ "expected monomorphic typed term: " ++ PPS.render PPS.defaultOpts typed_term'
+      typed_term' <- ppTypedTerm sc typed_term
+      fail $ Text.unpack $ "Expected monomorphic typed term: " <> typed_term'

--- a/saw-central/src/SAWCentral/Crucible/LLVM/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/ResolveSetupValue.hs
@@ -10,6 +10,7 @@ Stability   : provisional
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
@@ -38,7 +39,7 @@ import Control.Lens ( (^.), view )
 import Control.Monad
 import Control.Monad.Except
 import Control.Monad.State
-import Data.Maybe (fromMaybe, fromJust)
+import Data.Maybe (fromMaybe, fromJust, mapMaybe)
 import Data.Void (absurd)
 
 import qualified Data.Dwarf as Dwarf
@@ -50,9 +51,14 @@ import qualified Data.Vector as V
 import           Data.Word (Word64)
 import           Numeric.Natural
 
+import qualified Prettyprinter as PP
 import Prettyprinter ((<+>))
 
+import qualified Text.PrettyPrint.HughesPJ as PPHPJ -- for importing llvm-pretty docs
+
 import qualified Text.LLVM.AST as L
+import qualified Text.LLVM.DebugUtils as L
+import qualified Text.LLVM.PP as LPP
 
 import qualified Cryptol.Eval.Type as Cryptol (TValue(..), tValTy, evalValType)
 import qualified Cryptol.TypeCheck.AST as Cryptol (Schema(..))
@@ -75,7 +81,6 @@ import SAWCore.SharedTerm
 import CryptolSAWCore.Cryptol (translateType)
 import CryptolSAWCore.TypedTerm
 import SAWCoreWhat4.ReturnTrip
-import qualified Text.LLVM.DebugUtils as L
 
 import           SAWCentral.Crucible.Common (Sym, sawCoreState, HasSymInterface(..))
 import           SAWCentral.Crucible.Common.MethodSpec (AllocIndex(..), SetupValue(..), prettyAllocIndex)
@@ -87,9 +92,329 @@ import SAWCentral.Crucible.LLVM.Setup.Value (LLVMPtr)
 type LLVMVal = Crucible.LLVMVal Sym
 
 
+------------------------------------------------------------
+-- LLVM printing support
 
-exceptToFail :: MonadFail m => Except String a -> m a
-exceptToFail m = either fail pure $ runExcept m
+-- | Wrapper for an llvm-pretty printer.
+--
+--   llvm-pretty uses @Text.PrettyPrint.HughesPJ@ rather than
+--   @Prettyprinter@ so we can't use the generated docs directly.
+--
+--   FUTURE: move this to its own file like @CryPP@ so we can just
+--   do `LLVMPP.pretty` or whatever and not expose the plumbing.
+--   ...or, just migrate llvm-pretty to @Prettyprinter@...
+--
+--   XXX: this should not arbitrarily bake in the latest supported
+--   LLVM version but should use the version of the module we're
+--   working on. Don't know how to get that info though.
+llpretty :: ((?config :: LPP.Config) => a -> PPHPJ.Doc) -> a -> PPS.Doc
+llpretty pp item =
+    let hpjdoc = LPP.ppLLVM LPP.llvmVlatest $ pp item in
+    let str = PPHPJ.render hpjdoc in
+    PP.pretty str
+
+-- | Print an `L.BitfieldInfo`. FUTURE: move to llvm-pretty
+prettyBitfieldInfo :: PPS.Opts -> L.BitfieldInfo -> PPS.Doc
+prettyBitfieldInfo ppopts info =
+  let off = PPS.prettyWord64 ppopts (L.biBitfieldOffset info)
+      sz = PPS.prettyWord64 ppopts (L.biFieldSize info)
+  in
+  sz <+> "bits at offset" <+> off
+
+-- | Print an `L.StructFieldInfo`. FUTURE: move to llvm-pretty
+prettyStructFieldInfo :: PPS.Opts -> L.StructFieldInfo -> PPS.Doc
+prettyStructFieldInfo ppopts sfi =
+    let name = PP.pretty $ L.sfiName sfi
+        offset = PPS.prettyWord64 ppopts $ L.sfiOffset sfi
+        mbf = prettyBitfieldInfo ppopts <$> L.sfiBitfield sfi
+        info = prettyLLVMInfo ppopts $ L.sfiInfo sfi
+        part1 = name <+> "@" <> offset <+> ":" <+> info
+        part2 = case mbf of
+            Nothing -> []
+            Just bf -> ["..." <+> bf]
+    in
+    PP.hsep $ [part1] ++ part2
+
+-- | Print an `L.UnionFieldInfo`. FUTURE: move to llvm-pretty
+prettyUnionFieldInfo :: PPS.Opts -> L.UnionFieldInfo -> PPS.Doc
+prettyUnionFieldInfo ppopts ufi =
+    let name = PP.pretty $ L.ufiName ufi
+        info = prettyLLVMInfo ppopts $ L.ufiInfo ufi
+    in
+    name <+> ":" <+> info
+
+-- | Print an `L.Info`. FUTURE: move to llvm-pretty
+--   XXX: what output syntax should this use?
+prettyLLVMInfo :: PPS.Opts -> L.Info -> PPS.Doc
+prettyLLVMInfo ppopts info0 = case info0 of
+    L.Pointer info1 ->
+        "pointer" <+> prettyLLVMInfo ppopts info1
+    L.Structure mname fields ->
+        let mname' = case mname of
+              Nothing -> "anonymous struct"
+              Just name -> "struct" <+> PP.pretty name
+            fields' = PP.indent 3 $ PP.vsep $ map (prettyStructFieldInfo ppopts) fields
+        in
+        PP.vsep [mname', fields']
+    L.Union mname fields ->
+        let mname' = case mname of
+              Nothing -> "anonymous union"
+              Just name -> "union" <+> PP.pretty name
+            fields' = PP.indent 3 $ PP.vsep $ map (prettyUnionFieldInfo ppopts) fields
+        in
+        PP.vsep [mname', fields']
+    L.Typedef name info1 ->
+        "typedef" <+> PP.pretty name <+> prettyLLVMInfo ppopts info1
+    L.ArrInfo info1 ->
+        "array" <+> prettyLLVMInfo ppopts info1
+    L.BaseType name _ ->
+        PP.pretty name
+    L.Unknown ->
+        "unknown"
+
+------------------------------------------------------------
+-- Errors
+
+-- | Errors from various functions in here.
+--
+--   Unlike the roughly corresponding `MIRTypeOfError`, this one does
+--   not print in advance; instead it throws unprinted values and
+--   relies on the intercept site to be able to do the printing. In
+--   both cases the printing needs access to the `PPS.Opts` and also
+--   sometimes needs `IO`. However, here we use `ExceptT` to issue an
+--   error of arbitrary type; the MIR code uses @MonadThrow@ to throw
+--   `Exception`s, and the latter is tied to `Show` in a way that
+--   makes it impossible for the receiver to print correctly.
+--
+--   Probably either this code or the MIR code should be rewritten
+--   to work like the other one. It isn't clear yet which is better,
+--   and we should put off that decision until we have access to
+--   the new @SAWSupport.Console@ error mechanism in this layer.
+--
+data LLVMSetupError
+  = LLVMUnresolvedPrestateVar AllocIndex
+  | LLVMUnrepresentableType ToLLVMTypeErr
+  | LLVMUnexpectedPolymorphic TypedTermType
+  | LLVMEmptyArray
+  | LLVMTypeFromDebugFailure L.Info
+  | LLVMInvalidCast L.Type String
+  | LLVMNonPointerCast Crucible.MemType
+  | LLVMArrayOutOfBounds Int Natural
+  | LLVMStructOutOfBounds Int Crucible.MemType
+  | LLVMInvalidElem Crucible.MemType (Maybe String)
+  | LLVMUnknownGlobal Text
+  | LLVMInvalidType L.Type String
+  | LLVMNoStruct Text L.Info
+  | LLVMNoStructField Text (Maybe String) [L.StructFieldInfo]
+  | LLVMBadOffsetStructField Text (Maybe String) Crucible.MemType
+  | LLVMNoBitfieldStruct Text L.Info
+  | LLVMNoBitfieldStructField Text (Maybe String) [L.StructFieldInfo]
+  | LLVMBadOffsetBitfieldStructField Text (Maybe String) Crucible.MemType
+  | LLVMNoUnion Text L.Info
+  | LLVMNoUnionField Text (Maybe String) [L.UnionFieldInfo]
+  | LLVMNoGlobalDebugInfo Text
+  | LLVMNoLocalTypeInfo AllocIndex
+
+ppLLVMSetupError :: SharedContext -> PPS.Opts -> LLVMSetupError -> IO Text
+ppLLVMSetupError sc ppopts err = case err of
+    LLVMUnresolvedPrestateVar i ->
+        let i' = prettyAllocIndex i in
+        pure $ PPS.renderText ppopts $ "typeOfSetupValue: Unresolved" <+>
+            "prestate variable:" <+> i'
+    LLVMUnrepresentableType suberr ->
+        pure $ PPS.renderText ppopts $ prettyToLLVMTypeErr suberr
+    LLVMUnexpectedPolymorphic tp -> do
+        tp' <- prettyTypedTermType sc tp
+        pure $ PPS.renderText ppopts $ "typeOfSetupValue: expected" <+>
+              "monomorphic term; instead got " <+> tp'
+    LLVMEmptyArray ->
+        pure $ "typeOfSetupValue: invalid empty llvm_array_value"
+    LLVMTypeFromDebugFailure info ->
+        let info' = prettyLLVMInfo ppopts info in
+        pure $ PPS.renderText ppopts $ PP.vsep [
+            "Could not determine LLVM type from computed debug type information:",
+            PP.indent 3 info'
+        ]
+    LLVMInvalidCast ltp suberr ->
+        let ltp' = llpretty LPP.ppType ltp
+            -- suberr comes from Crucible code and is just a String
+            suberr' = PP.pretty suberr
+        in
+        pure $ PPS.renderText ppopts $ PP.vsep [
+            "typeOfSetupValue: invalid type in cast" <+> ltp',
+            "Details:",
+            suberr'
+        ]
+    LLVMNonPointerCast memTy ->
+        let memTy' = Crucible.ppMemType memTy in
+        pure $ PPS.renderText ppopts $ PP.vsep [
+            "typeOfSetupValue: Tried to cast the type of a non-pointer value",
+            "Actual type of value:" <+> memTy'
+        ]
+    LLVMArrayOutOfBounds i n ->
+        let i' = PPS.prettyInt ppopts i
+            n' = PPS.prettyNatural ppopts n
+        in
+        pure $ PPS.renderText ppopts $ PP.vsep [
+            "typeOfSetupValue: Array index out of bounds",
+            "Index:" <+> i',
+            "Array length:" <+> n'
+        ]
+    LLVMStructOutOfBounds i memTy ->
+        let i' = PPS.prettyInt ppopts i
+            memTy' = Crucible.ppMemType memTy
+        in
+        pure $ PPS.renderText ppopts $ PP.vsep [
+            "typeOfSetupValue: Struct type index out of bounds",
+            "Index:" <+> i',
+            "Type:" <+> memTy'
+        ]
+    LLVMInvalidElem memTy mSuberr ->
+        let memTy' = Crucible.ppMemType memTy in
+
+        -- If you insert PP.emptyDoc in PP.vsep you get a blank line,
+        -- which seems like a bug. But we don't get to decide that.
+        let line1 = "typeOfSetupValue: llvm_elem requires pointer to struct or array"
+            line2 = "found:" <+> memTy'
+            rest = case mSuberr of
+                Nothing -> []
+                Just suberr ->
+                    -- suberr comes from Crucible code and is just a String
+                    [PP.pretty suberr]
+        in
+        pure $ PPS.renderText ppopts $ PP.vsep ([line1, line2] ++ rest)
+    LLVMUnknownGlobal name ->
+        pure $ "typeOfSetupValue: Unknown global " <> name
+    LLVMInvalidType ty suberr ->
+        let ty' = llpretty LPP.ppType ty
+            -- suberr comes from Crucible code and is just a String
+            suberr' = PP.pretty suberr
+        in
+        pure $ PPS.renderText ppopts $ PP.vsep [
+            "typeOfSetupValue: invalid type" <+> ty',
+            "Details:",
+            suberr'
+        ]
+    LLVMNoStruct n info ->
+        let n' = PP.pretty n
+            info' = case info of
+                L.Unknown -> "Perhaps you need to compile with debug symbols enabled."
+                _ -> prettyLLVMInfo ppopts info
+        in
+        pure $ PPS.renderText ppopts $ PP.vsep [      
+            "Unable to resolve struct field name:" <+> n',
+            "Could not resolve setup value debug information into a struct type.",
+            info'
+        ]
+    LLVMNoStructField n snm xs ->
+        let n' = PP.pretty n
+            snm' = case snm of
+                Nothing -> "an anonymous struct"
+                Just nm -> "a struct" <+> PP.pretty nm
+            xs' = PP.vsep $ map (\x -> "-" <+> PP.pretty (L.sfiName x)) xs
+        in
+        pure $ PPS.renderText ppopts $ PP.vsep [
+            "Unable to resolve struct field name:" <+> n',
+            "Found" <+> snm' <+> "with these fields:",
+            xs'
+        ]
+    LLVMBadOffsetStructField n snm vty ->
+        let n' = PP.pretty n
+            snm' = case snm of
+                Nothing -> "an anonymous struct"
+                Just nm -> "a struct" <+> PP.pretty nm
+            vty' = Crucible.ppMemType vty
+        in
+        pure $ PPS.renderText ppopts $ PP.vsep [
+            "Found struct field name" <+> n' <+> "in struct with name" <+> snm' <> ".",
+            "However, the offset of this field found in the debug information could not" <+>
+                "be correlated with the computed LLVM type of the setup value.",
+            "Field type:" <+> vty'
+        ]
+    LLVMNoBitfieldStruct n info ->
+        let n' = PP.pretty n
+            info' = case info of
+               L.Unknown -> "Perhaps you need to compile with debug symbols enabled."
+               _ -> prettyLLVMInfo ppopts info
+        in
+        pure $ PPS.renderText ppopts $ PP.vsep [
+            "Unable to resolve struct bitfield name:" <+> n',
+            "Could not resolve setup value debug information into a struct type.",
+            info'
+        ]
+    LLVMNoBitfieldStructField n snm xs ->
+        let n' = PP.pretty n
+            snm' = case snm of
+                Nothing -> "an anonymous struct"
+                Just nm -> "a struct" <+> PP.pretty nm
+            prettyX x = do
+                bfi <- L.sfiBitfield x
+                let name' = PP.pretty $ L.sfiName x
+                let bfi' = prettyBitfieldInfo ppopts bfi
+                pure $ "-" <+> name' <> ":" <+> bfi'
+            xs' = PP.vsep $ mapMaybe prettyX xs
+        in
+        pure $ PPS.renderText ppopts $ PP.vsep [
+            "Unable to resolve struct bitfield name:" <+> n',
+            "Found" <+> snm' <+> "with these bitfield fields:",
+            xs'
+        ]
+    LLVMBadOffsetBitfieldStructField n snm vty ->
+        let n' = PP.pretty n
+            snm' = case snm of
+                Nothing -> "an anonymous struct"
+                Just nm -> "a struct" <+> PP.pretty nm
+            vty' = Crucible.ppMemType vty
+        in
+        pure $ PPS.renderText ppopts $ PP.vsep [
+            "Found struct field name" <+> n' <+> "in struct with name" <+> snm' <> ".",
+            "However, the offset of this field found in the debug information could not" <+>
+                "be correlated with the computed LLVM type of the setup value," <+>
+                "or that field is not a bitfield.",
+            "Field type:" <+> vty'
+        ]
+    LLVMNoUnion n info ->
+        let n' = PP.pretty n
+            info' = case info of
+                L.Unknown -> "Perhaps you need to compile with debug symbols enabled."
+                _ -> prettyLLVMInfo ppopts info
+        in
+        pure $ PPS.renderText ppopts $ PP.vsep [
+            "Unable to resolve union field name:" <+> n',
+            "Could not resolve setup value debug information into a union type.",
+            info'
+        ]
+    LLVMNoUnionField n unm xs ->
+        let n' = PP.pretty n
+            unm' = case unm of
+                Nothing -> "an anonymous union"
+                Just nm -> "a union" <+> PP.pretty nm
+            xs' = PP.vsep $ map (\x -> "-" <+> PP.pretty (L.ufiName x)) xs
+        in
+        pure $ PPS.renderText ppopts $ PP.vsep [
+            "Unable to resolve union field name:" <+> n',
+            "Found" <+> unm' <+> "with these fields:",
+            xs'
+        ]
+    LLVMNoGlobalDebugInfo name ->
+        pure $ "Debug info for global name '" <> name <> "' not found."
+    LLVMNoLocalTypeInfo i ->
+        let i' = prettyAllocIndex i in
+        pure $ PPS.renderText ppopts $
+            "Type information not found for local allocation value:" <+> i'
+
+
+exceptToFail :: (MonadFail m, MonadIO m) => SharedContext -> Except LLVMSetupError a -> m a
+exceptToFail sc m = case runExcept m of
+    Right result -> pure result
+    Left err -> do
+        ppopts <- liftIO $ scGetPPOpts sc
+        msg <- liftIO $ ppLLVMSetupError sc ppopts err
+        fail $ Text.unpack msg
+
+
+------------------------------------------------------------
+-- Everything else
 
 -- | Attempt to look up LLVM debug metadata regarding the type of the
 --   given setup value.  This is a best-effort procedure, as the
@@ -101,20 +426,20 @@ resolveSetupValueInfo ::
   Map AllocIndex LLVMAllocSpec    {- ^ allocation types  -} ->
   Map AllocIndex Crucible.Ident   {- ^ allocation type names -} ->
   SetupValue (LLVM arch)          {- ^ pointer value -} ->
-  Except String L.Info            {- ^ debug type info of pointed-to type -}
+  Except LLVMSetupError L.Info   {- ^ debug type info of pointed-to type -}
 resolveSetupValueInfo cc env nameEnv v =
   case v of
     SetupGlobal _ name ->
       case lookup (L.Symbol $ Text.unpack name) globalTys of
         Just (L.Alias alias) -> pure (L.guessAliasInfo mdMap alias)
-        _ -> throwError $ Text.unpack $ "Debug info for global name '" <> name <> "' not found."
+        _ -> throwError $ LLVMNoGlobalDebugInfo name
 
     SetupVar i ->
       case Map.lookup i nameEnv of
         Just alias -> pure (L.guessAliasInfo mdMap alias)
         Nothing    ->
            -- TODO? is this a panic situation?
-           throwError $ "Type information for local allocation value not found: " ++ show i
+           throwError $ LLVMNoLocalTypeInfo i
 
     SetupCast (L.Alias alias) _ -> pure (L.guessAliasInfo mdMap alias)
 
@@ -122,42 +447,22 @@ resolveSetupValueInfo cc env nameEnv v =
       do i <- resolveSetupValueInfo cc env nameEnv a
          case findStruct i of
            Nothing ->
-             throwError $ Text.unpack $ Text.unlines $
-               [ "Unable to resolve struct field name: '" <> n <> "'"
-               , "Could not resolve setup value debug information into a struct type."
-               , case i of
-                   L.Unknown -> "Perhaps you need to compile with debug symbols enabled."
-                   _ -> Text.pack $ show i
-               ]
+             throwError $ LLVMNoStruct n i
            Just (snm, xs) ->
              let nstr = Text.unpack n in
              case [ i' | L.StructFieldInfo{L.sfiName = n', L.sfiInfo = i' } <- xs, nstr == n' ] of
-               [] -> throwError $ Text.unpack $ Text.unlines $
-                       [ "Unable to resolve struct field name: '" <> n <> "'"] ++
-                       [ "Struct with name '" <> Text.pack str <> "' found."  | Just str <- [snm] ] ++
-                       [ "The following field names were found for this struct:" ] ++
-                       map ("- " <>) [Text.pack n' | L.StructFieldInfo{L.sfiName = n'} <- xs]
+               [] -> throwError $ LLVMNoStructField n snm xs
                i':_ -> pure i'
 
     SetupUnion () a u ->
       do i <- resolveSetupValueInfo cc env nameEnv a
          case findUnion i of
            Nothing ->
-             throwError $ Text.unpack $ Text.unlines $
-               [ "Unable to resolve union field name: '" <> u <> "'"
-               , "Could not resolve setup value debug information into a union type."
-               , case i of
-                   L.Unknown -> "Perhaps you need to compile with debug symbols enabled."
-                   _ -> Text.pack $ show i
-               ]
+             throwError $ LLVMNoUnion u i
            Just (unm, xs) ->
              let ustr = Text.unpack u in
              case [ i' | L.UnionFieldInfo{L.ufiName = n', L.ufiInfo = i'} <- xs, ustr == n' ] of
-               [] -> throwError $ Text.unpack $ Text.unlines $
-                       [ "Unable to resolve union field name: '" <> u <> "'"] ++
-                       [ "Union with name '" <> Text.pack str <> "' found."  | Just str <- [unm] ] ++
-                       [ "The following field names were found for this union:" ] ++
-                       map ("- " <>) [Text.pack n' | L.UnionFieldInfo{L.ufiName = n'} <- xs]
+               [] -> throwError $ LLVMNoUnionField u unm xs
                i':_ -> pure i'
 
     _ -> pure L.Unknown
@@ -198,25 +503,15 @@ recoverStructFieldInfo ::
   SetupValue (LLVM arch)        {- ^ the value to examine -} ->
   L.Info                        {- ^ extracted LLVM debug information about the type of the value -} ->
   Text                        {- ^ the name of the field -} ->
-  Except String Crucible.FieldInfo
+  Except LLVMSetupError Crucible.FieldInfo
 recoverStructFieldInfo cc env nameEnv v info n =
   case findStruct info of
     Nothing ->
-      throwError $ Text.unpack $ Text.unlines $
-        [ "Unable to resolve struct field name: '" <> n <> "'"
-        , "Could not resolve setup value debug information into a struct type."
-        , case info of
-            L.Unknown -> "Perhaps you need to compile with debug symbols enabled."
-            _ -> Text.pack $ show info
-        ]
+      throwError $ LLVMNoStruct n info
     Just (snm,xs) ->
       let nstr = Text.unpack n in
       case [o | L.StructFieldInfo{L.sfiName = n', L.sfiOffset = o} <- xs, nstr == n' ] of
-        [] -> throwError $ Text.unpack $ Text.unlines $
-                [ "Unable to resolve struct field name: '" <> n <> "'"] ++
-                [ "Struct with name '" <> Text.pack str <> "' found."  | Just str <- [snm] ] ++
-                [ "The following field names were found for this struct:" ] ++
-                map ("- " <>) [Text.pack n' | L.StructFieldInfo{L.sfiName = n'} <- xs]
+        [] -> throwError $ LLVMNoStructField n snm xs
         o:_ ->
           do vty <- typeOfSetupValue cc env nameEnv v
              case do Crucible.PtrType symTy <- pure vty
@@ -225,14 +520,7 @@ recoverStructFieldInfo cc env nameEnv v info n =
                      V.find (\fi -> Crucible.bytesToBits (Crucible.fiOffset fi) == fromIntegral o)
                             (Crucible.siFields si)
                of
-               Nothing ->
-                 throwError $ Text.unpack $ Text.unlines $
-                   [ "Found struct field name: '" <> n <> "'"] ++
-                   [ "in struct with name '" <> Text.pack str <> "'."  | Just str <- [snm] ] ++
-                   [ "However, the offset of this field found in the debug information could not"
-                   , "be correlated with the computed LLVM type of the setup value:"
-                   , Text.pack $ show vty
-                   ]
+               Nothing -> throwError $ LLVMBadOffsetStructField n snm vty
                Just fld -> return fld
 
 -- | Attempt to turn type information from DWARF debug data back into
@@ -371,18 +659,12 @@ resolveSetupBitfield ::
   Map AllocIndex Crucible.Ident {- ^ allocation type names -} ->
   SetupValue (LLVM arch) {- ^ pointer to struct -} ->
   String {- ^ field name -} ->
-  Except String BitfieldIndex {- ^ information about bitfield -}
+  Except LLVMSetupError BitfieldIndex {- ^ information about bitfield -}
 resolveSetupBitfield cc env nameEnv v n =
   do info <- resolveSetupValueInfo cc env nameEnv v
      case findStruct info of
        Nothing ->
-         throwError $ unlines $
-           [ "Unable to resolve struct bitfield name: '" ++ show n ++ "'"
-           , "Could not resolve setup value debug information into a struct type."
-           , case info of
-               L.Unknown -> "Perhaps you need to compile with debug symbols enabled."
-               _ -> show info
-           ]
+         throwError $ LLVMNoBitfieldStruct (Text.pack n) info
        Just (snm, xs) ->
          case [ (fieldOffsetStartingFromStruct, bfInfo) | L.StructFieldInfo
                      { L.sfiName = n'
@@ -390,11 +672,7 @@ resolveSetupBitfield cc env nameEnv v n =
                      , L.sfiBitfield = Just bfInfo
                      } <- xs, n == n' ] of
 
-           [] -> throwError $ unlines $
-                   [ "Unable to resolve struct bitfield name: '" ++ n ++ "'"] ++
-                   [ "Struct with name '" ++ str ++ "' found."  | Just str <- [snm] ] ++
-                   [ "The following bitfield names were found for this struct:" ] ++
-                   map ("- "++) [n' | L.StructFieldInfo{L.sfiName = n', L.sfiBitfield = Just{}} <- xs]
+           [] -> throwError $ LLVMNoBitfieldStructField (Text.pack n) snm xs
 
            ((fieldOffsetStartingFromStruct, bfInfo):_) ->
              do memTy <- typeOfSetupValue cc env nameEnv v
@@ -413,15 +691,7 @@ resolveSetupBitfield cc env nameEnv v n =
                                              }
                   of
                   Nothing ->
-                    throwError $ unlines $
-                      [ "Found struct field name: '" ++ n ++ "'"] ++
-                      [ "in struct with name '" ++ str ++ "'."  | Just str <- [snm] ] ++
-                      [ "However, the offset of this field found in the debug information could not"
-                      , "be correlated with the computed LLVM type of the setup value, or the field"
-                      , "is not a bitfield."
-                      , show memTy
-                      ]
-
+                    throwError $ LLVMBadOffsetBitfieldStructField (Text.pack n) snm memTy
                   Just bfi -> return bfi
 
 -- | Attempt to compute the @MemType@ of a setup value.
@@ -430,19 +700,13 @@ typeOfSetupValue :: forall arch.
   Map AllocIndex LLVMAllocSpec  {- ^ allocation types  -} ->
   Map AllocIndex Crucible.Ident {- ^ allocation type names -} ->
   SetupValue (LLVM arch)        {- ^ value to compute the type of -} ->
-  Except String Crucible.MemType
+  Except LLVMSetupError Crucible.MemType
 typeOfSetupValue cc env nameEnv val =
-  -- XXX: convert this code to use structured errors so we can print them
-  -- downstream where we can use IO.
-  let ppopts = PPS.defaultOpts in
-
   case val of
     SetupVar i ->
       case Map.lookup i env of
         Nothing ->
-          let i' = prettyAllocIndex i in
-          throwError $ PPS.render ppopts $ "typeOfSetupValue: Unresolved" <+>
-              "prestate variable:" <+> i'
+          throwError $ LLVMUnresolvedPrestateVar i
         Just spec ->
           return (Crucible.PtrType (Crucible.MemType (spec ^. allocSpecType)))
 
@@ -450,12 +714,10 @@ typeOfSetupValue cc env nameEnv val =
       case ttType tt of
         TypedTermSchema (Cryptol.Forall [] [] ty) ->
           case toLLVMType dl (Cryptol.evalValType mempty ty) of
-            Left err -> throwError (toLLVMTypeErrToString err)
+            Left err -> throwError $ LLVMUnrepresentableType err
             Right memTy -> return memTy
         tp ->
-          let tp' = prettyTypedTermTypePure ppopts tp in
-          throwError $ PPS.render ppopts $ "typeOfSetupValue: expected" <+>
-              "monomorphic term; instead got " <+> tp'
+          throwError $ LLVMUnexpectedPolymorphic tp
 
     SetupStruct packed vs ->
       do memTys <- traverse (typeOfSetupValue cc env nameEnv) vs
@@ -469,11 +731,12 @@ typeOfSetupValue cc env nameEnv val =
     SetupSlice empty ->
       absurd empty
 
-    SetupArray () [] -> throwError "typeOfSetupValue: invalid empty llvm_array_value"
+    SetupArray () [] ->
+      throwError LLVMEmptyArray
     SetupArray () (v : vs) ->
       do memTy <- typeOfSetupValue cc env nameEnv v
          _memTys <- traverse (typeOfSetupValue cc env nameEnv) vs
-         -- TODO: check that all memTys are compatible with memTy
+         -- TODO XXX: check that all memTys are compatible with memTy
          return (Crucible.ArrayType (fromIntegral (length (v:vs))) memTy)
 
     SetupField () v n ->
@@ -484,10 +747,7 @@ typeOfSetupValue cc env nameEnv val =
     SetupUnion () v n ->
       do info <- resolveSetupValueInfo cc env nameEnv (SetupUnion () v n)
          case reverseDebugInfoType info of
-           Nothing -> throwError $ unlines
-                        [ "Could not determine LLVM type from computed debug type information:"
-                        , show info
-                        ]
+           Nothing -> throwError $ LLVMTypeFromDebugFailure info
            Just ltp -> typeOfSetupValue cc env nameEnv (SetupCast ltp v)
 
     SetupCast ltp v ->
@@ -495,22 +755,14 @@ typeOfSetupValue cc env nameEnv val =
          if Crucible.isPointerMemType memTy
            then
              case let ?lc = lc in Crucible.liftMemType (L.PtrTo ltp) of
-               Left err -> throwError $ unlines
-                             [ "typeOfSetupValue: invalid type " ++ show ltp
-                             , "Details:"
-                             , err
-                             ]
+               Left err -> throwError $ LLVMInvalidCast ltp err
                Right mt -> pure mt
 
            else
-             throwError $ unwords $
-               [ "typeOfSetupValue: tried to cast the type of a non-pointer value"
-               , "actual type of value: " ++ show memTy
-               ]
+             throwError $ LLVMNonPointerCast memTy
 
     SetupElem () v i -> do
       do memTy <- typeOfSetupValue cc env nameEnv v
-         let msg = "typeOfSetupValue: llvm_elem requires pointer to struct or array, found " ++ show memTy
          case memTy of
            Crucible.PtrType symTy ->
              case let ?lc = lc in Crucible.asMemType symTy of
@@ -518,19 +770,16 @@ typeOfSetupValue cc env nameEnv val =
                  case memTy' of
                    Crucible.ArrayType n memTy''
                      -- i == n is valid because pointers can point one-past-the-end of an array
+                     -- also note that this relies on `fromIntegral` promoting i to unsigned
                      | fromIntegral i <= n -> return (Crucible.PtrType (Crucible.MemType memTy''))
-                     | otherwise -> throwError $ unwords $
-                         [ "typeOfSetupValue: array type index out of bounds"
-                         , "(index: " ++ show i ++ ")"
-                         , "(array length: " ++ show n ++ ")"
-                         ]
+                     | otherwise -> throwError $ LLVMArrayOutOfBounds i n
                    Crucible.StructType si ->
                      case Crucible.siFieldInfo si i of
                        Just fi -> return (Crucible.PtrType (Crucible.MemType (Crucible.fiType fi)))
-                       Nothing -> throwError $ "typeOfSetupValue: struct type index out of bounds: " ++ show i
-                   _ -> throwError msg
-               Left err -> throwError (unlines [msg, "Details:", err])
-           _ -> throwError msg
+                       Nothing -> throwError $ LLVMStructOutOfBounds i memTy'
+                   _ -> throwError $ LLVMInvalidElem memTy Nothing
+               Left err -> throwError $ LLVMInvalidElem memTy (Just err)
+           _ -> throwError $ LLVMInvalidElem memTy Nothing
 
     SetupNull () ->
       -- We arbitrarily set the type of NULL to void*, because a) it
@@ -546,27 +795,19 @@ typeOfSetupValue cc env nameEnv val =
                 [ (L.decName d, L.decFunType d) | d <- L.modDeclares m ] ++
                 [ (L.defName d, L.defFunType d) | d <- L.modDefines m ]
       case lookup (L.Symbol $ Text.unpack name) tys of
-        Nothing -> throwError $ Text.unpack $ "typeOfSetupValue: unknown global " <> name
+        Nothing -> throwError $ LLVMUnknownGlobal name
         Just ty ->
           case let ?lc = lc in Crucible.liftType ty of
-            Left err -> throwError $ unlines
-                          [ "typeOfSetupValue: invalid type " ++ show ty
-                          , "Details:"
-                          , err
-                          ]
+            Left err -> throwError $ LLVMInvalidType ty err
             Right symTy -> return (Crucible.PtrType symTy)
 
     SetupGlobalInitializer () name -> do
       case Map.lookup (L.Symbol $ Text.unpack name) (view Crucible.globalInitMap $ ccLLVMModuleTrans cc) of
         Just (g, _) ->
           case let ?lc = lc in Crucible.liftMemType (L.globalType g) of
-            Left err -> throwError $ unlines
-                          [ "typeOfSetupValue: invalid type " ++ show (L.globalType g)
-                          , "Details:"
-                          , err
-                          ]
+            Left err -> throwError $ LLVMInvalidType (L.globalType g) err
             Right memTy -> return memTy
-        Nothing -> throwError $ Text.unpack $ "resolveSetupVal: global not found: " <> name
+        Nothing -> throwError $ LLVMUnknownGlobal name
 
     SetupMux empty _ _ _ ->
       absurd empty
@@ -583,10 +824,9 @@ resolveSetupElemOffset ::
   Map AllocIndex Crucible.Ident   {- ^ allocation type names -} ->
   SetupValue (LLVM arch)          {- ^ base pointer -} ->
   Int                             {- ^ element index -} ->
-  Except String Crucible.Bytes    {- ^ element offset -}
+  Except LLVMSetupError Crucible.Bytes  {- ^ element offset -}
 resolveSetupElemOffset cc env nameEnv v i = do
   do memTy <- typeOfSetupValue cc env nameEnv v
-     let msg = "resolveSetupVal: llvm_elem requires pointer to struct or array, found " ++ show memTy
      case memTy of
        Crucible.PtrType symTy ->
          case let ?lc = lc in Crucible.asMemType symTy of
@@ -598,10 +838,10 @@ resolveSetupElemOffset cc env nameEnv v i = do
                Crucible.StructType si ->
                  case Crucible.siFieldOffset si i of
                    Just d -> return d
-                   Nothing -> throwError $ "resolveSetupVal: struct type index out of bounds: " ++ show (i, memTy')
-               _ -> throwError msg
-           Left err -> throwError $ unlines [msg, "Details:", err]
-       _ -> throwError msg
+                   Nothing -> throwError $ LLVMStructOutOfBounds i memTy'
+               _ -> throwError $ LLVMInvalidElem memTy Nothing
+           Left err -> throwError $ LLVMInvalidElem memTy (Just err)
+       _ -> throwError $ LLVMInvalidElem memTy Nothing
   where
     lc = ccTypeCtx cc
     dl = Crucible.llvmDataLayout lc
@@ -662,7 +902,9 @@ resolveSetupVal cc mem env tyenv nameEnv val =
       let tp = Crucible.llvmValStorableType (V.head vals)
       return $ Crucible.LLVMValArray tp vals
     SetupField () v n -> do
-      do fld <- exceptToFail $
+         st <- sawCoreState sym
+         let sc = saw_sc st
+         fld <- exceptToFail sc $
                   do info <- resolveSetupValueInfo cc tyenv nameEnv v
                      recoverStructFieldInfo cc tyenv nameEnv v info n
          ptr <- resolveSetupVal cc mem env tyenv nameEnv v
@@ -673,8 +915,10 @@ resolveSetupVal cc mem env tyenv nameEnv val =
                 return (Crucible.LLVMValInt blk off')
            _ -> fail "resolveSetupVal: llvm_field requires pointer value"
 
-    SetupElem () v i ->
-      do delta <- exceptToFail (resolveSetupElemOffset cc tyenv nameEnv v i)
+    SetupElem () v i -> do
+         st <- sawCoreState sym
+         let sc = saw_sc st
+         delta <- exceptToFail sc (resolveSetupElemOffset cc tyenv nameEnv v i)
          ptr <- resolveSetupVal cc mem env tyenv nameEnv v
          case ptr of
            Crucible.LLVMValInt blk off ->
@@ -727,8 +971,10 @@ resolveSetupValBitfield ::
   IO (BitfieldIndex, LLVMVal)
 resolveSetupValBitfield cc mem env tyenv nameEnv val fieldName =
   do let sym = cc^.ccSym
+     st <- sawCoreState sym
+     let sc = saw_sc st
      lval <- resolveSetupVal cc mem env tyenv nameEnv val
-     bfIndex <- exceptToFail (resolveSetupBitfield cc tyenv nameEnv val fieldName)
+     bfIndex <- exceptToFail sc (resolveSetupBitfield cc tyenv nameEnv val fieldName)
      let delta = biFieldByteOffset bfIndex
      offsetLval <- case lval of
                      Crucible.LLVMValInt blk off ->
@@ -819,7 +1065,10 @@ resolveSAWTerm cc tp tm =
                         tm' <- scAt sc sz_tm tp_tm tm i_tm
                         resolveSAWTerm cc tp' tm'
            case toLLVMType dl tp' of
-             Left e -> fail ("In resolveSAWTerm: " ++ toLLVMTypeErrToString e)
+             Left e -> do
+               ppopts <- scGetPPOpts sc
+               fail $ PPS.render ppopts $
+                   "In resolveSAWTerm:" <+> prettyToLLVMTypeErr e
              Right memTy -> do
                gt <- Crucible.toStorableType memTy
                Crucible.LLVMValArray gt . V.fromList <$> mapM f [ 0 .. (sz-1) ]
@@ -828,11 +1077,14 @@ resolveSAWTerm cc tp tm =
       Cryptol.TVTuple tps ->
         do st <- sawCoreState sym
            let sc = saw_sc st
+           ppopts <- scGetPPOpts sc
            tms <- mapM (scTupleSelector sc tm) [0 .. length tps - 1]
            vals <- zipWithM (resolveSAWTerm cc) tps tms
            storTy <-
              case toLLVMType dl tp of
-               Left e -> fail ("In resolveSAWTerm: " ++ toLLVMTypeErrToString e)
+               Left e ->
+                   fail $ PPS.render ppopts $
+                       "In resolveSAWTerm:" <+> prettyToLLVMTypeErr e
                Right memTy -> Crucible.toStorableType memTy
            fields <-
              case Crucible.storageTypeF storTy of
@@ -861,21 +1113,17 @@ scPtrWidthBvNat cc n =
      w <- scNat sc $ natValue Crucible.PtrWidth
      scBvNat sc w =<< scNat sc (fromIntegral n)
 
-data ToLLVMTypeErr = NotYetSupported String | Impossible String
+data ToLLVMTypeErr = UnsupportedTranslation PPS.Doc | Impossible PPS.Doc
 
-toLLVMTypeErrToString :: ToLLVMTypeErr -> String
-toLLVMTypeErrToString =
+prettyToLLVMTypeErr :: ToLLVMTypeErr -> PPS.Doc
+prettyToLLVMTypeErr =
   \case
-    NotYetSupported ty ->
-      unwords [ "SAW doesn't yet support translating Cryptol's"
-              , ty
-              , "type(s) into crucible-llvm's type system."
-              ]
+    UnsupportedTranslation ty ->
+        "SAW doesn't yet support translating Cryptol's" <+> ty <+>
+            "type(s) into crucible-llvm's type system."
     Impossible ty ->
-      unwords [ "User error: It's impossible to store Cryptol"
-              , ty
-              , "values in crucible-llvm's memory model."
-              ]
+        "User error: It's impossible to store Cryptol" <+> ty <+>
+            "values in crucible-llvm's memory model."
 
 toLLVMType ::
   Crucible.DataLayout ->
@@ -883,12 +1131,12 @@ toLLVMType ::
   Either ToLLVMTypeErr Crucible.MemType
 toLLVMType dl tp =
   case tp of
-    Cryptol.TVBit -> Left (NotYetSupported "bit") -- FIXME
-    Cryptol.TVInteger -> Left (NotYetSupported "integer")
-    Cryptol.TVIntMod _ -> Left (NotYetSupported "integer (mod n)")
-    Cryptol.TVFloat{} -> Left (NotYetSupported "float e p")
-    Cryptol.TVArray{} -> Left (NotYetSupported "array a b")
-    Cryptol.TVRational -> Left (NotYetSupported "rational")
+    Cryptol.TVBit -> Left (UnsupportedTranslation "bit") -- FIXME
+    Cryptol.TVInteger -> Left (UnsupportedTranslation "integer")
+    Cryptol.TVIntMod _ -> Left (UnsupportedTranslation "integer-mod-n")
+    Cryptol.TVFloat{} -> Left (UnsupportedTranslation "float")
+    Cryptol.TVArray{} -> Left (UnsupportedTranslation "array")
+    Cryptol.TVRational -> Left (UnsupportedTranslation "rational")
 
     Cryptol.TVSeq n Cryptol.TVBit
       | n > 0 -> Right (Crucible.IntType (fromInteger n))
@@ -902,19 +1150,20 @@ toLLVMType dl tp =
       tps' <- mapM (toLLVMType dl) tps
       let si = Crucible.mkStructInfo dl False tps'
       return (Crucible.StructType si)
-    Cryptol.TVRec _flds -> Left (NotYetSupported "record")
+    Cryptol.TVRec _flds -> Left (UnsupportedTranslation "record")
     Cryptol.TVFun _ _ -> Left (Impossible "function")
     Cryptol.TVNominal {} -> Left (Impossible "nominal")
 
 toLLVMStorageType ::
   forall w .
   Crucible.HasPtrWidth w =>
+  PPS.Opts ->
   Crucible.DataLayout ->
   Cryptol.TValue ->
   IO Crucible.StorageType
-toLLVMStorageType data_layout cryptol_type =
+toLLVMStorageType ppopts data_layout cryptol_type =
   case toLLVMType data_layout cryptol_type of
-    Left e -> fail $ toLLVMTypeErrToString e
+    Left e -> fail $ PPS.render ppopts $ prettyToLLVMTypeErr e
     Right memory_type -> Crucible.toStorableType @_ @w memory_type
 
 -- FIXME: This struct-padding logic is already implemented in
@@ -974,6 +1223,7 @@ memArrayToSawCoreTerm crucible_context endianess typed_term = do
   let data_layout = Crucible.llvmDataLayout $ ccTypeCtx crucible_context
   st <- sawCoreState sym
   let sc = saw_sc st
+  ppopts <- scGetPPOpts sc
   let cryenv = crucible_context ^. ccCryptolEnv
 
   byte_type_term <- translateType sc cryenv $ Cryptol.tValTy $ Cryptol.TVSeq 8 Cryptol.TVBit
@@ -1020,7 +1270,7 @@ memArrayToSawCoreTerm crucible_context endianess typed_term = do
 
         Cryptol.TVSeq size element_cryptol_type -> do
           element_storage_size <- liftIO $
-            Crucible.storageTypeSize <$> toLLVMStorageType
+            Crucible.storageTypeSize <$> toLLVMStorageType ppopts
               data_layout
               element_cryptol_type
 
@@ -1043,7 +1293,7 @@ memArrayToSawCoreTerm crucible_context endianess typed_term = do
 
         Cryptol.TVTuple tuple_element_cryptol_types -> do
           (Crucible.Struct field_storage_types) <- liftIO $
-            Crucible.storageTypeF <$> toLLVMStorageType data_layout cryptol_type
+            Crucible.storageTypeF <$> toLLVMStorageType ppopts data_layout cryptol_type
 
           V.forM_ (V.izipWith (,,) field_storage_types (V.fromList tuple_element_cryptol_types)) $
             \(field_index, field_storage_type, tuple_element_cryptol_type) -> do

--- a/saw-central/src/SAWCentral/Crucible/LLVM/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/ResolveSetupValue.hs
@@ -106,7 +106,8 @@ type LLVMVal = Crucible.LLVMVal Sym
 --
 --   XXX: this should not arbitrarily bake in the latest supported
 --   LLVM version but should use the version of the module we're
---   working on. Don't know how to get that info though.
+--   working on. There apparently isn't any good way to get that in
+--   general, though.
 llpretty :: ((?config :: LPP.Config) => a -> PPHPJ.Doc) -> a -> PPS.Doc
 llpretty pp item =
     let hpjdoc = LPP.ppLLVM LPP.llvmVlatest $ pp item in
@@ -144,7 +145,10 @@ prettyUnionFieldInfo ppopts ufi =
     name <+> ":" <+> info
 
 -- | Print an `L.Info`. FUTURE: move to llvm-pretty
---   XXX: what output syntax should this use?
+--
+--   This uses more or less arbitrary output syntax, which is probably
+--   ok because LLVM doesn't define any syntax for these and I don't
+--   think DWARF does either.
 prettyLLVMInfo :: PPS.Opts -> L.Info -> PPS.Doc
 prettyLLVMInfo ppopts info0 = case info0 of
     L.Pointer info1 ->

--- a/saw-central/src/SAWCentral/Crucible/LLVM/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/ResolveSetupValue.hs
@@ -20,7 +20,7 @@ module SAWCentral.Crucible.LLVM.ResolveSetupValue
   , resolveSetupVal
   , resolveSetupValBitfield
   , typeOfSetupValue
-  , exceptToFail
+  , llvmExceptToFail
   , resolveTypedTerm
   , resolveSAWPred
   , resolveSAWSymBV
@@ -408,8 +408,8 @@ ppLLVMSetupError sc ppopts err = case err of
             "Type information not found for local allocation value:" <+> i'
 
 
-exceptToFail :: (MonadFail m, MonadIO m) => SharedContext -> Except LLVMSetupError a -> m a
-exceptToFail sc m = case runExcept m of
+llvmExceptToFail :: (MonadFail m, MonadIO m) => SharedContext -> Except LLVMSetupError a -> m a
+llvmExceptToFail sc m = case runExcept m of
     Right result -> pure result
     Left err -> do
         ppopts <- liftIO $ scGetPPOpts sc
@@ -908,7 +908,7 @@ resolveSetupVal cc mem env tyenv nameEnv val =
     SetupField () v n -> do
          st <- sawCoreState sym
          let sc = saw_sc st
-         fld <- exceptToFail sc $
+         fld <- llvmExceptToFail sc $
                   do info <- resolveSetupValueInfo cc tyenv nameEnv v
                      recoverStructFieldInfo cc tyenv nameEnv v info n
          ptr <- resolveSetupVal cc mem env tyenv nameEnv v
@@ -922,7 +922,7 @@ resolveSetupVal cc mem env tyenv nameEnv val =
     SetupElem () v i -> do
          st <- sawCoreState sym
          let sc = saw_sc st
-         delta <- exceptToFail sc (resolveSetupElemOffset cc tyenv nameEnv v i)
+         delta <- llvmExceptToFail sc (resolveSetupElemOffset cc tyenv nameEnv v i)
          ptr <- resolveSetupVal cc mem env tyenv nameEnv v
          case ptr of
            Crucible.LLVMValInt blk off ->
@@ -978,7 +978,7 @@ resolveSetupValBitfield cc mem env tyenv nameEnv val fieldName =
      st <- sawCoreState sym
      let sc = saw_sc st
      lval <- resolveSetupVal cc mem env tyenv nameEnv val
-     bfIndex <- exceptToFail sc (resolveSetupBitfield cc tyenv nameEnv val fieldName)
+     bfIndex <- llvmExceptToFail sc (resolveSetupBitfield cc tyenv nameEnv val fieldName)
      let delta = biFieldByteOffset bfIndex
      offsetLval <- case lval of
                      Crucible.LLVMValInt blk off ->

--- a/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
@@ -1544,8 +1544,9 @@ assertPointsTo path func env tyenv nameEnv pointsTo@(LLVMPointsTo md cond tptr t
     err <- LO.matchPointsToValue opts sc cc ms MS.PostState md cond ptr tptval
     case err of
       Just msg -> do
+        ppopts <- liftIO $ scGetPPOpts sc
         doc <- LO.prettyPointsToAsLLVMVal opts cc sc ms pointsTo
-        O.failure loc (O.BadPointerLoad doc msg)
+        O.failure ppopts loc (O.BadPointerLoad doc msg)
       Nothing -> pure ()
 assertPointsTo _path _func env tyenv nameEnv pointsTo@(LLVMPointsToBitfield md tptr fieldName tptval) = do
   opts <- use x86Options
@@ -1559,8 +1560,9 @@ assertPointsTo _path _func env tyenv nameEnv pointsTo@(LLVMPointsToBitfield md t
     err <- LO.matchPointsToBitfieldValue opts sc cc ms MS.PostState md ptr bfIndex tptval
     case err of
       Just msg -> do
+        ppopts <- liftIO $ scGetPPOpts sc
         doc <- LO.prettyPointsToAsLLVMVal opts cc sc ms pointsTo
-        O.failure loc (O.BadPointerLoad doc msg)
+        O.failure ppopts loc (O.BadPointerLoad doc msg)
       Nothing -> pure ()
 
 -- | Gather and run the solver on goals from the simulator.

--- a/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
@@ -1369,9 +1369,10 @@ setArgs path func env tyenv nameEnv args = do
   sym <- use x86Sym
   cc <- use x86CrucibleContext
   mem <- use x86Mem
+  sc <- use x86SharedContext
   let
     setRegSetupValue rs (reg, sval) =
-      exceptToFail (typeOfSetupValue cc tyenv nameEnv sval) >>= \case
+      exceptToFail sc (typeOfSetupValue cc tyenv nameEnv sval) >>= \case
         ty | C.LLVM.isPointerMemType ty -> do
           val <- C.LLVM.unpackMemValue sym (C.LLVM.LLVMPointerRepr $ knownNat @64)
             =<< resolveSetupVal cc mem env tyenv nameEnv sval
@@ -1399,7 +1400,7 @@ setArgs path func env tyenv nameEnv args = do
   -- (right-to-left21) order."
   let stackArgs = reverse $ Prelude.drop (length argRegs) args
   forM_ stackArgs $ \sval -> do
-    liftIO $ exceptToFail (typeOfSetupValue cc tyenv nameEnv sval) >>= \case
+    liftIO $ exceptToFail sc (typeOfSetupValue cc tyenv nameEnv sval) >>= \case
       C.LLVM.PtrType _ -> pure ()
       C.LLVM.IntType 64 -> pure ()
       _ -> fail "Stack argument is not a 64 bit integer."

--- a/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
@@ -1372,7 +1372,7 @@ setArgs path func env tyenv nameEnv args = do
   sc <- use x86SharedContext
   let
     setRegSetupValue rs (reg, sval) =
-      exceptToFail sc (typeOfSetupValue cc tyenv nameEnv sval) >>= \case
+      llvmExceptToFail sc (typeOfSetupValue cc tyenv nameEnv sval) >>= \case
         ty | C.LLVM.isPointerMemType ty -> do
           val <- C.LLVM.unpackMemValue sym (C.LLVM.LLVMPointerRepr $ knownNat @64)
             =<< resolveSetupVal cc mem env tyenv nameEnv sval
@@ -1400,7 +1400,7 @@ setArgs path func env tyenv nameEnv args = do
   -- (right-to-left21) order."
   let stackArgs = reverse $ Prelude.drop (length argRegs) args
   forM_ stackArgs $ \sval -> do
-    liftIO $ exceptToFail sc (typeOfSetupValue cc tyenv nameEnv sval) >>= \case
+    liftIO $ llvmExceptToFail sc (typeOfSetupValue cc tyenv nameEnv sval) >>= \case
       C.LLVM.PtrType _ -> pure ()
       C.LLVM.IntType 64 -> pure ()
       _ -> fail "Stack argument is not a 64 bit integer."

--- a/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
@@ -122,8 +122,10 @@ import Data.Traversable (mapAccumL)
 import Data.Type.Equality (TestEquality(..))
 import qualified Data.Vector as V
 import Numeric.Natural (Natural)
-import qualified Prettyprinter as PP
 import System.IO (stdout)
+
+import qualified Prettyprinter as PP
+import Prettyprinter ((<+>))
 
 import qualified Cryptol.Eval.Type as Cryptol (evalType)
 import qualified Cryptol.Parser.AST.Builder as C
@@ -153,6 +155,8 @@ import qualified Mir.TransTy as Mir
 import qualified What4.Config as W4
 import qualified What4.Interface as W4
 import qualified What4.ProgramLoc as W4
+
+import qualified SAWSupport.Pretty as PPS
 
 import SAWCore.FiniteValue (prettyFirstOrderValue)
 import SAWCore.Name (VarName(..))
@@ -1461,11 +1465,14 @@ setupPrestateConditions mspec cc env = aux []
       case val of
         TypedTerm (TypedTermSchema sch) tm ->
           aux acc (Crucible.insertGlobal var (sch,tm) globals) xs
-        TypedTerm tp _ ->
-          fail $ unlines
-            [ "Setup term for global variable expected to have Cryptol schema type, but got"
-            , show (prettyTypedTermTypePure tp)
-            ]
+        TypedTerm tp _ -> do
+          let sym = cc ^. mccSym
+          st <- sawCoreState sym
+          let sc = saw_sc st
+          ppopts <- scGetPPOpts sc
+          tp' <- prettyTypedTermType sc tp
+          fail $ PPS.render ppopts $ "Setup term for global variable should" <+>
+              "have Cryptol schema type, but got" <+> tp'
 
 verifyObligations ::
   MIRCrucibleContext ->

--- a/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
@@ -375,7 +375,8 @@ mir_find_mangled_adt :: Mir.RustModule -> Text -> TopLevel Mir.Adt
 mir_find_mangled_adt rm name = do
   let cs = rm ^. Mir.rmCS
       col = cs ^. Mir.collection
-  did <- findDefId cs name
+  ppopts <- getPPOpts
+  did <- findDefId ppopts cs name
   findAdtMangled col did
 
 -- | Consult the given 'Mir.RustModule' to find an 'Mir.Adt'" with the given
@@ -386,16 +387,18 @@ mir_find_adt :: Mir.RustModule -> Text -> [Mir.Ty] -> TopLevel Mir.Adt
 mir_find_adt rm origName substs = do
   let cs = rm ^. Mir.rmCS
       col = cs ^. Mir.collection
-  origDid <- findDefId cs origName
+  ppopts <- getPPOpts
+  origDid <- findDefId ppopts cs origName
   findAdt col origDid (Mir.Substs substs)
 
 -- | Find an instantiation of a polymorphic function.
-mir_find_name :: MonadFail m => Mir.RustModule -> Text -> [Mir.Ty] -> m Text
+mir_find_name :: Mir.RustModule -> Text -> [Mir.Ty] -> TopLevel Text
 mir_find_name rm origName tys =
   do
     let cs  = rm ^. Mir.rmCS
         col = cs ^. Mir.collection
-    origId <- findDefId cs origName
+    ppopts <- getPPOpts
+    origId <- findDefId ppopts cs origName
     findFnInstance col origId (Mir.Substs tys)
 
 -- | Generate a fresh term of the given Cryptol type. The name will be used when
@@ -1798,22 +1801,30 @@ vecId = "alloc::vec::Vec"
 
 -- | Perform a round-trip conversion from this `Mir.Ty` to a Cryptol type and
 -- back again. See `withCryNormalizedLayouts`.
-cryNormalizeMIRTy :: Mir.Ty -> Either String Mir.Ty
+--
+-- The only caller of this function throws away the error messages it returns,
+-- so I've disabled the code that generates them.
+cryNormalizeMIRTy :: Mir.Ty -> Either () Mir.Ty
 cryNormalizeMIRTy mty = case cryptolTypeOfActual mty of
   Nothing ->
-    bail ["failed to convert", show mty, "to Cryptol"]
+    -- let mty' = PP.viaShow mty in
+    -- "Failed to convert" <+> mty' <+> "to Cryptol"
+    Left ()
   Just cryTy ->
     case Cryptol.evalType mempty cryTy of
-      Left nat ->
-        bail ["unexpected Cryptol `Nat`:", show nat]
+      Left _nat ->
+        -- let nat' = PP.viaShow nat' in (...show, or CryPP.pretty?)
+        -- "Unexpected Cryptol `Nat`:" <+> nat'
+        Left ()
       Right cryTV ->
         case toMIRType cryTV of
-          Left err ->
-            bail ["failed to convert", show cryTV, "to MIR:", toMIRTypeErrToString err]
+          Left _err ->
+            -- let cryTV' = CryPP.pretty cryTV in
+            -- let err' = prettyToMIRTypeErr err in
+            -- "Failed to convert" <+> cryTV' <+> "to MIR:" <+> err'
+            Left ()
           Right mty' ->
             Right mty'
-  where
-    bail ws = Left $ unwords $ "cryNormalizeMIRTy:" : ws
 
 -- | For each @(ty, layM)@ entry in the provided layouts, encode @ty@ as a
 -- Cryptol type and decode the result back to a `Mir.Ty` (via
@@ -1975,7 +1986,8 @@ findFn :: Mir.RustModule -> Text -> TopLevel Mir.Fn
 findFn rm nm = do
   let cs = rm ^. Mir.rmCS
       col = cs ^. Mir.collection
-  did <- findDefId cs nm
+  ppopts <- getPPOpts
+  did <- findDefId ppopts cs nm
   case Map.lookup did (col ^. Mir.functions) of
       Just x -> return x
       Nothing -> fail $ Text.unpack $ "Couldn't find MIR function named: " <> nm

--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -194,11 +194,10 @@ assignVar cc md var sref@(Some ref) =
 -- message. See @Note [MIR compositional verification and mutable allocations]@.
 checkMutableAllocPostconds ::
   Options ->
-  SharedContext ->
   MIRCrucibleContext ->
   CrucibleMethodSpecIR ->
   OverrideMatcher MIR md ()
-checkMutableAllocPostconds opts sc cc cs = do
+checkMutableAllocPostconds opts cc cs = do
   sub <- use setupValueSub
 
   -- Gather all of the references used in `mir_points_to` statements in the
@@ -208,7 +207,7 @@ checkMutableAllocPostconds opts sc cc cs = do
     traverse
       (\(MirPointsTo _cond ref _val) -> do
         MIRVal refShp refVal <-
-          resolveSetupValueMIR opts cc sc cs ref
+          resolveSetupValueMIR opts cc cs ref
         case testRefShape refShp of
           Just IsRefShape{} ->
             pure $ MirReferenceMuxConcrete refVal
@@ -564,13 +563,12 @@ then we will need to rethink this plan.
 computeReturnValue ::
   Options                     {- ^ saw script debug and print options     -} ->
   MIRCrucibleContext          {- ^ context of the crucible simulation     -} ->
-  SharedContext               {- ^ context for generating saw terms       -} ->
   MS.CrucibleMethodSpecIR MIR {- ^ method specification                   -} ->
   Crucible.TypeRepr ret       {- ^ representation of function return type -} ->
   Maybe SetupValue            {- ^ optional symbolic return value         -} ->
   OverrideMatcher MIR md (Crucible.RegValue Sym ret)
                               {- ^ concrete return value                  -}
-computeReturnValue opts cc sc spec ty mbVal =
+computeReturnValue opts cc spec ty mbVal =
   case mbVal of
     Nothing ->
       -- We know that the returned value is (), so assert that the type
@@ -581,7 +579,7 @@ computeReturnValue opts cc sc spec ty mbVal =
         Mir.MirAggregateRepr -> liftIO Mir.mirAggregate_zstIO
         _ -> fail_
     Just val -> do
-      MIRVal shp val' <- resolveSetupValueMIR opts cc sc spec val
+      MIRVal shp val' <- resolveSetupValueMIR opts cc spec val
       case W4.testEquality ty (shapeType shp) of
         Just Refl -> pure val'
         Nothing   -> fail_
@@ -698,7 +696,7 @@ executeCond ::
 executeCond opts sc cc cs ss =
   do refreshTerms sc ss
      F.traverse_ (executeAllocation opts sc cc) (Map.assocs (ss ^. MS.csAllocs))
-     checkMutableAllocPostconds opts sc cc cs
+     checkMutableAllocPostconds opts cc cs
      F.traverse_ (executePointsTo opts sc cc cs) (ss ^. MS.csPointsTos)
      F.traverse_ (executeSetupCondition opts sc cc cs) (ss ^. MS.csConditions)
 
@@ -706,16 +704,15 @@ executeCond opts sc cc cs ss =
 -- section of the CrucibleSetup block.
 executeEqual ::
   Options                                          ->
-  SharedContext                                    ->
   MIRCrucibleContext                               ->
   CrucibleMethodSpecIR                             ->
   MS.ConditionMetadata ->
   SetupValue       {- ^ first value to compare  -} ->
   SetupValue       {- ^ second value to compare -} ->
   OverrideMatcher MIR w ()
-executeEqual opts sc cc spec md v1 v2 =
-  do val1 <- resolveSetupValueMIR opts cc sc spec v1
-     val2 <- resolveSetupValueMIR opts cc sc spec v2
+executeEqual opts cc spec md v1 v2 =
+  do val1 <- resolveSetupValueMIR opts cc spec v1
+     val2 <- resolveSetupValueMIR opts cc spec v2
      p <- liftIO (equalValsPred cc val1 val2)
      addAssume p md
 
@@ -745,7 +742,7 @@ executeSetupCondition ::
 executeSetupCondition opts sc cc spec =
   \case
     MS.SetupCond_Equal md val1 val2 ->
-      executeEqual opts sc cc spec md val1 val2
+      executeEqual opts cc spec md val1 val2
     MS.SetupCond_Pred md tm -> executePred sc cc md tm
     MS.SetupCond_Ghost md var val -> executeGhost sc md var val
 
@@ -1065,7 +1062,6 @@ learnCond opts sc cc cs prepost ss =
 -- section of the CrucibleSetup block.
 learnEqual ::
   Options                                          ->
-  SharedContext                                    ->
   MIRCrucibleContext                               ->
   CrucibleMethodSpecIR                             ->
   MS.ConditionMetadata                             ->
@@ -1073,9 +1069,9 @@ learnEqual ::
   SetupValue       {- ^ first value to compare  -} ->
   SetupValue       {- ^ second value to compare -} ->
   OverrideMatcher MIR w ()
-learnEqual opts sc cc spec md prepost v1 v2 =
-  do val1 <- resolveSetupValueMIR opts cc sc spec v1
-     val2 <- resolveSetupValueMIR opts cc sc spec v2
+learnEqual opts cc spec md prepost v1 v2 =
+  do val1 <- resolveSetupValueMIR opts cc spec v1
+     val2 <- resolveSetupValueMIR opts cc spec v2
      p <- liftIO (equalValsPred cc val1 val2)
      let name = "equality " ++ MS.stateCond prepost
      let loc = MS.conditionLoc md
@@ -1099,7 +1095,7 @@ learnPointsTo opts sc cc spec prepost pointsTo@(MirPointsTo md reference target)
          sym = backendGetSym bak
      globals <- OM (use overrideGlobals)
      MIRVal referenceShp referenceVal <-
-       resolveSetupValueMIR opts cc sc spec reference
+       resolveSetupValueMIR opts cc spec reference
      -- By the time we reach here, we have already checked (in mir_points_to)
      -- that we are in fact dealing with a reference value, so the call to
      -- `testRefShape` below should always succeed.
@@ -1197,7 +1193,7 @@ learnSetupCondition ::
   OverrideMatcher MIR w ()
 learnSetupCondition opts sc cc spec prepost cond =
   case cond of
-    MS.SetupCond_Equal md val1 val2 -> learnEqual opts sc cc spec md prepost val1 val2
+    MS.SetupCond_Equal md val1 val2 -> learnEqual opts cc spec md prepost val1 val2
     MS.SetupCond_Pred md tm         -> learnPred sc cc md prepost (ttTerm tm)
     MS.SetupCond_Ghost md var val   -> learnGhost sc md prepost var val
 
@@ -1988,7 +1984,7 @@ methodSpecHandler_poststate ::
   OverrideMatcher MIR RW (Crucible.RegValue Sym ret)
 methodSpecHandler_poststate opts sc cc retTy cs =
   do executeCond opts sc cc cs (cs ^. MS.csPostState)
-     computeReturnValue opts cc sc cs retTy (cs ^. MS.csRetValue)
+     computeReturnValue opts cc cs retTy (cs ^. MS.csRetValue)
 
 -- | Use a method spec to override the behavior of a function.
 --   This function computes the pre-state portion of the override,
@@ -2064,7 +2060,7 @@ notEqual cond opts loc cc sc spec expected actual = do
   sym <- Ov.getSymInterface
   expected' <- liftIO $ MS.prettySetupValue sc expected
   let mv'actual = prettyMIRVal sym actual
-  smv'actual <- prettySetupValueAsMIRVal opts cc sc spec expected
+  smv'actual <- prettySetupValueAsMIRVal opts cc spec expected
   ppopts <- liftIO $ scGetPPOpts sc
   let msg = PP.vsep
         [ "Equality" <+> PP.pretty (MS.stateCond cond)
@@ -2098,24 +2094,23 @@ prettyArgs sym cc cs (Crucible.RegMap args) = do
 prettySetupValueAsMIRVal ::
   Options              {- ^ output/verbosity options -} ->
   MIRCrucibleContext ->
-  SharedContext {- ^ context for constructing SAW terms -} ->
   MS.CrucibleMethodSpecIR MIR {- ^ for name and typing environments -} ->
   SetupValue ->
   OverrideMatcher MIR w (PP.Doc ann)
-prettySetupValueAsMIRVal opts cc sc spec setupval = do
+prettySetupValueAsMIRVal opts cc spec setupval = do
   sym <- Ov.getSymInterface
-  mirVal <- resolveSetupValueMIR opts cc sc spec setupval
+  mirVal <- resolveSetupValueMIR opts cc spec setupval
   pure $ prettyMIRVal sym mirVal
 
 resolveSetupValueMIR ::
   Options              ->
   MIRCrucibleContext   ->
-  SharedContext        ->
   CrucibleMethodSpecIR ->
   SetupValue           ->
   OverrideMatcher MIR w MIRVal
-resolveSetupValueMIR opts cc sc spec sval =
-  do m <- OM (use setupValueSub)
+resolveSetupValueMIR opts cc spec sval =
+  do sc <- liftIO $ saw_sc <$> sawCoreState (cc ^. mccSym)
+     m <- OM (use setupValueSub)
      s <- OM (use termSub)
      let tyenv = MS.csAllocations spec
          nameEnv = MS.csTypeNames spec

--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -91,7 +91,7 @@ import CryptolSAWCore.TypedTerm
 
 import SAWCentral.Crucible.Common
 import qualified SAWCentral.Crucible.Common.MethodSpec as MS
-import SAWCentral.Crucible.Common.MethodSpec (AllocIndex(..))
+import SAWCentral.Crucible.Common.MethodSpec (AllocIndex(..), prettyAllocIndex)
 import qualified SAWCentral.Crucible.Common.Override as Ov (getSymInterface)
 import SAWCentral.Crucible.Common.Override hiding (getSymInterface)
 import SAWCentral.Crucible.MIR.MethodSpecIR
@@ -651,11 +651,16 @@ enforcePointerValidity cc ss =
 -- statement from the postcondition section.
 executeAllocation ::
   Options ->
+  SharedContext ->
   MIRCrucibleContext ->
   (AllocIndex, Some MirAllocSpec) ->
   OverrideMatcher MIR w ()
-executeAllocation opts cc (var, someAlloc@(Some alloc)) =
-  do liftIO $ printOutLn opts Debug $ unwords ["executeAllocation:", show var, Text.unpack $ ppMirAllocSpec PPS.defaultOpts alloc]
+executeAllocation opts sc cc (var, someAlloc@(Some alloc)) =
+  do liftIO $ do
+         ppopts <- scGetPPOpts sc
+         let var' = prettyAllocIndex var
+             msg' = "executeAllocation:" <+> var' <+> prettyMirAllocSpec alloc
+         printOutLn opts Debug $ PPS.render ppopts msg'
      globals <- OM (use overrideGlobals)
      (ptr, globals') <- liftIO $ doAlloc cc globals someAlloc
      OM (overrideGlobals .= globals')
@@ -689,7 +694,7 @@ executeCond ::
   OverrideMatcher MIR RW ()
 executeCond opts sc cc cs ss =
   do refreshTerms sc ss
-     F.traverse_ (executeAllocation opts cc) (Map.assocs (ss ^. MS.csAllocs))
+     F.traverse_ (executeAllocation opts sc cc) (Map.assocs (ss ^. MS.csAllocs))
      checkMutableAllocPostconds opts sc cc cs
      F.traverse_ (executePointsTo opts sc cc cs) (ss ^. MS.csPointsTos)
      F.traverse_ (executeSetupCondition opts sc cc cs) (ss ^. MS.csConditions)
@@ -779,9 +784,10 @@ handleSingleOverrideBranch opts sc cc call_loc mdMap h (OverrideWithPrecondition
      (methodSpecHandler_poststate opts sc cc retTy cs)
   case res of
     Left (OF loc rsn)  -> do
+      ppopts <- liftIO $ scGetPPOpts sc
       -- TODO, better pretty printing for reasons
       let rsn' = prettyOverrideFailureReason rsn
-          rsn'' = PPS.render PPS.defaultOpts rsn'
+          rsn'' = PPS.render ppopts rsn'
       liftIO
         $ Crucible.abortExecBecause
         $ Crucible.AssertionFailure
@@ -853,9 +859,10 @@ handleOverrideBranches opts sc cc call_loc css h branches (true, false, unknown)
                    (methodSpecHandler_poststate opts sc cc retTy cs)
                 case res of
                   Left (OF loc rsn)  -> do
+                    ppopts <- liftIO $ scGetPPOpts sc
                     -- TODO, better pretty printing for reasons
                     let rsn' = prettyOverrideFailureReason rsn
-                        rsn'' = PPS.render PPS.defaultOpts rsn'
+                        rsn'' = PPS.render ppopts rsn'
                     liftIO
                       $ Crucible.abortExecBecause
                       $ Crucible.AssertionFailure
@@ -1139,11 +1146,10 @@ learnPointsTo opts sc cc spec prepost pointsTo@(MirPointsTo md reference target)
                                      lenWord
              matchArg opts sc cc spec prepost md (MIRVal arrShp ag) referentArray
            _ -> do
-             referentArray' <- liftIO $ MS.prettySetupValue sc referentArray
-             let referentArray'' = PPS.renderText PPS.defaultOpts referentArray'
+             referentArray' <- liftIO $ MS.ppSetupValue sc referentArray
              panic "learnPointsTo"
                [ "Unexpected non-array SetupValue as MirPointsToMultiTarget:"
-               , referentArray''
+               , referentArray'
                ]
   where
     iTypes = cc ^. mccIntrinsicTypes
@@ -2052,6 +2058,7 @@ notEqual cond opts loc cc sc spec expected actual = do
   expected' <- liftIO $ MS.prettySetupValue sc expected
   let mv'actual = prettyMIRVal sym actual
   smv'actual <- prettySetupValueAsMIRVal opts cc sc spec expected
+  ppopts <- liftIO $ scGetPPOpts sc
   let msg = PP.vsep
         [ "Equality" <+> PP.pretty (MS.stateCond cond)
         , "Expected value (as a SAW value):"
@@ -2061,7 +2068,7 @@ notEqual cond opts loc cc sc spec expected actual = do
         , "Actual value: "
         , mv'actual
         ]
-      msg' = PPS.render PPS.defaultOpts msg
+      msg' = PPS.render ppopts msg
   pure $ Crucible.SimError loc $ Crucible.AssertFailureSimError msg' ""
 
 -- | Pretty-print the arguments passed to an override

--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -1424,8 +1424,9 @@ matchArg opts sc cc cs prepost md = go False []
                     Some structRefShp@(RefShape _ structTy structMutbl structRepr)
                       | tyToPtrKind fieldRefTy == tyToPtrKind structRefTy
                       , fieldMutbl == structMutbl -> do
+                        ppopts <- omGetPPOpts
                         (fieldTy', iInt, adt) <-
-                          findStructField col (mode, structRefTy) structTy fieldName
+                          findStructField ppopts col (mode, structRefTy) structTy fieldName
                         unless (fieldTy == fieldTy') fail_
                         case tyToShapeEq col structTy structRepr of
                           TransparentShape _ _ ->
@@ -1581,7 +1582,8 @@ matchArg opts sc cc cs prepost md = go False []
                      (MIRVal actualArrRefShp actualArrRef)
                      expectedArrRef
 
-             actualSliceInfo <- sliceRefTyToSliceInfo actualSliceRefTy
+             ppopts <- omGetPPOpts
+             actualSliceInfo <- sliceRefTyToSliceInfo ppopts actualSliceRefTy
              case slice of
                MirSetupSliceRaw{} ->
                  panic "matchArg" ["SliceRaw not yet implemented"]
@@ -1620,8 +1622,9 @@ matchArg opts sc cc cs prepost md = go False []
                  matchSlice expectedArrRefTy expectedArrRef
 
         ([], MIRVal (RefShape (Mir.TyRef _ _) _ _ xTpr) x, MS.SetupGlobal () name) -> do
-          static <- findStatic colState name
-          Mir.StaticVar yGlobalVar <- findStaticVar colState (static ^. Mir.sName)
+          ppopts <- omGetPPOpts
+          static <- findStatic ppopts colState name
+          Mir.StaticVar yGlobalVar <- findStaticVar ppopts colState (static ^. Mir.sName)
           let y = staticRefMux sym yGlobalVar
           case W4.testEquality xTpr (Crucible.globalType yGlobalVar) of
             Nothing -> fail_
@@ -1630,7 +1633,8 @@ matchArg opts sc cc cs prepost md = go False []
                 Mir.mirRef_eqIO bak x y
               addAssert pred_ md =<< notEq
         (_, MIRVal actualShp _, MS.SetupGlobalInitializer () name) -> do
-          static <- findStatic colState name
+          ppopts <- omGetPPOpts
+          static <- findStatic ppopts colState name
           staticInitMirVal <- findStaticInitializer cc static
           projRes <- runMaybeT $ applyProjToMIRVal sym col projStack staticInitMirVal
           case projRes of

--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -148,9 +148,10 @@ instance IsSymBackend Sym bak => Mir.MonadAssert Sym bak (MatchAssertM w) where
     addAssert p md (Crucible.SimError loc msg)
 
   maFail _ msg = MatchAssertM $ ReaderT $ \env -> do
+    ppopts <- omGetPPOpts
     let md = maeConditionMetadata env
         loc = MS.conditionLoc md
-    failure loc =<< maeFailureReason env msg
+    failure ppopts loc =<< maeFailureReason env msg
 
 runMatchAssert :: MatchAssertM w a -> MatchAssertEnv w -> OverrideMatcher MIR w a
 runMatchAssert (MatchAssertM m) = runReaderT m
@@ -585,7 +586,9 @@ computeReturnValue opts cc sc spec ty mbVal =
         Just Refl -> pure val'
         Nothing   -> fail_
   where
-    fail_ = failure (spec ^. MS.csLoc) (BadReturnSpecification (Some ty))
+    fail_ = do
+        ppopts <- omGetPPOpts
+        failure ppopts (spec ^. MS.csLoc) (BadReturnSpecification (Some ty))
 
 decodeMIRVal :: Mir.Collection -> Mir.Ty -> Crucible.AnyValue Sym -> Maybe MIRVal
 decodeMIRVal col ty (Crucible.AnyValue repr rv)
@@ -783,16 +786,14 @@ handleSingleOverrideBranch opts sc cc call_loc mdMap h (OverrideWithPrecondition
      (st^.osLocation)
      (methodSpecHandler_poststate opts sc cc retTy cs)
   case res of
-    Left (OF loc rsn)  -> do
-      ppopts <- liftIO $ scGetPPOpts sc
+    Left (OF ppopts loc rsn)  -> do
       -- TODO, better pretty printing for reasons
-      let rsn' = prettyOverrideFailureReason rsn
-          rsn'' = PPS.render ppopts rsn'
+      let rsn' = ppOverrideFailureReason ppopts rsn
       liftIO
         $ Crucible.abortExecBecause
         $ Crucible.AssertionFailure
         $ Crucible.SimError loc
-        $ Crucible.AssertFailureSimError "assumed false" rsn''
+        $ Crucible.AssertFailureSimError "assumed false" (Text.unpack rsn')
     Right (ret,st') ->
       do liftIO $ forM_ (st'^.osAssumes) $ \(_md,asum) ->
            Crucible.addAssumption bak
@@ -858,16 +859,14 @@ handleOverrideBranches opts sc cc call_loc css h branches (true, false, unknown)
                    (st^.osLocation)
                    (methodSpecHandler_poststate opts sc cc retTy cs)
                 case res of
-                  Left (OF loc rsn)  -> do
-                    ppopts <- liftIO $ scGetPPOpts sc
+                  Left (OF ppopts loc rsn)  -> do
                     -- TODO, better pretty printing for reasons
-                    let rsn' = prettyOverrideFailureReason rsn
-                        rsn'' = PPS.render ppopts rsn'
+                    let rsn' = ppOverrideFailureReason ppopts rsn
                     liftIO
                       $ Crucible.abortExecBecause
                       $ Crucible.AssertionFailure
                       $ Crucible.SimError loc
-                      $ Crucible.AssertFailureSimError "assumed false" rsn''
+                      $ Crucible.AssertFailureSimError "assumed false" (Text.unpack rsn')
                   Right (ret,st') ->
                     do liftIO $ forM_ (st'^.osAssumes) $ \(_md,asum) ->
                          Crucible.addAssumption bak
@@ -1053,13 +1052,14 @@ learnCond ::
   StateSpec ->
   OverrideMatcher MIR w ()
 learnCond opts sc cc cs prepost ss =
-  do let loc = cs ^. MS.csLoc
+  do ppopts <- liftIO $ scGetPPOpts sc
+     let loc = cs ^. MS.csLoc
      matchPointsTos opts sc cc cs prepost (ss ^. MS.csPointsTos)
      F.traverse_ (learnSetupCondition opts sc cc cs prepost) (ss ^. MS.csConditions)
      assertTermEqualities sc cc
      enforcePointerValidity cc ss
      enforceDisjointness cc loc ss
-     enforceCompleteSubstitution loc ss
+     enforceCompleteSubstitution ppopts loc ss
 
 -- | Process a "mir_equal" statement from the precondition
 -- section of the CrucibleSetup block.
@@ -1664,7 +1664,9 @@ matchArg opts sc cc cs prepost md = go False []
       loc   = MS.conditionLoc md
 
       fail_ :: OverrideMatcher MIR w a
-      fail_ = failure loc =<< structuralMismatch
+      fail_ = do
+         ppopts <- omGetPPOpts
+         failure ppopts loc =<< structuralMismatch
 
       structuralMismatch :: OverrideMatcher MIR w (OverrideFailureReason MIR)
       structuralMismatch =
@@ -1809,7 +1811,8 @@ matchPointsTos opts sc cc spec prepost = go False []
     -- not all conditions processed, no progress, failure
     go False delayed [] = do
         delayed' <- liftIO $ mapM (prettyMirPointsTo sc) delayed
-        failure (spec ^. MS.csLoc) (AmbiguousPointsTos delayed')
+        ppopts <- liftIO $ scGetPPOpts sc
+        failure ppopts (spec ^. MS.csLoc) (AmbiguousPointsTos delayed')
 
     -- not all conditions processed, progress made, resume delayed conditions
     go True delayed [] = go False [] delayed

--- a/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
@@ -16,7 +16,6 @@ module SAWCentral.Crucible.MIR.ResolveSetupValue
   , typeOfSetupValue
   , lookupAllocIndex
   , toMIRType
-  , toMIRTypeErrToString
   , resolveTypedTerm
   , resolveBoolTerm
   , resolveSAWPred
@@ -289,147 +288,162 @@ buildMirAggregateArrayWithVal sym elemSz elemShp len vals f =
 
 type SetupValue = MS.SetupValue MIR
 
+-- | Errors from lifting to MIR types.
+--
+--   We print various objects to prettyprinter docs before consing the
+--   error so that we don't have to do that printing in places that
+--   don't have the `SharedContext` and/or can't use `IO`.
+--
+--   We also embed the `PPS.Opts` so that the `Show` instance required
+--   for this to be an `X.Exception` can render the docs correctly.
+--   XXX: this is ugly. It's possible that when we manage to get the
+--   new SAW error infrastructure deployed into the Crucible code that
+--   we can make this type not need to be an `X.Exception` any more
+--   and can drop the `Show` instance.
+--
+--   (I have stuffed the `PPS.Opts` into (almost) every constructor
+--   instead of creating a wrapper type to hold it; this is to favor
+--   the readability of the call sites of the constructors, which just
+--   take an extra argument, over the printer code, which gets kind of
+--   laborious. One could fix this by writing N boilerplate wrapper
+--   functions instead, one for each constructor, but I don't have the
+--   patience for that and it's not better anyway.)
+--
 data MIRTypeOfError
-  = MIRPolymorphicType Cryptol.Schema
-  | MIRNonRepresentableType Cryptol.Type ToMIRTypeErr
-  | MIRInvalidTypedTerm TypedTermType
-  | MIRInvalidIdentifier String
-  | MIRStaticNotFound Mir.DefId
-  | MIRSliceNonReference Mir.Ty
-  | MIRSliceNonArrayReference Mir.Ty
-  | MIRSliceWrongTy Mir.Ty
-  | MIRStrSliceNonU8Array Mir.Ty
-  | MIRMuxNonBoolCondition Mir.Ty
-  | MIRMuxDifferentBranchTypes Mir.Ty Mir.Ty
-  | MIRCastNonRawPtr Mir.Ty
-  | MIRIndexOutOfBounds
+  = MIRPolymorphicType PPS.Opts Cryptol.Schema
+  | MIRNonRepresentableType PPS.Opts Cryptol.Type ToMIRTypeErr
+  | MIRInvalidTypedTerm PPS.Opts PPS.Doc -- printed offending term
+  | MIRInvalidIdentifier PPS.Opts PPS.Doc
+  | MIRStaticNotFound PPS.Opts Mir.DefId
+  | MIRSliceNonReference PPS.Opts Mir.Ty
+  | MIRSliceNonArrayReference PPS.Opts Mir.Ty
+  | MIRSliceWrongTy PPS.Opts Mir.Ty
+  | MIRStrSliceNonU8Array PPS.Opts Mir.Ty
+  | MIRMuxNonBoolCondition PPS.Opts Mir.Ty
+  | MIRMuxDifferentBranchTypes PPS.Opts Mir.Ty Mir.Ty
+  | MIRCastNonRawPtr PPS.Opts Mir.Ty
+  | MIRIndexOutOfBounds PPS.Opts
       Mir.Ty -- ^ sequence type
       Int    -- ^ sequence length
       Int    -- ^ attempted index
-  | MIRIndexWrongTy MirIndexingMode Mir.Ty
-  | MIRInvalidFieldAccess
+  | MIRIndexWrongTy PPS.Opts MirIndexingMode Mir.Ty
+  | MIRInvalidFieldAccess PPS.Opts
       Mir.Ty -- ^ struct type
       [Text] -- ^ valid field names
       Text   -- ^ attempted to access this invalid field name
-  | MIRAccessTransparentSecondaryField
+  | MIRAccessTransparentSecondaryField PPS.Opts
       Mir.Ty -- ^ @#[repr(transparent)]@ struct type
       Text   -- ^ primary field name
       Text   -- ^ attempted to access this secondary ZST field name
-  | MIRFieldAccessWrongTy MirFieldAccessMode Mir.Ty
+  | MIRFieldAccessWrongTy PPS.Opts MirFieldAccessMode Mir.Ty
+
+ppMIRTypeOfError :: MIRTypeOfError -> Text
+ppMIRTypeOfError err =
+  let (ppopts_, msg_) = case err of
+        MIRPolymorphicType ppopts s ->
+            let s' = CryPP.pretty s in
+            (ppopts, "Expected monomorphic term; instead got:" <+> s')
+        MIRNonRepresentableType ppopts ty suberr ->
+            let ty' = CryPP.pretty ty
+                suberr' = prettyToMIRTypeErr ppopts suberr
+            in
+            (ppopts, PP.vsep [
+                "Type" <+> ty' <+> "not representable in MIR:",
+                suberr'
+            ])
+        MIRInvalidTypedTerm ppopts tp ->
+            (ppopts, "Expected typed term with Cryptol-representable type, but got" <+> tp)
+        MIRInvalidIdentifier ppopts errMsg ->
+            (ppopts, errMsg)
+        MIRStaticNotFound ppopts did ->
+            let did' = PP.pretty did in
+            (ppopts, "Could not find static named:" <+> did')
+        MIRSliceNonReference ppopts ty ->
+            let ty' = PP.pretty ty in
+            (ppopts, "Expected a reference, but got" <+> ty')
+        MIRSliceNonArrayReference ppopts ty ->
+            let ty' = PP.pretty ty in
+            (ppopts, "Expected a reference to an array, but got" <+> ty')
+        MIRSliceWrongTy ppopts ty ->
+            let ty' = PP.pretty ty in
+            (ppopts, "Expected a slice type, but got" <+> ty')
+        MIRStrSliceNonU8Array ppopts ty ->
+            let ty' = PP.pretty ty in
+            (ppopts, "Expected a value of type &[u8; <length>], but got" <+> ty')
+        MIRMuxNonBoolCondition ppopts ty ->
+            let ty' = PP.pretty ty in
+            (ppopts, "Expected a bool-typed condition in a mux, but got" <+> ty')
+        MIRMuxDifferentBranchTypes ppopts tTy fTy ->
+            let tTy' = PP.pretty tTy in
+            let fTy' = PP.pretty fTy in
+            (ppopts, PP.vsep [
+                "Mismatch in mux branch types:",
+                "True  branch type:" <+> tTy',
+                "False branch type:" <+> fTy'
+            ])
+        MIRCastNonRawPtr ppopts ty ->
+            let ty' = PP.pretty ty in
+            (ppopts, PP.vsep [
+                "Casting only works on raw pointers.",
+                "Expected a raw pointer (*const T or *mut T), but got" <+> ty'
+            ])
+        MIRIndexOutOfBounds ppopts xsTy len i ->
+            let xsTy' = PP.pretty xsTy in
+            let len' = PPS.prettyInt ppopts len in
+            let i' = PPS.prettyInt ppopts i in
+            (ppopts, PP.vsep [
+                "Index out of bounds:",
+                "Indexing into:" <+> xsTy',
+                "with length:  " <+> len',
+                "at index:     " <+> i'
+            ])
+        MIRIndexWrongTy ppopts ixMode ty ->
+            let expected = case ixMode of
+                    MirIndexIntoVal -> "an array"
+                    MirIndexIntoRef -> "a reference (or raw pointer) to an array"
+                    MirIndexOffsetRef -> "a reference or raw pointer"
+                ty' = PP.pretty ty
+            in
+            (ppopts, "Expected" <+> expected <> ", but got" <+> ty')
+        MIRInvalidFieldAccess ppopts structTy structFields invalidField ->
+            let structTy' = PP.pretty structTy
+                structFields' = PPS.commaSepAll $ map PP.pretty structFields
+                invalidField' = PPS.prettyStringDQ invalidField
+            in
+            (ppopts, PP.vsep [
+                "Field" <+> invalidField' <+> "does not exist.",
+                "On struct type:" <+> structTy',
+                "Valid fields are:" <+> structFields'
+            ])
+        MIRAccessTransparentSecondaryField ppopts structTy primaryField secondaryField ->
+            let structTy' = PP.pretty structTy
+                primaryField' = PPS.prettyStringDQ primaryField
+                secondaryField' = PP.pretty secondaryField
+            in
+            (ppopts, PP.vsep [
+                "Cannot access zero-sized field" <+> secondaryField' <+>
+                    "of #[repr(transparent)] struct:",
+                "On #[repr(transparent)] struct type:" <+> structTy',
+                "The inner field that can be accessed is:" <+> primaryField'
+            ])
+        MIRFieldAccessWrongTy ppopts accessMode ty ->
+            let expected = case accessMode of
+                    MirFieldAccessByVal -> "a struct"
+                    MirFieldAccessByRef -> "a reference (or raw pointer) to a struct"
+                ty' = PP.pretty ty
+            in
+            (ppopts, "Expected" <+> expected <> ", but got" <+> ty')
+  in
+  PPS.renderText ppopts_ msg_
 
 instance Show MIRTypeOfError where
-  show (MIRPolymorphicType s) =
-    unlines
-    [ "Expected monomorphic term"
-    , "instead got:"
-    , Text.unpack (CryPP.pp s)
-    ]
-  show (MIRNonRepresentableType ty err) =
-    unlines
-    [ "Type not representable in MIR:"
-    , Text.unpack (CryPP.pp ty)
-    , toMIRTypeErrToString err
-    ]
-  show (MIRInvalidTypedTerm tp) =
-    unlines
-    [ "Expected typed term with Cryptol-representable type, but got"
-    , show (prettyTypedTermTypePure PPS.defaultOpts tp)
-    ]
-  show (MIRInvalidIdentifier errMsg) =
-    errMsg
-  show (MIRStaticNotFound did) =
-    staticNotFoundErr did
-  show (MIRSliceNonReference ty) =
-    unlines
-    [ "Expected a reference, but got"
-    , show (PP.pretty ty)
-    ]
-  show (MIRSliceNonArrayReference ty) =
-    unlines
-    [ "Expected a reference to an array, but got"
-    , show (PP.pretty ty)
-    ]
-  show (MIRSliceWrongTy ty) =
-    unlines
-    [ "Expected a slice type, but got"
-    , show (PP.pretty ty)
-    ]
-  show (MIRStrSliceNonU8Array ty) =
-    unlines
-    [ "Expected a value of type &[u8; <length>], but got"
-    , show (PP.pretty ty)
-    ]
-  show (MIRMuxNonBoolCondition ty) =
-    unlines
-    [ "Expected a bool-typed condition in a mux, but got"
-    , show (PP.pretty ty)
-    ]
-  show (MIRMuxDifferentBranchTypes tTy fTy) =
-    unlines
-    [ "Mismatch in mux branch types:"
-    , "True  branch type: " ++ show (PP.pretty tTy)
-    , "False branch type: " ++ show (PP.pretty fTy)
-    ]
-  show (MIRCastNonRawPtr ty) =
-    unlines
-    [ "Casting only works on raw pointers"
-    , "Expected a raw pointer (*const T or *mut T), but got"
-    , show (PP.pretty ty)
-    ]
-  show (MIRIndexOutOfBounds xsTy len i) =
-    unlines
-    [ "Index out of bounds:"
-    , "Indexing into: " ++ show (PP.pretty xsTy)
-    , "with length:   " ++ show len
-    , "at index:      " ++ show i
-    ]
-  show (MIRIndexWrongTy ixMode ty) =
-    unlines
-    [ "Expected " ++ expected ++ ", but got"
-    , show (PP.pretty ty)
-    ]
-    where
-      expected =
-        case ixMode of
-          MirIndexIntoVal -> "an array"
-          MirIndexIntoRef -> "a reference (or raw pointer) to an array"
-          MirIndexOffsetRef -> "a reference or raw pointer"
-  show (MIRInvalidFieldAccess structTy structFields invalidField) =
-    unlines
-    [ "Field '" ++ Text.unpack invalidField ++ "' does not exist:"
-    , "On struct type: " ++ show (PP.pretty structTy)
-    , "Valid fields are: " ++ Text.unpack (Text.intercalate ", " structFields)
-    ]
-  show (MIRAccessTransparentSecondaryField structTy primaryField secondaryField) =
-    unlines
-    [ "Cannot access zero-sized field '" ++ Text.unpack secondaryField
-      ++ "' of #[repr(transparent)] struct:"
-    , "On #[repr(transparent)] struct type: " ++ show (PP.pretty structTy)
-    , "The inner field that can be accessed is: " ++ Text.unpack primaryField
-    ]
-  show (MIRFieldAccessWrongTy accessMode ty) =
-    unlines
-    [ "Expected " ++ expected ++ ", but got"
-    , show (PP.pretty ty)
-    ]
-    where
-      expected =
-        case accessMode of
-          MirFieldAccessByVal -> "a struct"
-          MirFieldAccessByRef -> "a reference (or raw pointer) to a struct"
-
-staticNotFoundErr :: Mir.DefId -> String
-staticNotFoundErr did =
-  unlines
-  [ "Could not find static named:"
-  , show did
-  ]
+  show err = Text.unpack $ ppMIRTypeOfError err
 
 instance X.Exception MIRTypeOfError
 
 typeOfSetupValue ::
   forall m.
-  X.MonadThrow m =>
+  (X.MonadThrow m, MonadIO m) =>
   MIRCrucibleContext ->
   Map AllocIndex (Some MirAllocSpec) ->
   Map AllocIndex Text ->
@@ -460,10 +474,16 @@ typeOfSetupValue mcc env nameEnv val =
     MS.SetupTuple () vals -> do
       tys <- traverse (typeOfSetupValue mcc env nameEnv) vals
       pure $ Mir.TyTuple tys
-    MS.SetupGlobal () name ->
-      staticTyRef <$> findStatic cs name
+    MS.SetupGlobal () name -> do
+      let sym = mcc ^. mccSym
+      sc <- liftIO $ saw_sc <$> sawCoreState sym
+      ppopts <- liftIO $ scGetPPOpts sc
+      staticTyRef <$> findStatic ppopts cs name
     MS.SetupGlobalInitializer () name -> do
-      static <- findStatic cs name
+      let sym = mcc ^. mccSym
+      sc <- liftIO $ saw_sc <$> sawCoreState sym
+      ppopts <- liftIO $ scGetPPOpts sc
+      static <- findStatic ppopts cs name
       pure $ static ^. Mir.sTy
     MS.SetupSlice slice ->
       case slice of
@@ -477,12 +497,18 @@ typeOfSetupValue mcc env nameEnv val =
           typeOfSliceFromArrayRef sliceInfo arrRef
     MS.SetupMux () c t f -> do
       cTy <- typeOfTypedTerm c
-      unless (cTy == Mir.TyBool) $
-        X.throwM $ MIRMuxNonBoolCondition cTy
+      unless (cTy == Mir.TyBool) $ do
+        let sym = mcc ^. mccSym
+        sc <- liftIO $ saw_sc <$> sawCoreState sym
+        ppopts <- liftIO $ scGetPPOpts sc
+        X.throwM $ MIRMuxNonBoolCondition ppopts cTy
       tTy <- typeOfSetupValue mcc env nameEnv t
       fTy <- typeOfSetupValue mcc env nameEnv f
-      unless (checkCompatibleTys tTy fTy) $
-        X.throwM $ MIRMuxDifferentBranchTypes tTy fTy
+      unless (checkCompatibleTys tTy fTy) $ do
+        let sym = mcc ^. mccSym
+        sc <- liftIO $ saw_sc <$> sawCoreState sym
+        ppopts <- liftIO $ scGetPPOpts sc
+        X.throwM $ MIRMuxDifferentBranchTypes ppopts tTy fTy
       pure tTy
     MS.SetupCast newPointeeTy oldPtr -> do
       -- Make sure the cast is valid
@@ -490,14 +516,26 @@ typeOfSetupValue mcc env nameEnv val =
       case oldPtrTy of
         Mir.TyRawPtr _ mutbl ->
           pure $ Mir.TyRawPtr newPointeeTy mutbl
-        _ -> X.throwM $ MIRCastNonRawPtr oldPtrTy
+        _ -> do
+          let sym = mcc ^. mccSym
+          sc <- liftIO $ saw_sc <$> sawCoreState sym
+          ppopts <- liftIO $ scGetPPOpts sc
+          X.throwM $ MIRCastNonRawPtr ppopts oldPtrTy
 
     MS.SetupElem ixMode xs i -> do
       xsTy <- typeOfSetupValue mcc env nameEnv xs
       let boundsCheck len res
             | i >= 0 && i < len = pure res
-            | otherwise = X.throwM $ MIRIndexOutOfBounds xsTy len i
-          throwWrongTy = X.throwM $ MIRIndexWrongTy ixMode xsTy
+            | otherwise = do
+                  let sym = mcc ^. mccSym
+                  sc <- liftIO $ saw_sc <$> sawCoreState sym
+                  ppopts <- liftIO $ scGetPPOpts sc
+                  X.throwM $ MIRIndexOutOfBounds ppopts xsTy len i
+          throwWrongTy = do
+              let sym = mcc ^. mccSym
+              sc <- liftIO $ saw_sc <$> sawCoreState sym
+              ppopts <- liftIO $ scGetPPOpts sc
+              X.throwM $ MIRIndexWrongTy ppopts ixMode xsTy
       case ixMode of
         MirIndexIntoVal ->
           case xsTy of
@@ -514,8 +552,11 @@ typeOfSetupValue mcc env nameEnv val =
     MS.SetupField accessMode structValOrPtr fieldName -> do
       structValOrPtrTy <- typeOfSetupValue mcc env nameEnv structValOrPtr
       let findFieldType structValTy = do
+            let sym = mcc ^. mccSym
+            sc <- liftIO $ saw_sc <$> sawCoreState sym
+            ppopts <- liftIO $ scGetPPOpts sc
             (fieldValTy, _, _) <-
-              findStructField col (accessMode, structValOrPtrTy) structValTy fieldName
+              findStructField ppopts col (accessMode, structValOrPtrTy) structValTy fieldName
             pure fieldValTy
       case accessMode of
         MirFieldAccessByVal ->
@@ -527,8 +568,11 @@ typeOfSetupValue mcc env nameEnv val =
             Some (RefShape structPtrTy structValTy mutbl _) -> do
               fieldValTy <- findFieldType structValTy
               pure $ ptrKindToTy (tyToPtrKind structPtrTy) fieldValTy mutbl
-            _ ->
-              X.throwM $ MIRFieldAccessWrongTy accessMode structValOrPtrTy
+            _ -> do
+              let sym = mcc ^. mccSym
+              sc <- liftIO $ saw_sc <$> sawCoreState sym
+              ppopts <- liftIO $ scGetPPOpts sc
+              X.throwM $ MIRFieldAccessWrongTy ppopts accessMode structValOrPtrTy
 
     MS.SetupNull empty                -> absurd empty
     MS.SetupUnion empty _ _           -> absurd empty
@@ -538,23 +582,39 @@ typeOfSetupValue mcc env nameEnv val =
 
     typeOfSliceFromArrayRef :: MirSliceInfo -> SetupValue -> m Mir.Ty
     typeOfSliceFromArrayRef sliceInfo arrRef = do
+      let sym = mcc ^. mccSym
+      sc <- liftIO $ saw_sc <$> sawCoreState sym
+      ppopts <- liftIO $ scGetPPOpts sc
       arrRefTy <- typeOfSetupValue mcc env nameEnv arrRef
       case arrRefTy of
         Mir.TyRef arrTy mut -> do
-          (sliceTy, _elemTy, _len) <- arrayToSliceTys sliceInfo mut arrTy
+          (sliceTy, _elemTy, _len) <- arrayToSliceTys ppopts sliceInfo mut arrTy
           pure $ Mir.TyRef sliceTy mut
-        _ ->
-          X.throwM $ MIRSliceNonReference arrRefTy
+        _ -> do
+          X.throwM $ MIRSliceNonReference ppopts arrRefTy
 
     typeOfTypedTerm :: TypedTerm -> m Mir.Ty
     typeOfTypedTerm tt =
       case ttType tt of
         TypedTermSchema (Cryptol.Forall [] [] ty) ->
           case toMIRType (Cryptol.evalValType mempty ty) of
-            Left err -> X.throwM (MIRNonRepresentableType ty err)
+            Left err -> do
+                let sym = mcc ^. mccSym
+                sc <- liftIO $ saw_sc <$> sawCoreState sym
+                ppopts <- liftIO $ scGetPPOpts sc
+                X.throwM (MIRNonRepresentableType ppopts ty err)
             Right mirTy -> return mirTy
-        TypedTermSchema s -> X.throwM (MIRPolymorphicType s)
-        tp -> X.throwM (MIRInvalidTypedTerm tp)
+        TypedTermSchema s -> do
+            let sym = mcc ^. mccSym
+            sc <- liftIO $ saw_sc <$> sawCoreState sym
+            ppopts <- liftIO $ scGetPPOpts sc
+            X.throwM (MIRPolymorphicType ppopts s)
+        tp -> do
+            let sym = mcc ^. mccSym
+            sc <- liftIO $ saw_sc <$> sawCoreState sym
+            ppopts <- liftIO $ scGetPPOpts sc
+            tp' <- liftIO $ prettyTypedTermType sc tp
+            X.throwM (MIRInvalidTypedTerm ppopts tp')
 
 lookupAllocIndex :: Map AllocIndex a -> AllocIndex -> a
 lookupAllocIndex env i =
@@ -647,7 +707,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
               checkFields
                 nm
                 "Enum"
-                ("fields in enum variant " ++ show (variant ^. Mir.vname))
+                ("fields in enum variant " <> Mir.idText (variant ^. Mir.vname))
                 expectedFlds
                 actualFldTys
 
@@ -737,7 +797,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
                     checkFields
                       nm
                       "Enum"
-                      ("fields in enum variant " ++ show (variant ^. Mir.vname))
+                      ("fields in enum variant " <> Mir.idText (variant ^. Mir.vname))
                       expectedFlds
                       actualFldTys
                     Some (Functor.Pair fldShpAssn valAssn) <-
@@ -842,9 +902,14 @@ resolveSetupVal mcc env tyenv nameEnv val =
                   Just mv -> pure mv
                   -- FIXME: use a different error kind here (this is a type
                   -- or size mismatch error; bounds are checked elsewhere)
-                  Nothing -> X.throwM $ MIRIndexOutOfBounds arrTy (fromIntegral len) i
-              else
-                X.throwM $ MIRIndexOutOfBounds arrTy (fromIntegral len) i
+                  Nothing -> do
+                      sc <- liftIO $ saw_sc <$> sawCoreState sym
+                      ppopts <- liftIO $ scGetPPOpts sc
+                      X.throwM $ MIRIndexOutOfBounds ppopts arrTy (fromIntegral len) i
+              else do
+                sc <- liftIO $ saw_sc <$> sawCoreState sym
+                ppopts <- liftIO $ scGetPPOpts sc
+                X.throwM $ MIRIndexOutOfBounds ppopts arrTy (fromIntegral len) i
         MirIndexIntoRef
           | RefShape ptrTy
                      (Mir.TyArray elemTy len)
@@ -861,12 +926,16 @@ resolveSetupVal mcc env tyenv nameEnv val =
                 let elemSize = tySize col elemTy
                 MIRVal (RefShape elemPtrTy elemTy mutbl elemTpr) <$>
                   Mir.subindexMirRefIO bak iTypes elemTpr xsVal i_sym elemSize
-              else
-                X.throwM $ MIRIndexOutOfBounds ptrTy len i
+              else do
+                sc <- liftIO $ saw_sc <$> sawCoreState sym
+                ppopts <- liftIO $ scGetPPOpts sc
+                X.throwM $ MIRIndexOutOfBounds ppopts ptrTy len i
         MirIndexOffsetRef ->
           panic "resolveSetupValue" ["MirIndexOffsetRef not yet implemented"]
-        _ ->
-          X.throwM $ MIRIndexWrongTy ixMode (shapeMirTy xsShp)
+        _ -> do
+          sc <- liftIO $ saw_sc <$> sawCoreState sym
+          ppopts <- liftIO $ scGetPPOpts sc
+          X.throwM $ MIRIndexWrongTy ppopts ixMode (shapeMirTy xsShp)
     MS.SetupField accessMode structValOrPtrSV fieldName -> do
       structValOrPtrMV <- resolveSetupVal mcc env tyenv nameEnv structValOrPtrSV
       case accessMode of
@@ -884,8 +953,10 @@ resolveSetupVal mcc env tyenv nameEnv val =
           MIRVal structPtrShp structPtrRV <- pure structValOrPtrMV
           case structPtrShp of
             RefShape structPtrTy structValTy mutbl structRepr -> do
+              sc <- liftIO $ saw_sc <$> sawCoreState sym
+              ppopts <- liftIO $ scGetPPOpts sc
               (fieldValTy, iInt, adt) <-
-                findStructField col (accessMode, structPtrTy) structValTy fieldName
+                findStructField ppopts col (accessMode, structPtrTy) structValTy fieldName
               let -- Construct a MIRVal for the resulting field pointer with the
                   -- given pointee TypeRepr and pointer RegValue.
                   fieldMIRVal :: TypeRepr tp -> RegValue Sym Mir.MirReferenceType -> MIRVal
@@ -908,10 +979,12 @@ resolveSetupVal mcc env tyenv nameEnv val =
                   -- structRepr is the field's TypeRepr
                   pure $ fieldMIRVal structRepr structPtrRV
                 _ ->
-                  X.throwM $ MIRFieldAccessWrongTy accessMode structPtrTy
-            _ ->
+                  X.throwM $ MIRFieldAccessWrongTy ppopts accessMode structPtrTy
+            _ -> do
+              sc <- liftIO $ saw_sc <$> sawCoreState sym
+              ppopts <- liftIO $ scGetPPOpts sc
               X.throwM $
-                MIRFieldAccessWrongTy accessMode (shapeMirTy structPtrShp)
+                MIRFieldAccessWrongTy ppopts accessMode (shapeMirTy structPtrShp)
     MS.SetupCast newPointeeTy oldPtrSetupVal -> do
       MIRVal oldShp ref <- resolveSetupVal mcc env tyenv nameEnv oldPtrSetupVal
       case oldShp of
@@ -926,18 +999,24 @@ resolveSetupVal mcc env tyenv nameEnv val =
           -- See Note [Raw pointer casts] in SAWCentral.Crucible.MIR.Setup.Value
           -- for more info.
           pure $ MIRVal (RefShape newPtrTy newPointeeTy mutbl newPointeeTpr) ref
-        _ ->
-          X.throwM $ MIRCastNonRawPtr $ shapeMirTy oldShp
+        _ -> do
+          sc <- liftIO $ saw_sc <$> sawCoreState sym
+          ppopts <- liftIO $ scGetPPOpts sc
+          X.throwM $ MIRCastNonRawPtr ppopts $ shapeMirTy oldShp
     MS.SetupUnion empty _ _           -> absurd empty
     MS.SetupGlobal () name -> do
-      static <- findStatic cs name
-      Mir.StaticVar gv <- findStaticVar cs (static ^. Mir.sName)
+      sc <- liftIO $ saw_sc <$> sawCoreState sym
+      ppopts <- liftIO $ scGetPPOpts sc
+      static <- findStatic ppopts cs name
+      Mir.StaticVar gv <- findStaticVar ppopts cs (static ^. Mir.sName)
       let sMut = staticMutability static
           sTy  = static ^. Mir.sTy
       pure $ MIRVal (RefShape (staticTyRef static) sTy sMut (globalType gv))
            $ staticRefMux sym gv
     MS.SetupGlobalInitializer () name -> do
-      static <- findStatic cs name
+      sc <- liftIO $ saw_sc <$> sawCoreState sym
+      ppopts <- liftIO $ scGetPPOpts sc
+      static <- findStatic ppopts cs name
       findStaticInitializer mcc static
     MS.SetupMux () c t f -> do
       MIRVal cShp cVal <- resolveTypedTerm mcc c
@@ -946,7 +1025,10 @@ resolveSetupVal mcc env tyenv nameEnv val =
       Refl <-
         case W4.testEquality cTpr BoolRepr of
           Just r -> pure r
-          Nothing -> X.throwM $ MIRMuxNonBoolCondition cTy
+          Nothing -> do
+              sc <- liftIO $ saw_sc <$> sawCoreState sym
+              ppopts <- liftIO $ scGetPPOpts sc
+              X.throwM $ MIRMuxNonBoolCondition ppopts cTy
 
       MIRVal tShp tVal <- resolveSetupVal mcc env tyenv nameEnv t
       let tTy = shapeMirTy tShp
@@ -957,7 +1039,10 @@ resolveSetupVal mcc env tyenv nameEnv val =
       Refl <-
         case W4.testEquality tTpr fTpr of
           Just r -> pure r
-          Nothing -> X.throwM $ MIRMuxDifferentBranchTypes tTy fTy
+          Nothing -> do
+              sc <- liftIO $ saw_sc <$> sawCoreState sym
+              ppopts <- liftIO $ scGetPPOpts sc
+              X.throwM $ MIRMuxDifferentBranchTypes ppopts tTy fTy
 
       let muxShp = tShp
       let muxTpr = tTpr
@@ -973,32 +1058,38 @@ resolveSetupVal mcc env tyenv nameEnv val =
     -- types and that the types of each field match.
     checkFields ::
       Mir.DefId {- The struct or enum name. (Only used for error messages.) -} ->
-      String {- "Struct" or "Enum". (Only used for error messages.) -} ->
-      String {- What type of fields are we checking?
-                (Only used for error messages.) -} ->
+      Text {- "Struct" or "Enum". (Only used for error messages.) -} ->
+      Text {- What type of fields are we checking?
+              (Only used for error messages.) -} ->
       [Mir.Field] {- The expected fields. -} ->
       [Mir.Ty] {- The actual field types. -} ->
       IO ()
-    checkFields adtNm what fieldDiscr expectedFlds actualFldTys = do
+    checkFields adtNm what fieldDescr expectedFlds actualFldTys = do
       let expectedFldsNum = length expectedFlds
       let actualFldsNum = length actualFldTys
-      unless (expectedFldsNum == actualFldsNum) $
-        fail $ unlines
-          [ "Mismatch in number of " ++ fieldDiscr
-          , what ++ " name: " ++ show adtNm
-          , "Expected number of fields: " ++ show expectedFldsNum
-          , "Actual number of fields:   " ++ show actualFldsNum
+      unless (expectedFldsNum == actualFldsNum) $ do
+        let sym = mcc ^. mccSym
+        sc <- liftIO $ saw_sc <$> sawCoreState sym
+        ppopts <- liftIO $ scGetPPOpts sc
+        fail $ PPS.render ppopts $ PP.vsep [
+            "Mismatch in number of" <+> PP.pretty fieldDescr,
+            PP.pretty what <+> "name:" <+> PP.pretty adtNm,
+            "Expected number of fields:" <+> PPS.prettyInt ppopts expectedFldsNum,
+            "Actual number of fields:  " <+> PPS.prettyInt ppopts actualFldsNum
           ]
       zipWithM_
         (\expectedFld actualFldTy ->
           let expectedFldTy = expectedFld ^. Mir.fty in
           let expectedFldName = expectedFld ^. Mir.fName in
-          unless (checkCompatibleTys expectedFldTy actualFldTy) $
-            fail $ unlines
-              [ what ++ " field type mismatch"
-              , "Field name: " ++ show expectedFldName
-              , "Expected type: " ++ show (PP.pretty expectedFldTy)
-              , "Given type:    " ++ show (PP.pretty actualFldTy)
+          unless (checkCompatibleTys expectedFldTy actualFldTy) $ do
+            let sym = mcc ^. mccSym
+            sc <- liftIO $ saw_sc <$> sawCoreState sym
+            ppopts <- liftIO $ scGetPPOpts sc
+            fail $ PPS.render ppopts $ PP.vsep [
+                PP.pretty what <+> "field type mismatch",
+                "Field name:" <+> PP.pretty expectedFldName,
+                "Expected:" <+> PP.pretty expectedFldTy,
+                "Found:   " <+> PP.pretty actualFldTy
               ])
         expectedFlds
         actualFldTys
@@ -1046,7 +1137,9 @@ resolveSetupVal mcc env tyenv nameEnv val =
       MIRVal arrRefShp arrRefVal <- resolveSetupVal mcc env tyenv nameEnv arrRef
       case arrRefShp of
         RefShape _ arrTy mut Mir.MirAggregateRepr -> do
-          (sliceTy, elemTy, len) <- arrayToSliceTys sliceInfo mut arrTy
+          sc <- liftIO $ saw_sc <$> sawCoreState sym
+          ppopts <- liftIO $ scGetPPOpts sc
+          (sliceTy, elemTy, len) <- arrayToSliceTys ppopts sliceInfo mut arrTy
           Some elemTpr <- case Mir.tyToRepr col elemTy of
             Left err -> panic "resolveSetupSliceFromArrayRef" ["Unsupported type", Text.pack err]
             Right x -> return x
@@ -1055,7 +1148,10 @@ resolveSetupVal mcc env tyenv nameEnv val =
           refVal <- Mir.subindexMirRefIO bak iTypes elemTpr arrRefVal zeroBV elemSize
           let sliceShp = SliceShape (Mir.TyRef sliceTy mut) elemTy mut elemTpr
           pure $ SetupSliceFromArrayRef sliceShp refVal len
-        _ -> X.throwM $ MIRSliceNonReference $ shapeMirTy arrRefShp
+        _ -> do
+          sc <- liftIO $ saw_sc <$> sawCoreState sym
+          ppopts <- liftIO $ scGetPPOpts sc
+          X.throwM $ MIRSliceNonReference ppopts $ shapeMirTy arrRefShp
 
     -- Resolve a transparent struct or enum value.
     resolveTransparentSetupVal :: Mir.Adt -> SetupValue -> IO MIRVal
@@ -1168,7 +1264,10 @@ resolveSAWTerm mcc tp tm =
       let cryenv = mcc ^. mccCryptolEnv
       doIndex <- indexSeqTerm cryenv sym (sz, tp') tm
       case toMIRType tp' of
-        Left e -> fail ("In resolveSAWTerm: " ++ toMIRTypeErrToString e)
+        Left err -> do
+          sc <- liftIO $ saw_sc <$> sawCoreState sym
+          ppopts <- liftIO $ scGetPPOpts sc
+          fail $ Text.unpack $ "In resolveSAWTerm: " <> ppToMIRTypeErr ppopts err
         Right mirTy -> do
           Some (shp :: TypeShape tp) <- pure $ tyToShape col mirTy
 
@@ -1209,21 +1308,32 @@ resolveSAWTerm mcc tp tm =
     sym = mcc ^. mccSym
     col = mcc ^. mccRustModule ^. Mir.rmCS ^. Mir.collection
 
-data ToMIRTypeErr = NotYetSupported String | Impossible String
+data ToMIRTypeErr =
+    UnsupportedTranslation PPS.Doc
+  | Impossible PPS.Doc
+  | IrregularBitvector Integer
+  | HugeBitvector Integer
 
-toMIRTypeErrToString :: ToMIRTypeErr -> String
-toMIRTypeErrToString =
-  \case
-    NotYetSupported ty ->
-      unwords [ "SAW doesn't yet support translating Cryptol's"
-              , ty
-              , "type(s) into crucible-mir's type system."
-              ]
+prettyToMIRTypeErr :: PPS.Opts -> ToMIRTypeErr -> PPS.Doc
+prettyToMIRTypeErr ppopts err = case err of
+    UnsupportedTranslation ty ->
+        "SAW doesn't yet support translating Cryptol's" <+> ty <+>
+            "types into crucible-mir's type system."
     Impossible ty ->
-      unwords [ "User error: It's impossible to store Cryptol"
-              , ty
-              , "values in crucible-mir's memory model."
-              ]
+        "User error: It's impossible to store Cryptol" <+> ty <+>
+            "values in crucible-mir's memory model."
+    IrregularBitvector n ->
+        let n' = PPS.prettyInteger ppopts n in
+        "User error: It's impossible to store irregular-sized bitvectors" <+>
+            "(here" <+> n' <> ") in crucible-mir's memory model."
+    HugeBitvector n ->
+        let n' = PPS.prettyInteger ppopts n in
+        "Huge bitvectors (here" <+> n' <> ") are not available in" <+>
+            "crucible-mir's memory model"
+
+ppToMIRTypeErr :: PPS.Opts -> ToMIRTypeErr -> Text
+ppToMIRTypeErr ppopts err =
+    PPS.renderText ppopts $ prettyToMIRTypeErr ppopts err
 
 toMIRType ::
   Cryptol.TValue ->
@@ -1231,11 +1341,11 @@ toMIRType ::
 toMIRType tp =
   case tp of
     Cryptol.TVBit -> Right Mir.TyBool
-    Cryptol.TVInteger -> Left (NotYetSupported "integer")
-    Cryptol.TVIntMod _ -> Left (Impossible "integer (mod n)")
-    Cryptol.TVFloat{} -> Left (NotYetSupported "float e p")
-    Cryptol.TVArray{} -> Left (NotYetSupported "array a b")
-    Cryptol.TVRational -> Left (NotYetSupported "rational")
+    Cryptol.TVInteger -> Left (UnsupportedTranslation "integer")
+    Cryptol.TVIntMod _ -> Left (Impossible "integer-mod-n")
+    Cryptol.TVFloat{} -> Left (UnsupportedTranslation "float e p")
+    Cryptol.TVArray{} -> Left (UnsupportedTranslation "array a b")
+    Cryptol.TVRational -> Left (UnsupportedTranslation "rational")
     Cryptol.TVSeq n Cryptol.TVBit ->
       case n of
         8   -> Right $ Mir.TyUint Mir.B8
@@ -1243,7 +1353,8 @@ toMIRType tp =
         32  -> Right $ Mir.TyUint Mir.B32
         64  -> Right $ Mir.TyUint Mir.B64
         128 -> Right $ Mir.TyUint Mir.B128
-        _   -> Left (Impossible ("unsupported bitvector size: " ++ show n))
+        _ | n > 128  -> Left (HugeBitvector n)
+        _ | otherwise  -> Left (IrregularBitvector n)
     Cryptol.TVSeq n t -> do
       t' <- toMIRType t
       let n' = fromIntegral n
@@ -1252,9 +1363,9 @@ toMIRType tp =
     Cryptol.TVTuple tps -> do
       tps' <- traverse toMIRType tps
       Right $ Mir.TyTuple tps'
-    Cryptol.TVRec _flds -> Left (NotYetSupported "record")
+    Cryptol.TVRec _flds -> Left (UnsupportedTranslation "record")
     Cryptol.TVFun _ _ -> Left (Impossible "function")
-    Cryptol.TVNominal {} -> Left (Impossible "nominal")
+    Cryptol.TVNominal {} -> Left (Impossible "nominal-type")
 
 -- | Index into a 'Term' which has a Cryptol sequence type. Curried so that we
 -- can save some work if we want to index multiple times into the same term.
@@ -1300,16 +1411,18 @@ indexMirArray sym i elemSz elemShp (Mir.MirAggregate _totalSize m) = do
 -- Returns 'Nothing' if the field is uninitialized. Throws if there is an error
 -- with the field access itself (e.g. no such field name).
 accessMirStructFieldVal ::
-  X.MonadThrow m =>
+  (X.MonadThrow m, MonadIO m) =>
   Sym ->
   Mir.Collection ->
   Text ->
   MIRVal ->
   m (Maybe MIRVal)
-accessMirStructFieldVal sym col fieldName (MIRVal structShp structRV) =
+accessMirStructFieldVal sym col fieldName (MIRVal structShp structRV) = do
+  sc <- liftIO $ saw_sc <$> sawCoreState sym
+  ppopts <- liftIO $ scGetPPOpts sc
   case structShp of
     StructShape structTy _ fieldShps -> do
-      (_, iInt, adt) <- findStructField col (MirFieldAccessByVal, structTy) structTy fieldName
+      (_, iInt, adt) <- findStructField ppopts col (MirFieldAccessByVal, structTy) structTy fieldName
       Some i <- pure $ structFieldShapeIntIndex adt iInt fieldShps
       let RV fieldRV = structRV Ctx.! i
       pure $
@@ -1321,10 +1434,10 @@ accessMirStructFieldVal sym col fieldName (MIRVal structShp structRV) =
     TransparentShape structTy innerShp -> do
       -- We still need to call findStructField, to check that the field exists
       -- and is the primary field
-      _ <- findStructField col (MirFieldAccessByVal, structTy) structTy fieldName
+      _ <- findStructField ppopts col (MirFieldAccessByVal, structTy) structTy fieldName
       pure $ Just $ MIRVal innerShp structRV
     _ ->
-      X.throwM $ MIRFieldAccessWrongTy MirFieldAccessByVal (shapeMirTy structShp)
+      X.throwM $ MIRFieldAccessWrongTy ppopts MirFieldAccessByVal (shapeMirTy structShp)
 
 -- | Create a symbolic @usize@ from an 'Int'.
 usizeBvLit :: W4.IsSymExprBuilder sym => sym -> Int -> IO (W4.SymBV sym Mir.SizeBits)
@@ -1469,11 +1582,12 @@ equalValsPred cc mv1 mv2 =
 -- array type.
 arrayToSliceTys ::
   X.MonadThrow m =>
+  PPS.Opts ->
   MirSliceInfo ->
   Mir.Mutability ->
   Mir.Ty ->
   m (Mir.Ty, Mir.Ty, Int)
-arrayToSliceTys sliceInfo mut arrTy@(Mir.TyArray ty len) =
+arrayToSliceTys ppopts sliceInfo mut arrTy@(Mir.TyArray ty len) =
   case sliceInfo of
     MirArraySlice ->
       pure (Mir.TySlice ty, ty, len)
@@ -1481,11 +1595,11 @@ arrayToSliceTys sliceInfo mut arrTy@(Mir.TyArray ty len) =
       |  checkCompatibleTys ty u8
       -> pure (Mir.TyStr, u8, len)
       |  otherwise
-      -> X.throwM $ MIRStrSliceNonU8Array $ Mir.TyRef arrTy mut
+      -> X.throwM $ MIRStrSliceNonU8Array ppopts $ Mir.TyRef arrTy mut
   where
     u8 = Mir.TyUint Mir.B8
-arrayToSliceTys _sliceInfo mut arrTy =
-  X.throwM $ MIRSliceNonArrayReference $ Mir.TyRef arrTy mut
+arrayToSliceTys ppopts _sliceInfo mut arrTy =
+  X.throwM $ MIRSliceNonArrayReference ppopts $ Mir.TyRef arrTy mut
 
 -- | Retrieve the \"element type\" of a slice type. If the supplied type is an
 -- array slice type (e.g., @[u32]@), return the underlying type (e.g., @u32@).
@@ -1493,31 +1607,33 @@ arrayToSliceTys _sliceInfo mut arrTy =
 -- throw an exception.
 sliceElemTy ::
   X.MonadThrow m =>
+  PPS.Opts ->
   Mir.Ty ->
   m Mir.Ty
-sliceElemTy (Mir.TySlice ty) =
+sliceElemTy _ppopts (Mir.TySlice ty) =
   pure ty
-sliceElemTy Mir.TyStr =
+sliceElemTy _ppopts Mir.TyStr =
   pure $ Mir.TyUint Mir.B8
-sliceElemTy ty =
-  X.throwM $ MIRSliceWrongTy ty
+sliceElemTy ppopts ty =
+  X.throwM $ MIRSliceWrongTy ppopts ty
 
 -- | Take a slice reference type and return the corresponding 'MirSliceInfo'.
 -- Throw an exception if the supplied type is not a slice reference type.
 sliceRefTyToSliceInfo ::
   X.MonadThrow m =>
+  PPS.Opts ->
   Mir.Ty ->
   m MirSliceInfo
-sliceRefTyToSliceInfo (Mir.TyRef sliceTy _) =
+sliceRefTyToSliceInfo ppopts (Mir.TyRef sliceTy _) =
   case sliceTy of
     Mir.TySlice _ ->
       pure MirArraySlice
     Mir.TyStr ->
       pure MirStrSlice
     _ ->
-      X.throwM $ MIRSliceWrongTy sliceTy
-sliceRefTyToSliceInfo ty =
-  X.throwM $ MIRSliceNonReference ty
+      X.throwM $ MIRSliceWrongTy ppopts sliceTy
+sliceRefTyToSliceInfo ppopts ty =
+  X.throwM $ MIRSliceNonReference ppopts ty
 
 -- | Allocate memory for each 'mir_alloc', 'mir_alloc_mut',
 -- 'mir_alloc_raw_ptr_const', or 'mir_alloc_raw_ptr_mut'.
@@ -1679,9 +1795,11 @@ fieldOrVariantShortName defId =
       ]
 
 -- | Like 'findDefIdEither', but any errors are thrown with 'fail'.
-findDefId :: MonadFail m => Mir.CollectionState -> Text -> m Mir.DefId
-findDefId cs defName =
-  either fail pure $ findDefIdEither cs defName
+findDefId :: MonadFail m => PPS.Opts -> Mir.CollectionState -> Text -> m Mir.DefId
+findDefId ppopts cs defName =
+  case findDefIdEither cs defName of
+      Right result -> pure result
+      Left msg -> fail $ PPS.render ppopts msg
 
 -- | Given a definition name @defName@, attempt to look up its corresponding
 -- 'Mir.DefId'. If successful, return it with 'Right'. Currently, the following
@@ -1700,16 +1818,17 @@ findDefId cs defName =
 -- function will return the @$lang@-based 'DefId' instead (e.g.,
 -- @$lang::Option@), as the latter 'DefId' is what will be used throughout the
 -- rest of the MIR code.
-findDefIdEither :: Mir.CollectionState -> Text -> Either String Mir.DefId
+findDefIdEither :: Mir.CollectionState -> Text -> Either (PP.Doc ann) Mir.DefId
 findDefIdEither cs defName = do
     (crate, path) <-
       case edid of
         crate:path -> pure (crate, path)
-        [] -> Left $ unlines
-                [ "The definition `" ++ defNameStr ++ "` lacks a crate."
-                , "Consider providing one, e.g., `<crate_name>::" ++ defNameStr ++ "`."
-                ]
-    let crateStr = Text.unpack crate
+        [] ->
+            let defName' = PP.pretty defName in
+            Left $ PP.vsep [
+                "The definition \"" <+> defName' <+> "lacks a crate.",
+                "Consider providing one, e.g., <crate_name>::" <> defName' <> "."
+            ]
     origDefId <-
       case Text.splitOn "/" crate of
         [crateNoDisambig, disambig] ->
@@ -1722,48 +1841,53 @@ findDefIdEither cs defName = do
                 -> Right $ Mir.textId $ Text.intercalate "::"
                          $ (crate <> "/" <> disambig) : path
                 |  otherwise
-                -> Left $ unlines $
-                     [ "ambiguous crate " ++ crateStr
-                     , "crate disambiguators:"
-                     ] ++ F.toList (Text.unpack <$> allDisambigs)
-              Nothing -> Left $ "unknown crate " ++ crateStr
-        _ -> Left $ "Malformed crate name: " ++ show crateStr
+                ->
+                    let allDisambigs' = map PP.pretty $ F.toList allDisambigs in
+                    Left $ PP.vsep [
+                       "Ambiguous crate" <+> PP.pretty crate,
+                       "Crate disambiguators:",
+                       PP.indent 3 $ PP.vsep allDisambigs'
+                    ]
+              Nothing -> Left $ "Unknown crate" <+> PP.pretty crate
+        _ -> Left $ "Malformed crate name:" <+> PP.pretty crate
     Right $ Map.findWithDefault origDefId origDefId langItemDefIds
   where
     crateDisambigs = cs ^. Mir.crateHashesMap
     langItemDefIds = cs ^. Mir.collection . Mir.langItems
 
-    defNameStr = Text.unpack defName
     edid = Text.splitOn "::" defName
 
 -- | Consult the given 'Mir.CollectionState' to find a 'Mir.Static' with the
 -- given 'String' as an identifier. If such a 'Mir.Static' cannot be found, this
 -- will raise an error.
-findStatic :: X.MonadThrow m => Mir.CollectionState -> Text -> m Mir.Static
-findStatic cs name = do
+findStatic :: X.MonadThrow m => PPS.Opts -> Mir.CollectionState -> Text -> m Mir.Static
+findStatic ppopts cs name = do
   did <- case findDefIdEither cs name of
-    Left err -> X.throwM $ MIRInvalidIdentifier err
+    Left err -> X.throwM $ MIRInvalidIdentifier ppopts err
     Right did -> pure did
   case Map.lookup did (cs ^. Mir.collection . Mir.statics) of
-    Nothing -> X.throwM $ MIRStaticNotFound did
+    Nothing -> X.throwM $ MIRStaticNotFound ppopts did
     Just static -> pure static
 
 -- | Consult the given 'MIRCrucibleContext' to find the 'MIRVal' used to
 -- initialize a 'Mir.Static' value. If such a 'MIRVal' cannot be found, this
 -- will raise an error.
 findStaticInitializer ::
-  X.MonadThrow m =>
+  (X.MonadThrow m, MonadIO m) =>
   MIRCrucibleContext ->
   Mir.Static ->
   m MIRVal
 findStaticInitializer mcc static = do
-  Mir.StaticVar gv <- findStaticVar cs staticDefId
+  let sym = mcc ^. mccSym
+  sc <- liftIO $ saw_sc <$> sawCoreState sym
+  ppopts <- liftIO $ scGetPPOpts sc
+  Mir.StaticVar gv <- findStaticVar ppopts cs staticDefId
   let staticShp = tyToShapeEq col (static ^. Mir.sTy) (globalType gv)
   case MapF.lookup gv (mcc^.mccStaticInitializerMap) of
     Just (RV staticInitVal) ->
       pure $ MIRVal staticShp staticInitVal
-    Nothing ->
-      X.throwM $ MIRStaticNotFound staticDefId
+    Nothing -> do
+      X.throwM $ MIRStaticNotFound ppopts staticDefId
   where
     staticDefId = static ^. Mir.sName
     cs  = mcc ^. mccRustModule . Mir.rmCS
@@ -1774,12 +1898,13 @@ findStaticInitializer mcc static = do
 -- an error.
 findStaticVar ::
   X.MonadThrow m =>
+  PPS.Opts ->
   Mir.CollectionState ->
   Mir.DefId ->
   m Mir.StaticVar
-findStaticVar cs staticDefId =
+findStaticVar ppopts cs staticDefId =
   case Map.lookup staticDefId (cs ^. Mir.staticMap) of
-    Nothing -> X.throwM $ MIRStaticNotFound staticDefId
+    Nothing -> X.throwM $ MIRStaticNotFound ppopts staticDefId
     Just sv -> pure sv
 
 -- | Compute the 'Mir.Mutability' of a 'Mir.Static' value.
@@ -1870,17 +1995,18 @@ variantIntIndex adtNm variantIdx variantsSize =
 -- field in a @#[repr(transparent)]@ struct.
 findStructField ::
   X.MonadThrow m =>
+  PPS.Opts ->
   Mir.Collection ->
   (MirFieldAccessMode, Mir.Ty)
     {-^ the original Ty the user passed, only used for error reporting -} ->
   Mir.Ty {-^ the struct type -} ->
   Text {-^ field name -}->
   m (Mir.Ty, Int, Mir.Adt)
-findStructField col (accessMode, origTy) structTy shortFieldName = do
+findStructField ppopts col (accessMode, origTy) structTy shortFieldName = do
   adtName <-
     case structTy of
       Mir.TyAdt adtName _ _ -> pure adtName
-      _ -> X.throwM $ MIRFieldAccessWrongTy accessMode origTy
+      _ -> X.throwM $ MIRFieldAccessWrongTy ppopts accessMode origTy
   adt <-
     case col ^. Mir.adts . at adtName of
       Just adt -> pure adt
@@ -1890,7 +2016,7 @@ findStructField col (accessMode, origTy) structTy shortFieldName = do
         ]
   case adt ^. Mir.adtkind of
     Mir.Struct -> pure ()
-    _ -> X.throwM $ MIRFieldAccessWrongTy accessMode origTy
+    _ -> X.throwM $ MIRFieldAccessWrongTy ppopts accessMode origTy
   variant <-
     case adt ^. Mir.adtvariants of
       [variant] -> pure variant
@@ -1903,8 +2029,9 @@ findStructField col (accessMode, origTy) structTy shortFieldName = do
   (i, field) <-
     case FWI.ifind (\_ fld -> getShortName fld == shortFieldName) fields of
       Just result -> pure result
-      Nothing -> X.throwM $
-        MIRInvalidFieldAccess structTy (map getShortName fields) shortFieldName
+      Nothing -> do
+        X.throwM $
+            MIRInvalidFieldAccess ppopts structTy (map getShortName fields) shortFieldName
   case Mir.findReprTransparentField col adt of
     Just primaryFieldIndex
       | primaryFieldIndex /= i -> do
@@ -1919,7 +2046,7 @@ findStructField col (accessMode, origTy) structTy shortFieldName = do
               , "Index: " <> Text.pack (show primaryFieldIndex)
               ]
         X.throwM $
-          MIRAccessTransparentSecondaryField
+          MIRAccessTransparentSecondaryField ppopts
             structTy
             (getShortName primaryField)
             shortFieldName

--- a/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
@@ -1325,10 +1325,10 @@ prettyToMIRTypeErr ppopts err = case err of
     IrregularBitvector n ->
         let n' = PPS.prettyInteger ppopts n in
         "User error: It's impossible to store irregular-sized bitvectors" <+>
-            "(here" <+> n' <> ") in crucible-mir's memory model."
+            PP.parens ("here" <+> n') <+> "in crucible-mir's memory model."
     HugeBitvector n ->
         let n' = PPS.prettyInteger ppopts n in
-        "Huge bitvectors (here" <+> n' <> ") are not available in" <+>
+        "Huge bitvectors" <+> PP.parens ("here" <+> n') <+> "are not available in" <+>
             "crucible-mir's memory model"
 
 ppToMIRTypeErr :: PPS.Opts -> ToMIRTypeErr -> Text

--- a/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
@@ -408,21 +408,21 @@ ppMIRTypeOfError err =
         MIRInvalidFieldAccess ppopts structTy structFields invalidField ->
             let structTy' = PP.pretty structTy
                 structFields' = PPS.commaSepAll $ map PP.pretty structFields
-                invalidField' = PPS.prettyStringDQ invalidField
+                invalidField' = PP.pretty invalidField
             in
             (ppopts, PP.vsep [
-                "Field" <+> invalidField' <+> "does not exist.",
+                "No such field:" <+> invalidField',
                 "On struct type:" <+> structTy',
                 "Valid fields are:" <+> structFields'
             ])
         MIRAccessTransparentSecondaryField ppopts structTy primaryField secondaryField ->
             let structTy' = PP.pretty structTy
-                primaryField' = PPS.prettyStringDQ primaryField
+                primaryField' = PP.pretty primaryField
                 secondaryField' = PP.pretty secondaryField
             in
             (ppopts, PP.vsep [
-                "Cannot access zero-sized field" <+> secondaryField' <+>
-                    "of #[repr(transparent)] struct:",
+                "Cannot access zero-sized field of #[repr(transparent)] struct:" <+>
+                    secondaryField',
                 "On #[repr(transparent)] struct type:" <+> structTy',
                 "The inner field that can be accessed is:" <+> primaryField'
             ])

--- a/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
@@ -81,7 +81,9 @@ import qualified Data.Parameterized.TraversableFC.WithIndex as FCI
 import qualified Data.Text as Text
 import           Data.Text (Text)
 import           Data.Void (absurd)
+
 import qualified Prettyprinter as PP
+import Prettyprinter ((<+>))
 
 import qualified Cryptol.Eval.Type as Cryptol (TValue(..), tValTy, evalValType)
 import qualified Cryptol.TypeCheck.AST as Cryptol (Type, Schema(..))
@@ -102,6 +104,8 @@ import qualified Mir.TransTy as Mir
 import qualified What4.BaseTypes as W4
 import qualified What4.Interface as W4
 import qualified What4.Partial as W4
+
+import qualified SAWSupport.Pretty as PPS
 
 import qualified CryptolSAWCore.Pretty as CryPP
 import CryptolSAWCore.Cryptol (CryptolEnv, translateType)
@@ -329,7 +333,7 @@ instance Show MIRTypeOfError where
   show (MIRInvalidTypedTerm tp) =
     unlines
     [ "Expected typed term with Cryptol-representable type, but got"
-    , show (prettyTypedTermTypePure tp)
+    , show (prettyTypedTermTypePure PPS.defaultOpts tp)
     ]
   show (MIRInvalidIdentifier errMsg) =
     errMsg
@@ -1110,11 +1114,14 @@ resolveTypedTerm mcc tm =
   case ttType tm of
     TypedTermSchema (Cryptol.Forall [] [] ty) ->
       resolveSAWTerm mcc (Cryptol.evalValType mempty ty) (ttTerm tm)
-    tp -> fail $ unlines
-            [ "resolveTypedTerm: expected monomorphic term"
-            , "but got a term of type"
-            , show (prettyTypedTermTypePure tp)
-            ]
+    tp -> do
+      let sym = mcc ^. mccSym
+      st <- sawCoreState sym
+      let sc = saw_sc st
+      ppopts <- scGetPPOpts sc
+      tp' <- prettyTypedTermType sc tp
+      fail $ PPS.render ppopts $ "resolveTypedTerm: expected monomorphic" <+>
+          "term, but got a term of type" <+> tp'
 
 resolveSAWPred ::
   MIRCrucibleContext ->

--- a/saw-central/src/SAWCentral/ImportAIG.hs
+++ b/saw-central/src/SAWCentral/ImportAIG.hs
@@ -24,7 +24,7 @@ import Prettyprinter
 
 import qualified Data.AIG as AIG
 
-import qualified SAWSupport.Pretty as PPS (defaultOpts, render)
+import qualified SAWSupport.Pretty as PPS (render)
 
 import SAWCore.Name (VarName)
 import SAWCore.Recognizer
@@ -55,8 +55,9 @@ bitblastSharedTerm sc v (asBitvectorType -> Just w) = do
       scAt sc wt boolType v =<< scNat sc (fromIntegral i)
   modify (V.++ inputs)
 bitblastSharedTerm sc _ tp = do
+  ppopts <- liftIO $ scGetPPOpts sc
   tp' <- liftIO $ prettyTerm sc tp
-  throwTP $ PPS.render PPS.defaultOpts $ vcat [
+  throwTP $ PPS.render ppopts $ vcat [
       "Could not parse AIG input type:",
       indent 2 tp'
    ]

--- a/saw-central/src/SAWCentral/JavaExpr.hs
+++ b/saw-central/src/SAWCentral/JavaExpr.hs
@@ -6,6 +6,7 @@ Maintainer  : atomb
 Stability   : provisional
 -}
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -47,6 +48,7 @@ module SAWCentral.JavaExpr
   , parseJavaExpr
   , MethodLocation (..)
   , JavaType(..)
+  , prettyJavaType
   ) where
 
 -- Imports
@@ -63,7 +65,11 @@ import qualified Data.Text as Text
 import qualified Data.Vector as V
 import Text.Read hiding (lift)
 
+import qualified Prettyprinter as PP
+
 import Lang.JVM.Codebase as JSS
+
+import qualified SAWSupport.Pretty as PPS
 
 import CryptolSAWCore.Cryptol (CryptolEnv, translateType)
 import SAWCore.Name (VarName(..))
@@ -364,3 +370,16 @@ data JavaType
   | JavaArray Int JavaType
   | JavaClass Text
   deriving (Eq, Show)
+
+prettyJavaType :: PPS.Opts -> JavaType -> PPS.Doc
+prettyJavaType ppopts ty0 = case ty0 of
+    JavaBoolean -> "bool"
+    JavaByte -> "byte"
+    JavaChar -> "char"
+    JavaShort -> "short"
+    JavaInt -> "int"
+    JavaLong -> "long"
+    JavaFloat -> "float"
+    JavaDouble -> "double"
+    JavaArray sz ty1 -> prettyJavaType ppopts ty1 <> "[" <> PPS.prettyInt ppopts sz <> "]"
+    JavaClass name -> PP.pretty name

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -157,7 +157,8 @@ import Data.Parameterized.Nonce
 import qualified What4.Expr.Builder as W4
 import What4.ProgramLoc (ProgramLoc)
 
-import qualified SAWSupport.Pretty as PPS (Doc, Opts, defaultOpts, render, renderText)
+import qualified SAWSupport.Pretty as PPS (Doc, Opts, render, renderText)
+import SAWSupport.Position
 
 import SAWCore.Recognizer
 import SAWCore.Rewriter
@@ -1227,7 +1228,13 @@ specializeTheorem _sc _what4PushMuxOps db _loc _rsn thm [] = return (thm, db)
 specializeTheorem sc what4PushMuxOps db loc rsn thm ts =
   do res <- specializeProp sc (_thmProp thm) ts
      case res of
-       Left err -> fail (unlines ["specialize_theorem: failed to specialize", ppTermError err])
+       Left err -> do
+         err' <- prettyTermError sc err
+         ppopts <- scGetPPOpts sc
+         fail $ PPS.render ppopts $ PP.vsep [
+             "specialize_theorem: failed to specialize",
+             err'
+          ]
        Right p' ->
          constructTheorem sc what4PushMuxOps db p' (ApplyEvidence thm (map Left ts)) loc Nothing rsn 0
 
@@ -1595,37 +1602,46 @@ checkEvidence sc what4PushMuxOps = \e p -> do
 
       SolverEvidence stats sqt' ->
         do ok <- sequentSubsumes sc sqt' sqt
-           unless ok $ fail $ unlines
+           unless ok $ do
+             ppopts <- scGetPPOpts sc
+             fail $ PPS.render ppopts $ PP.vsep
                [ "Solver proof does not prove the required sequent"
-               , ppSequent PPS.defaultOpts nenv sqt
-               , ppSequent PPS.defaultOpts nenv sqt'
+               , prettySequent ppopts nenv sqt
+               , prettySequent ppopts nenv sqt'
                ]
            return (mempty, ProvedTheorem stats)
 
       Admitted msg pos sqt' ->
         do ok <- sequentSubsumes sc sqt' sqt
-           unless ok $ fail $ unlines
-               [ "Admitted proof does not match the required sequent " ++ show pos
-               , Text.unpack msg
-               , ppSequent PPS.defaultOpts nenv sqt
-               , ppSequent PPS.defaultOpts nenv sqt'
+           unless ok $ do
+             ppopts <- scGetPPOpts sc
+             let pos' = prettyPosition pos
+             fail $ PPS.render ppopts $ PP.vsep
+               [ "Admitted proof does not match the required sequent" <+> pos'
+               , pretty msg
+               , prettySequent ppopts nenv sqt
+               , prettySequent ppopts nenv sqt'
                ]
            return (mempty, AdmittedTheorem msg)
 
       QuickcheckEvidence n sqt' ->
         do ok <- sequentSubsumes sc sqt' sqt
-           unless ok $ fail $ unlines
+           unless ok $ do
+             ppopts <- scGetPPOpts sc
+             fail $ PPS.render ppopts $ PP.vsep
                [ "Quickcheck evidence does not match the required sequent"
-               , ppSequent PPS.defaultOpts nenv sqt
-               , ppSequent PPS.defaultOpts nenv sqt'
+               , prettySequent ppopts nenv sqt
+               , prettySequent ppopts nenv sqt'
                ]
            return (mempty, TestedTheorem n)
 
       SplitEvidence e1 e2 ->
         splitSequent sc sqt >>= \case
-          Nothing -> fail $ unlines
+          Nothing -> do
+              ppopts <- scGetPPOpts sc
+              fail $ PPS.render ppopts $ PP.vsep
                        [ "Split evidence does not apply"
-                       , ppSequent PPS.defaultOpts nenv sqt
+                       , prettySequent ppopts nenv sqt
                        ]
           Just (sqt1,sqt2) ->
             do d1 <- check nenv e1 sqt1
@@ -1649,13 +1665,17 @@ checkEvidence sc what4PushMuxOps = \e p -> do
                         ]
                    return (d, sy)
 
-              _ -> fail $ unlines $
-                    [ "Not enough hypotheses in apply hypothesis: " ++ show n
-                    , ppSequent PPS.defaultOpts nenv sqt
+              _ -> do
+                  ppopts <- scGetPPOpts sc
+                  fail $ PPS.render ppopts $ PP.vsep
+                    [ "Not enough hypotheses in apply hypothesis:" <+> PP.viaShow n
+                    , prettySequent ppopts nenv sqt
                     ]
-          _ -> fail $ unlines $
+          _ -> do
+              ppopts <- scGetPPOpts sc
+              fail $ PPS.render ppopts $ PP.vsep
                     [ "Apply hypothesis evidence requires a conclusion-focused sequent."
-                    , ppSequent PPS.defaultOpts nenv sqt
+                    , prettySequent ppopts nenv sqt
                     ]
 
       ApplyEvidence thm es ->
@@ -1672,9 +1692,11 @@ checkEvidence sc what4PushMuxOps = \e p -> do
                        sp'
                     ]
                return (Set.insert (thmNonce thm) d, sy)
-          _ -> fail $ unlines $
+          _ -> do
+              ppopts <- scGetPPOpts sc
+              fail $ PPS.render ppopts $ PP.vsep
                     [ "Apply evidence requires a conclusion-focused sequent"
-                    , ppSequent PPS.defaultOpts nenv sqt
+                    , prettySequent ppopts nenv sqt
                     ]
 
       UnfoldEvidence vars e' ->
@@ -1705,37 +1727,45 @@ checkEvidence sc what4PushMuxOps = \e p -> do
 
       ConversionEvidence sqt' e' ->
         do ok <- convertibleSequents sc sqt sqt'
-           unless ok $ fail $ unlines
-             [ "Converted sequent does not match goal"
-             , ppSequent PPS.defaultOpts nenv sqt
-             , ppSequent PPS.defaultOpts nenv sqt'
-             ]
+           unless ok $ do
+               ppopts <- scGetPPOpts sc
+               fail $ PPS.render ppopts $ PP.vsep [
+                   "Converted sequent does not match goal",
+                   prettySequent ppopts nenv sqt,
+                   prettySequent ppopts nenv sqt'
+                ]
            check nenv e' sqt'
 
       NormalizeSequentEvidence sqt' e' ->
         do ok <- normalizeSequentSubsumes sc sqt' sqt
-           unless ok $ fail $ unlines
-             [ "Normalized sequent does not subsume goal"
-             , ppSequent PPS.defaultOpts nenv sqt
-             , ppSequent PPS.defaultOpts nenv sqt'
-             ]
+           unless ok $ do
+               ppopts <- scGetPPOpts sc
+               fail $ PPS.render ppopts $ PP.vsep [
+                   "Normalized sequent does not subsume goal",
+                   prettySequent ppopts nenv sqt,
+                   prettySequent ppopts nenv sqt'
+                ]
            check nenv e' sqt'
 
       StructuralEvidence sqt' e' ->
         do ok <- sequentSubsumes sc sqt' sqt
-           unless ok $ fail $ unlines
-             [ "Sequent does not subsume goal"
-             , ppSequent PPS.defaultOpts nenv sqt
-             , ppSequent PPS.defaultOpts nenv sqt'
-             ]
+           unless ok $ do
+               ppopts <- scGetPPOpts sc
+               fail $ PPS.render ppopts $ PP.vsep [
+                   "Sequent does not subsume goal",
+                   prettySequent ppopts nenv sqt,
+                   prettySequent ppopts nenv sqt'
+                ]
            check nenv e' sqt'
 
       AxiomEvidence ->
         do ok <- sequentIsAxiom sc sqt
-           unless ok $ fail $ unlines
-             [ "Sequent is not an instance of the sequent calculus axiom"
-             , ppSequent PPS.defaultOpts nenv sqt
-             ]
+           unless ok $ do
+               ppopts <- scGetPPOpts sc
+               fail $ PPS.render ppopts $ PP.vsep [
+                   "Sequent is not an instance of the sequent calculus axiom",
+                   prettySequent ppopts nenv sqt
+                ]
            return (mempty, ProvedTheorem mempty)
 
       CutEvidence p ehyp egl ->
@@ -2255,8 +2285,13 @@ tacticSpecializeHyp sc ts = Tactic \gl ->
     HypFocusedSequent (FB hs1 h hs2) gs ->
       do res <- liftIO (specializeProp sc h ts)
          case res of
-           Left err ->
-             fail (unlines ["specialize_hyp tactic: failed to specialize", ppTermError err])
+           Left err -> do
+             ppopts <- liftIO $ scGetPPOpts sc
+             err' <- liftIO $ prettyTermError sc err
+             fail $ PPS.render ppopts $ PP.vsep [
+                 "specialize_hyp tactic: failed to specialize",
+                 err'
+              ]
            Right h' ->
              do let gl' = gl{ goalSequent = HypFocusedSequent (FB hs1 h (hs2++[h'])) gs }
                 return ((), mempty, [gl'], specializeHypEvidence (genericLength hs1) h' ts)
@@ -2270,9 +2305,13 @@ tacticInsert :: (F.MonadFail m, MonadIO m) => SharedContext -> Theorem -> [Term]
 tacticInsert sc thm ts = Tactic \gl ->
   do res <- liftIO (specializeProp sc (_thmProp thm) ts)
      case res of
-       Left err ->
-         fail (unlines (["goal_insert_and_specialize tactic: failed to specialize"] ++
-                        [ppTermError err]))
+       Left err -> do
+         ppopts <- liftIO $ scGetPPOpts sc
+         err' <- liftIO $ prettyTermError sc err
+         fail $ PPS.render ppopts $ PP.vsep [
+             "goal_insert_and_specialize tactic: failed to specialize:",
+             err'
+          ]
        Right h ->
          do let gl' = gl{ goalSequent = addHypothesis h (goalSequent gl) }
             return ((), mempty, [gl'], insertEvidence thm h ts)

--- a/saw-central/src/SAWCentral/Prover/Exporter.hs
+++ b/saw-central/src/SAWCentral/Prover/Exporter.hs
@@ -50,7 +50,7 @@ import Data.Foldable(toList)
 
 import Control.Monad (unless)
 import Control.Monad.Except (runExceptT)
-import Control.Monad.State (gets)
+import Control.Monad.State (gets, liftIO)
 import qualified Data.AIG as AIG
 import qualified Data.ByteString as BS
 import Data.Maybe (mapMaybe)
@@ -479,7 +479,9 @@ writeRocqTerm name notations skips path t = do
   mm <- io $ scGetModuleMap sc
   tp <- io $ scTypeOf sc t
   case Rocq.translateTermAsDeclImports configuration mm (Rocq.Ident (Text.unpack name)) t tp of
-    Left err -> throwTopLevel $ "Error translating: " ++ show err
+    Left err -> do
+      err' <- liftIO $ Rocq.ppTranslationError sc err
+      throwTopLevel $ "Error translating: " ++ Text.unpack err'
     Right doc -> io $ case path of
       ""  -> print doc
       "-" -> print doc
@@ -534,7 +536,9 @@ writeRocqCryptolModule inputFile outputFile notations skips = io $ do
   let nm = Rocq.Ident (takeBaseName inputFile)
   res <- Rocq.translateCryptolModule sc import_env nm configuration cryptolPreludeDecls cm
   case res of
-    Left e -> putStrLn $ show e
+    Left err -> do
+      err' <- Rocq.ppTranslationError sc err
+      putStrLn $ Text.unpack err'
     Right cmDoc -> do
       let doc = vcat [ Rocq.preamble configuration, cmDoc ]
       case outputFile of
@@ -559,7 +563,8 @@ writeRocqSAWCorePrelude outputFile notations skips = do
   mm  <- scGetModuleMap sc
   m   <- scFindModule sc nameOfSAWCorePrelude
   let configuration = rocqTranslationConfiguration notations skips
-  let doc = vcat [ Rocq.preamble configuration, Rocq.translateSAWModule configuration mm m ]
+  m'  <- Rocq.translateSAWModule sc configuration mm m 
+  let doc = vcat [ Rocq.preamble configuration, m']
   case outputFile of
     ""  -> print doc
     "-" -> print doc
@@ -581,7 +586,8 @@ writeRocqCryptolPrimitivesForSAWCore cryFile notations skips = do
         withImportSAWCorePreludeExtra $
         withImportSAWCorePrelude $
         rocqTranslationConfiguration notations skips
-  let doc = vcat [ Rocq.preamble configuration, Rocq.translateSAWModule configuration mm m ]
+  m' <- Rocq.translateSAWModule sc configuration mm m 
+  let doc = vcat [ Rocq.preamble configuration, m']
   case cryFile of
     ""  -> print doc
     "-" -> print doc

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -703,12 +703,12 @@ prettyValue sc = visit (0 :: Int)
               body' = PP.flatAlt (PP.indent 3 body) body
           pure $ PP.group $ PP.braces (PP.line <> body' <> PP.line)
 
-      VLambda _env _mname pat e ->
-          let pat' = SS.prettyPattern pat
-              e' = SS.prettyExpr e
+      VLambda _env _mname pat e -> do
+          ppopts <- scGetPPOpts sc
+          let pat' = SS.prettyPattern ppopts pat
+              e' = SS.prettyExpr ppopts e
               line1 = "\\" <+> pat' <+> "->"
               line2 = PP.flatAlt (PP.indent 3 e') e'
-          in
           pure $ PP.group (line1 <> PP.line <> line2)
 
       VBuiltin name _args _wrapper ->
@@ -722,13 +722,13 @@ prettyValue sc = visit (0 :: Int)
       VReturn _pos _chain v -> do
           v' <- visit (prec + 1) v
           pure $ "return" <+> v'
-      VDo _chain _env body ->
+      VDo _chain _env body -> do
+        ppopts <- scGetPPOpts sc
         -- The printer for expressions doesn't print positions, so we can
         -- feed in a dummy.
         let pos = SS.PosInternal "<<do-block>>"
             e = SS.Block pos body
-        in
-        pure $ SS.prettyExpr e
+        pure $ SS.prettyExpr ppopts e
       VBindOnce _pos _chain v1 v2 -> do
         v1' <- visit 0 v1
         v2' <- visit 0 v2

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -1596,7 +1596,7 @@ throwLLVMFun nm msg = do
 -- | Get the current interpreter position and convert to a What4 position.
 getW4Position :: Text -> CrucibleSetup arch ProgramLoc
 getW4Position s = do
-  pos <- lift $ lift $ getPosition
+  pos <- lift $ lift getPosition
   return $ SS.toW4Loc s pos
 
 --

--- a/saw-central/src/SAWCentral/VerificationSummary.hs
+++ b/saw-central/src/SAWCentral/VerificationSummary.hs
@@ -116,6 +116,10 @@ thmToJSON thm = object ([
          Just ploc -> [("ploc" .= plocToJSON ploc)]
   )
 
+--       ppopts <- scGetPPOpts sc
+--       nenv <- scGetNamingEnv sc
+--    , ("term" .= (show $ ppProp ppopts nenv $ thmProp thm))
+
 theoremStatus :: TheoremSummary -> [(Key,Value)]
 theoremStatus summary = case summary of
       ProvedTheorem stats ->
@@ -130,8 +134,6 @@ theoremStatus summary = case summary of
         [ ("status"   .= ("assumed" :: String))
         , ("admitmsg" .= msg)
         ]
-
---    , ("term" .= (show $ ppProp PPS.defaultOpts $ thmProp thm))
 
 plocToJSON :: ProgramLoc -> Value
 plocToJSON ploc = object

--- a/saw-core-rocq/src/SAWCoreRocq/CryptolModule.hs
+++ b/saw-core-rocq/src/SAWCoreRocq/CryptolModule.hs
@@ -45,7 +45,7 @@ translateCryptolModule ::
   -- | List of already translated global declarations
   [Rocq.Ident] ->
   CryptolModule ->
-  IO (Either (TranslationError Term) [Rocq.Decl])
+  IO (Either TranslationError [Rocq.Decl])
 translateCryptolModule sc env configuration globalDecls (CryptolModule _ tm) =
   do defs <-
        forM (Map.assocs tm) $ \(nm, t) ->

--- a/saw-core-rocq/src/SAWCoreRocq/Monad.hs
+++ b/saw-core-rocq/src/SAWCoreRocq/Monad.hs
@@ -1,13 +1,14 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 
 {- |
 Module      : SAWCoreRocq.Monad
 Copyright   : Galois, Inc. 2018
 License     : BSD3
-Maintainer  : atomb@galois.com
+Maintainer  : saw@galois.com
 Stability   : experimental
 Portability : portable
 -}
@@ -19,39 +20,42 @@ module SAWCoreRocq.Monad
   , TranslationError(..)
   , WithTranslationConfiguration(..)
   , runTranslationMonad
+  , ppTranslationError
   ) where
 
 import qualified Control.Monad.Except as Except
 import Control.Monad.Reader (MonadReader, ReaderT(..))
 import Control.Monad.State (MonadState, StateT(..))
+import Data.Text (Text)
 import Prelude hiding (fail)
+
+import Prettyprinter ((<+>))
 
 import qualified SAWSupport.Pretty as PPS
 import SAWCore.SharedTerm
-import SAWCore.Term.Pretty (ppTermPure)
 
-data TranslationError a
-  = NotSupported a
-  | NotExpr a
-  | NotType a
-  | LocalVarOutOfBounds a
-  | BadTerm a
-  | CannotCreateDefaultValue a
+data TranslationError
+  = NotSupported Term
+  | NotExpr Term
+  | NotType Term
+  | LocalVarOutOfBounds Term
+  | BadTerm Term
+  | CannotCreateDefaultValue Term
 
-instance {-# OVERLAPPING #-} Show (TranslationError Term) where
-  show = showError (ppTermPure PPS.defaultOpts)
-
-instance {-# OVERLAPPABLE #-} Show a => Show (TranslationError a) where
-  show = showError show
-
-showError :: (a -> String) -> TranslationError a -> String
-showError printer err = case err of
-  NotSupported a -> "Not supported: " ++ printer a
-  NotExpr a      -> "Expecting an expression term: " ++ printer a
-  NotType a      -> "Expecting a type term: " ++ printer a
-  LocalVarOutOfBounds a -> "Local variable reference is out of bounds: " ++ printer a
-  BadTerm a -> "Malformed term: " ++ printer a
-  CannotCreateDefaultValue a -> "Unable to generate a default value of the given type: " ++ printer a
+ppTranslationError :: SharedContext -> TranslationError -> IO Text
+ppTranslationError sc err = do
+  let (msg, tm) = case err of
+        NotSupported t -> ("Not supported:", t)
+        NotExpr t      -> ("Expecting an expression term:", t)
+        NotType t      -> ("Expecting a type term: ", t)
+        LocalVarOutOfBounds t ->
+            ("Local variable reference is out of bounds:", t)
+        BadTerm t      -> ("Malformed term:", t)
+        CannotCreateDefaultValue t ->
+            ("Unable to generate a default value of the given type:", t)
+  ppopts <- scGetPPOpts sc
+  tm' <- prettyTerm sc tm
+  pure $ PPS.renderText ppopts $ msg <+> tm'
 
 data TranslationConfiguration = TranslationConfiguration
   { constantRenaming :: [(String, String)]
@@ -94,7 +98,7 @@ type TranslationConfigurationMonad r m =
   )
 
 type TranslationMonad r s m =
-  ( Except.MonadError (TranslationError Term)  m
+  ( Except.MonadError TranslationError  m
   , TranslationConfigurationMonad r m
   , MonadState s m
   )
@@ -104,6 +108,6 @@ runTranslationMonad ::
   r ->
   s ->
   (forall m. TranslationMonad r s m => m a) ->
-  Either (TranslationError Term) (a, s)
+  Either TranslationError (a, s)
 runTranslationMonad configuration r s m =
   runStateT (runReaderT m (WithTranslationConfiguration configuration r)) s

--- a/saw-core-rocq/src/SAWCoreRocq/Monad.hs
+++ b/saw-core-rocq/src/SAWCoreRocq/Monad.hs
@@ -26,10 +26,9 @@ import Control.Monad.Reader (MonadReader, ReaderT(..))
 import Control.Monad.State (MonadState, StateT(..))
 import Prelude hiding (fail)
 
+import qualified SAWSupport.Pretty as PPS
 import SAWCore.SharedTerm
--- import SAWCore.Term.CtxTerm
-import SAWCore.Term.Pretty (ppTermPureDefaults)
--- import qualified SAWCore.UntypedAST as Un
+import SAWCore.Term.Pretty (ppTermPure)
 
 data TranslationError a
   = NotSupported a
@@ -40,7 +39,7 @@ data TranslationError a
   | CannotCreateDefaultValue a
 
 instance {-# OVERLAPPING #-} Show (TranslationError Term) where
-  show = showError ppTermPureDefaults
+  show = showError (ppTermPure PPS.defaultOpts)
 
 instance {-# OVERLAPPABLE #-} Show a => Show (TranslationError a) where
   show = showError show

--- a/saw-core-rocq/src/SAWCoreRocq/Rocq.hs
+++ b/saw-core-rocq/src/SAWCoreRocq/Rocq.hs
@@ -18,6 +18,7 @@ module SAWCoreRocq.Rocq (
   translateTermAsDeclImports,
   translateCryptolModule,
   translateSAWModule,
+  ppTranslationError  -- re-export from Module for convenience downstream
   ) where
 
 import           Data.String.Interpolate      (i)
@@ -67,7 +68,7 @@ Import VectorNotations.
 
 translateTermAsDeclImports ::
   TranslationConfiguration -> ModuleMap -> Rocq.Ident -> Term -> Term ->
-  Either (TranslationError Term) (Doc ann)
+  Either TranslationError (Doc ann)
 translateTermAsDeclImports configuration mm name t tp = do
   doc <-
     TermTranslation.translateDefDoc
@@ -78,19 +79,15 @@ translateTermAsDeclImports configuration mm name t tp = do
   return $ vcat [preamble configuration, hardline <> doc]
 
 -- | Translate a SAW core module to a Rocq module
-translateSAWModule :: TranslationConfiguration -> ModuleMap -> Module -> Doc ann
-translateSAWModule configuration mm m =
-  let name = show $ translateModuleName (moduleName m)
-  in
-  vcat $ []
-  ++ [ text $ "Module " ++ name ++ "."
-     , ""
-     ]
-  ++ [ SAWModuleTranslation.translateDecl configuration (Just $ moduleName m) mm decl
-     | decl <- moduleDecls m ]
-  ++ [ text $ "End " ++ name ++ "."
-     , ""
-     ]
+translateSAWModule :: SharedContext -> TranslationConfiguration -> ModuleMap -> Module -> IO (Doc ann)
+translateSAWModule sc configuration mm m = do
+  let name = translateModuleName (moduleName m)
+      name' = pretty $ moduleNameText name
+  decls' <- mapM (SAWModuleTranslation.translateDecl sc configuration (Just $ moduleName m) mm) (moduleDecls m)
+
+  let top = "Module" <+> name' <> "."
+      bot = "End" <+> name' <> "."
+  pure $ vsep $ [top, ""] ++ decls' ++ [bot, ""]
 
 -- | Translate a Cryptol module to a Rocq module
 translateCryptolModule ::
@@ -100,7 +97,7 @@ translateCryptolModule ::
   -- | List of already translated global declarations
   [Rocq.Ident] ->
   CryptolModule ->
-  IO (Either (TranslationError Term) (Doc ann))
+  IO (Either TranslationError (Doc ann))
 translateCryptolModule sc env nm configuration globalDecls m = do
   translated <- CMT.translateCryptolModule sc env configuration globalDecls m
   return $ Rocq.prettyDecl . Rocq.Section (escapeIdent nm) <$> translated

--- a/saw-core-rocq/src/SAWCoreRocq/SAWModule.hs
+++ b/saw-core-rocq/src/SAWCoreRocq/SAWModule.hs
@@ -18,6 +18,7 @@ Portability : portable
 module SAWCoreRocq.SAWModule (translateDecl) where
 
 import qualified Control.Monad.Except         as Except
+import           Control.Monad                (fail)
 import           Control.Monad.Reader         (asks)
 import qualified Data.Text                    as Text
 import           Prelude                      hiding (fail)
@@ -44,7 +45,7 @@ runModuleTranslationMonad ::
   Maybe ModuleName ->
   ModuleMap ->
   (forall m. ModuleTranslationMonad m => m a) ->
-  Either (M.TranslationError Term) (a, ())
+  Either M.TranslationError (a, ())
 runModuleTranslationMonad configuration modName mm =
   M.runTranslationMonad configuration (modName, mm) ()
 
@@ -184,21 +185,24 @@ liftTermTranslationMonad n = do
     Right (a, _) -> return a
 
 translateDecl ::
+  SharedContext ->
   M.TranslationConfiguration ->
   Maybe ModuleName ->
   ModuleMap ->
   ModuleDecl ->
-  Doc ann
-translateDecl configuration modname mm decl =
+  IO (Doc ann)
+translateDecl sc configuration modname mm decl =
+  let translateDecl' :: (forall m. ModuleTranslationMonad m => m Rocq.Decl) -> IO (Doc ann)
+      translateDecl' d =
+        case runModuleTranslationMonad configuration modname mm d of
+          Right (tdecl, _) -> pure $ Rocq.prettyDecl tdecl
+          Left e -> do
+              msg <- ppTranslationError sc e
+              fail $ Text.unpack msg
+  in
   case decl of
-    TypeDecl td -> do
-      case runModuleTranslationMonad configuration modname mm (translateDataType td) of
-        Left e           -> error $ show e
-        Right (tdecl, _) -> Rocq.prettyDecl tdecl
-    DefDecl dd -> do
-      case runModuleTranslationMonad configuration modname mm (translateDef dd) of
-        Left e           -> error $ show e
-        Right (tdecl, _) -> Rocq.prettyDecl tdecl
+    TypeDecl td -> translateDecl' $ translateDataType td
+    DefDecl dd -> translateDecl' $ translateDef dd
     InjectCodeDecl ns txt
-      | ns == "Rocq" -> pretty txt
-      | otherwise    -> mempty
+      | ns == "Rocq" -> pure $ pretty txt
+      | otherwise    -> pure $ mempty

--- a/saw-core-rocq/src/SAWCoreRocq/SAWModule.hs
+++ b/saw-core-rocq/src/SAWCoreRocq/SAWModule.hs
@@ -205,4 +205,4 @@ translateDecl sc configuration modname mm decl =
     DefDecl dd -> translateDecl' $ translateDef dd
     InjectCodeDecl ns txt
       | ns == "Rocq" -> pure $ pretty txt
-      | otherwise    -> pure $ mempty
+      | otherwise    -> pure mempty

--- a/saw-core-rocq/src/SAWCoreRocq/Term.hs
+++ b/saw-core-rocq/src/SAWCoreRocq/Term.hs
@@ -264,7 +264,7 @@ runTermTranslationMonad ::
   [Rocq.Ident] ->
   [Rocq.Ident] ->
   (forall m. TermTranslationMonad m => m a) ->
-  Either (TranslationError Term) (a, TranslationState)
+  Either TranslationError (a, TranslationState)
 runTermTranslationMonad configuration mname mm globalDecls localEnv =
   runTranslationMonad configuration
   (TranslationReader {
@@ -680,7 +680,7 @@ translateTermToDocWith ::
   [Rocq.Ident] -> -- ^ names of local variables in scope
   (Rocq.Term -> Rocq.Term -> Doc ann) ->
   Term -> Term ->
-  Either (TranslationError Term) (Doc ann)
+  Either TranslationError (Doc ann)
 translateTermToDocWith configuration r mm globalDecls localEnv f t tp_trm = do
   ((term, tp), state) <-
     runTermTranslationMonad configuration r mm globalDecls localEnv
@@ -701,7 +701,7 @@ translateDefDoc ::
   ModuleMap ->
   [Rocq.Ident] ->
   Rocq.Ident -> Term -> Term ->
-  Either (TranslationError Term) (Doc ann)
+  Either TranslationError (Doc ann)
 translateDefDoc configuration r mm globalDecls name =
   translateTermToDocWith configuration r mm globalDecls [name]
   (\ t tp -> Rocq.prettyDecl $ mkDefinition name t tp)

--- a/saw-core/src/SAWCore/FiniteValue.hs
+++ b/saw-core/src/SAWCore/FiniteValue.hs
@@ -58,7 +58,7 @@ import Prettyprinter hiding (Doc)
 import Data.Aeson ( FromJSON(..), ToJSON(..), FromJSONKey(..), ToJSONKey(..) )
 import qualified Data.Aeson as JSON
 
-import SAWSupport.Pretty (prettyNat)
+import SAWSupport.Pretty (prettyInteger)
 import qualified SAWSupport.Pretty as PPS (Doc, Opts)
 
 import qualified SAWCore.Recognizer as R
@@ -258,7 +258,7 @@ prettyFirstOrderValue opts = loop
    FOVIntMod _ i -> pretty i
    FOVRational r ->
      pretty (numerator r) <+> pretty "%" <+> pretty (denominator r)
-   FOVWord _w i  -> prettyNat opts i
+   FOVWord _w i  -> prettyInteger opts i
    FOVVec _ xs   -> brackets (sep (punctuate comma (map loop xs)))
    FOVArray _kty d vs ->
       let ppEntry' k' v = k' <+> pretty ":=" <+> loop v

--- a/saw-core/src/SAWCore/Rewriter.hs
+++ b/saw-core/src/SAWCore/Rewriter.hs
@@ -272,8 +272,11 @@ scMatch sc ctxt pat term =
         IntMap.intersection xm (varTypes x) ==
         IntMap.intersection ym (varTypes y) = pure s
     match xenv yenv ybinds x y s@(MatchState m cs) =
-      -- (lift $ putStrLn $ "matching (lhs): " ++ ppTermPure PPS.defaultOpts x) >>
-      -- (lift $ putStrLn $ "matching (rhs): " ++ ppTermPure PPS.defaultOpts y) >>
+      -- do
+      --   x' <- ppTerm sc x
+      --   y' <- ppTerm sc y
+      --   (lift $ putStrLn $ "matching (lhs): " ++ x')
+      --   (lift $ putStrLn $ "matching (rhs): " ++ y')
       case asVarPat xenv x of
         -- If the lhs pattern is of the form (?u b1..bk) where ?u is a
         -- unification variable and b1..bk are all locally bound

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -54,8 +54,9 @@ module SAWCore.SharedTerm
   , prettyName
   , ppTerm
   , prettyTerm
-  , ppTermError
+  , prettyTermErrorPure
   , prettyTermError
+  , ppTermError
   , scGetPPOpts -- reexport from SAWCore.Term.Certified
   , scModifyPPOpts
   , scWithPPOpts
@@ -308,7 +309,7 @@ import Numeric.Natural (Natural)
 import qualified Prettyprinter as PP
 
 import qualified SAWSupport.IntRangeSet as IntRangeSet
-import qualified SAWSupport.Pretty as PPS (Doc, Opts, defaultOpts, withOpts, render, renderText)
+import qualified SAWSupport.Pretty as PPS (Doc, Opts, withOpts, render, renderText)
 
 import SAWCore.Cache
 import SAWCore.Change
@@ -339,13 +340,8 @@ import qualified SAWCore.QualName as QN
 
 --------------------------------------------------------------------------------
 
-ppTermError :: TermError -> String
-ppTermError err =
-  PPS.render PPS.defaultOpts $
-  prettyTermError PPS.defaultOpts emptyDisplayNameEnv err
-
-prettyTermError :: PPS.Opts -> DisplayNameEnv -> TermError -> PPS.Doc
-prettyTermError opts ne err =
+prettyTermErrorPure :: PPS.Opts -> DisplayNameEnv -> TermError -> PPS.Doc
+prettyTermErrorPure opts ne err =
   PP.vsep $
   case err of
     StaleTerm t s ->
@@ -533,14 +529,25 @@ prettyTermError opts ne err =
         Left s -> PP.indent 2 $ PP.pretty (show s)
         Right ty -> ishow ty
 
+prettyTermError :: SharedContext -> TermError -> IO PPS.Doc
+prettyTermError sc err = do
+  ppopts <- scGetPPOpts sc
+  ne <- scGetNamingEnv sc
+  pure $ prettyTermErrorPure ppopts ne err
+
+ppTermError :: SharedContext -> TermError -> IO Text
+ppTermError sc err = do
+  ppopts <- scGetPPOpts sc
+  err' <- prettyTermError sc err
+  pure $ PPS.renderText ppopts err'  
+
 execSCM :: SharedContext -> SCM a -> IO a
 execSCM sc m =
   do result <- runSCM sc m
      case result of
        Left err ->
-         do ne <- scGetNamingEnv sc
-            opts <- scGetPPOpts sc
-            fail (PPS.render opts (prettyTermError opts ne err))
+         do err' <- ppTermError sc err
+            fail $ Text.unpack err'
        Right a -> pure a
 
 -- | Build a variant of a 'Term' with a specific type.
@@ -1027,7 +1034,8 @@ scTypeOfName sc nm =
      case lookupVarIndexInMap (nameIndex nm) mm of
        Just r -> pure (resolvedNameType r)
        Nothing -> do
-         nm' <- ppName sc PPS.defaultOpts nm
+         ppopts <- scGetPPOpts sc
+         nm' <- ppName sc ppopts nm
          fail ("scTypeOfName: Name not found: " ++ Text.unpack nm')
 
 --------------------------------------------------------------------------------

--- a/saw-core/src/SAWCore/Simulator/Value.hs
+++ b/saw-core/src/SAWCore/Simulator/Value.hs
@@ -73,6 +73,8 @@ import qualified Data.Vector as V
 import Numeric.Natural
 import GHC.Stack
 
+import qualified SAWSupport.Pretty as PPS
+
 import SAWCore.Module (DataType)
 import SAWCore.Name
 import SAWCore.Panic (panic)
@@ -249,7 +251,7 @@ instance Show (Extra l) => Show (TValue l) where
                         . showString " " . showParen True (showsPrec p a)
       VSort s        -> shows s
 
-      VTyTerm _ tm   -> showString "TyTerm (" . (\x -> ppTermPureDefaults tm ++ x) . showString ")"
+      VTyTerm _ tm   -> showString "TyTerm (" . (\x -> ppTermPure PPS.defaultOpts tm ++ x) . showString ")"
 
 data Nil = Nil
 

--- a/saw-core/src/SAWCore/Term/Pretty.hs
+++ b/saw-core/src/SAWCore/Term/Pretty.hs
@@ -24,16 +24,6 @@ If you do not have the `SharedContext`, or are trying to print from
 pure code and changing this is infeasible, use the pure versions
 defined herein: `ppTermPure` or `prettyTermPure` for a `Doc`.
 
-If you do not have the prettyprinting options value either, there is
-`ppTermPureDefaults`, which uses the default prettyprinting options.
-Use of this should be minimized, because if we're going to give the
-user control over printing we should actually honor their settings.
-This function may be removed in the long run.
-
-(Referencing SAWSupport.Pretty's defaultOpts value explicitly instead
-is probably preferred, because that makes it clear to passersby that
-it isn't really right.)
-
 The following additional functions allow explicit manipulation of the
 name context used by the SAWCore term prettyprinting logic, and should
 therefore only be used from code where that makes sense:
@@ -51,7 +41,6 @@ therefore only be used from code where that makes sense:
 module SAWCore.Term.Pretty
   ( prettyTermPure
   , ppTermPure
-  , ppTermPureDefaults
   , ppTermWithEnv
   , prettyNameWithEnv
   , prettyTermWithEnv
@@ -81,7 +70,7 @@ import qualified Data.IntMap.Strict as IntMap
 
 import SAWSupport.Pretty (prettyInteger, prettyTypeConstraint)
 import qualified SAWSupport.Pretty as PPS (
-    Style(..), Doc, MemoStyle(..), Opts(..), defaultOpts, render, prettyLetBlock
+    Style(..), Doc, MemoStyle(..), Opts(..), render, prettyLetBlock
  )
 
 import SAWCore.Panic (panic)
@@ -738,17 +727,6 @@ prettyTermWithNameList opts ctx trm =
 ppTermPure :: PPS.Opts -> Term -> String
 ppTermPure opts t =
   PPS.render opts $ prettyTermPure opts t
-
--- | Pretty-print a term and render it to a string, using default options.
---
---   Does not integrate the current `DisplayNameEnv` from the
---   `SharedContext`; use ppTerm instead unless you really can't get
---   the `SharedContext` and/or can't afford to be in `IO`.
---
---   Even then, use `ppTermPure` unless you really don't have the
---   prettyprinting options and can't get them.
-ppTermPureDefaults :: Term -> String
-ppTermPureDefaults t = ppTermPure PPS.defaultOpts t
 
 
 --------------------------------------------------------------------------------

--- a/saw-core/src/SAWCore/Term/Pretty.hs
+++ b/saw-core/src/SAWCore/Term/Pretty.hs
@@ -79,7 +79,7 @@ import Prettyprinter
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IntMap
 
-import SAWSupport.Pretty (prettyNat, prettyTypeConstraint)
+import SAWSupport.Pretty (prettyInteger, prettyTypeConstraint)
 import qualified SAWSupport.Pretty as PPS (
     Style(..), Doc, MemoStyle(..), Opts(..), defaultOpts, render, prettyLetBlock
  )
@@ -537,7 +537,7 @@ prettyTerm' prec = atNextDepthM "..." . prettyTerm''
            Nothing ->
              case t of
                (asNat -> Just n) ->
-                 prettyNat <$> asks ppOpts <*> pure (toInteger n)
+                 prettyInteger <$> asks ppOpts <*> pure (toInteger n)
                (asRecordType -> Just alist) ->
                  prettyRecord True <$> traverse (traverse (prettyTerm' PrecTerm)) alist
                (asRecordValue -> Just alist) ->

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -49,7 +49,6 @@ import SAWCore.Name
 import qualified SAWCore.QualName as QN
 import SAWCore.Parser.Position
 import SAWCore.Term.Functor
-import SAWCore.Term.Pretty (ppTermPureDefaults)
 import SAWCore.SharedTerm
 import SAWCore.Recognizer
 import qualified SAWCore.Term.Certified as SC
@@ -462,11 +461,11 @@ processDecls (Un.TypeDecl NoQualifier (PosPair p nm) tp :
      (ctx, req_body_tp) <-
        case matchResult of
          Just x -> return x
-         Nothing ->
+         Nothing -> do
+             typed_tp' <- liftIO $ ppTerm sc typed_tp
              throwTCError $
-             DeclError nm ("More variables " ++ show (map Un.termVarLocalName vars) ++
-                           " than length of function type:\n" ++
-                           ppTermPureDefaults typed_tp)
+                 DeclError nm ("More variables " ++ show (map Un.termVarLocalName vars) ++
+                               " than length of function type:\n" ++ typed_tp')
 
      -- Step 3: type-check the body of the definition in the context of its
      -- variables, and build a function that takes in those variables

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -32,7 +32,7 @@ import Numeric.Natural
 
 import Prettyprinter hiding (Doc)
 
-import qualified SAWSupport.Pretty as PPS (Doc, Opts, defaultOpts, render)
+import qualified SAWSupport.Pretty as PPS (Doc, Opts, render)
 
 import SAWCore.Panic (panic)
 
@@ -65,8 +65,8 @@ inferCompleteTerm sc mnm t =
        Right t' -> pure (Right t')
        Left err ->
          do ne <- scGetNamingEnv sc
-            let opts = PPS.defaultOpts
-            pure (Left (prettyTCError opts ne err))
+            ppopts <- scGetPPOpts sc
+            pure (Left (prettyTCError ppopts ne err))
 
 -- | Pretty-print a type-checking error
 ppTCError :: PPS.Opts -> TCError -> String
@@ -109,7 +109,7 @@ prettyTCError opts ne e = helper Nothing e where
                      , helper mp err'
                      ]
       TermError err' ->
-        ppWithPos mp [ prettyTermError opts ne err' ]
+        ppWithPos mp [ prettyTermErrorPure opts ne err' ]
 
 ----------------------------------------------------------------------
 -- Type Checking Monad

--- a/saw-script/src/SAWScript/AutoMatch.hs
+++ b/saw-script/src/SAWScript/AutoMatch.hs
@@ -260,15 +260,15 @@ autoTagSourceFiles leftPath rightPath =
          return (leftSource, rightSource)
 
 -- | Take two tagged source files and load them up to generate an interaction which matches the modules together
-autoMatchFiles :: TaggedSourceFile -> TaggedSourceFile -> TopLevel (Interaction MatchResult)
-autoMatchFiles leftSource@(TaggedSourceFile _ leftPath) rightSource@(TaggedSourceFile _ rightPath) = do
+autoMatchFiles :: PPS.Opts -> TaggedSourceFile -> TaggedSourceFile -> TopLevel (Interaction MatchResult)
+autoMatchFiles ppopts leftSource@(TaggedSourceFile _ leftPath) rightSource@(TaggedSourceFile _ rightPath) = do
    leftModInteract  <- loadDecls leftSource
    rightModInteract <- loadDecls rightSource
    return . frame (separator SuperThickSep) $ do
       info Nothing $ "Aligning declarations between " ++ leftPath ++ corresponds ++ rightPath
       separator ThickSep
       maybe (return $ MatchResult [] Nothing False False)
-            (processResults leftSource rightSource <=< uncurry matchModules) =<<
+            (processResults ppopts leftSource rightSource <=< uncurry matchModules) =<<
          pairA <$> leftModInteract <*> rightModInteract
 
 -- | Load the declarations from the given file, dispatching on the source language to determine how to do this
@@ -318,10 +318,11 @@ actAfterMatch interpretStmts MatchResult{..} = do
 -- | The top level entry-point for AutoMatch
 --   Requires a StmtInterpreter to be passed as input to resolve import cycle
 autoMatch :: StmtInterpreter -> FilePath -> FilePath -> TopLevel ()
-autoMatch interpreter leftFile rightFile =
+autoMatch interpreter leftFile rightFile = do
+   ppopts <- getPPOpts
    autoTagSourceFiles leftFile rightFile &
       (either (io . putStrLn) $
-         uncurry autoMatchFiles >=> io . interactIO >=> actAfterMatch interpreter)
+         uncurry (autoMatchFiles ppopts) >=> io . interactIO >=> actAfterMatch interpreter)
 
 -- | Just a bunch of SAWScript statments as output and a supply of unique identifiers
 type ScriptWriter s tp = WriterT [SAWScript.Stmt] (ReaderT (NonceGenerator (ST s) tp) (ST s))
@@ -339,10 +340,12 @@ execScriptWriter c = snd (runScriptWriter c)
 --   generate an interaction which asks the user what to do after the matching
 --   and gives the appropriate MatchResult. Contains the logic for generating
 --   SAWScript based upon the assignments.
-processResults :: TaggedSourceFile -> TaggedSourceFile
-               -> [(Decl, Decl, Assignments)]
-               -> Interaction MatchResult
-processResults (TaggedSourceFile leftLang  leftFile) (TaggedSourceFile rightLang rightFile) matchings = do
+processResults :: PPS.Opts ->
+        TaggedSourceFile ->
+        TaggedSourceFile ->
+        [(Decl, Decl, Assignments)] ->
+        Interaction MatchResult
+processResults ppopts (TaggedSourceFile leftLang  leftFile) (TaggedSourceFile rightLang rightFile) matchings = do
 
       MatchResult script <$> (do separator ThickSep
                                  doSave <- confirm "Save generated script to file?"
@@ -423,7 +426,7 @@ processResults (TaggedSourceFile leftLang  leftFile) (TaggedSourceFile rightLang
          returning theoremName . tell $
             [SAWScript.StmtBind triggerPos (SAWScript.PVar triggerPos triggerPos theoremName Nothing) .
                 SAWScript.Code triggerPos .
-                   PPS.renderText PPS.defaultOpts . CryPP.pretty .
+                   PPS.renderText ppopts . CryPP.pretty .
                       cryptolAbstractNamesSAW leftArgs .
                          cryptolApplyFunction (Cryptol.EParens . Cryptol.EVar . nameCryptolFromSAW $ "==") $
                             [ cryptolApplyFunctionSAW leftFunction  leftArgs

--- a/saw-script/src/SAWScript/AutoMatch.hs
+++ b/saw-script/src/SAWScript/AutoMatch.hs
@@ -300,9 +300,11 @@ type StmtInterpreter = TopLevelRO -> TopLevelRW -> [SAWScript.Stmt] -> IO ()
 
 -- | How to interpret a MatchResult to the TopLevel monad
 actAfterMatch :: StmtInterpreter -> MatchResult -> TopLevel ()
-actAfterMatch interpretStmts MatchResult{..} =
-   let renderedScript = SAWScript.prettyWholeModule generatedScript
-   in do io . awhen afterMatchSave $ \file ->
+actAfterMatch interpretStmts MatchResult{..} = do
+   ppopts <- getPPOpts
+   let renderedScript = SAWScript.prettyWholeModule ppopts generatedScript
+   do
+         io . awhen afterMatchSave $ \file ->
                  withFile file WriteMode $ \handle ->
                      hPutDoc handle renderedScript
          io . when afterMatchPrint $ putDoc renderedScript

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -64,7 +64,7 @@ import qualified Mir.Mir as MIR
 import SAWSupport.Position
 import qualified SAWSupport.ScopedMap as ScopedMap
 import SAWSupport.ScopedMap (ScopedMap)
-import qualified SAWSupport.Pretty as PPS (MemoStyle(..), Opts(..), renderStdout)
+import qualified SAWSupport.Pretty as PPS (MemoStyle(..), Opts(..), renderStdout, defaultOpts)
 
 import SAWCore.FiniteValue (FirstOrderValue(..))
 
@@ -624,7 +624,8 @@ interpretExpr expr =
           env <- gets rwEnviron
           return $ VLambda env mname pat e
       SS.Application pos e1 e2 -> do
-          let v1info = "Expression: " <> SS.ppExpr e1
+          ppopts <- getPPOpts
+          let v1info = "Expression: " <> SS.ppExpr ppopts e1
           v1 <- interpretExpr e1
           v2 <- interpretExpr e2
           let v2' = injectPositionIntoMonadicValue (SS.getPos e2) v2
@@ -644,12 +645,13 @@ interpretExpr expr =
               interpretExpr (if b then e2 else e3)
             _ -> do
               sc <- getSharedContext
+              ppopts <- liftIO $ scGetPPOpts sc
               v1' <- liftIO $ ppValue sc v1
               panic "interpretExpr" [
                   "Ill-typed value in if-expression (should be Bool)",
                   "Source position: " <> ppPosition pos,
                   "Value found: " <> v1',
-                  "Expression: " <> SS.ppExpr e1
+                  "Expression: " <> SS.ppExpr ppopts e1
                ]
 
 -- Eval a "decl group", which is a let-binding or group of mutually
@@ -662,6 +664,7 @@ interpretDeclGroup rebindable dg = case dg of
         v <- interpretExpr expr
         bindPattern rebindable pat mt v
     SS.Recursive ds -> do
+        ppopts <- getPPOpts
         let
 
             -- Get a value for the body of one of the declarations.
@@ -682,7 +685,7 @@ interpretDeclGroup rebindable dg = case dg of
                     panic "interpretDeclGroup" [
                         "Found non-function in a recursive declaration group",
                         "Name: " <> x,
-                        "Expression found: " <> SS.ppExpr e0
+                        "Expression found: " <> SS.ppExpr ppopts e0
                     ]
 
             -- Get the type (scheme) for one of the declarations.
@@ -703,7 +706,7 @@ interpretDeclGroup rebindable dg = case dg of
                 SS.PTuple{} ->
                     panic "interpretDeclGroup" [
                         "Found tuple pattern in a recursive declaration group",
-                        "Pattern: " <> SS.ppPattern pat
+                        "Pattern: " <> SS.ppPattern ppopts pat
                     ]
 
             -- Get all the info for a decl.
@@ -961,7 +964,9 @@ processStmtBind printBinds pos pat expr = do
 
   -- Reject polymorphic values. XXX: as noted above this should either
   -- be inside the typechecker or restricted to the repl.
-  when (isPolymorphic ty) $ fail $ "Not a monomorphic type: " ++ Text.unpack (SS.ppType ty)
+  when (isPolymorphic ty) $ do
+      ppopts <- liftTopLevel $ getPPOpts
+      fail $ "Not a monomorphic type: " ++ Text.unpack (SS.ppType ppopts ty)
 
   -- Now bind the resulting value using bindMonadAction.
   --
@@ -995,8 +1000,10 @@ processStmtBind printBinds pos pat expr = do
 
     -- Print function type if result was a function
     case ty of
-      SS.TyCon _ SS.FunCon _ ->
-        liftTopLevel $ printOutLnTop Info $ Text.unpack $ name <> " : " <> SS.ppType ty
+      SS.TyCon _ SS.FunCon _ -> liftTopLevel $ do
+        ppopts <- getPPOpts
+        let ty' = SS.ppType ppopts ty
+        printOutLnTop Info $ Text.unpack $ name <> " : " <> ty'
       _ -> return ()
 
   liftTopLevel $ bindPattern SS.ReadOnlyVar pat (Just (SS.tMono ty)) result
@@ -1014,6 +1021,7 @@ interpretTopStmt printBinds stmt = do
   ctx <- getMonadContext
 
   stmt' <- do
+      ppopts <- liftTopLevel $ getPPOpts
       -- XXX this is not the right way to do this
       --    - shouldn't have to flatten the environments
       --    - shouldn't be typechecking one statement at a time regardless
@@ -1025,7 +1033,7 @@ interpretTopStmt printBinds stmt = do
           varenv2 = Map.union varenv1 rbenv'
           varenv3 = ScopedMap.seed varenv2
 
-      processTypeCheck $ checkStmt avail varenv3 tyenv ctx stmt
+      processTypeCheck $ checkStmt ppopts avail varenv3 tyenv ctx stmt
 
   case stmt' of
 
@@ -1122,7 +1130,8 @@ interpretFile file runMain =
   where
     interp = do
       opts <- getOptions
-      stmts <- io $ Loader.findAndLoadFileUnchecked opts file
+      ppopts <- getPPOpts
+      stmts <- io $ Loader.findAndLoadFileUnchecked opts ppopts file
 
       -- Since #2807, to maintain the historical behavior of "main"
       -- we need to run any "main" _inside_ the pushdir/popdir pair
@@ -1188,9 +1197,10 @@ interpretMain = do
       -- Don't fail or complain if there's no main.
       return ()
     Just (Current, tyFound, v) -> case tyFound of
-        SS.Forall _ (SS.TyCon _ SS.BlockCon [_, _]) ->
+        SS.Forall _ (SS.TyCon _ SS.BlockCon [_, _]) -> do
             -- It looks like a monadic value, so check more carefully.
-            case typesMatch avail tyenv tyFound tyExpected of
+            ppopts <- getPPOpts
+            case typesMatch ppopts avail tyenv tyFound tyExpected of
               False ->
                   -- While we accept any TopLevel a, don't encourage people
                   -- to do that.
@@ -2318,19 +2328,21 @@ print_value v = do
   v' <- liftIO $ ppValue sc v
   printOutLnTop Info (Text.unpack v')
 
-dump_file_AST :: BuiltinContext -> Options -> Text -> IO ()
+dump_file_AST :: BuiltinContext -> Options -> Text -> TopLevel ()
 dump_file_AST _bic opts filetxt = do
-    let file = Text.unpack filetxt
-    stmts <- Loader.findAndLoadFileUnchecked opts file
-    mapM_ print stmts
+    ppopts <- getPPOpts
+    liftIO $ do
+        let file = Text.unpack filetxt
+        stmts <- Loader.findAndLoadFileUnchecked opts ppopts file
+        mapM_ print stmts
 
 parser_printer_roundtrip :: BuiltinContext -> Options -> Text -> TopLevel ()
 parser_printer_roundtrip _bic opts filetxt = do
     let file = Text.unpack filetxt
     ppopts <- getPPOpts
     liftIO $ do
-      stmts <- Loader.findAndLoadFileUnchecked opts file
-      PPS.renderStdout ppopts $ SS.prettyWholeModule stmts
+      stmts <- Loader.findAndLoadFileUnchecked opts ppopts file
+      PPS.renderStdout ppopts $ SS.prettyWholeModule ppopts stmts
 
 exec :: Text -> [Text] -> Text -> IO Text
 exec name args input = do
@@ -7578,6 +7590,14 @@ primValueEnv ::
    Map SS.Name (SS.Pos, PrimitiveLifecycle, SS.Schema, Value, Maybe [Text])
 primValueEnv opts bic = Map.mapWithKey extract primitives
   where
+      -- XXX: This is evaluated at startup so the default options are
+      -- all we have. However, the result of this is that if the user
+      -- changes the print options, the types printed with the help
+      -- texts are not affected, which is not correct. We should
+      -- change this so the help text header is generated on the fly
+      -- when printed.
+      ppopts = PPS.defaultOpts
+
       header = [
           "Description",
           "-----------",
@@ -7589,7 +7609,7 @@ primValueEnv opts bic = Map.mapWithKey extract primitives
           HideDeprecated -> ["DEPRECATED AND UNAVAILABLE BY DEFAULT", ""]
           Experimental -> ["EXPERIMENTAL", ""]
       name n p = [
-          "    " <> n <> " : " <> SS.ppSchema (primitiveType p),
+          "    " <> n <> " : " <> SS.ppSchema ppopts (primitiveType p),
           ""
        ]
       doc n p =

--- a/saw-script/src/SAWScript/Loader.hs
+++ b/saw-script/src/SAWScript/Loader.hs
@@ -123,8 +123,8 @@ wrapDir dir m = do
 --   the EOF token name passed to `prettyParseError`, which should
 --   generally be either "end of line" or "end of file".
 --
-readAny :: FilePath -> Text -> Text -> ([Token Pos] -> Either ParseError a) -> WithMsgs a
-readAny fileName str eofName parser =
+readAny :: PPS.Opts -> FilePath -> Text -> Text -> ([Token Pos] -> Either ParseError a) -> WithMsgs a
+readAny ppopts fileName str eofName parser =
     case lexSAW fileName eofName str of
         Left (_verbosity, pos, msg) ->
             Left [(pos, PP.pretty msg)]
@@ -138,7 +138,7 @@ readAny fileName str eofName parser =
             in
             case parser tokens of
                 Left err ->
-                    let (optpos, err') = prettyParseError eofName err
+                    let (optpos, err') = prettyParseError ppopts eofName err
                         pos = case optpos of
                             Nothing ->
                                 -- Happy is unable to provide the
@@ -162,8 +162,8 @@ readAny fileName str eofName parser =
                     Right (msgs, tree)
 
 -- | Use the readAny result to panic if any messages were generated.
-panicOnMsgs :: Text -> WithMsgs a -> a
-panicOnMsgs whoAmI result =
+panicOnMsgs :: PPS.Opts -> Text -> WithMsgs a -> a
+panicOnMsgs ppopts whoAmI result =
   -- Properly, printing the positions with the errors should be done
   -- by the error infrastructure. However, the error infrastructure
   -- necessarily needs to run in `IO`, and we need to _not_ run in
@@ -172,7 +172,7 @@ panicOnMsgs whoAmI result =
   -- stuff to SAWConsole just to avoid needing this code.
   let pp (pos, msg) =
         let msg' = PP.pretty (PosSupport.ppPosition pos) <> ":" PP.<+> msg in
-        PPS.renderText PPS.defaultOpts msg'
+        PPS.renderText ppopts msg'
   in
   case result of
    Left errs ->
@@ -231,14 +231,14 @@ dispatchMsgs' (errs_or_result, warns) = do
             pure tree
 
 -- | Call `readAny` then `panicOnMsgs`.
-readAnyPure :: FilePath -> Text -> Text -> ([Token Pos] -> Either ParseError a) -> Text -> a
-readAnyPure fileName str eofName parser whoAmI =
-    panicOnMsgs whoAmI $ readAny fileName str eofName parser
+readAnyPure :: PPS.Opts -> FilePath -> Text -> Text -> ([Token Pos] -> Either ParseError a) -> Text -> a
+readAnyPure ppopts fileName str eofName parser whoAmI =
+    panicOnMsgs ppopts whoAmI $ readAny ppopts fileName str eofName parser
 
 -- | Call `readAny` then `dispatchMsgs`.
-readAnyIO :: FilePath -> Text -> Text -> ([Token Pos] -> Either ParseError a) -> IO a
-readAnyIO fileName str eofName parser =
-    dispatchMsgs $ readAny fileName str eofName parser
+readAnyIO :: PPS.Opts -> FilePath -> Text -> Text -> ([Token Pos] -> Either ParseError a) -> IO a
+readAnyIO ppopts fileName str eofName parser =
+    dispatchMsgs $ readAny ppopts fileName str eofName parser
 
 -- | Run the readAny result through the `Include` module to resolve
 --   @include@ statements.
@@ -247,9 +247,9 @@ readAnyIO fileName str eofName parser =
 --   returning the failure.
 --
 resolveIncludes ::
-    Int -> SeenSet -> IncludePath -> Options -> Inc.Processor a -> a -> IO a
-resolveIncludes depth seen incpath opts process tree =
-    process (includeFile depth seen incpath opts) tree
+    Int -> SeenSet -> IncludePath -> Options -> PPS.Opts -> Inc.Processor a -> a -> IO a
+resolveIncludes depth seen incpath opts ppopts process tree =
+    process (includeFile depth seen incpath opts ppopts) tree
 
 -- | Read a type schema from a string. This is used to digest the type
 --   signatures for builtins, and the expansions for builtin typedefs.
@@ -280,8 +280,11 @@ readSchemaPure ::
     Text ->
     Schema
 readSchemaPure fakeFileName lc tyenv str =
-    let schema = readAnyPure fakeFileName str "end-of-input" parseSchema (Text.pack fakeFileName) in
-    panicOnMsgs' (Text.pack fakeFileName) $ checkSchema lc tyenv schema
+    -- This is for use during initialization, so we can use the default ppopts
+    let ppopts = PPS.defaultOpts in
+
+    let schema = readAnyPure ppopts fakeFileName str "end-of-input" parseSchema (Text.pack fakeFileName) in
+    panicOnMsgs' (Text.pack fakeFileName) $ checkSchema ppopts lc tyenv schema
 
 -- | Read a schema pattern from a string. This is used by the
 --   :search REPL command.
@@ -292,11 +295,11 @@ readSchemaPure fakeFileName lc tyenv str =
 -- patterns, so no need to process includes in what we read.
 --
 readSchemaPattern ::
-    Options ->
+    Options -> PPS.Opts ->
     FilePath -> Environ -> RebindableEnv -> Set PrimitiveLifecycle -> Text ->
     IO SchemaPattern
-readSchemaPattern _opts fileName environ rbenv avail str = do
-  pat <- readAnyIO fileName str "end-of-line" parseSchemaPattern
+readSchemaPattern _opts ppopts fileName environ rbenv avail str = do
+  pat <- readAnyIO ppopts fileName str "end-of-line" parseSchemaPattern
   let Environ varenv tyenv _cryenv = environ
 
   -- XXX it should not be necessary to do this munging
@@ -321,15 +324,15 @@ readSchemaPattern _opts fileName environ rbenv avail str = do
 -- to resolve any that appear.
 --
 readExpression ::
-    Options ->
+    Options -> PPS.Opts ->
     FilePath -> Environ -> RebindableEnv -> Set PrimitiveLifecycle -> Text ->
     IO (Schema, Expr)
-readExpression opts fileName environ rbenv avail str = do
+readExpression opts ppopts fileName environ rbenv avail str = do
   seen <- emptySeenSet
   let incpath = (".", Options.importPath opts)
 
-  expr0 <- readAnyIO fileName str "end-of-line" parseExpression
-  expr <- resolveIncludes 0{-depth-} seen incpath opts Inc.processExpr expr0
+  expr0 <- readAnyIO ppopts fileName str "end-of-line" parseExpression
+  expr <- resolveIncludes 0{-depth-} seen incpath opts ppopts Inc.processExpr expr0
   let Environ varenv tyenv _cryenvs = environ
 
   -- XXX it should not be necessary to do this munging
@@ -344,7 +347,7 @@ readExpression opts fileName environ rbenv avail str = do
   let pos = Pos.getPos expr
       decl = Decl pos (PWild pos Nothing) Nothing expr
 
-  decl' <- dispatchMsgs' $ checkDecl avail varenv''' tyenv decl
+  decl' <- dispatchMsgs' $ checkDecl ppopts avail varenv''' tyenv decl
 
   let expr' = dDef decl'
       schema = case dType decl' of
@@ -365,13 +368,13 @@ readExpression opts fileName environ rbenv avail str = do
 --
 --   May produce more than one statement if the statement given is an
 --   @include@.
-readREPLTextUnchecked :: Options -> FilePath -> Text -> IO [Stmt]
-readREPLTextUnchecked opts fileName str = do
+readREPLTextUnchecked :: Options -> PPS.Opts -> FilePath -> Text -> IO [Stmt]
+readREPLTextUnchecked opts ppopts fileName str = do
   seen <- emptySeenSet
   let incpath = (".", Options.importPath opts)
 
-  stmts <- readAnyIO fileName str "end-of-line" parseREPLText
-  resolveIncludes 0{-depth-} seen incpath opts Inc.processStmts stmts
+  stmts <- readAnyIO ppopts fileName str "end-of-line" parseREPLText
+  resolveIncludes 0{-depth-} seen incpath opts ppopts Inc.processStmts stmts
 
 -- | Find a file, potentially looking in a list of multiple search paths (as
 -- specified via the @SAW_IMPORT_PATH@ environment variable or
@@ -407,8 +410,8 @@ locateFile (current, rawdirs) file = do
 -- | Load the 'Stmt's in a @.saw@ file.
 --   Doesn't run the typechecker (yet).
 includeFile ::
-    Int -> SeenSet -> IncludePath -> Options -> FilePath -> Bool -> IO [Stmt]
-includeFile depth seen incpath opts fname once = do
+    Int -> SeenSet -> IncludePath -> Options -> PPS.Opts -> FilePath -> Bool -> IO [Stmt]
+includeFile depth seen incpath opts ppopts fname once = do
   fname' <- locateFile incpath fname
   alreadySeen <- seenSetMember fname' seen 
   if depth > 128 then
@@ -428,8 +431,8 @@ includeFile depth seen incpath opts fname once = do
       Cons.noteN $ "Loading file \"" <> Text.pack fname' <> "\""
       ftext <- TextIO.readFile fname'
 
-      stmts <- wrapDir current' $ readAnyIO fname ftext "end-of-file" parseModule
-      resolveIncludes (depth + 1) seen incpath' opts Inc.processStmts stmts
+      stmts <- wrapDir current' $ readAnyIO ppopts fname ftext "end-of-file" parseModule
+      resolveIncludes (depth + 1) seen incpath' opts ppopts Inc.processStmts stmts
 
 -- | Find a file, potentially looking in a list of multiple search paths (as
 -- specified via the @SAW_IMPORT_PATH@ environment variable or
@@ -437,10 +440,10 @@ includeFile depth seen incpath opts fname once = do
 -- found, load it. If not, fail by returning `Left`.
 --
 -- Doesn't run the typechecker (yet).
-findAndLoadFileUnchecked :: Options -> FilePath -> IO [Stmt]
-findAndLoadFileUnchecked opts fp = do
+findAndLoadFileUnchecked :: Options -> PPS.Opts -> FilePath -> IO [Stmt]
+findAndLoadFileUnchecked opts ppopts fp = do
   let depth = 0
   seen <- emptySeenSet
   let incpath = (".", Options.importPath opts)
       once = False
-  includeFile depth seen incpath opts fp once
+  includeFile depth seen incpath opts ppopts fp once

--- a/saw-script/src/SAWScript/Parser.y
+++ b/saw-script/src/SAWScript/Parser.y
@@ -371,8 +371,8 @@ data ParseError
 -- Note: we return the position and the document separately so they
 -- can be passed to the error infrastructure separately.
 --
-prettyParseError :: Text -> ParseError -> (Maybe Pos, PPS.Doc)
-prettyParseError eofName pe = case pe of
+prettyParseError :: PPS.Opts -> Text -> ParseError -> (Maybe Pos, PPS.Doc)
+prettyParseError ppopts eofName pe = case pe of
     HappyError nextToks possibles ->
         let (optpos, tstr) = case nextToks of
 	      [] -> (Nothing, eofName)
@@ -392,7 +392,7 @@ prettyParseError eofName pe = case pe of
         in
 	(optpos, doc)
     InvalidPattern pos e ->
-        (Just pos, "Parse error: invalid pattern" <+> prettyExpr e)
+        (Just pos, "Parse error: invalid pattern" <+> prettyExpr ppopts e)
     EmptyBlock pos ->
         (Just pos, "do block must include at least one expression")
     InvalidBlock pos ->

--- a/saw-script/src/SAWScript/REPL/Command.hs
+++ b/saw-script/src/SAWScript/REPL/Command.hs
@@ -91,30 +91,31 @@ cdCmd f
 envCmd :: REPL ()
 envCmd = do
   (rbenv, scopes) <- getSAWScriptVarEnv
+  ppopts <- getPPOpts
   liftIO $ do
       let blankline = TextIO.putStrLn ""
 
       unless (null rbenv) $ do
           let printrb (x, ty) = do
                 let x' = PP.pretty x
-                    ty' = prettySchema ty
+                    ty' = prettySchema ppopts ty
                     line1 = x' <+> ":"
                     line2 = "rebindable" <+> ty'
                     line2' = PP.flatAlt (PP.indent 3 line2) line2
                     body = PP.group (line1 <> PP.line <> line2')
-                TextIO.putStrLn $ PPS.renderText PPS.defaultOpts body
+                TextIO.putStrLn $ PPS.renderText ppopts body
           mapM_ printrb rbenv
           blankline
 
       let printscope entries = do
             let printentry (x, ty) = do
                   let x' = PP.pretty x
-                      ty' = prettySchema ty
+                      ty' = prettySchema ppopts ty
                       line1 = x' <+> ":"
                       line2 = ty'
                       line2' = PP.flatAlt (PP.indent 3 line2) line2
                       body = PP.group (line1 <> PP.line <> line2')
-                  TextIO.putStrLn $ PPS.renderText PPS.defaultOpts body
+                  TextIO.putStrLn $ PPS.renderText ppopts body
             mapM_ printentry entries
 
       -- Insert a blank line in the output where there's a scope boundary
@@ -174,11 +175,12 @@ searchCmd str
 
      ro <- getTopLevelRO
      rw <- getTopLevelRW
+     ppopts <- getPPOpts
      let opts = roOptions ro
          environ = rwEnviron rw
          rebindables = rwRebindables rw
      pat <- liftIO $
-         Loader.readSchemaPattern opts replFileName environ rebindables avail str
+         Loader.readSchemaPattern opts ppopts replFileName environ rebindables avail str
 
      let primsAvail = rwPrimsAvail rw
      let Environ varenv tyenv _cryenv = environ
@@ -231,7 +233,7 @@ searchCmd str
 
          printMatch (name, (lc, ty)) = do
            let name' = PP.pretty name
-               ty' = prettySchema ty
+               ty' = prettySchema ppopts ty
                lc' = case lc of
                    Current -> Nothing
                    WarnDeprecated -> Just "(DEPRECATED AND WILL WARN)"
@@ -246,7 +248,7 @@ searchCmd str
                    Just banner -> ty' <> "  " <> banner  -- separate by 2 spaces
                line2 = PP.flatAlt line2long line2short
                body = PP.group (line1 <> PP.line <> line2)
-           TextIO.putStrLn $ PPS.renderText PPS.defaultOpts body
+           TextIO.putStrLn $ PPS.renderText ppopts body
          printMatches matches =
            liftIO $ mapM_ printMatch (Map.assocs matches)
 
@@ -290,16 +292,17 @@ searchCmd str
 tenvCmd :: REPL ()
 tenvCmd = do
   scopes <- getSAWScriptTypeEnv
+  ppopts <- getPPOpts
   liftIO $ do
       let blankline = TextIO.putStrLn ""
 
       let printscope entries = do
             let printentry (x, ty) = do
                   let x' = PP.pretty x
-                      ty' = prettyNamedType ty
+                      ty' = prettyNamedType ppopts ty
                       body = x' <+> "=" <+> ty'
                       body' = PP.group body
-                  TextIO.putStrLn $ PPS.renderText PPS.defaultOpts body'
+                  TextIO.putStrLn $ PPS.renderText ppopts body'
             mapM_ printentry entries
 
       -- Insert a blank line in the output where there's a scope boundary
@@ -312,13 +315,14 @@ typeOfCmd str
   | otherwise = do
      ro <- getTopLevelRO
      rw <- getTopLevelRW
+     ppopts <- getPPOpts
      let opts = roOptions ro
          environ = rwEnviron rw
          rebindables = rwRebindables rw
          avail = rwPrimsAvail rw
      (schema, _expr) <- liftIO $
-         Loader.readExpression opts replFileName environ rebindables avail str
-     liftIO $ TextIO.putStrLn $ ppSchema schema
+         Loader.readExpression opts ppopts replFileName environ rebindables avail str
+     liftIO $ TextIO.putStrLn $ ppSchema ppopts schema
 
 
 ------------------------------------------------------------
@@ -412,13 +416,14 @@ genericHelp = map cmdHelp commandList
 executeSAWScriptText :: Text -> REPL ()
 executeSAWScriptText str = exceptionProtect $ do
   ro <- getTopLevelRO
+  ppopts <- getPPOpts
   let opts = roOptions ro
   -- XXX: for now use liftTopLevel as well as liftIO to make sure this uses
   -- TopLevel's MonadIO instance and therefore goes through the exception goo
   -- in Value.hs. That will make sure stack traces get printed from anything
   -- that blows up in the loader. (Note that while by default stack traces
   -- from here aren't particularly interesting, we might be in a nested REPL.)
-  stmts <- liftTopLevel $ liftIO $ Loader.readREPLTextUnchecked opts replFileName str
+  stmts <- liftTopLevel $ liftIO $ Loader.readREPLTextUnchecked opts ppopts replFileName str
   mbPst <- getProofState
   case mbPst of
       Nothing -> void $ liftTopLevel (interpretTopStmts True stmts)

--- a/saw-script/src/SAWScript/REPL/Monad.hs
+++ b/saw-script/src/SAWScript/REPL/Monad.hs
@@ -28,6 +28,7 @@ module SAWScript.REPL.Monad (
   , getTopLevelRO
   , getTopLevelRW
   , getProofState
+  , getPPOpts
   ) where
 
 import Control.Monad.Catch (
@@ -42,6 +43,7 @@ import System.IO.Error (isUserError, ioeGetErrorString)
 import System.Exit (ExitCode)
 
 import qualified SAWSupport.PanicSupport as PanicSupport
+import qualified SAWSupport.Pretty as PPS
 import qualified SAWSupport.ConsoleSupport as Cons
 
 import CryptolSAWCore.CryptolEnv
@@ -55,8 +57,8 @@ import SAWCentral.TopLevel (
 import SAWCentral.Value (
     ProofScript(..),
     rwGetCryptolEnv, TopLevelShellHook, ProofScriptShellHook,
-    getPPOpts
  )
+import qualified SAWCentral.Value as SV (getPPOpts) -- don't conflict with ours
 
 import SAWScript.Panic (panic)
 import SAWScript.Interpreter (buildTopLevelEnv)
@@ -168,7 +170,7 @@ liftProofScript m = do
     modify (\st -> st { rProofState = Just pst' })
     liftTopLevel $ case result of
        Left (stats, cex) ->
-         do ppOpts <- getPPOpts
+         do ppOpts <- SV.getPPOpts
             fail (Text.unpack $ ppProofResult ppOpts (InvalidProof stats cex pst'))
        Right x -> return x
 
@@ -189,6 +191,9 @@ getCryptolEnv :: REPL CryptolEnv
 getCryptolEnv = do
     rw <- getTopLevelRW
     return $ rwGetCryptolEnv rw
+
+getPPOpts :: REPL PPS.Opts
+getPPOpts = liftTopLevel SV.getPPOpts
 
 
 ------------------------------------------------------------

--- a/saw-script/src/SAWScript/Typechecker.hs
+++ b/saw-script/src/SAWScript/Typechecker.hs
@@ -26,6 +26,7 @@ import Control.Monad.Reader (MonadReader(..), ReaderT(..), asks)
 import Control.Monad.State (MonadState(..), StateT, gets, modify, runState)
 import Control.Monad.Identity (Identity)
 import qualified Data.Text as Text
+import Data.Text (Text)
 import Data.List (genericTake, genericLength)
 import Data.Either (partitionEithers)
 import qualified Data.Map as Map
@@ -33,6 +34,7 @@ import Data.Map (Map)
 import qualified Data.Set as Set
 import Data.Set (Set)
 
+import qualified SAWSupport.Pretty as PPS
 import SAWSupport.Position
 import qualified SAWSupport.ScopedMap as ScopedMap
 import SAWSupport.ScopedMap (ScopedMap)
@@ -263,9 +265,8 @@ instance AppSubst NamedType where
 
 data ContextName = ContextName Pos Name
 
-instance Show ContextName where
-  show (ContextName pos name) = show name ++ " (" ++ show pos ++ ")"
-
+ppContextName :: ContextName -> Text
+ppContextName (ContextName pos name) = "\"" <> name <> "\" (" <> ppPosition pos <> ")"
 
 
 ------------------------------------------------------------
@@ -280,7 +281,10 @@ newtype TI a = TI { unTI :: ReaderT RO (StateT RW Identity) a }
 -- | The read-only portion
 data RO = RO {
     -- | The variable availability (lifecycle set)
-    primsAvail :: Set PrimitiveLifecycle
+    primsAvail :: Set PrimitiveLifecycle,
+
+    -- | The prettyprinter options
+    tiPPOpts :: PPS.Opts
 }
 
 -- | The read-write portion
@@ -523,7 +527,7 @@ patternBindingsWithSchema pat sch =
 -- always either a list of two message strings or empty. Function types
 -- we see go in it (replacing anything already there, so we keep only
 -- the outermost of a series) and are shifted out of it when we see
--- something else. It could be a Maybe (String, String), but the code
+-- something else. It could be a Maybe (Text, Text), but the code
 -- is noticeably more convenient the way it is.
 --
 -- The initial message is kept separate so that the expected/found
@@ -554,21 +558,21 @@ patternBindingsWithSchema pat sch =
 --
 
 data FailMGU = FailMGU
-                    [String]    -- initial error message (often multiple lines)
-                    [String]    -- list of found/expected message pairs
-                    [String]    -- current found/expected function pair if any
+                    [Text]    -- initial error message (often multiple lines)
+                    [Text]    -- list of found/expected message pairs
+                    [Text]    -- current found/expected function pair if any
 
 -- common code for printing expected/found types
-showTypes :: Type -> Type -> [String]
-showTypes ty1 ty2 =
-  let expected = "Expected: " ++ Text.unpack (ppType ty1)
-      found    = "Found:    " ++ Text.unpack (ppType ty2)
+ppTypes :: PPS.Opts -> Type -> Type -> [Text]
+ppTypes ppopts ty1 ty2 =
+  let expected = "Expected: " <> ppType ppopts ty1
+      found    = "Found:    " <> ppType ppopts ty2
   in
   [expected, found, ""]
 
 -- logic for showing details of a type
-showTypeDetails :: Type -> String
-showTypeDetails ty =
+ppTypeDetails :: PPS.Opts -> Type -> Text
+ppTypeDetails ppopts ty =
   let pr pos what =
         -- XXX: just doing ppType here uglifies the message for
         -- records the prettyprinter thinks don't fit on one line; it
@@ -599,9 +603,9 @@ showTypeDetails ty =
         -- Blah.
         --
         let pos' = ppPosition pos
-            ty' = ppType ty
+            ty' = ppType ppopts ty
         in
-        Text.unpack $ pos' <> ": The type " <> ty' <> " arises from " <> what
+        pos' <> ": The type " <> ty' <> " arises from " <> what
   in
   case getPos ty of
     PosInferred InfFresh pos -> pr pos "a fresh type variable introduced here"
@@ -610,28 +614,28 @@ showTypeDetails ty =
     pos -> pr pos "this type annotation"
 
 -- fail with expected/found types
-failMGU :: String -> Type -> Type -> Either FailMGU a
-failMGU start ty1 ty2 = Left (FailMGU start' ("" : showTypes ty1 ty2) [])
-  where start' = [start, showTypeDetails ty1, showTypeDetails ty2]
+failMGU :: PPS.Opts -> Text -> Type -> Type -> Either FailMGU a
+failMGU ppopts start ty1 ty2 = Left (FailMGU start' ("" : ppTypes ppopts ty1 ty2) [])
+  where start' = [start, ppTypeDetails ppopts ty1, ppTypeDetails ppopts ty2]
 
 -- fail with no types
-failMGU' :: String -> Either FailMGU a
+failMGU' :: Text -> Either FailMGU a
 failMGU' start = Left (FailMGU [start] [] [])
 
 -- add another expected/found type pair to the failure
 -- (pull in the last function-type lines if any)
-failMGUAdd :: FailMGU -> Type -> Type -> FailMGU
-failMGUAdd (FailMGU start eflines lastfunlines) ty1 ty2 =
-  FailMGU start (eflines ++ lastfunlines ++ showTypes ty1 ty2) []
+failMGUAdd :: PPS.Opts -> FailMGU -> Type -> Type -> FailMGU
+failMGUAdd ppopts (FailMGU start eflines lastfunlines) ty1 ty2 =
+  FailMGU start (eflines ++ lastfunlines ++ ppTypes ppopts ty1 ty2) []
 
 -- add another pair that's a function type
 -- (overwrite any previous function type lines)
-failMGUAddFun :: FailMGU -> Type -> Type -> FailMGU
-failMGUAddFun (FailMGU start eflines _) ty1 ty2 =
-  FailMGU start eflines (showTypes ty1 ty2)
+failMGUAddFun :: PPS.Opts -> FailMGU -> Type -> Type -> FailMGU
+failMGUAddFun ppopts (FailMGU start eflines _) ty1 ty2 =
+  FailMGU start eflines (ppTypes ppopts ty1 ty2)
 
 -- print the failure as a string list
-ppFailMGU :: FailMGU -> [String]
+ppFailMGU :: FailMGU -> [Text]
 ppFailMGU (FailMGU start eflines lastfunlines) =
   start ++ eflines ++ lastfunlines
 
@@ -662,8 +666,8 @@ resolveUnificationVar i t2 =
 -- Given two types, produce either a failure report or a substitution
 -- (to add to the cumulative substitution we build up) that makes them
 -- the same.
-mgu :: Type -> Type -> Either FailMGU Subst
-mgu t1 t2 = case (t1, t2) of
+mgu :: PPS.Opts -> Type -> Type -> Either FailMGU Subst
+mgu ppopts t1 t2 = case (t1, t2) of
 
   (TyUnifyVar _ i, TyUnifyVar _ j) | i == j ->
       -- same unification var, nothing to do
@@ -674,57 +678,57 @@ mgu t1 t2 = case (t1, t2) of
       case resolveUnificationVar i t2 of
           Just someSubst -> return someSubst
           Nothing -> do
-              let t1' = Text.unpack $ ppType t1
-                  t2' = Text.unpack $ ppType t2
-              let msg = "Occurs check failure: cannot unify " ++ t1' ++
-                        " with " ++ t2' ++ " because " ++ t1' ++
-                        " appears within " ++ t2'
-              failMGU msg t1 t2
+              let t1' = ppType ppopts t1
+                  t2' = ppType ppopts t2
+              let msg = "Occurs check failure: cannot unify " <> t1' <>
+                        " with " <> t2' <> " because " <> t1' <>
+                        " appears within " <> t2'
+              failMGU ppopts msg t1 t2
 
   (_, TyUnifyVar _ i) ->
       -- the other side is a unification var, resolve it
       case resolveUnificationVar i t1 of
           Just someSubst -> return someSubst
           Nothing -> do
-              let t1' = Text.unpack $ ppType t1
-                  t2' = Text.unpack $ ppType t2
-              let msg = "Occurs check failure: cannot unify " ++ t1' ++
-                        " with " ++ t2' ++ " because " ++ t2' ++
-                        " appears within " ++ t1'
-              failMGU msg t1 t2
+              let t1' = ppType ppopts t1
+                  t2' = ppType ppopts t2
+              let msg = "Occurs check failure: cannot unify " <> t1' <>
+                        " with " <> t2' <> " because " <> t2' <>
+                        " appears within " <> t1'
+              failMGU ppopts msg t1 t2
 
   (TyRecord _ ts1, TyRecord _ ts2)
     | Map.keys ts1 /= Map.keys ts2 ->
       -- records with different keys
-      failMGU "Record field names mismatch." t1 t2
+      failMGU ppopts "Record field names mismatch." t1 t2
 
     | otherwise ->
       -- records with the same field names, try unifying the field types
-      case mgus (Map.elems ts1) (Map.elems ts2) of
+      case mgus ppopts (Map.elems ts1) (Map.elems ts2) of
         Right result -> Right result
-        Left msgs -> Left $ failMGUAdd msgs t1 t2
+        Left msgs -> Left $ failMGUAdd ppopts msgs t1 t2
 
   (TyCon _ tc1 ts1, TyCon _ tc2 ts2)
     | tc1 == tc2 ->
       -- same type constructor, unify the args
-      case mgus ts1 ts2 of
+      case mgus ppopts ts1 ts2 of
         Right result -> Right result
         Left msgs ->
           -- oops, didn't work. handle functions specially for
           -- nicer error reporting
           case tc1 of
-            FunCon -> Left $ failMGUAddFun msgs t1 t2
-            _ -> Left $ failMGUAdd msgs t1 t2
+            FunCon -> Left $ failMGUAddFun ppopts msgs t1 t2
+            _ -> Left $ failMGUAdd ppopts msgs t1 t2
 
     | otherwise ->
       -- Wrong type constructors
       case tc1 of
         FunCon ->
-          failMGU ("Term is not a function. (Maybe a function is applied " ++
+          failMGU ppopts ("Term is not a function. (Maybe a function is applied " <>
                    "to too many arguments?)") t1 t2
         _ ->
-          failMGU ("Mismatch of type constructors. Expected: " ++ Text.unpack (ppTyCon tc1) ++
-                   " but got " ++ Text.unpack (ppTyCon tc2)) t1 t2
+          failMGU ppopts ("Mismatch of type constructors. Expected: " <> ppTyCon ppopts tc1 <>
+                   " but got " <> ppTyCon ppopts tc2) t1 t2
 
   (TyVar _ a, TyVar _ b) | a == b ->
       -- Same named variable
@@ -732,18 +736,18 @@ mgu t1 t2 = case (t1, t2) of
 
   (_, _) ->
       -- Did not work
-      failMGU "Mismatch of types." t1 t2
+      failMGU ppopts "Mismatch of types." t1 t2
 
 -- Run mgu on two lists of types.
-mgus :: [Type] -> [Type] -> Either FailMGU Subst
-mgus t1s t2s = case (t1s, t2s) of
+mgus :: PPS.Opts -> [Type] -> [Type] -> Either FailMGU Subst
+mgus ppopts t1s t2s = case (t1s, t2s) of
     ([], []) ->
         return emptySubst
     (t1 : t1s', t2 : t2s') -> do
         -- unify the first types
-        s <- mgu t1 t2
+        s <- mgu ppopts t1 t2
         -- apply that substitution and then recurse
-        s' <- mgus (map (appSubst s) t1s') (map (appSubst s) t2s')
+        s' <- mgus ppopts (map (appSubst s) t1s') (map (appSubst s) t2s')
         return (mergeSubst s' s)
     (_, _) ->
       -- XXX this is no good, it will always print one of the lengths as 0!
@@ -762,8 +766,14 @@ mgus t1s t2s = case (t1s, t2s) of
       -- any. (And for tuples, the arity is part of the constructor,
       -- so tuples of different arity won't get as far as trying to
       -- unify the arguments.)
-      failMGU' $ "Wrong number of arguments. Expected " ++ show (length t1s) ++
-                 " but got " ++ show (length t2s)
+      --
+      -- Update 20260410: the parser is no longer so restricted; we
+      -- should check if this is live and fix it if so.
+      let t1s' = Text.pack $ show (length t1s)
+          t2s' = Text.pack $ show (length t2s)
+      in
+      failMGU' $ "Wrong number of arguments. Expected " <> t1s' <>
+                 " but got " <> t2s'
 
 --
 -- Unify two types.
@@ -807,20 +817,22 @@ mgus t1s t2s = case (t1s, t2s) of
 --
 unify :: ContextName -> Type -> Pos -> Type -> TI ()
 unify cname t1 pos t2 = do
+  ppopts <- asks tiPPOpts
+
   t1' <- applyCurrentSubst =<< resolveCurrentTypedefs t1
   t2' <- applyCurrentSubst =<< resolveCurrentTypedefs t2
-  case mgu t1' t2' of
+  case mgu ppopts t1' t2' of
     Right s -> modify $ \rw -> rw { subst = mergeSubst s $ subst rw }
     Left msgs ->
-       recordError pos $ unlines $ firstline : morelines'
+       recordError pos $ Text.unpack $ Text.unlines $ firstline : morelines'
        where
          firstline = "Type mismatch."
-         morelines = ppFailMGU msgs ++ ["within " ++ show cname]
+         morelines = ppFailMGU msgs ++ ["within " <> ppContextName cname]
          -- Indent all but the first line by four spaces.
          -- Don't indent blank lines; that produces trailing whitespace.
          adjust msg = case msg of
-             [] -> []
-             _ -> "    " ++ msg
+             "" -> ""
+             _ -> "    " <> msg
          morelines' = map adjust morelines
 
 -- Check if two types match but don't actually unify them
@@ -833,9 +845,11 @@ unify cname t1 pos t2 = do
 -- needed.
 matches :: Type -> Type -> TI Bool
 matches t1 t2 = do
+  ppopts <- asks tiPPOpts
+
   t1' <- applyCurrentSubst =<< resolveCurrentTypedefs t1
   t2' <- applyCurrentSubst =<< resolveCurrentTypedefs t2
-  case mgu t1' t2' of
+  case mgu ppopts t1' t2' of
     Right _ -> return True
     Left _ -> return False
 
@@ -1080,8 +1094,9 @@ inferExpr (ln, expr) = case expr of
                   Text.unpack n ++ "; please use a type annotation"
               getErrorTyVar pos
           _ -> do
+              ppopts <- asks tiPPOpts
               recordError pos $
-                  "Record lookup on non-record value of type " ++ Text.unpack (ppType t1)
+                  "Record lookup on non-record value of type " ++ Text.unpack (ppType ppopts t1)
               getErrorTyVar pos
       return (Lookup pos e1 n, elTy)
 
@@ -1103,8 +1118,9 @@ inferExpr (ln, expr) = case expr of
                   show i ++ "; please use a type annotation"
               getErrorTyVar pos
           _ -> do
+              ppopts <- asks tiPPOpts
               recordError pos $ 
-                  "Tuple lookup on non-tuple value of type " ++ Text.unpack (ppType t1)
+                  "Tuple lookup on non-tuple value of type " ++ Text.unpack (ppType ppopts t1)
               getErrorTyVar pos
       return (TLookup pos e1 i, elTy)
 
@@ -1207,11 +1223,11 @@ checkExpr cname e t = do
 --    - or it is present and already declared "rebindable", in which
 --      case it must have the same type.
 inferPattern :: ContextName -> Rebindable -> Pattern -> TI (Type, Pattern)
-inferPattern cname rebindable pat =
+inferPattern cname rebindable pat = do
   let resolveType pos mt = case mt of
         Nothing -> getFreshTyVar pos
         Just t -> checkType kindStar t
-  in
+
   case pat of
     PWild pos mt ->
       do t <- resolveType pos mt
@@ -1271,8 +1287,8 @@ inferPattern cname rebindable pat =
 -- Check the type of a pattern, by inferring and then unifying the
 -- result.
 checkPattern :: Rebindable -> ContextName -> Type -> Pattern -> TI Pattern
-checkPattern rebindable cname t pat =
-  do (pt, pat') <- inferPattern cname rebindable pat
+checkPattern rebindable cname t pat = do
+     (pt, pat') <- inferPattern cname rebindable pat
      unify cname t (getPos pat) pt
      return pat'
 
@@ -1339,7 +1355,8 @@ wrapReturn e =
 --
 -- Updates the environment and returns an updated statement.
 inferStmt :: ContextName -> Bool -> Pos -> Type -> Stmt -> TI Stmt
-inferStmt cname atSyntacticTopLevel blockpos ctx s =
+inferStmt cname atSyntacticTopLevel blockpos ctx s = do
+    ppopts <- asks tiPPOpts
     case s of
         StmtBind spos pat e -> do
             (pty, pat') <- inferPattern cname ReadOnlyVar pat
@@ -1396,8 +1413,8 @@ inferStmt cname atSyntacticTopLevel blockpos ctx s =
             -- The special case for the wrong monad
             let allowWrongMonad ctx' valty' = do
                   recordError spos $ "Monadic bind with the wrong monad; " ++
-                                     "found " ++ Text.unpack (ppType ctx') ++
-                                     " but expected " ++ Text.unpack (ppType ctx)
+                                     "found " ++ Text.unpack (ppType ppopts ctx') ++
+                                     " but expected " ++ Text.unpack (ppType ppopts ctx)
                   recordError spos $ "This creates the action but does " ++
                                      "not execute it; if you meant to do " ++
                                      "that, prefix the " ++
@@ -1846,6 +1863,8 @@ lookupTyCon tycon = case tycon of
 checkType :: Kind -> Type -> TI Type
 checkType kind ty = case ty of
   TyCon pos tycon args -> do
+      ppopts <- asks tiPPOpts
+
       -- First, look up the constructor.
       let params = lookupTyCon tycon
       let nparams = genericLength params
@@ -1854,21 +1873,19 @@ checkType kind ty = case ty of
 
       if nargs > nparams then do
           -- XXX special case for BlockCon (remove along with BlockCon)
-          case (tycon, args) of
-              (BlockCon, arg : _) ->
-                  recordError pos ("Too many type arguments for type " ++
-                                   "constructor " ++ Text.unpack (ppType arg) ++
-                                   "; found " ++ show (nargs - 1) ++
-                                   " but expected only " ++ show (nparams - 1))
-              (_, _) ->
-                  recordError pos ("Too many type arguments for type " ++
-                                   "constructor " ++ Text.unpack (ppTyCon tycon) ++
-                                   "; found " ++ show nargs ++
-                                   " but expected only " ++ show nparams)
+          let (nargs', nparams', tycon') =
+                case (tycon, args) of
+                    (BlockCon, arg : _) -> (nargs - 1, nparams - 1, ppType ppopts arg)
+                    (_, _) -> (nargs, nparams, ppTyCon ppopts tycon)
+
+          recordError pos ("Too many type arguments for type " <>
+                                   "constructor " <> Text.unpack tycon' <>
+                                   "; found " <> show nargs' <>
+                                   " but expected only " <> show nparams')
           getErrorTyVar pos
       else if nargs + argsleft /= nparams then do
-          recordError pos ("Kind mismatch: expected " ++ Text.unpack (ppKind kind) ++
-                           " but found " ++ Text.unpack (ppKind $ Kind (nparams - nargs)))
+          recordError pos ("Kind mismatch: expected " <> Text.unpack (ppKind kind) <>
+                           " but found " <> Text.unpack (ppKind (Kind (nparams - nargs))))
           getErrorTyVar pos
       else do
           -- note that this will ignore the extra params, and return
@@ -1958,18 +1975,18 @@ type Result a = (Either MsgList a, MsgList)
 -- Note that the error and warning lists accumulate in reverse order
 -- (later messages are consed onto the head of the list) so we
 -- reverse on the way out.
-runTIWithEnv :: Set PrimitiveLifecycle -> VarEnv -> TyEnv -> TI a -> (a, Subst, MsgList, MsgList)
-runTIWithEnv avail env tenv m = (a, subst rw', reverse $ errors rw', reverse $ warnings rw')
+runTIWithEnv :: PPS.Opts -> Set PrimitiveLifecycle -> VarEnv -> TyEnv -> TI a -> (a, Subst, MsgList, MsgList)
+runTIWithEnv ppopts avail env tenv m = (a, subst rw', reverse $ errors rw', reverse $ warnings rw')
   where
-    m' = runReaderT (unTI m) (RO avail)
+    m' = runReaderT (unTI m) (RO avail ppopts)
     rw = initialRW env tenv
     (a, rw') = runState m' rw
 
 -- Run the TI monad and interpret/collect the results
 -- (failure if any errors were produced)
-evalTIWithEnv :: Set PrimitiveLifecycle -> VarEnv -> TyEnv -> TI a -> Result a
-evalTIWithEnv avail env tenv m =
-  case runTIWithEnv avail env tenv m of
+evalTIWithEnv :: PPS.Opts -> Set PrimitiveLifecycle -> VarEnv -> TyEnv -> TI a -> Result a
+evalTIWithEnv ppopts avail env tenv m =
+  case runTIWithEnv ppopts avail env tenv m of
     (res, _, [], warns) -> (Right res, warns)
     (_, _, errs, warns) -> (Left errs, warns)
 
@@ -1980,8 +1997,8 @@ evalTIWithEnv avail env tenv m =
 --
 -- The third is a current position, and the fourth is the
 -- context/monad type associated with the execution.
-checkStmt :: Set PrimitiveLifecycle -> VarEnv -> TyEnv -> Context -> Stmt -> Result Stmt
-checkStmt avail env tenv ctx stmt =
+checkStmt :: PPS.Opts -> Set PrimitiveLifecycle -> VarEnv -> TyEnv -> Context -> Stmt -> Result Stmt
+checkStmt ppopts avail env tenv ctx stmt =
     -- XXX: we shouldn't need this position here.
     -- The position is used for the following things:
     --
@@ -2019,15 +2036,15 @@ checkStmt avail env tenv ctx stmt =
             ProofScript -> ContextName pos "<proofscript>"
         ctxtype = TyCon pos (ContextCon ctx) []
     in
-    evalTIWithEnv avail env tenv (inferSingleStmt cname pos ctxtype stmt)
+    evalTIWithEnv ppopts avail env tenv (inferSingleStmt cname pos ctxtype stmt)
 
 -- | Check a single declaration. (This is an external interface.)
 --
 -- The first two arguments are the starting variable and typedef
 -- environments to use.
-checkDecl :: Set PrimitiveLifecycle -> VarEnv -> TyEnv -> Decl -> Result Decl
-checkDecl avail env tenv decl =
-    evalTIWithEnv avail env tenv (inferDecl ReadOnlyVar decl)
+checkDecl :: PPS.Opts -> Set PrimitiveLifecycle -> VarEnv -> TyEnv -> Decl -> Result Decl
+checkDecl ppopts avail env tenv decl =
+    evalTIWithEnv ppopts avail env tenv (inferDecl ReadOnlyVar decl)
 
 -- | Check a found type (first argument) against an expected type
 --   (second argument) and return True if they can be unified.
@@ -2035,8 +2052,8 @@ checkDecl avail env tenv decl =
 --   Both types are schemes because that's what we need upstream.
 --
 --   (This is an external interface.)
-typesMatch :: Set PrimitiveLifecycle -> TyEnv -> Schema -> Schema -> Bool
-typesMatch avail tenv schema'found schema'expected =
+typesMatch :: PPS.Opts -> Set PrimitiveLifecycle -> TyEnv -> Schema -> Schema -> Bool
+typesMatch ppopts avail tenv schema'found schema'expected =
   let unpack (Forall as ty) = do
         -- Generate unification vars for all the forall-bindings
         let generate (pos'a, a) = do
@@ -2052,7 +2069,7 @@ typesMatch avail tenv schema'found schema'expected =
         ty'expected <- unpack schema'expected
         matches ty'found ty'expected
   in
-  case evalTIWithEnv avail ScopedMap.empty tenv match of
+  case evalTIWithEnv ppopts avail ScopedMap.empty tenv match of
     (Left _errors, _warnings) -> False          -- not actually reachable
     (Right b, _warnings) -> b                   -- return match success/failure
 
@@ -2085,8 +2102,8 @@ typesMatch avail tenv schema'found schema'expected =
 -- deprecated types; experimental objects can see experimental types;
 -- everything can see current types.
 --
-checkSchema :: PrimitiveLifecycle -> TyEnv -> Schema -> Result Schema
-checkSchema contextLC tyenv schema = do
+checkSchema :: PPS.Opts -> PrimitiveLifecycle -> TyEnv -> Schema -> Result Schema
+checkSchema ppopts contextLC tyenv schema = do
   let check = do
         let Forall tyvars ty = schema
         -- Generate unification vars for all the forall-bindings
@@ -2106,7 +2123,7 @@ checkSchema contextLC tyenv schema = do
           WarnDeprecated -> [Current, WarnDeprecated]
           HideDeprecated -> [Current, WarnDeprecated, HideDeprecated, Experimental]
           Experimental -> [Current, Experimental]
-  evalTIWithEnv avail ScopedMap.empty tyenv check
+  evalTIWithEnv ppopts avail ScopedMap.empty tyenv check
 
 -- | Check a schema (type) pattern as used by :search. (This is an
 -- external interface.)

--- a/saw-server/src/SAWServer/SAWServer.hs
+++ b/saw-server/src/SAWServer/SAWServer.hs
@@ -109,10 +109,10 @@ data SAWTask
   | JVMSetup ServerName
   | MIRSetup ServerName
 
--- | Print a `SAWTask`. This produces exactly the same output as the
---   former `Show` instance, including having no space between "Setup"
---   and the quoted name, since the output is apparently part of the
---   wire protocol.
+-- | Print a `SAWTask`. This output is apparently part of the wire
+--   protocol. Whether no space between "Setup" and the quoted name
+--   was intended or not isn't clear, but probably can't be changed
+--   now without a bunch of extra work.
 ppSAWTask :: SAWTask -> Text
 ppSAWTask task = case task of
   ProofScriptTask -> "ProofScript"

--- a/saw-server/src/SAWServer/SAWServer.hs
+++ b/saw-server/src/SAWServer/SAWServer.hs
@@ -14,7 +14,8 @@ module SAWServer.SAWServer
   ) where
 
 import Prelude hiding (mod)
-import Control.Lens ( Lens', view, lens, over )
+import Control.Lens ( Lens', view, lens, over, (^.) )
+import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (FromJSON(..), ToJSON(..), withText)
 import Data.Bifoldable (Bifoldable(..))
 import Data.Bifunctor (Bifunctor(..))
@@ -33,6 +34,9 @@ import System.Directory (getCurrentDirectory)
 import System.Environment (lookupEnv)
 import System.IO.Silently (silence)
 
+import qualified Prettyprinter as PP
+import Prettyprinter ((<+>))
+
 import qualified Cryptol.Parser.AST as P
 import qualified Cryptol.TypeCheck.AST as Cryptol (Schema)
 #if USE_BUILTIN_ABC
@@ -48,15 +52,16 @@ import Mir.Intrinsics (MIR)
 import Mir.Mir (Adt)
 
 import qualified SAWSupport.ScopedMap as ScopedMap
-import qualified SAWSupport.Pretty as PPS (defaultOpts)
+import qualified SAWSupport.Pretty as PPS (Doc, Opts, renderText)
 
 import qualified SAWCentral.Trace as Trace (empty)
 
---import qualified CryptolSAWCore.CryptolEnv as CryptolEnv
 import SAWCore.Module (emptyModule)
 import SAWCore.Name (mkModuleName)
-import SAWCore.SharedTerm (mkSharedContext, scLoadModule)
-import CryptolSAWCore.TypedTerm (TypedTerm, ppTypedTermPure, CryptolModule)
+import SAWCore.SharedTerm (SharedContext, mkSharedContext, scLoadModule, scGetPPOpts)
+
+import CryptolSAWCore.TypedTerm (TypedTerm, prettyTypedTerm, prettyTypedTermPure, CryptolModule)
+import qualified CryptolSAWCore.Pretty as CryPP
 
 import SAWCentral.Crucible.LLVM.X86 (defaultStackBaseAlign)
 import qualified SAWCentral.Crucible.Common as CC (defaultSAWCoreBackendTimeout, PathSatSolver(..))
@@ -104,12 +109,16 @@ data SAWTask
   | JVMSetup ServerName
   | MIRSetup ServerName
 
-instance Show SAWTask where
-  show ProofScriptTask = "ProofScript"
-  show (LLVMCrucibleSetup n) = "(LLVMCrucibleSetup" ++ show n ++ ")"
-  show (JVMSetup n) = "(JVMSetup" ++ show n ++ ")"
-  show (MIRSetup n) = "(MIRSetup" ++ show n ++ ")"
-
+-- | Print a `SAWTask`. This produces exactly the same output as the
+--   former `Show` instance, including having no space between "Setup"
+--   and the quoted name, since the output is apparently part of the
+--   wire protocol.
+ppSAWTask :: SAWTask -> Text
+ppSAWTask task = case task of
+  ProofScriptTask -> "ProofScript"
+  LLVMCrucibleSetup (ServerName n) -> "(LLVMCrucibleSetup\"" <> n <> "\")"
+  JVMSetup (ServerName n) -> "(JVMSetup\"" <> n <> "\")"
+  MIRSetup (ServerName n) -> "(MIRSetup\"" <> n <> "\")"
 
 data CrucibleSetupVal ty e
   = NullValue
@@ -207,7 +216,7 @@ instance Show (SetupStep ty) where
   show _ = "⟨SetupStep⟩" -- TODO
 
 instance ToJSON SAWTask where
-  toJSON = toJSON . show
+  toJSON t = toJSON $ ppSAWTask t
 
 data SAWState =
   SAWState
@@ -218,9 +227,6 @@ data SAWState =
     , _sawTopLevelRW :: TopLevelRW
     , _trackedFiles :: Map FilePath (Hash.Digest Hash.SHA256)
     }
-
-instance Show SAWState where
-  show (SAWState e _ t _ _ tf) = "(SAWState " ++ show e ++ " _sc_ " ++ show t ++ " _ro_ _rw" ++ show tf ++ ")"
 
 sawEnv :: Lens' SAWState SAWEnv
 sawEnv = lens _sawEnv (\v e -> v { _sawEnv = e })
@@ -240,6 +246,35 @@ sawTopLevelRW = lens _sawTopLevelRW (\v rw -> v { _sawTopLevelRW = rw })
 trackedFiles :: Lens' SAWState (Map FilePath (Hash.Digest Hash.SHA256))
 trackedFiles = lens _trackedFiles (\v tf -> v { _trackedFiles = tf })
 
+-- | This is used only for debug logging, so keep it non-monadic to
+--   avoid evaluating any of it when not in debug mode.
+prettySAWStatePure :: PPS.Opts -> SAWState -> PPS.Doc
+prettySAWStatePure ppopts st =
+    let env' = prettySAWEnvPure ppopts $ st ^. sawEnv
+        prettyOneTask (task, taskenv) =
+            let task' = PP.pretty $ ppSAWTask task
+                taskenv' = prettySAWEnvPure ppopts taskenv
+            in
+            PP.vsep [task', "--------", taskenv']
+        tasks' = PP.vsep $ map prettyOneTask (st ^. sawTask)
+        prettyTrackedFile (fp, hash) =
+            PP.pretty fp <+> "->" <+> PP.viaShow hash
+
+        tf' = PP.vsep $ map prettyTrackedFile $ Map.toList $ st ^. trackedFiles
+    in
+    PP.vsep [
+        "SAWState:",
+        PP.indent 3 "Env:",
+        PP.indent 6 env',
+        PP.indent 3 "Tasks:",
+        PP.indent 6 tasks',
+        PP.indent 3 "Tracked files:",
+        PP.indent 6 tf'
+    ]
+
+ppSAWStatePure :: PPS.Opts -> SAWState -> Text
+ppSAWStatePure ppopts st =
+  PPS.renderText ppopts $ prettySAWStatePure ppopts st
 
 pushTask :: SAWTask -> Argo.Command SAWState ()
 pushTask t = Argo.modifyState mod
@@ -361,10 +396,21 @@ initialState readFileFn =
 
 newtype SAWEnv =
   SAWEnv { sawEnvBindings :: Map ServerName ServerVal }
-  deriving stock Show
 
 emptyEnv :: SAWEnv
 emptyEnv = SAWEnv Map.empty
+
+
+-- | Print a whole environment. This is only used for debug logging,
+--   so avoid making it monadic to avoid evaluating parts of it that
+--   won't actually be used most of the time.
+prettySAWEnvPure :: PPS.Opts -> SAWEnv -> PPS.Doc
+prettySAWEnvPure ppopts (SAWEnv env) =
+    let once (ServerName name, v) =
+          let v' = prettyServerValPure ppopts v in
+          PP.pretty name <+> PP.align v'
+    in
+    PP.vsep $ map once $ Map.toList env
 
 newtype ServerName = ServerName Text
   deriving stock (Eq, Show, Ord)
@@ -398,24 +444,57 @@ data ServerVal
   | VYosysTheorem YosysTheorem
   | VYosysSequential YosysSequential
 
-instance Show ServerVal where
-  show (VTerm t) = "(VTerm " ++ Text.unpack (ppTypedTermPure PPS.defaultOpts t) ++ ")"
-  show (VSimpset ss) = "(VSimpset " ++ show (prettySimpset PPS.defaultOpts ss) ++ ")"
-  show (VType t) = "(VType " ++ show t ++ ")"
-  show (VCryptolModule _) = "VCryptolModule"
-  show (VJVMClass _) = "VJVMClass"
-  show (VJVMCrucibleSetup _) = "VJVMCrucibleSetup"
-  show (VLLVMCrucibleSetup _) = "VLLVMCrucibleSetup"
-  show (VLLVMModule (Some _)) = "VLLVMModule"
-  show (VMIRModule _) = "VMIRModule"
-  show (VMIRAdt _) = "VMIRAdt"
-  show (VLLVMMethodSpecIR _) = "VLLVMMethodSpecIR"
-  show (VJVMMethodSpecIR _) = "VJVMMethodSpecIR"
-  show (VMIRMethodSpecIR _) = "VMIRMethodSpecIR"
-  show (VGhostVar x) = "(VGhostVar " ++ show x ++ ")"
-  show (VYosysImport _) = "VYosysImport"
-  show (VYosysTheorem _) = "VYosysTheorem"
-  show (VYosysSequential _) = "VYosysSequential"
+-- | Shared ServerVal printing code for the straightforward cases
+prettyServerValCommon :: PPS.Opts -> ServerVal -> PPS.Doc
+prettyServerValCommon ppopts v = case v of
+  VTerm _ -> "VTerm" -- not reached
+  VSimpset set ->
+      let set' = prettySimpset ppopts set in
+      "(VSimpset" <+> set' <> ")"
+  VType t -> "(VType " <> CryPP.pretty t <> ")"
+  VCryptolModule _ -> "VCryptolModule"
+  VJVMClass _ -> "VJVMClass"
+  VJVMCrucibleSetup _ -> "VJVMCrucibleSetup"
+  VLLVMCrucibleSetup _ -> "VLLVMCrucibleSetup"
+  VLLVMModule (Some _) -> "VLLVMModule"
+  VMIRModule _ -> "VMIRModule"
+  VMIRAdt _ -> "VMIRAdt"
+  VLLVMMethodSpecIR _ -> "VLLVMMethodSpecIR"
+  VJVMMethodSpecIR _ -> "VJVMMethodSpecIR"
+  VMIRMethodSpecIR _ -> "VMIRMethodSpecIR"
+  VGhostVar x -> "(VGhostVar" <+> PP.pretty x <> ")"
+  VYosysImport _ -> "VYosysImport"
+  VYosysTheorem _ -> "VYosysTheorem"
+  VYosysSequential _ -> "VYosysSequential"
+
+-- | Print a ServerVal when we have IO.
+prettyServerVal :: SharedContext -> ServerVal -> IO PPS.Doc
+prettyServerVal sc v = case v of
+  VTerm t -> do
+      t' <- prettyTypedTerm sc t
+      pure $ "(VTerm" <+> t' <> ")"
+  _ -> do
+      ppopts <- scGetPPOpts sc
+      pure $ prettyServerValCommon ppopts v
+
+ppServerVal :: SharedContext -> ServerVal -> IO Text
+ppServerVal sc v = do
+  ppopts <- scGetPPOpts sc
+  v' <- prettyServerVal sc v
+  pure $ PPS.renderText ppopts v'
+
+-- | Print a ServerVal when we don't have IO.
+--
+-- This prints SAWCore elements in degraded mode and should be
+-- avoided.
+--
+prettyServerValPure :: PPS.Opts -> ServerVal -> PPS.Doc
+prettyServerValPure ppopts v = case v of
+  VTerm t ->
+      let t' = prettyTypedTermPure ppopts t in
+      "(VTerm" <+> t' <> ")"
+  _ ->
+      prettyServerValCommon ppopts v
 
 class IsServerVal a where
   toServerVal :: a -> ServerVal
@@ -477,6 +556,12 @@ instance IsServerVal RustModule where
 instance IsServerVal Adt where
   toServerVal = VMIRAdt
 
+getPPOpts :: SAWState -> IO PPS.Opts
+getPPOpts st = do
+  let sc = rwSharedContext $ st ^. sawTopLevelRW
+  v <- scGetPPOpts sc
+  pure $ v
+
 setServerVal :: IsServerVal val => ServerName -> val -> Argo.Command SAWState ()
 setServerVal name val =
   do Argo.debugLog $ "Saving " <> (Text.pack (show name))
@@ -486,14 +571,16 @@ setServerVal name val =
          SAWEnv (Map.insert name (toServerVal val) env)
      Argo.debugLog $ "Saved " <> (Text.pack (show name))
      st <- Argo.getState @SAWState
-     Argo.debugLog $ "State is " <> Text.pack (show st)
+     ppopts <- liftIO $ getPPOpts st
+     Argo.debugLog $ "State is " <> ppSAWStatePure ppopts st
 
 
 getServerVal :: ServerName -> Argo.Command SAWState ServerVal
 getServerVal n =
   do sawenv <- view sawEnv <$> Argo.getState
      st <- Argo.getState @SAWState
-     Argo.debugLog $ "Looking up " <> Text.pack (show n) <> " in " <> Text.pack (show st)
+     ppopts <- liftIO $ getPPOpts st
+     Argo.debugLog $ "Looking up " <> Text.pack (show n) <> " in " <> ppSAWStatePure ppopts st
      case getServerValEither sawenv n of
        Left ex -> Argo.raise ex
        Right val -> return val

--- a/saw-support/src/SAWSupport/Pretty.hs
+++ b/saw-support/src/SAWSupport/Pretty.hs
@@ -88,6 +88,7 @@ module SAWSupport.Pretty (
     defaultOpts,
     withOpts,
     limitMaxDepth,
+    prettyStringDQ,
     ppStringLiteral,
     prettyInteger,
     prettyNatural,
@@ -239,6 +240,16 @@ limitMaxDepth limit opts =
 ------------------------------------------------------------
 -- Common prettyprint operations
 -- (for base types and common constructs not tied to any particular AST)
+
+-- | Print a string in double quotes. Does not escape any of the
+--   characters.
+--
+--   This is here as much to make sure that people don't find and use
+--   `ppStringLiteral` for miscellaneous quoting as it is because it's
+--   all that useful in its own right.
+--
+prettyStringDQ :: Text -> PP.Doc ann
+prettyStringDQ s = "\"" <> PP.pretty s <> "\""
 
 -- | Print a string literal. Escape characters as needed so it comes
 --   out in a form that can be read back in.

--- a/saw-support/src/SAWSupport/Pretty.hs
+++ b/saw-support/src/SAWSupport/Pretty.hs
@@ -89,7 +89,10 @@ module SAWSupport.Pretty (
     withOpts,
     limitMaxDepth,
     ppStringLiteral,
-    prettyNat,
+    prettyInteger,
+    prettyNatural,
+    prettyWord64,
+    prettyInt,
     prettyTypeConstraint,
     prettyTypeSig,
     replicate,
@@ -105,12 +108,14 @@ import Prelude hiding (replicate)
 
 import System.IO (stdout)
 import Numeric (showIntAtBase, showHex)
+import Numeric.Natural (Natural)
 import qualified Data.Char as Char
 import Data.IORef (IORef)
 import qualified Data.IORef as IORef
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as TextL
+import Data.Word (Word64)
 
 import Prettyprinter (pretty, (<+>) )
 import qualified Prettyprinter as PP
@@ -280,9 +285,9 @@ ppStringLiteral s = "\"" <> Text.concatMap escapeChar s <> "\""
              let c' = showHex (Char.ord c) "" in
              "\\x" <> Text.pack c' <> "\\&"
 
--- | Pretty-print an integer in the correct base
-prettyNat :: Opts -> Integer -> Doc
-prettyNat (Opts{..}) i
+-- | Pretty-print an `Integer` in the correct base
+prettyInteger :: Opts -> Integer -> Doc
+prettyInteger (Opts{..}) i
   | ppBase > 36 = pretty i
   | otherwise = prefix <> pretty value
   where
@@ -295,6 +300,18 @@ prettyNat (Opts{..}) i
 
     value  = showIntAtBase (toInteger ppBase) (digits !!) i ""
     digits = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+-- | Pretty-print a `Natural` in the correct base
+prettyNatural :: Opts -> Natural -> Doc
+prettyNatural opts i = prettyInteger opts (fromIntegral i)
+
+-- | Pretty-print a `Word64` in the correct base
+prettyWord64 :: Opts -> Word64 -> Doc
+prettyWord64 opts i = prettyInteger opts (fromIntegral i)
+
+-- | Pretty-print an `Int` in the correct base
+prettyInt :: Opts -> Int -> Doc
+prettyInt opts i = prettyInteger opts (fromIntegral i)
 
 -- | Pretty-print a type constraint (also known as an ascription) @x : tp@
 --   This is the formatting used by SAWCore.

--- a/saw.cabal
+++ b/saw.cabal
@@ -288,6 +288,7 @@ library saw-core-rocq
     parameterized-utils,
 
     -- internal sublibraries in the saw tree
+    saw:saw-support,
     saw:saw-core,
     saw:cryptol-saw-core
 

--- a/saw.cabal
+++ b/saw.cabal
@@ -721,6 +721,7 @@ library saw-server
     directory,
     lens,
     mtl,
+    prettyprinter,
     silently,
     text,
     unordered-containers,


### PR DESCRIPTION
After this the following references to `PPS.defaultOpts` remain:

1. The definition in SAWSupport.Pretty.
2. In SAWSupport.Position, a use in the default implementation of `ppPosition` in terms of `prettyPosition`. If we ever get positions where this matters, the signature should be changed. There are not supposed to be more than a handful of special cases that directly use either `ppPosition` or `prettyPosition` so this will not be a major problem.
3. In SAWSupport.Console, multiple uses in the `IO` instance of `SAWConsole`. This instance is supposed to go away eventually in favor of instances attached to monads that have state and can look up the printing options under the covers.
4. In SAWCore.Term.Certified, the correct use during system initialization.
5. In SAWCore.Simulator.Value, a use printing terms in the `Show` instance for `TValue`. This should go away, but is a can of worms so won't be just yet.
6. In SAWScript.Loader, a use during system startup associated with parsing the type signatures of SAWScript builtins. This will only ever be used if that fails, which will then panic.
7. In SAWScript.Interpreter, a use during system startup associated with printing the type signatures of SAWScript builtins into their help texts. This could be removed, but I'm going to hold off until we figure out how to manage the help texts in conjunction with getting them into the manual as well as compiled in.
8. In the saw-core `otherTests`, four uses in some non-user-facing test code that should ideally not be there but would be messy to remove.

Diff says this branch removes 66 other references, all of which were incorrect...

As with other similar changes, I've also found and removed a bunch of `Show` misuse, and cleaned up quite a few of the error messages that were doing the printing.

You will probably want to read this one commit at a time. The second commit has all the routine changes; each of the following ones is its own self-contained patch to kill off a small set of more ingrained uses.

The most important things to crosscheck are probably (a) that the error message changes aren't rubbish or accidentally messed up, and (b) nothing I did introducing `LLVMSetupError` accidentally changed the semantics. The plumbing changes can't really be seriously wrong or they wouldn't compile.