### PR TITLE
`cryptol-saw-core`: Import `ListSel` correctly on `Vec`s

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,9 @@ This release supports [version
 * Don't raise spurious type errors when importing Cryptol record or tuple
   update expressions.
 
+* Fix a panic when importing Cryptol list patterns (e.g.,
+  `(x, y) where [x, y] = [0x1, 0x2]`).
+
 # 1.5 -- 2026-01-31
 
 This release supports [version

--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -1396,18 +1397,24 @@ importExpr sc env expr =
           do i' <- scNat sc (fromIntegral i)
              t <- scTypeOf sc e'
              (n, a) <-
-               -- Note: we just imported the subexpression so its type
-               -- should still be "seq", and not have gotten unwrapped
-               -- to a raw SAWCore vector. If that ever happens, we
-               -- can add a second check using `asVectorType`.
-               case asSeqType t of
-                 Just (n, a) -> return (n, a)
-                 Nothing -> do
-                     t' <- ppTerm sc t
-                     panic "importExpr" [
-                         "ListSel: not a list type",
-                         "Type: " <> Text.pack t'
-                      ]
+                -- The SAWCore type of the list subexpression will either be
+                -- `seq` or `Vec` depending on how the list was constructed.
+                -- For instance, a Cryptol sequence literal like
+                -- `[x, y] : [2]a` will be translated to a SAWCore `Term` of
+                -- type `Vec 2 a`. On the other hand, a variable with the
+                -- Cryptol type `[2]a` will be translated to a SAWCore `Term`
+                -- of type `seq (TCNum 2) a`.
+               if | Just (n, a) <- asSeqType t ->
+                      return (n, a)
+                  | Just (n, a) <- asVectorType t -> do
+                      n' <- scGlobalApply sc "Cryptol.TCNum" [n]
+                      return (n', a)
+                  | otherwise -> do
+                      t' <- ppTerm sc t
+                      panic "importExpr" [
+                          "ListSel: not a list type",
+                          "Type: " <> Text.pack t'
+                       ]
              scGlobalApply sc "Cryptol.eListSel" [a, n, e', i']
 
     C.ESet t1 e1 sel e2 ->

--- a/intTests/test3179/test.saw
+++ b/intTests/test3179/test.saw
@@ -1,0 +1,1 @@
+print {{ (x, y) where [x, y] = [0x0, 0x1] }};

--- a/intTests/test3179/test.sh
+++ b/intTests/test3179/test.sh
@@ -1,0 +1,3 @@
+set -e
+
+$SAW test.saw


### PR DESCRIPTION
Depending on how much evaluation has occurred, a `ListSel` can either occur on a `seq` or a `Vec`, but the code was only considering the `seq` case. Adding a corresponding `Vec` case proves straightforward.

Fixes #3179.