### PR TITLE
add timeout_handle and timeout saw-script commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ This release supports [version
 
 ## New Features
 
+* Add new SAWScript commands `timeout_handle` and `timeout` for adding
+  time limits to scripts.
+
 * Add new SAWScript MIR commands `mir_field_value` and `mir_field_ref` for
   accessing fields of structs by value and by reference.
 

--- a/intTests/test1646/test15.log.good
+++ b/intTests/test1646/test15.log.good
@@ -432,6 +432,9 @@ term_tree_size : Term -> Int
 test_solver_cache_stats :
    Int -> Int -> Int -> Int -> Int -> TopLevel ()
 time : {a} TopLevel a -> TopLevel a
+timeout : {a} Int -> TopLevel a -> TopLevel a
+timeout_handle :
+   {a} Int -> TopLevel a -> TopLevel a -> TopLevel a
 trivial : ProofScript ()
 true : Bool
 type : Term -> Type

--- a/intTests/test_search/search02.log.good
+++ b/intTests/test_search/search02.log.good
@@ -33,6 +33,9 @@ tail : {a} [a] -> [a]
 term_eval : Term -> Term
 term_eval_unint : [String] -> Term -> Term
 time : {a} TopLevel a -> TopLevel a
+timeout : {a} Int -> TopLevel a -> TopLevel a
+timeout_handle :
+   {a} Int -> TopLevel a -> TopLevel a -> TopLevel a
 unfold_term : [String] -> Term -> Term
 10 more matches tagged experimental; use enable_experimental to see them
 --------------------------------

--- a/intTests/test_timeout/test.saw
+++ b/intTests/test_timeout/test.saw
@@ -1,0 +1,67 @@
+enable_experimental;
+
+let {{
+  f : [16] -> [16] -> Bit
+  f x y = fromInteger ((toInteger y) + (toInteger x)) == x + y
+}};
+
+let proof tac = do {
+  thm <- prove_print tac {{ f }};
+  return false;
+};
+
+let hdl = do {
+  print "Timed out. (expected)";
+  return true;
+};
+
+let err_unless cond msg = if cond then return () else fail msg;
+
+let go to act = do {
+  (elapsed, res) <- with_time (timeout_handle to
+    (do { act; return false; })
+    (do { print "Timed out. (expected)"; return true; })
+    );
+  // add some wiggle room since the elapsed time will always slightly
+  // exceed the timeout
+  err_unless (eval_bool {{ `(elapsed) <= (`(to)+200) }})
+    "Timeout did not trigger in time";
+  err_unless res
+    "Unexpected success";
+  return false;
+};
+
+go 2000 (do { prove z3 {{ f }}; prove z3 {{ f }}; prove z3 {{ f }}; proof z3; });
+
+// inner timeout first
+(elapsed, _) <- with_time (timeout_handle 5000 (go 1000 (proof z3)) (fail "Unexpected timeout"));
+err_unless (eval_bool {{ `(elapsed) <= `(1200) }})
+  "Timeout did not trigger in time";
+
+// outer timeout first
+(elapsed2, b) <- with_time (timeout_handle 1000 (go 5000 (proof z3)) (do { print "Timed out. (expected)"; return true;}));
+err_unless b "Unexpected success";
+err_unless (eval_bool {{ `(elapsed2) <= `(1200) }})
+  "Timeout did not trigger in time";
+
+let plus i j = eval_int {{ (`(i) + `(j) : [32]) }};
+let minus i j = eval_int {{ (`(i) - `(j) : [32]) }};
+let eq i j = eval_bool {{ ((`(i) : [32]) == `(j)) }};
+
+rec fib n = if eq n 0 then 0 else if eq n 1 then 1 else plus (fib (minus n 1)) (fib (minus n 2));
+
+// function is evaluated first if not wrapped in a do-block
+timeout_handle 1000 (return (fib 7)) (fail "Unexpected timeout");
+
+go 1000 (do { return (fib 7); });
+
+go 1000 (fails (proof z3));
+go 1000 (fails (proof (w4_unint_z3 [])));
+
+go 1000 (proof z3);
+go 1000 (proof (w4_unint_z3 []));
+
+
+
+
+fails (timeout 1000 (proof z3));

--- a/intTests/test_timeout/test.saw
+++ b/intTests/test_timeout/test.saw
@@ -1,5 +1,7 @@
 enable_experimental;
 
+// Note: this script requires solver caching to be disabled
+
 let err_unless cond msg = if cond then return () else fail msg;
 
 let go to act = do {
@@ -83,4 +85,5 @@ go test_timeout (proof (w4_unint_z3 []));
 
 fails (timeout test_timeout (proof z3));
 
+print "Success!";
 

--- a/intTests/test_timeout/test.saw
+++ b/intTests/test_timeout/test.saw
@@ -61,6 +61,28 @@ err_unless (eval_bool {{ `(elapsed_max) < `(10000) }})
 let test_timeout = eval_int {{ (`(elapsed_min) / 2 : [32]) }};
 let test_timeout_long = eval_int {{ (`(elapsed_min) * 2 : [32]) }};
 
+b0 <- timeout_handle test_timeout (do {
+  x <- fresh_symbolic "x" {| Integer |};
+  let t = parse_core "x";
+  proof z3;
+  return false;
+}) (return true);
+
+err_unless b0 "Unexpected success";
+// ensure that the context is restored to before the timeout
+fails (do { return (parse_core "x"); });
+
+
+b1 <- timeout_handle 1000 (do {
+  x <- fresh_symbolic "x" {| Integer |};
+  return true;
+}) (return false);
+err_unless b1 "Unexpected timeout";
+
+// now the name should be defined, and
+// unambiguous, since the previous declaration was reverted
+let _ = parse_core "x";
+
 go test_timeout_long (do { proof z3; proof z3; proof z3; proof z3; });
 
 // inner timeout first

--- a/intTests/test_timeout/test.saw
+++ b/intTests/test_timeout/test.saw
@@ -1,20 +1,5 @@
 enable_experimental;
 
-let {{
-  f : [16] -> [16] -> Bit
-  f x y = fromInteger ((toInteger y) + (toInteger x)) == x + y
-}};
-
-let proof tac = do {
-  thm <- prove_print tac {{ f }};
-  return false;
-};
-
-let hdl = do {
-  print "Timed out. (expected)";
-  return true;
-};
-
 let err_unless cond msg = if cond then return () else fail msg;
 
 let go to act = do {
@@ -31,18 +16,7 @@ let go to act = do {
   return false;
 };
 
-go 2000 (do { prove z3 {{ f }}; prove z3 {{ f }}; prove z3 {{ f }}; proof z3; });
-
-// inner timeout first
-(elapsed, _) <- with_time (timeout_handle 5000 (go 1000 (proof z3)) (fail "Unexpected timeout"));
-err_unless (eval_bool {{ `(elapsed) <= `(1200) }})
-  "Timeout did not trigger in time";
-
-// outer timeout first
-(elapsed2, b) <- with_time (timeout_handle 1000 (go 5000 (proof z3)) (do { print "Timed out. (expected)"; return true;}));
-err_unless b "Unexpected success";
-err_unless (eval_bool {{ `(elapsed2) <= `(1200) }})
-  "Timeout did not trigger in time";
+// Timeout during script evaluation
 
 let plus i j = eval_int {{ (`(i) + `(j) : [32]) }};
 let minus i j = eval_int {{ (`(i) - `(j) : [32]) }};
@@ -55,13 +29,58 @@ timeout_handle 1000 (return (fib 7)) (fail "Unexpected timeout");
 
 go 1000 (do { return (fib 7); });
 
-go 1000 (fails (proof z3));
-go 1000 (fails (proof (w4_unint_z3 [])));
+// Timeout during solver call
 
-go 1000 (proof z3);
-go 1000 (proof (w4_unint_z3 []));
+// This property is simply something that Z3 (as of 4.8.14)
+// takes more than 1 second to solve, but less than 5.
+// It may be replaced with anything similarly time-consuming
+// if necessary.
+let {{
+  f : [5] -> [5] -> Bit
+  f x y = fromInteger ((toInteger y) + (toInteger x)) == x + y
+}};
+
+let proof tac = do {
+  thm <- prove_print tac {{ f }};
+  return false;
+};
+
+(elapsed_z3, _) <- with_time (proof z3);
+(elapsed_w4_z3, _) <- with_time (proof (w4_unint_z3 []));
+let elapsed_min = eval_int {{  `(min elapsed_z3 elapsed_w4_z3) : [32] }};
+let elapsed_max = eval_int {{  `(max elapsed_z3 elapsed_w4_z3) : [32] }};
+
+// Sanity check on the time it takes to solve the above property.
+err_unless (eval_bool {{ `(elapsed_min) > `(1000) }})
+  "Test property was proven too quickly.";
+err_unless (eval_bool {{ `(elapsed_max) < `(10000) }})
+  "Test property took too long to prove.";
+
+let test_timeout = eval_int {{ (`(elapsed_min) / 2 : [32]) }};
+let test_timeout_long = eval_int {{ (`(elapsed_min) * 2 : [32]) }};
+
+go test_timeout_long (do { proof z3; proof z3; proof z3; proof z3; });
+
+// inner timeout first
+(elapsed, _) <- with_time (timeout_handle test_timeout_long
+  (go test_timeout (proof z3)) (fail "Unexpected timeout"));
+err_unless (eval_bool {{ `(elapsed) <= `(test_timeout) + 200 }})
+  "Timeout did not trigger in time";
+
+// outer timeout first
+(elapsed2, b) <- with_time (timeout_handle test_timeout
+  (go test_timeout_long (proof z3))
+  (do { print "Timed out. (expected)"; return true;}));
+err_unless b "Unexpected success";
+err_unless (eval_bool {{ `(elapsed2) <= `(test_timeout) + 200 }})
+  "Timeout did not trigger in time";
+
+go test_timeout (fails (proof z3));
+go test_timeout (fails (proof (w4_unint_z3 [])));
+
+go test_timeout (proof z3);
+go test_timeout (proof (w4_unint_z3 []));
+
+fails (timeout test_timeout (proof z3));
 
 
-
-
-fails (timeout 1000 (proof z3));

--- a/intTests/test_timeout/test.saw
+++ b/intTests/test_timeout/test.saw
@@ -107,5 +107,8 @@ go test_timeout (proof (w4_unint_z3 []));
 
 fails (timeout test_timeout (proof z3));
 
+
+fails (timeout_handle 18446744073709551616 (return true) (return false));
+
 print "Success!";
 

--- a/intTests/test_timeout/test.sh
+++ b/intTests/test_timeout/test.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+$SAW test.saw

--- a/intTests/test_timeout/test.sh
+++ b/intTests/test_timeout/test.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-$SAW test.saw
+SAW_SOLVER_CACHE_PATH="" $SAW test.saw

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -10,6 +10,7 @@ Stability   : provisional
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module SAWCentral.Builtins (
     showPrim,
@@ -173,6 +174,8 @@ module SAWCentral.Builtins (
     timePrim,
     failPrim,
     failsPrim,
+    timeoutHandlePrim,
+    timeoutPrim,
     eval_bool,
     eval_bool_inner,
     eval_int,
@@ -216,6 +219,9 @@ module SAWCentral.Builtins (
     write_vcd
   ) where
 
+import Control.Concurrent (threadDelay, yield, throwTo)
+import Control.Concurrent.Async (async, waitEither, asyncThreadId, AsyncCancelled(..), poll, uninterruptibleCancel)
+import System.Exit (ExitCode(..))
 import Control.Lens (view)
 import Control.Monad (foldM, unless, when)
 import Control.Monad.Catch (throwM)
@@ -1962,9 +1968,18 @@ failsPrim m = do
   topRW <- getTopLevelRW
   x <- liftIO $ Ex.try (runTopLevel m topRO topRW)
   case x of
+    Left e@ExitTimeout ->
+      -- Avoid trapping timeout-specific exit code (see below)
+      throwM e
     Left (ex :: Ex.SomeException)
       | Just (e :: PanicSupport.PanicException) <- Ex.fromException ex ->
               -- Avoid trapping panics
+              throwM e
+      | Just (e :: Ex.AsyncException) <- Ex.fromException ex ->
+              -- Avoid trapping asynchronous exceptions
+              throwM e
+      | Just (e :: AsyncCancelled) <- Ex.fromException ex ->
+              -- Avoid trapping thread cancellation
               throwM e
       | Just (_ :: Cons.Fatal) <- Ex.fromException ex -> do
               -- The message has already been printed if we get a Fatal,
@@ -1976,6 +1991,59 @@ failsPrim m = do
               liftIO $ print ex
     Right _ ->
       do liftIO $ fail "Expected failure, but succeeded instead!"
+
+-- SBV doesn't reliably terminate or clean up the solver process if
+-- AsyncCancelled or ThreadKilled is thrown, so we throw ExitFailure with
+-- the exit code used by the 'timeout' command in linux. The specific
+-- exit code shouldn't really matter, it just needs to be consistent.
+pattern ExitTimeout :: Ex.SomeException
+pattern ExitTimeout <- (Ex.fromException -> Just (ExitFailure 124 :: ExitCode)) where
+    ExitTimeout = Ex.SomeException (ExitFailure 124 :: ExitCode)
+
+timeoutHandlePrim :: Integer -> TopLevel SV.Value -> TopLevel SV.Value -> TopLevel SV.Value
+timeoutHandlePrim i m hdl = do
+  topRO <- getTopLevelRO
+  topRW <- getTopLevelRW
+  res <- io $ Ex.mask $ \restore -> do
+    act <- async (restore $ runTopLevel m topRO topRW)
+    timer <- async (restore $ threadDelay (fromIntegral i * 1000))
+
+    -- Normal thread cancellation (i.e. sending ThreadKilled or AsyncCancelled) does not
+    -- reliably terminate the action when it is waiting for a solver process to finish.
+    -- Sending an ExitFailure exception is generally interpreted as the solver process
+    -- exiting abnormally, which unblocks the thread and triggers any cleanup.
+    -- This does not reliably terminate the thread though, since (depending on the context)
+    -- it may decide that this is non-fatal and continue running.
+    -- To mitigate this, we continue to send exit exceptions
+    -- until the thread actually terminates.
+    let kill_act = do
+          status <- poll act
+          case status of
+            Nothing -> do
+              throwTo (asyncThreadId act) ExitTimeout
+              yield
+              kill_act
+            _ -> return ()
+
+    let cleanup = do
+          uninterruptibleCancel timer
+          kill_act
+          -- this should be redundant, since kill_act won't return until
+          -- the action thread has terminated
+          uninterruptibleCancel act
+
+    res <- (restore $ waitEither timer act) `Ex.finally` cleanup
+    case res of
+      Left () -> return Nothing
+      Right (v, topRW') -> return $ Just (v, topRW')
+  case res of
+    Nothing -> hdl
+    Just (v, topRW') -> do
+      putTopLevelRW topRW'
+      return v
+
+timeoutPrim :: Integer -> TopLevel SV.Value -> TopLevel SV.Value
+timeoutPrim i m = timeoutHandlePrim i m (failPrim "Timed out")
 
 eval_bool :: TypedTerm -> TopLevel Bool
 eval_bool = eval_bool_inner "eval_bool"

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -10,7 +10,6 @@ Stability   : provisional
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE PatternSynonyms #-}
 
 module SAWCentral.Builtins (
     showPrim,
@@ -219,9 +218,7 @@ module SAWCentral.Builtins (
     write_vcd
   ) where
 
-import Control.Concurrent (threadDelay, yield, throwTo)
-import Control.Concurrent.Async (async, waitEither, asyncThreadId, AsyncCancelled(..), poll, uninterruptibleCancel)
-import System.Exit (ExitCode(..))
+import Control.Concurrent.Async (AsyncCancelled)
 import Control.Lens (view)
 import Control.Monad (foldM, unless, when)
 import Control.Monad.Catch (throwM)
@@ -252,6 +249,7 @@ import qualified Data.Text.IO as TextIO
 import System.IO
 import System.IO.Temp (withSystemTempFile, emptySystemTempFile)
 import System.FilePath (hasDrive, (</>))
+import System.Timeout (Timeout,timeout)
 import System.Process (callCommand, readProcessWithExitCode)
 import Text.Printf (printf)
 import Text.Read (readMaybe)
@@ -1152,10 +1150,10 @@ proveSBV conf = proveUnintSBV conf []
 -- @unints@ are kept as uninterpreted functions.
 proveUnintSBV :: SBV.SMTConfig -> [Text] -> ProofScript ()
 proveUnintSBV conf unints =
-  do timeout <- psTimeout <$> get
+  do to <- psTimeout <$> get
      unintSet <- SV.scriptTopLevel (resolveNames unints)
      wrapProver (sbvBackends conf) []
-                (Prover.proveUnintSBV conf timeout) unintSet
+                (Prover.proveUnintSBV conf to) unintSet
 
 -- | Given a continuation which calls a prover, call the continuation on the
 -- given 'Sequent' and return a 'SolveResult'. If there is a 'SolverCache',
@@ -1968,9 +1966,6 @@ failsPrim m = do
   topRW <- getTopLevelRW
   x <- liftIO $ Ex.try (runTopLevel m topRO topRW)
   case x of
-    Left e@ExitTimeout ->
-      -- Avoid trapping timeout-specific exit code (see below)
-      throwM e
     Left (ex :: Ex.SomeException)
       | Just (e :: PanicSupport.PanicException) <- Ex.fromException ex ->
               -- Avoid trapping panics
@@ -1980,6 +1975,9 @@ failsPrim m = do
               throwM e
       | Just (e :: AsyncCancelled) <- Ex.fromException ex ->
               -- Avoid trapping thread cancellation
+              throwM e
+      | Just (e :: Timeout) <- Ex.fromException ex ->
+              -- Avoid trapping timeouts
               throwM e
       | Just (_ :: Cons.Fatal) <- Ex.fromException ex -> do
               -- The message has already been printed if we get a Fatal,
@@ -1992,52 +1990,17 @@ failsPrim m = do
     Right _ ->
       do liftIO $ fail "Expected failure, but succeeded instead!"
 
--- SBV doesn't reliably terminate or clean up the solver process if
--- AsyncCancelled or ThreadKilled is thrown, so we throw ExitFailure with
--- the exit code used by the 'timeout' command in linux. The specific
--- exit code shouldn't really matter, it just needs to be consistent.
-pattern ExitTimeout :: Ex.SomeException
-pattern ExitTimeout <- (Ex.fromException -> Just (ExitFailure 124 :: ExitCode)) where
-    ExitTimeout = Ex.SomeException (ExitFailure 124 :: ExitCode)
-
 timeoutHandlePrim :: Integer -> TopLevel SV.Value -> TopLevel SV.Value -> TopLevel SV.Value
 timeoutHandlePrim i m hdl = do
   topRO <- getTopLevelRO
   topRW <- getTopLevelRW
-  res <- io $ Ex.mask $ \restore -> do
-    act <- async (restore $ runTopLevel m topRO topRW)
-    timer <- async (restore $ threadDelay (fromIntegral i * 1000))
-
-    -- Normal thread cancellation (i.e. sending ThreadKilled or AsyncCancelled) does not
-    -- reliably terminate the action when it is waiting for a solver process to finish.
-    -- Sending an ExitFailure exception is generally interpreted as the solver process
-    -- exiting abnormally, which unblocks the thread and triggers any cleanup.
-    -- This does not reliably terminate the thread though, since (depending on the context)
-    -- it may decide that this is non-fatal and continue running.
-    -- To mitigate this, we continue to send exit exceptions
-    -- until the thread actually terminates.
-    let kill_act = do
-          status <- poll act
-          case status of
-            Nothing -> do
-              throwTo (asyncThreadId act) ExitTimeout
-              yield
-              kill_act
-            _ -> return ()
-
-    let cleanup = do
-          uninterruptibleCancel timer
-          kill_act
-          -- this should be redundant, since kill_act won't return until
-          -- the action thread has terminated
-          uninterruptibleCancel act
-
-    res <- (restore $ waitEither timer act) `Ex.finally` cleanup
-    case res of
-      Left () -> return Nothing
-      Right (v, topRW') -> return $ Just (v, topRW')
+  let sc = rwSharedContext topRW
+  scc <- io $ checkpointSharedContext sc
+  res <- io $ timeout (fromIntegral i * 1000) (runTopLevel m topRO topRW)
   case res of
-    Nothing -> hdl
+    Nothing -> do
+      io $ restoreSharedContext scc sc
+      hdl
     Just (v, topRW') -> do
       putTopLevelRW topRW'
       return v

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -1990,20 +1990,27 @@ failsPrim m = do
     Right _ ->
       do liftIO $ fail "Expected failure, but succeeded instead!"
 
+safeInt :: Integer -> Maybe Int
+safeInt i = if i <= toInteger (maxBound :: Int) && i >= toInteger (minBound :: Int)
+    then Just (fromIntegral i)
+    else Nothing
+
 timeoutHandlePrim :: Integer -> TopLevel SV.Value -> TopLevel SV.Value -> TopLevel SV.Value
-timeoutHandlePrim i m hdl = do
-  topRO <- getTopLevelRO
-  topRW <- getTopLevelRW
-  let sc = rwSharedContext topRW
-  scc <- io $ checkpointSharedContext sc
-  res <- io $ timeout (fromIntegral i * 1000) (runTopLevel m topRO topRW)
-  case res of
-    Nothing -> do
-      io $ restoreSharedContext scc sc
-      hdl
-    Just (v, topRW') -> do
-      putTopLevelRW topRW'
-      return v
+timeoutHandlePrim millis m hdl = case safeInt (millis * 1000) of
+  Nothing -> fail $ "Timeout is out of bounds: " ++ show millis
+  Just micros -> do
+    topRO <- getTopLevelRO
+    topRW <- getTopLevelRW
+    let sc = rwSharedContext topRW
+    scc <- io $ checkpointSharedContext sc
+    res <- io $ timeout micros (runTopLevel m topRO topRW)
+    case res of
+      Nothing -> do
+        io $ restoreSharedContext scc sc
+        hdl
+      Just (v, topRW') -> do
+        putTopLevelRW topRW'
+        return v
 
 timeoutPrim :: Integer -> TopLevel SV.Value -> TopLevel SV.Value
 timeoutPrim i m = timeoutHandlePrim i m (failPrim "Timed out")

--- a/saw-core-sbv/src/SAWCoreSBV/SBV.hs
+++ b/saw-core-sbv/src/SAWCoreSBV/SBV.hs
@@ -1029,7 +1029,7 @@ version :: String
 version = VERSION_sbv
 
 -- | Wrap an action such that, if any asynchronous exceptions are raised during execution,
---   the action is cancelled by raising `ExitFailure` repeatedly until it terminates.
+--   the action is cancelled by raising 'ExitFailure' repeatedly until it terminates.
 cancelToExit :: IO a -> IO a
 cancelToExit f = mask $ \restore -> do
   act <- async (restore $ f)
@@ -1037,13 +1037,41 @@ cancelToExit f = mask $ \restore -> do
         status <- poll act
         case status of
           Nothing -> do
+            -- This is only reached if this thread (not the action thread)
+            -- receives an asynchronous exception. The action thread is terminated
+            -- via 'ExitFailure', but the original exception is what is
+            -- re-thrown.
             throwTo (asyncThreadId act) (ExitFailure 1)
             yield
             kill_act
           _ -> return ()
+  -- If the action masks the AsyncCancelled exception, then
+  -- attempting to cancel it normally will just block instead.
+  -- We could use "Control.Concurrent.Async.cancelWith" with ExitFailure,
+  -- but it's possible that the inner action may decide this is non-fatal
+  -- and continue running.
+  -- Instead, kill_act repeatedly sends ExitFailure and only performs
+  -- normal thread cancellation (which is likely redundant) after the
+  -- thread has terminated.
+
   let cleanup = kill_act >> uninterruptibleCancel act
+  -- There are three exit cases for waitCatch:
+  -- * normal exit: returns a Right result, the cleanup action
+  --     is essentially a no-op since the thread is already terminated
+  -- * exception thrown by act: the action itself threw an exception,
+  --     This returns a Left result, and the cleanup action is similarly
+  --     redundant since the thread has already terminated.
+  -- * asynchronous exception thrown to this thread:
+  --     waitCatch itself does not catch the exception. It
+  --     is caught by 'finally', which triggers the cleanup.
+  --     In this case, the thread is still running and is killed
+  --     explicitly by kill_act. After cleanup, the original exception
+  --     is rethrown.
   res <- (restore $ waitCatch act) `finally` cleanup
   case res of
+    -- Here the exception is only something thrown by the action. In particular,
+    -- it will only be 'ExitFailure' if this was thrown during the action,
+    -- not as part of the cleanup.
     Left e -> throwIO e
     Right a -> return a
 

--- a/saw-core-sbv/src/SAWCoreSBV/SBV.hs
+++ b/saw-core-sbv/src/SAWCoreSBV/SBV.hs
@@ -25,8 +25,8 @@ module SAWCoreSBV.SBV
   , module SAWCoreSBV.SWord
   , SAWCoreSBV.SBV.generateSMTBenchmarkSat
   , version
+  , SAWCoreSBV.SBV.satWith
   -- re-exports
-  , SBV.satWith
   , SBV.defaultSolverConfig
   , SBV.Solver(..)
   , SBV.SMTConfig(..)
@@ -47,6 +47,11 @@ import Data.SBV.Internals (UICodeKind(..))
 #endif
 
 import SAWCoreSBV.SWord
+
+import           Control.Concurrent (yield, throwTo)
+import           Control.Concurrent.Async (waitCatch, async, asyncThreadId, poll, uninterruptibleCancel)
+import           Control.Exception (mask, finally, throwIO)
+import           System.Exit (ExitCode(..))
 
 import Control.Lens ((<&>))
 
@@ -1022,3 +1027,27 @@ generateSMTBenchmarkSat script =
 
 version :: String
 version = VERSION_sbv
+
+-- | Wrap an action such that, if any asynchronous exceptions are raised during execution,
+--   the action is cancelled by raising `ExitFailure` repeatedly until it terminates.
+cancelToExit :: IO a -> IO a
+cancelToExit f = mask $ \restore -> do
+  act <- async (restore $ f)
+  let kill_act = do
+        status <- poll act
+        case status of
+          Nothing -> do
+            throwTo (asyncThreadId act) (ExitFailure 1)
+            yield
+            kill_act
+          _ -> return ()
+  let cleanup = kill_act >> uninterruptibleCancel act
+  res <- (restore $ waitCatch act) `finally` cleanup
+  case res of
+    Left e -> throwIO e
+    Right a -> return a
+
+-- | Wrapper around 'SBV.satWith' that ensures asynchronous exceptions are
+--   not masked and will cause the solver process to terminate.
+satWith :: SMTConfig -> Symbolic SVal -> IO SatResult
+satWith conf script = cancelToExit $ SBV.satWith conf script

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -2728,6 +2728,29 @@ primitives = Map.fromList $
     , "does."
     ]
 
+  , prim "timeout_handle"      "{a} Int -> TopLevel a -> TopLevel a -> TopLevel a"
+    (pureVal timeoutHandlePrim)
+    Current
+    [ "Takes a timeout (in milliseconds), an action to run and a"
+    , "handler, respectively. If the the action runs for longer than"
+    , "the given timeout, it is terminated and the handler is executed"
+    , "instead. Note: non-monadic code must be wrapped in a do-block"
+    , "for the timeout to apply. For example,"
+    , "    timeout_handle 1 (return e) (fails \"timeout\")"
+    , "will not fail if \"e\" takes longer than 1ms to execute."
+    , "However,"
+    , "    timeout_handle 1 (do { return e; }) (fails \"timeout\")"
+    , "will work as expected."
+    ]
+
+  , prim "timeout"      "{a} Int -> TopLevel a -> TopLevel a"
+    (pureVal timeoutPrim)
+    Current
+    [ "Takes a timeout (in milliseconds) and an action to run. "
+    , "If the the action runs for longer than the given timeout, it is"
+    , "terminated and an error is raised. See also: timeout_handle."
+    ]
+
   , prim "env"                 "TopLevel ()"
     (pureVal envCmd)
     HideDeprecated

--- a/saw.cabal
+++ b/saw.cabal
@@ -356,6 +356,7 @@ library saw-core-sbv
   build-depends:
     -- upstream packages from hackage
     base == 4.*,
+    async,
     containers,
     lens,
     mtl,

--- a/saw.cabal
+++ b/saw.cabal
@@ -436,6 +436,7 @@ library saw-central
     -- upstream packages from hackage
     base >= 4.9,
     aeson >= 2.0 && < 2.3,
+    async,
     binary,
     bimap,
     bytestring,


### PR DESCRIPTION
fixes #3171 

notably the implementation is complicated by the fact that the actions we want to time out are often waiting for external processes, so we have to send exit exceptions to the threads in order for them to unblock.