### PR TITLE
Fix `sawCoreState`

### DIFF
--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -291,7 +291,7 @@ import qualified SAWCoreSBV.SBV as SBVSim
 
 -- saw-core-what4
 import qualified SAWCoreWhat4.What4 as W4Sim
-import SAWCoreWhat4.ReturnTrip (newSAWCoreExprBuilder)
+import SAWCoreWhat4.ReturnTrip (newSAWCoreExprBuilder, sawCoreState)
 
 -- sbv
 import qualified Data.SBV.Dynamic as SBV
@@ -323,7 +323,6 @@ import SAWCentral.Options as Opts
 import SAWCentral.Panic (panic)
 import SAWCentral.Proof
 import SAWCentral.Crucible.Common (PathSatSolver(..))
-import qualified SAWCentral.Crucible.Common as Common
 import SAWCentral.TopLevel
 import qualified SAWCentral.AST as SAST
 import qualified SAWCentral.Value as SV
@@ -1776,7 +1775,7 @@ term_eval unints (TypedTerm schema t0) =
      unintSet <- resolveNames unints
      what4PushMuxOps <- gets rwWhat4PushMuxOps
      sym <- liftIO $ newSAWCoreExprBuilder sc what4PushMuxOps
-     st <- liftIO $ Common.sawCoreState sym
+     let st = sawCoreState sym
      t1 <- liftIO $ W4Sim.w4EvalTerm sym st sc Map.empty unintSet t0
      pure (TypedTerm schema t1)
 

--- a/saw-central/src/SAWCentral/Crucible/Common.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common.hs
@@ -25,7 +25,6 @@ module SAWCentral.Crucible.Common
   , newSAWCoreBackend
   , newSAWCoreBackendWithTimeout
   , defaultSAWCoreBackendTimeout
-  , sawCoreState
   , baseCryptolType
   , getGlobalPair
   , runCFG
@@ -60,14 +59,13 @@ import qualified What4.Expr as W4
 import qualified What4.Interface as W4
 import qualified What4.ProgramLoc as W4 (plSourceLoc)
 
-import Control.Lens ( (^.) )
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((</>))
 import qualified Prettyprinter as PP
 
 
 import SAWCore.SharedTerm as SC
-import SAWCoreWhat4.ReturnTrip (SAWCoreExprBuilder, SAWCoreState, baseSCType, bindSAWTerm)
+import SAWCoreWhat4.ReturnTrip (SAWCoreExprBuilder, SAWCoreState, sawCoreState, baseSCType, bindSAWTerm)
 
 import SAWCentral.Options (Options, Verbosity(..), printOutLn)
 
@@ -86,9 +84,6 @@ data SomeOnlineBackend =
     SomeOnlineBackend (Backend solver)
 
 data SAWCruciblePersonality sym = SAWCruciblePersonality
-
-sawCoreState :: Sym -> IO (SAWCoreState Nonce.GlobalNonceGenerator)
-sawCoreState sym = pure (sym ^. W4.userState)
 
 defaultSAWCoreBackendTimeout :: Integer
 defaultSAWCoreBackendTimeout = 10000
@@ -255,7 +250,7 @@ termToRegValue ::
 termToRegValue sym tp t =
   case Crucible.asBaseType tp of
     Crucible.AsBaseType btp -> do
-      st <- sawCoreState sym
+      let st = sawCoreState sym
       bindSAWTerm sym st btp t
 
     Crucible.NotBaseType ->

--- a/saw-central/src/SAWCentral/Crucible/Common/MethodSpec.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/MethodSpec.hs
@@ -149,7 +149,7 @@ import           SAWCore.SharedTerm as SAWVerifier
 import           SAWCoreWhat4.Position ()
 import           SAWCoreWhat4.ReturnTrip as SAWVerifier
 
-import           SAWCentral.Crucible.Common (Sym, sawCoreState)
+import           SAWCentral.Crucible.Common (Sym)
 import           SAWCentral.Crucible.Common.Setup.Value
 import           SAWCentral.Crucible.LLVM.Setup.Value (LLVM)
 import           SAWCentral.Crucible.JVM.Setup.Value ()
@@ -372,8 +372,8 @@ instance Crucible.IntrinsicClass Sym GhostValue where
          , Text.unpack (CryPP.pp thnSch)
          , Text.unpack (CryPP.pp elsSch)
          ]
-       st <- sawCoreState sym
-       let sc  = saw_sc st
+       let st = SAWVerifier.sawCoreState sym
+           sc = saw_sc st
        prd' <- toSC sym st prd
        typ  <- scTypeOf sc thn
        res  <- scIte sc typ prd' thn els

--- a/saw-central/src/SAWCentral/Crucible/Common/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/Override.hs
@@ -132,7 +132,7 @@ import qualified What4.LabeledPred as W4
 import qualified What4.ProgramLoc as W4
 
 import           SAWCentral.Exceptions
-import           SAWCentral.Crucible.Common (Backend, OnlineSolver, Sym, sawCoreState)
+import           SAWCentral.Crucible.Common (Backend, OnlineSolver, Sym)
 import           SAWCentral.Crucible.Common.MethodSpec as MS
 import           SAWCentral.Crucible.Common.Setup.Value as MS
 import           SAWCentral.Utils (bullets)
@@ -446,8 +446,7 @@ runOverrideMatcher sym g a t free loc (OM m) =
 omGetPPOpts :: OverrideMatcher ext rorw PPS.Opts
 omGetPPOpts = do
   sym <- getSymInterface
-  w4St <- liftIO $ sawCoreState sym
-  let sc = RT.saw_sc w4St
+  let sc = RT.sawCoreSharedContext sym
   liftIO $ scGetPPOpts sc
 
 addTermEq ::

--- a/saw-central/src/SAWCentral/Crucible/Common/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/ResolveSetupValue.hs
@@ -65,8 +65,8 @@ resolveTerm ::
   IO (Crucible.RegValue Sym (Crucible.BaseToType t))
 resolveTerm sym unint bt rr tm =
   do
-    st       <- sawCoreState sym
-    let sc = saw_sc st
+    let st = sawCoreState sym
+        sc = saw_sc st
     checkType sc
     tm'      <- basicRewrite sc tm
     canFold <- isConstFoldTerm sc unint tm'

--- a/saw-central/src/SAWCentral/Crucible/Common/Vacuity.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/Vacuity.hs
@@ -58,8 +58,8 @@ assumptionsContainContradiction ::
   TopLevel Bool
 assumptionsContainContradiction sym methodSpec tactic assumptions = 
   do
-     st <- io $ Common.sawCoreState sym
-     let sc  = saw_sc st
+     let st = sawCoreState sym
+         sc = saw_sc st
      let ploc = methodSpec^.MS.csLoc
      (goal',pgl) <- io $
       do

--- a/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Builtins.hs
@@ -318,9 +318,7 @@ verifyObligations ::
   [(String, MS.ConditionMetadata, Term)] ->
   TopLevel (SolverStats, [MS.VCStats])
 verifyObligations cc mspec tactic assumes asserts =
-  do let sym = cc^.jccSym
-     st <- io $ sawCoreState sym
-     let sc = saw_sc st
+  do let sc = sawCoreSharedContext (cc ^. jccSym)
      assume <- io $ scAndList sc (toListOf (folded . Crucible.labeledPred) assumes)
      let nm = mspec ^. csMethodName
      outs <- forM (zip [(0::Int)..] asserts) $ \(n, (msg, md, assert)) -> do
@@ -556,7 +554,7 @@ setupPrePointsTos mspec cc env pts mem0 = foldM doPointsTo mem0 pts
              rhs' <- injectSetupVal rhs
              CJ.doArrayStore bak mem lhs' idx rhs'
         JVMPointsToArray _loc lhs (Just rhs) ->
-          do sc <- saw_sc <$> sawCoreState sym
+          do let sc = sawCoreSharedContext (cc ^. jccSym)
              let cryenv = cc ^. jccCryptolEnv
              let lhs' = lookupAllocIndex env lhs
              (_ety, tts) <-
@@ -602,9 +600,7 @@ setupPrestateConditions mspec cc env = aux []
         TypedTerm (TypedTermSchema sch) tm ->
           aux acc (Crucible.insertGlobal var (sch,tm) globals) xs
         TypedTerm tp _ -> do
-          let sym = cc ^. jccSym
-          st <- sawCoreState sym
-          let sc = saw_sc st
+          let sc = sawCoreSharedContext (cc ^. jccSym)
           ppopts <- scGetPPOpts sc
           tp' <- prettyTypedTermType sc tp
           fail $ PPS.render ppopts $ "Setup term for global variable" <+>
@@ -620,7 +616,7 @@ assertEqualVals ::
   IO Term
 assertEqualVals cc v1 v2 =
   do let sym = cc^.jccSym
-     st <- sawCoreState sym
+         st = sawCoreState sym
      toSC sym st =<< equalValsPred cc v1 v2
 
 --------------------------------------------------------------------------------
@@ -643,12 +639,10 @@ registerOverride ::
   NonEmpty MethodSpec ->
   Crucible.OverrideSim (SAWCruciblePersonality Sym) Sym CJ.JVM rtp args ret ()
 registerOverride opts cc _ctx top_loc mdMap cs =
-  do let sym = cc^.jccSym
+  do let sc = sawCoreSharedContext (cc ^. jccSym)
      let jc = cc^.jccJVMContext
      let c0 = NE.head cs
      let method = c0 ^. MS.csMethod
-
-     sc <- saw_sc <$> liftIO (sawCoreState sym)
 
      mhandle <- liftIO $ getMethodHandle jc method
      case mhandle of
@@ -833,7 +827,7 @@ verifyPoststate cc mspec env0 globals ret mdMap =
 
     verifyObligation sc finalMdMap
       (Crucible.ProofGoal hyps (Crucible.LabeledPred concl simErr)) =
-      do st         <- sawCoreState sym
+      do let st = sawCoreState sym
          hypTerm <- toSC sym st =<< Crucible.assumptionsPred sym hyps
          conclTerm  <- toSC sym st concl
          obligation <- scImplies sc hypTerm conclTerm

--- a/saw-central/src/SAWCentral/Crucible/JVM/BuiltinsJVM.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/BuiltinsJVM.hs
@@ -164,7 +164,7 @@ jvm_extract c mname = do
   io $ do -- only the IO monad, nothing else
           sym <- newSAWCoreExprBuilder sc False
           SomeOnlineBackend bak <- newSAWCoreBackend pathSatSolver sym
-          st  <- sawCoreState sym
+          let st = sawCoreState sym
           CJ.setSimulatorVerbosity verbosity sym
 
           (CJ.JVMHandleInfo _m2 h) <- CJ.findMethodHandle ctx mcls meth

--- a/saw-central/src/SAWCentral/Crucible/JVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/Override.hs
@@ -88,7 +88,7 @@ import           SAWCore.Name (VarName(..))
 import           SAWCore.SharedTerm
 import           CryptolSAWCore.TypedTerm
 
-import           SAWCoreWhat4.ReturnTrip (toSC, saw_sc)
+import           SAWCoreWhat4.ReturnTrip (toSC, sawCoreState, sawCoreSharedContext)
 
 -- cryptol-saw-core
 import qualified CryptolSAWCore.Cryptol as Cryptol
@@ -579,28 +579,27 @@ valueToSC ::
 valueToSC sym _ _ Cryptol.TVBit (IVal x) =
   do b <- liftIO $ W4.bvIsNonzero sym x
       -- TODO: assert that x is 0 or 1
-     st <- liftIO (sawCoreState sym)
+     let st = sawCoreState sym
      liftIO (toSC sym st b)
 
 valueToSC sym _ _ (Cryptol.TVSeq 8 Cryptol.TVBit) (IVal x) =
-  do st <- liftIO (sawCoreState sym)
+  do let st = sawCoreState sym
      liftIO (toSC sym st =<< W4.bvTrunc sym (W4.knownNat @8) x)
 
 valueToSC sym _ _ (Cryptol.TVSeq 16 Cryptol.TVBit) (IVal x) =
-  do st <- liftIO (sawCoreState sym)
+  do let st = sawCoreState sym
      liftIO (toSC sym st =<< W4.bvTrunc sym (W4.knownNat @16) x)
 
 valueToSC sym _ _ (Cryptol.TVSeq 32 Cryptol.TVBit) (IVal x) =
-  do st <- liftIO (sawCoreState sym)
+  do let st = sawCoreState sym
      liftIO (toSC sym st x)
 
 valueToSC sym _ _ (Cryptol.TVSeq 64 Cryptol.TVBit) (LVal x) =
-  do st <- liftIO (sawCoreState sym)
+  do let st = sawCoreState sym
      liftIO (toSC sym st x)
 
 valueToSC sym md failMsg _tval _val =
-  do st <- liftIO (sawCoreState sym)
-     let sc = saw_sc st
+  do let sc = sawCoreSharedContext sym
      ppopts <- liftIO $ scGetPPOpts sc
      failure ppopts (MS.conditionLoc md) failMsg
 
@@ -971,7 +970,7 @@ resolveSetupValueJVM ::
   SetupValue           ->
   OverrideMatcher CJ.JVM w JVMVal
 resolveSetupValueJVM opts cc spec sval =
-  do sc <- liftIO $ saw_sc <$> sawCoreState (cc ^. jccSym)
+  do let sc = sawCoreSharedContext (cc ^. jccSym)
      m <- OM (use setupValueSub)
      s <- OM (use termSub)
      let tyenv = MS.csAllocations spec

--- a/saw-central/src/SAWCentral/Crucible/JVM/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/JVM/ResolveSetupValue.hs
@@ -48,7 +48,7 @@ import qualified SAWSupport.Pretty as PPS
 import SAWCore.SharedTerm
 import qualified CryptolSAWCore.Pretty as CryPP
 import CryptolSAWCore.TypedTerm
-import SAWCoreWhat4.ReturnTrip (saw_sc)
+import SAWCoreWhat4.ReturnTrip (sawCoreSharedContext)
 
 -- crucible
 
@@ -136,21 +136,18 @@ typeOfSetupValue cc env _nameEnv val =
         TypedTermSchema (Cryptol.Forall [] [] ty) ->
           case toJVMType (Cryptol.evalValType mempty ty) of
             Nothing -> do
-              let sym = cc ^. jccSym
-              sc <- liftIO $ saw_sc <$> sawCoreState sym
+              let sc = sawCoreSharedContext (cc ^. jccSym)
               ppopts <- liftIO $ scGetPPOpts sc
               let ty' = CryPP.pretty ty
               X.throwM (JVMNonRepresentableType ppopts ty')
             Just jty -> return jty
         TypedTermSchema s -> do
-          let sym = cc ^. jccSym
-          sc <- liftIO $ saw_sc <$> sawCoreState sym
+          let sc = sawCoreSharedContext (cc ^. jccSym)
           ppopts <- liftIO $ scGetPPOpts sc
           let s' = CryPP.pretty s
           X.throwM (JVMPolymorphicType ppopts s')
         tp -> do
-          let sym = cc ^. jccSym
-          sc <- liftIO $ saw_sc <$> sawCoreState sym
+          let sc = sawCoreSharedContext (cc ^. jccSym)
           ppopts <- liftIO $ scGetPPOpts sc
           tp' <- liftIO $ prettyTypedTermType sc tp
           X.throwM (JVMInvalidTypedTerm ppopts tp')
@@ -223,9 +220,7 @@ resolveTypedTerm cc tm =
     TypedTermSchema (Cryptol.Forall [] [] ty) ->
       resolveSAWTerm cc (Cryptol.evalValType mempty ty) (ttTerm tm)
     tp -> do
-        let sym = cc ^. jccSym
-        st <- sawCoreState sym
-        let sc = saw_sc st
+        let sc = sawCoreSharedContext (cc ^. jccSym)
         ppopts <- scGetPPOpts sc
         tp' <- prettyTypedTermType sc tp
         fail $ PPS.render ppopts $ "resolveSetupVal: expected monomorphic" <+>

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Builtins.hs
@@ -780,9 +780,7 @@ verifyObligations :: LLVMCrucibleContext arch
                   -> [(String, MS.ConditionMetadata, Term)]
                   -> TopLevel (SolverStats, [MS.VCStats])
 verifyObligations cc mspec tactic assumes asserts =
-  do let sym = cc^.ccSym
-     st     <- io $ Common.sawCoreState sym
-     let sc  = saw_sc st
+  do let sc = sawCoreSharedContext (cc ^. ccSym)
      useSequentGoals <- rwSequentGoals <$> getTopLevelRW
      let assumeTerms = toListOf (folded . Crucible.labeledPred) assumes
      assume <- io $ scAndList sc assumeTerms
@@ -1089,13 +1087,13 @@ setupPrePointsTos mspec opts cc env pts mem0 = foldM go mem0 pts
 
          cond' <- mapM (resolveSAWPred cc . ttTerm) cond
 
-         sc <- saw_sc <$> Common.sawCoreState (cc^.ccSym)
+         let sc = sawCoreSharedContext (cc ^. ccSym)
          storePointsToValue sc opts cc env tyenv nameEnv mem cond' ptr'' val Nothing
     go mem (LLVMPointsToBitfield _loc ptr fieldName val) =
       do (bfIndex, ptr') <- resolveSetupValBitfield cc mem env tyenv nameEnv ptr fieldName
          ptr'' <- unpackPtrVal ptr'
 
-         sc <- saw_sc <$> Common.sawCoreState (cc^.ccSym)
+         let sc = sawCoreSharedContext (cc ^. ccSym)
          storePointsToBitfieldValue sc opts cc env tyenv nameEnv mem ptr'' bfIndex val
 
     unpackPtrVal :: LLVMVal -> IO (LLVMPtr (Crucible.ArchWidth arch))
@@ -1139,9 +1137,7 @@ setupPrestateConditions mspec cc mem env = aux []
         TypedTerm (TypedTermSchema sch) tm ->
           aux acc (Crucible.insertGlobal var (sch,tm) globals) xs
         TypedTerm tp _ -> do
-          let sym = cc ^. ccSym
-          st <- Common.sawCoreState sym
-          let sc = saw_sc st
+          let sc = sawCoreSharedContext (cc ^. ccSym)
           ppopts <- scGetPPOpts sc
           tp' <- prettyTypedTermType sc tp
           fail $ PPS.render ppopts $ "Setup term for global variable should" <+>
@@ -1156,8 +1152,8 @@ assertEqualVals ::
   LLVMVal ->
   IO Term
 assertEqualVals cc v1 v2 =
-  do let sym = cc^.ccSym
-     st <- Common.sawCoreState sym
+  do let sym = cc ^. ccSym
+         st = sawCoreState sym
      toSC sym st =<< equalValsPred cc v1 v2
 
 --------------------------------------------------------------------------------
@@ -1228,7 +1224,7 @@ registerOverride ::
 registerOverride opts cc sim_ctx _top_loc mdMap cs =
   ccWithBackend cc $ \bak ->
   do let sym = Common.backendGetSym bak
-     sc <- saw_sc <$> liftIO (Common.sawCoreState sym)
+     let sc = sawCoreSharedContext sym
      let fstr = (NE.head cs)^.csName
          fsym = L.Symbol (Text.unpack fstr)
          llvmctx = ccLLVMContext cc
@@ -1274,7 +1270,7 @@ registerInvariantOverride ::
   NE.NonEmpty (MS.CrucibleMethodSpecIR (LLVM arch)) ->
   IO (Crucible.ExecutionFeature (SAWCruciblePersonality Sym) Sym Crucible.LLVM rtp)
 registerInvariantOverride opts cc top_loc mdMap all_cutpoints cs =
-  do sc <- saw_sc <$> Common.sawCoreState (cc^.ccSym)
+  do let sc = sawCoreSharedContext (cc ^. ccSym)
      let name = (NE.head cs) ^. csName
      parent <-
        case neNubOrd $ fmap (view csParentName) cs of
@@ -1660,7 +1656,7 @@ getPoststateObligations sc bak mdMap invSubst =
     sym = Crucible.backendGetSym bak
 
     verifyObligation finalMdMap (Crucible.ProofGoal hyps (Crucible.LabeledPred concl err)) =
-      do st <- Common.sawCoreState sym
+      do let st = sawCoreState sym
          hypTerm <- toSC sym st =<< W4.substituteSymFns sym invSubst =<< Crucible.assumptionsPred sym hyps
          conclTerm <- toSC sym st =<< W4.substituteSymFns sym invSubst concl
          obligation <- scImplies sc hypTerm conclTerm
@@ -1855,7 +1851,7 @@ setupArg sc sym ecRef tp = do
   elt <-
     case tp of
       Crucible.LLVMPointerRepr w -> do
-        st <- Common.sawCoreState sym
+        let st = sawCoreState sym
         elt <- bindSAWTerm sym st (Crucible.BaseBVRepr w) t
         Crucible.llvmPointer_bv sym elt
       _ -> Common.termToRegValue sym tp t
@@ -1882,7 +1878,7 @@ extractFromLLVMCFG ::
 extractFromLLVMCFG opts sc cc (Crucible.AnyCFG cfg) =
   ccWithBackend cc $ \bak ->
   do let sym = Common.backendGetSym bak
-     st <- Common.sawCoreState sym
+     let st = sawCoreState sym
      let h   = Crucible.cfgHandle cfg
      (ecs, args) <- setupArgs sc sym h
      let simCtx  = cc^.ccLLVMSimContext

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Override.hs
@@ -118,7 +118,7 @@ import           SAWCore.Name (VarName(..))
 import           SAWCore.SharedTerm
 import           SAWCore.Recognizer
 import           CryptolSAWCore.TypedTerm
-import           SAWCoreWhat4.ReturnTrip (SAWCoreState(..), toSC, bindSAWTerm)
+import           SAWCoreWhat4.ReturnTrip (sawCoreState, sawCoreSharedContext, toSC, bindSAWTerm)
 
 import           SAWCentral.Crucible.Common
 import           SAWCentral.Crucible.Common.MethodSpec (SetupValue(..), PointsTo)
@@ -1299,21 +1299,19 @@ valueToSC ::
   OverrideMatcher (LLVM arch) md Term
 valueToSC sym _md _failMsg _ts (Crucible.LLVMValZero gtp)
   = liftIO $
-     do st <- liftIO (sawCoreState sym)
-        let sc = saw_sc st
+     do let sc = sawCoreSharedContext sym
         zeroValueSC sc gtp
 
 valueToSC sym md failMsg (Cryptol.TVTuple tys) (Crucible.LLVMValStruct vals)
   | length tys == length vals
   = do terms <- traverse (\(ty, tm) -> valueToSC sym md failMsg ty (snd tm)) (zip tys (V.toList vals))
-       st <- liftIO (sawCoreState sym)
-       let sc = saw_sc st
+       let sc = sawCoreSharedContext sym
        liftIO (scTupleReduced sc terms)
 
 valueToSC sym md failMsg (Cryptol.TVSeq _n Cryptol.TVBit) (Crucible.LLVMValInt base off) =
   do let loc = MS.conditionLoc md
      baseZero <- liftIO (W4.natEq sym base =<< W4.natLit sym 0)
-     st <- liftIO (sawCoreState sym)
+     let st = sawCoreState sym
      offTm <- liftIO (toSC sym st off)
      case W4.asConstantPred baseZero of
        Just True  ->
@@ -1328,16 +1326,15 @@ valueToSC sym md failMsg (Cryptol.TVSeq _n Cryptol.TVBit) (Crucible.LLVMValInt b
 
 -- This is a case for pointers, when we opaque types in Cryptol to represent them...
 -- valueToSC sym _tval (Crucible.LLVMValInt base off) =
---   do base' <- Crucible.toSC sym base
+--   do let sc = sawCoreSharedContext sym
+--      base' <- Crucible.toSC sym base
 --      off'  <- Crucible.toSC sym off
---      sc    <- Crucible.saw_sc <$> sawCoreState sym
 --      Just <$> scTuple sc [base', off']
 
 valueToSC sym md failMsg (Cryptol.TVSeq n cryty) (Crucible.LLVMValArray ty vals)
   | toInteger (length vals) == n
   = do terms <- V.toList <$> traverse (valueToSC sym md failMsg cryty) vals
-       st <- liftIO (sawCoreState sym)
-       let sc = saw_sc st
+       let sc = sawCoreSharedContext sym
        t <- liftIO (typeToSC sc ty)
        liftIO (scVectorReduced sc t terms)
 
@@ -1352,8 +1349,7 @@ valueToSC _ _ _ _ Crucible.LLVMValFloat{} =
   fail  "valueToSC: Real not supported"
 
 valueToSC sym md failMsg _tval _val = do
-  st <- liftIO $ sawCoreState sym
-  let sc = saw_sc st
+  let sc = sawCoreSharedContext sym
   ppopts <- liftIO $ scGetPPOpts sc
   failure ppopts (MS.conditionLoc md) failMsg
 
@@ -1502,7 +1498,7 @@ matchPointsToValue opts sc cc spec prepost md maybe_cond ptr val =
                 | Crucible.LLVMPointer _ off <- ptr ->
                 do addAssert ok md $ Crucible.SimError loc $ Crucible.GenericSimError $ show errMsg
                    sub <- OM (use termSub)
-                   st <- liftIO (sawCoreState sym)
+                   let st = sawCoreState sym
 
                    ptr_width_tm <- liftIO $ scNat sc $ natValue ?ptrWidth
                    off_type_tm <- liftIO $ scBitvector sc $ natValue ?ptrWidth
@@ -1554,7 +1550,7 @@ matchPointsToValue opts sc cc spec prepost md maybe_cond ptr val =
                           case res of
                             Right (ok, arr) ->
                               do addAssert ok md $ Crucible.SimError loc $ Crucible.GenericSimError $ show errMsg
-                                 st <- liftIO (sawCoreState sym)
+                                 let st = sawCoreState sym
                                  arr_tm <- liftIO $ toSC sym st arr
                                  instantiateExtMatchTerm sc md prepost arr_tm $ ttTerm expected_arr_tm
                                  return Nothing
@@ -2071,7 +2067,7 @@ storePointsToValue sc opts cc env tyenv nameEnv base_mem maybe_cond ptr val mayb
               | Crucible.storageTypeSize storTy > 16
               , smt_array_memory_model_enabled -> do
                 arr_tm <- memArrayToSawCoreTerm cc (Crucible.memEndian mem) tm
-                st <- sawCoreState sym
+                let st = sawCoreState sym
                 arr <- bindSAWTerm
                   sym st
                   (W4.BaseArrayRepr
@@ -2088,7 +2084,7 @@ storePointsToValue sc opts cc env tyenv nameEnv base_mem maybe_cond ptr val mayb
                 resolveSetupVal cc mem env tyenv nameEnv val'
               Crucible.storeConstRaw bak mem ptr storTy alignment val''
         SymbolicSizeValue arr_tm sz_tm -> do
-          st <- sawCoreState sym
+          let st = sawCoreState sym
           arr <- bindSAWTerm
             sym st
             (W4.BaseArrayRepr
@@ -2383,7 +2379,7 @@ resolveSetupValueLLVM ::
   SetupValue (LLVM arch) ->
   OverrideMatcher (LLVM arch) md (Crucible.MemType, LLVMVal)
 resolveSetupValueLLVM opts cc spec sval =
-  do sc <- liftIO $ saw_sc <$> sawCoreState (cc ^. ccSym)
+  do let sc = sawCoreSharedContext (cc ^. ccSym)
      m <- OM (use setupValueSub)
      s <- OM (use termSub)
      mem <- readGlobal (Crucible.llvmMemVar (ccLLVMContext cc))
@@ -2420,7 +2416,7 @@ resolveSetupValueBitfieldLLVM ::
   String ->
   OverrideMatcher (LLVM arch) md (BitfieldIndex, LLVMVal)
 resolveSetupValueBitfieldLLVM opts cc spec sval fieldName =
-  do sc <- liftIO $ saw_sc <$> sawCoreState (cc ^. ccSym)
+  do let sc = sawCoreSharedContext (cc ^. ccSym)
      m <- OM (use setupValueSub)
      s <- OM (use termSub)
      mem <- readGlobal (Crucible.llvmMemVar (ccLLVMContext cc))

--- a/saw-central/src/SAWCentral/Crucible/LLVM/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/ResolveSetupValue.hs
@@ -82,7 +82,7 @@ import CryptolSAWCore.Cryptol (translateType)
 import CryptolSAWCore.TypedTerm
 import SAWCoreWhat4.ReturnTrip
 
-import           SAWCentral.Crucible.Common (Sym, sawCoreState, HasSymInterface(..))
+import           SAWCentral.Crucible.Common (Sym, HasSymInterface(..))
 import           SAWCentral.Crucible.Common.MethodSpec (AllocIndex(..), SetupValue(..), prettyAllocIndex)
 import qualified SAWCentral.Crucible.Common.ResolveSetupValue as Common
 
@@ -906,8 +906,7 @@ resolveSetupVal cc mem env tyenv nameEnv val =
       let tp = Crucible.llvmValStorableType (V.head vals)
       return $ Crucible.LLVMValArray tp vals
     SetupField () v n -> do
-         st <- sawCoreState sym
-         let sc = saw_sc st
+         let sc = sawCoreSharedContext sym
          fld <- llvmExceptToFail sc $
                   do info <- resolveSetupValueInfo cc tyenv nameEnv v
                      recoverStructFieldInfo cc tyenv nameEnv v info n
@@ -920,8 +919,7 @@ resolveSetupVal cc mem env tyenv nameEnv val =
            _ -> fail "resolveSetupVal: llvm_field requires pointer value"
 
     SetupElem () v i -> do
-         st <- sawCoreState sym
-         let sc = saw_sc st
+         let sc = sawCoreSharedContext sym
          delta <- llvmExceptToFail sc (resolveSetupElemOffset cc tyenv nameEnv v i)
          ptr <- resolveSetupVal cc mem env tyenv nameEnv v
          case ptr of
@@ -975,8 +973,7 @@ resolveSetupValBitfield ::
   IO (BitfieldIndex, LLVMVal)
 resolveSetupValBitfield cc mem env tyenv nameEnv val fieldName =
   do let sym = cc^.ccSym
-     st <- sawCoreState sym
-     let sc = saw_sc st
+     let sc = sawCoreSharedContext sym
      lval <- resolveSetupVal cc mem env tyenv nameEnv val
      bfIndex <- llvmExceptToFail sc (resolveSetupBitfield cc tyenv nameEnv val fieldName)
      let delta = biFieldByteOffset bfIndex
@@ -998,9 +995,7 @@ resolveTypedTerm cc tm =
     TypedTermSchema (Cryptol.Forall [] [] ty) ->
       resolveSAWTerm cc (Cryptol.evalValType mempty ty) (ttTerm tm)
     tp -> do
-      let sym = cc ^. ccSym
-      st <- sawCoreState sym
-      let sc = saw_sc st
+      let sc = sawCoreSharedContext (cc ^. ccSym)
       ppOpts <- scGetPPOpts sc
       tp' <- prettyTypedTermType sc tp
       fail $ PPS.render ppOpts $ "resolveSetupVal: expected monomorphic" <+>
@@ -1060,8 +1055,7 @@ resolveSAWTerm cc tp tm =
                  Crucible.ptrToPtrVal <$> Crucible.llvmPointer_bv sym v
           _ -> fail ("Invalid bitvector width: " ++ show sz)
       Cryptol.TVSeq sz tp' ->
-        do st <- sawCoreState sym
-           let sc = saw_sc st
+        do let sc = sawCoreSharedContext (cc ^. ccSym)
            let cryenv = cc ^. ccCryptolEnv
            sz_tm <- scNat sc (fromIntegral sz)
            tp_tm <- translateType sc cryenv (Cryptol.tValTy tp')
@@ -1079,8 +1073,7 @@ resolveSAWTerm cc tp tm =
       Cryptol.TVStream _tp' ->
         fail "resolveSAWTerm: invalid infinite stream type"
       Cryptol.TVTuple tps ->
-        do st <- sawCoreState sym
-           let sc = saw_sc st
+        do let sc = sawCoreSharedContext (cc ^. ccSym)
            ppopts <- scGetPPOpts sc
            tms <- mapM (scTupleSelector sc tm) [0 .. length tps - 1]
            vals <- zipWithM (resolveSAWTerm cc) tps tms
@@ -1111,9 +1104,7 @@ scPtrWidthBvNat ::
   a ->
   IO Term
 scPtrWidthBvNat cc n =
-  do let sym = cc^.ccSym
-     st <- sawCoreState sym
-     let sc = saw_sc st
+  do let sc = sawCoreSharedContext (cc ^. ccSym)
      w <- scNat sc $ natValue Crucible.PtrWidth
      scBvNat sc w =<< scNat sc (fromIntegral n)
 
@@ -1225,8 +1216,7 @@ memArrayToSawCoreTerm ::
 memArrayToSawCoreTerm crucible_context endianess typed_term = do
   let sym = crucible_context ^. ccSym
   let data_layout = Crucible.llvmDataLayout $ ccTypeCtx crucible_context
-  st <- sawCoreState sym
-  let sc = saw_sc st
+  let sc = sawCoreSharedContext sym
   ppopts <- scGetPPOpts sc
   let cryenv = crucible_context ^. ccCryptolEnv
 

--- a/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
@@ -452,7 +452,7 @@ llvm_verify_x86_common (Some (llvmModule :: LLVMModule x)) path nm globsyms chec
         ]
         config
       let ?w4EvalTactic = W4EvalTactic { doW4Eval = rwWhat4Eval rw }
-      sawst <- liftIO $ sawCoreState sym
+      let sawst = sawCoreState sym
       halloc <- getHandleAlloc
       let mvar = C.LLVM.llvmMemVar . view C.LLVM.transContext $ modTrans llvmModule
       sfs <- liftIO $ Macaw.newSymFuns sym
@@ -1583,7 +1583,7 @@ checkGoals bak opts nm loc sc tactic mdMap invSubst loopFunEquivConds = do
   poststate_gs <- liftIO $ getPoststateObligations sc bak mdMap invSubst
   loop_gs <- liftIO $ forM loopFunEquivConds $ \cond -> do
     let sym = C.backendGetSym bak
-    st <- Common.sawCoreState sym
+        st = sawCoreState sym
     condTerm <- toSC sym st =<< W4.substituteSymFns sym invSubst cond
     let defaultMd = MS.ConditionMetadata
           { MS.conditionLoc = loc

--- a/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
@@ -1363,7 +1363,7 @@ assertEqualVals ::
   IO Term
 assertEqualVals cc v1 v2 =
   do let sym = cc^.mccSym
-     st <- sawCoreState sym
+         st = sawCoreState sym
      toSC sym st =<< equalValsPred cc v1 v2
 
 registerOverride ::
@@ -1381,7 +1381,7 @@ registerOverride opts cc _ctx _top_loc mdMap cs =
      let method = c0 ^. MS.csMethod
      let rm = cc^.mccRustModule
 
-     sc <- saw_sc <$> liftIO (sawCoreState sym)
+     let sc = sawCoreSharedContext sym
 
      Crucible.AnyCFG cfg <- lookupDefIdCFG rm method
      let h = Crucible.cfgHandle cfg
@@ -1469,9 +1469,7 @@ setupPrestateConditions mspec cc env = aux []
         TypedTerm (TypedTermSchema sch) tm ->
           aux acc (Crucible.insertGlobal var (sch,tm) globals) xs
         TypedTerm tp _ -> do
-          let sym = cc ^. mccSym
-          st <- sawCoreState sym
-          let sc = saw_sc st
+          let sc = sawCoreSharedContext (cc ^. mccSym)
           ppopts <- scGetPPOpts sc
           tp' <- prettyTypedTermType sc tp
           fail $ PPS.render ppopts $ "Setup term for global variable should" <+>
@@ -1485,9 +1483,7 @@ verifyObligations ::
   [(String, MS.ConditionMetadata, Term)] ->
   TopLevel (SolverStats, [MS.VCStats])
 verifyObligations cc mspec tactic assumes asserts =
-  do let sym = cc^.mccSym
-     st <- io $ sawCoreState sym
-     let sc = saw_sc st
+  do let sc = sawCoreSharedContext (cc ^. mccSym)
      assume <- io $ scAndList sc (toListOf (folded . Crucible.labeledPred) assumes)
      let nm = show $ mspec ^. MS.csMethod
      outs <- forM (zip [(0::Int)..] asserts) $ \(n, (msg, md, assert)) -> do
@@ -1592,7 +1588,7 @@ verifyPoststate cc mspec env0 globals ret mdMap =
 
     verifyObligation sc finalMdMap
       (Crucible.ProofGoal hyps (Crucible.LabeledPred concl simErr)) =
-      do st         <- sawCoreState sym
+      do let st = sawCoreState sym
          hypTerm <- toSC sym st =<< Crucible.assumptionsPred sym hyps
          conclTerm  <- toSC sym st concl
          obligation <- scImplies sc hypTerm conclTerm
@@ -2374,7 +2370,7 @@ setupResultTerm sc cc mty0 tpr0 val0 =
                   \_off _sz shp' val' tval' -> go tval' (shapeType shp') val'
               scTupleReduced sc terms
             PrimShape {} -> do
-              st <- sawCoreState sym
+              let st = sawCoreState sym
               toSC sym st val
             ArrayShape _ _ eltSz eltShp len -> do
               eltTy <-

--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -85,7 +85,7 @@ import qualified SAWSupport.Pretty as PPS
 
 import SAWCore.Name (VarName(..))
 import SAWCore.SharedTerm
-import SAWCoreWhat4.ReturnTrip (saw_sc, toSC)
+import SAWCoreWhat4.ReturnTrip (saw_sc, toSC, sawCoreSharedContext)
 import qualified CryptolSAWCore.Cryptol as Cry
 import CryptolSAWCore.TypedTerm
 
@@ -2109,7 +2109,7 @@ resolveSetupValueMIR ::
   SetupValue           ->
   OverrideMatcher MIR w MIRVal
 resolveSetupValueMIR opts cc spec sval =
-  do sc <- liftIO $ saw_sc <$> sawCoreState (cc ^. mccSym)
+  do let sc = sawCoreSharedContext (cc ^. mccSym)
      m <- OM (use setupValueSub)
      s <- OM (use termSub)
      let tyenv = MS.csAllocations spec
@@ -2166,6 +2166,8 @@ valueToSC sym fail_ tval (MIRVal shp val) =
     _ ->
       fail_
   where
+    -- XXX this cannot use `sawCoreState`; the types blow up, which they
+    -- probably shouldn't.
     st = sym ^. W4.userState
     sc = saw_sc st
 

--- a/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
@@ -475,13 +475,11 @@ typeOfSetupValue mcc env nameEnv val =
       tys <- traverse (typeOfSetupValue mcc env nameEnv) vals
       pure $ Mir.TyTuple tys
     MS.SetupGlobal () name -> do
-      let sym = mcc ^. mccSym
-      sc <- liftIO $ saw_sc <$> sawCoreState sym
+      let sc = sawCoreSharedContext (mcc ^. mccSym)
       ppopts <- liftIO $ scGetPPOpts sc
       staticTyRef <$> findStatic ppopts cs name
     MS.SetupGlobalInitializer () name -> do
-      let sym = mcc ^. mccSym
-      sc <- liftIO $ saw_sc <$> sawCoreState sym
+      let sc = sawCoreSharedContext (mcc ^. mccSym)
       ppopts <- liftIO $ scGetPPOpts sc
       static <- findStatic ppopts cs name
       pure $ static ^. Mir.sTy
@@ -498,15 +496,13 @@ typeOfSetupValue mcc env nameEnv val =
     MS.SetupMux () c t f -> do
       cTy <- typeOfTypedTerm c
       unless (cTy == Mir.TyBool) $ do
-        let sym = mcc ^. mccSym
-        sc <- liftIO $ saw_sc <$> sawCoreState sym
+        let sc = sawCoreSharedContext (mcc ^. mccSym)
         ppopts <- liftIO $ scGetPPOpts sc
         X.throwM $ MIRMuxNonBoolCondition ppopts cTy
       tTy <- typeOfSetupValue mcc env nameEnv t
       fTy <- typeOfSetupValue mcc env nameEnv f
       unless (checkCompatibleTys tTy fTy) $ do
-        let sym = mcc ^. mccSym
-        sc <- liftIO $ saw_sc <$> sawCoreState sym
+        let sc = sawCoreSharedContext (mcc ^. mccSym)
         ppopts <- liftIO $ scGetPPOpts sc
         X.throwM $ MIRMuxDifferentBranchTypes ppopts tTy fTy
       pure tTy
@@ -517,8 +513,7 @@ typeOfSetupValue mcc env nameEnv val =
         Mir.TyRawPtr _ mutbl ->
           pure $ Mir.TyRawPtr newPointeeTy mutbl
         _ -> do
-          let sym = mcc ^. mccSym
-          sc <- liftIO $ saw_sc <$> sawCoreState sym
+          let sc = sawCoreSharedContext (mcc ^. mccSym)
           ppopts <- liftIO $ scGetPPOpts sc
           X.throwM $ MIRCastNonRawPtr ppopts oldPtrTy
 
@@ -527,13 +522,11 @@ typeOfSetupValue mcc env nameEnv val =
       let boundsCheck len res
             | i >= 0 && i < len = pure res
             | otherwise = do
-                  let sym = mcc ^. mccSym
-                  sc <- liftIO $ saw_sc <$> sawCoreState sym
+                  let sc = sawCoreSharedContext (mcc ^. mccSym)
                   ppopts <- liftIO $ scGetPPOpts sc
                   X.throwM $ MIRIndexOutOfBounds ppopts xsTy len i
           throwWrongTy = do
-              let sym = mcc ^. mccSym
-              sc <- liftIO $ saw_sc <$> sawCoreState sym
+              let sc = sawCoreSharedContext (mcc ^. mccSym)
               ppopts <- liftIO $ scGetPPOpts sc
               X.throwM $ MIRIndexWrongTy ppopts ixMode xsTy
       case ixMode of
@@ -552,8 +545,7 @@ typeOfSetupValue mcc env nameEnv val =
     MS.SetupField accessMode structValOrPtr fieldName -> do
       structValOrPtrTy <- typeOfSetupValue mcc env nameEnv structValOrPtr
       let findFieldType structValTy = do
-            let sym = mcc ^. mccSym
-            sc <- liftIO $ saw_sc <$> sawCoreState sym
+            let sc = sawCoreSharedContext (mcc ^. mccSym)
             ppopts <- liftIO $ scGetPPOpts sc
             (fieldValTy, _, _) <-
               findStructField ppopts col (accessMode, structValOrPtrTy) structValTy fieldName
@@ -569,8 +561,7 @@ typeOfSetupValue mcc env nameEnv val =
               fieldValTy <- findFieldType structValTy
               pure $ ptrKindToTy (tyToPtrKind structPtrTy) fieldValTy mutbl
             _ -> do
-              let sym = mcc ^. mccSym
-              sc <- liftIO $ saw_sc <$> sawCoreState sym
+              let sc = sawCoreSharedContext (mcc ^. mccSym)
               ppopts <- liftIO $ scGetPPOpts sc
               X.throwM $ MIRFieldAccessWrongTy ppopts accessMode structValOrPtrTy
 
@@ -582,8 +573,7 @@ typeOfSetupValue mcc env nameEnv val =
 
     typeOfSliceFromArrayRef :: MirSliceInfo -> SetupValue -> m Mir.Ty
     typeOfSliceFromArrayRef sliceInfo arrRef = do
-      let sym = mcc ^. mccSym
-      sc <- liftIO $ saw_sc <$> sawCoreState sym
+      let sc = sawCoreSharedContext (mcc ^. mccSym)
       ppopts <- liftIO $ scGetPPOpts sc
       arrRefTy <- typeOfSetupValue mcc env nameEnv arrRef
       case arrRefTy of
@@ -599,19 +589,16 @@ typeOfSetupValue mcc env nameEnv val =
         TypedTermSchema (Cryptol.Forall [] [] ty) ->
           case toMIRType (Cryptol.evalValType mempty ty) of
             Left err -> do
-                let sym = mcc ^. mccSym
-                sc <- liftIO $ saw_sc <$> sawCoreState sym
+                let sc = sawCoreSharedContext (mcc ^. mccSym)
                 ppopts <- liftIO $ scGetPPOpts sc
                 X.throwM (MIRNonRepresentableType ppopts ty err)
             Right mirTy -> return mirTy
         TypedTermSchema s -> do
-            let sym = mcc ^. mccSym
-            sc <- liftIO $ saw_sc <$> sawCoreState sym
+            let sc = sawCoreSharedContext (mcc ^. mccSym)
             ppopts <- liftIO $ scGetPPOpts sc
             X.throwM (MIRPolymorphicType ppopts s)
         tp -> do
-            let sym = mcc ^. mccSym
-            sc <- liftIO $ saw_sc <$> sawCoreState sym
+            let sc = sawCoreSharedContext (mcc ^. mccSym)
             ppopts <- liftIO $ scGetPPOpts sc
             tp' <- liftIO $ prettyTypedTermType sc tp
             X.throwM (MIRInvalidTypedTerm ppopts tp')
@@ -903,11 +890,11 @@ resolveSetupVal mcc env tyenv nameEnv val =
                   -- FIXME: use a different error kind here (this is a type
                   -- or size mismatch error; bounds are checked elsewhere)
                   Nothing -> do
-                      sc <- liftIO $ saw_sc <$> sawCoreState sym
+                      let sc = sawCoreSharedContext sym
                       ppopts <- liftIO $ scGetPPOpts sc
                       X.throwM $ MIRIndexOutOfBounds ppopts arrTy (fromIntegral len) i
               else do
-                sc <- liftIO $ saw_sc <$> sawCoreState sym
+                let sc = sawCoreSharedContext sym
                 ppopts <- liftIO $ scGetPPOpts sc
                 X.throwM $ MIRIndexOutOfBounds ppopts arrTy (fromIntegral len) i
         MirIndexIntoRef
@@ -927,13 +914,13 @@ resolveSetupVal mcc env tyenv nameEnv val =
                 MIRVal (RefShape elemPtrTy elemTy mutbl elemTpr) <$>
                   Mir.subindexMirRefIO bak iTypes elemTpr xsVal i_sym elemSize
               else do
-                sc <- liftIO $ saw_sc <$> sawCoreState sym
+                let sc = sawCoreSharedContext sym
                 ppopts <- liftIO $ scGetPPOpts sc
                 X.throwM $ MIRIndexOutOfBounds ppopts ptrTy len i
         MirIndexOffsetRef ->
           panic "resolveSetupValue" ["MirIndexOffsetRef not yet implemented"]
         _ -> do
-          sc <- liftIO $ saw_sc <$> sawCoreState sym
+          let sc = sawCoreSharedContext sym
           ppopts <- liftIO $ scGetPPOpts sc
           X.throwM $ MIRIndexWrongTy ppopts ixMode (shapeMirTy xsShp)
     MS.SetupField accessMode structValOrPtrSV fieldName -> do
@@ -953,7 +940,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
           MIRVal structPtrShp structPtrRV <- pure structValOrPtrMV
           case structPtrShp of
             RefShape structPtrTy structValTy mutbl structRepr -> do
-              sc <- liftIO $ saw_sc <$> sawCoreState sym
+              let sc = sawCoreSharedContext sym
               ppopts <- liftIO $ scGetPPOpts sc
               (fieldValTy, iInt, adt) <-
                 findStructField ppopts col (accessMode, structPtrTy) structValTy fieldName
@@ -981,7 +968,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
                 _ ->
                   X.throwM $ MIRFieldAccessWrongTy ppopts accessMode structPtrTy
             _ -> do
-              sc <- liftIO $ saw_sc <$> sawCoreState sym
+              let sc = sawCoreSharedContext sym
               ppopts <- liftIO $ scGetPPOpts sc
               X.throwM $
                 MIRFieldAccessWrongTy ppopts accessMode (shapeMirTy structPtrShp)
@@ -1000,12 +987,12 @@ resolveSetupVal mcc env tyenv nameEnv val =
           -- for more info.
           pure $ MIRVal (RefShape newPtrTy newPointeeTy mutbl newPointeeTpr) ref
         _ -> do
-          sc <- liftIO $ saw_sc <$> sawCoreState sym
+          let sc = sawCoreSharedContext sym
           ppopts <- liftIO $ scGetPPOpts sc
           X.throwM $ MIRCastNonRawPtr ppopts $ shapeMirTy oldShp
     MS.SetupUnion empty _ _           -> absurd empty
     MS.SetupGlobal () name -> do
-      sc <- liftIO $ saw_sc <$> sawCoreState sym
+      let sc = sawCoreSharedContext sym
       ppopts <- liftIO $ scGetPPOpts sc
       static <- findStatic ppopts cs name
       Mir.StaticVar gv <- findStaticVar ppopts cs (static ^. Mir.sName)
@@ -1014,7 +1001,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
       pure $ MIRVal (RefShape (staticTyRef static) sTy sMut (globalType gv))
            $ staticRefMux sym gv
     MS.SetupGlobalInitializer () name -> do
-      sc <- liftIO $ saw_sc <$> sawCoreState sym
+      let sc = sawCoreSharedContext sym
       ppopts <- liftIO $ scGetPPOpts sc
       static <- findStatic ppopts cs name
       findStaticInitializer mcc static
@@ -1026,7 +1013,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
         case W4.testEquality cTpr BoolRepr of
           Just r -> pure r
           Nothing -> do
-              sc <- liftIO $ saw_sc <$> sawCoreState sym
+              let sc = sawCoreSharedContext sym
               ppopts <- liftIO $ scGetPPOpts sc
               X.throwM $ MIRMuxNonBoolCondition ppopts cTy
 
@@ -1040,7 +1027,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
         case W4.testEquality tTpr fTpr of
           Just r -> pure r
           Nothing -> do
-              sc <- liftIO $ saw_sc <$> sawCoreState sym
+              let sc = sawCoreSharedContext sym
               ppopts <- liftIO $ scGetPPOpts sc
               X.throwM $ MIRMuxDifferentBranchTypes ppopts tTy fTy
 
@@ -1068,8 +1055,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
       let expectedFldsNum = length expectedFlds
       let actualFldsNum = length actualFldTys
       unless (expectedFldsNum == actualFldsNum) $ do
-        let sym = mcc ^. mccSym
-        sc <- liftIO $ saw_sc <$> sawCoreState sym
+        let sc = sawCoreSharedContext (mcc ^. mccSym)
         ppopts <- liftIO $ scGetPPOpts sc
         fail $ PPS.render ppopts $ PP.vsep [
             "Mismatch in number of" <+> PP.pretty fieldDescr,
@@ -1082,8 +1068,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
           let expectedFldTy = expectedFld ^. Mir.fty in
           let expectedFldName = expectedFld ^. Mir.fName in
           unless (checkCompatibleTys expectedFldTy actualFldTy) $ do
-            let sym = mcc ^. mccSym
-            sc <- liftIO $ saw_sc <$> sawCoreState sym
+            let sc = sawCoreSharedContext (mcc ^. mccSym)
             ppopts <- liftIO $ scGetPPOpts sc
             fail $ PPS.render ppopts $ PP.vsep [
                 PP.pretty what <+> "field type mismatch",
@@ -1137,7 +1122,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
       MIRVal arrRefShp arrRefVal <- resolveSetupVal mcc env tyenv nameEnv arrRef
       case arrRefShp of
         RefShape _ arrTy mut Mir.MirAggregateRepr -> do
-          sc <- liftIO $ saw_sc <$> sawCoreState sym
+          let sc = sawCoreSharedContext sym
           ppopts <- liftIO $ scGetPPOpts sc
           (sliceTy, elemTy, len) <- arrayToSliceTys ppopts sliceInfo mut arrTy
           Some elemTpr <- case Mir.tyToRepr col elemTy of
@@ -1149,7 +1134,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
           let sliceShp = SliceShape (Mir.TyRef sliceTy mut) elemTy mut elemTpr
           pure $ SetupSliceFromArrayRef sliceShp refVal len
         _ -> do
-          sc <- liftIO $ saw_sc <$> sawCoreState sym
+          let sc = sawCoreSharedContext sym
           ppopts <- liftIO $ scGetPPOpts sc
           X.throwM $ MIRSliceNonReference ppopts $ shapeMirTy arrRefShp
 
@@ -1211,9 +1196,7 @@ resolveTypedTerm mcc tm =
     TypedTermSchema (Cryptol.Forall [] [] ty) ->
       resolveSAWTerm mcc (Cryptol.evalValType mempty ty) (ttTerm tm)
     tp -> do
-      let sym = mcc ^. mccSym
-      st <- sawCoreState sym
-      let sc = saw_sc st
+      let sc = sawCoreSharedContext (mcc ^. mccSym)
       ppopts <- scGetPPOpts sc
       tp' <- prettyTypedTermType sc tp
       fail $ PPS.render ppopts $ "resolveTypedTerm: expected monomorphic" <+>
@@ -1265,7 +1248,7 @@ resolveSAWTerm mcc tp tm =
       doIndex <- indexSeqTerm cryenv sym (sz, tp') tm
       case toMIRType tp' of
         Left err -> do
-          sc <- liftIO $ saw_sc <$> sawCoreState sym
+          let sc = sawCoreSharedContext sym
           ppopts <- liftIO $ scGetPPOpts sc
           fail $ Text.unpack $ "In resolveSAWTerm: " <> ppToMIRTypeErr ppopts err
         Right mirTy -> do
@@ -1285,8 +1268,7 @@ resolveSAWTerm mcc tp tm =
     Cryptol.TVStream _tp' ->
       fail "resolveSAWTerm: unsupported infinite stream type"
     Cryptol.TVTuple tps -> do
-      st <- sawCoreState sym
-      let sc = saw_sc st
+      let sc = sawCoreSharedContext sym
       tms <- traverse (scTupleSelector sc tm) [0 .. length tps - 1]
       vals <- zipWithM (resolveSAWTerm mcc) tps tms
       let mirTys = map (\(MIRVal shp _) -> shapeMirTy shp) vals
@@ -1377,8 +1359,7 @@ indexSeqTerm ::
   Term {- ^ term to index into -} ->
   IO (Int -> IO Term) -- ^ the indexing function
 indexSeqTerm cryenv sym (sz, elemTp) tm = do
-  st <- sawCoreState sym
-  let sc = saw_sc st
+  let sc = sawCoreSharedContext sym
   sz_tm <- scNat sc (fromInteger sz)
   elemTp_tm <- translateType sc cryenv (Cryptol.tValTy elemTp)
   pure $ \i -> do
@@ -1418,7 +1399,7 @@ accessMirStructFieldVal ::
   MIRVal ->
   m (Maybe MIRVal)
 accessMirStructFieldVal sym col fieldName (MIRVal structShp structRV) = do
-  sc <- liftIO $ saw_sc <$> sawCoreState sym
+  let sc = sawCoreSharedContext sym
   ppopts <- liftIO $ scGetPPOpts sc
   case structShp of
     StructShape structTy _ fieldShps -> do
@@ -1878,8 +1859,7 @@ findStaticInitializer ::
   Mir.Static ->
   m MIRVal
 findStaticInitializer mcc static = do
-  let sym = mcc ^. mccSym
-  sc <- liftIO $ saw_sc <$> sawCoreState sym
+  let sc = sawCoreSharedContext (mcc ^. mccSym)
   ppopts <- liftIO $ scGetPPOpts sc
   Mir.StaticVar gv <- findStaticVar ppopts cs staticDefId
   let staticShp = tyToShapeEq col (static ^. Mir.sTy) (globalType gv)

--- a/saw-central/src/SAWCentral/Prover/Exporter.hs
+++ b/saw-central/src/SAWCentral/Prover/Exporter.hs
@@ -92,11 +92,10 @@ import qualified SAWCore.Simulator.Value as Sim
 import qualified SAWCoreWhat4.What4 as W4Sim
 import qualified SAWCoreSBV.SBV as SBV
 import qualified SAWCoreWhat4.What4 as W -- XXX duplicate!?
-import SAWCoreWhat4.ReturnTrip (newSAWCoreExprBuilder)
+import SAWCoreWhat4.ReturnTrip (newSAWCoreExprBuilder, sawCoreState)
 
 import qualified SAWCore.Parser.AST as Un
 
-import SAWCentral.Crucible.Common
 import SAWCentral.Proof
   (Prop, Sequent, propSize, sequentSharedSize, propToTerm, predicateToSATQuery, sequentToSATQuery)
 import SAWCentral.Prover.SolverStats
@@ -395,7 +394,7 @@ flattenSValue _ sval = fail $ "write_verilog: unsupported result type: " ++ show
 writeVerilog :: SharedContext -> FilePath -> Term -> IO ()
 writeVerilog sc path t = do
   sym <- newSAWCoreExprBuilder sc False
-  st  <- sawCoreState sym
+  let st = sawCoreState sym
   -- For writing Verilog in the general case, it's convenient for any
   -- lambda-bound inputs to appear first in the module input list, in
   -- order, followed by free variables (probably in the order seen

--- a/saw-core-what4/src/SAWCoreWhat4/ReturnTrip.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/ReturnTrip.hs
@@ -19,6 +19,8 @@ module SAWCoreWhat4.ReturnTrip
   , newSAWCoreExprBuilder
   , SAWCoreState(..)
   , newSAWCoreState
+  , sawCoreState
+  , sawCoreSharedContext
   , SAWExpr(..)
   , baseSCType
   , bindSAWTerm
@@ -112,6 +114,12 @@ newSAWCoreState sc =
             , saw_elt_cache = ch
             , saw_elt_cache_r = ch_r
             }
+
+sawCoreState :: SAWCoreExprBuilder -> SAWCoreState GlobalNonceGenerator
+sawCoreState sym = sym ^. B.userState
+
+sawCoreSharedContext :: SAWCoreExprBuilder -> SC.SharedContext
+sawCoreSharedContext sym = saw_sc $ sawCoreState sym
 
 data SAWExpr (bt :: BaseType) where
   SAWExpr :: !SC.Term -> SAWExpr bt


### PR DESCRIPTION
Move `sawCoreState` out of `IO`, move it to SAWCoreWhat4.ReturnTrip, add `sawCoreSharedContext`.

Followup to #3175.

Note: sits on top of #3181 so the diff will include those changes until it gets merged.