### PR TITLE
CI: Modernize actions/setup-java steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,12 +715,12 @@ jobs:
         if: runner.os != 'Windows'
         run: chmod +x dist-tests/*
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v5
         if: "matrix.suite == 'integration-tests'"
         with:
+          distribution: "zulu"
           java-version: "8"
           java-package: jdk
-          architecture: x64
 
       - uses: actions/cache/restore@v4
         name: Restore SMT solver result cache
@@ -807,11 +807,11 @@ jobs:
           chmod +x bin/*
           chmod +x dist-tests/*
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v5
         with:
+          distribution: "zulu"
           java-version: "8"
           java-package: jdk
-          architecture: x64
 
       # NOTE: This job uses the SMT solver cache to improve performance but it
       # does not save the updated SMT solver cache. This is because the


### PR DESCRIPTION
* Use the latest version of `actions/setup-java`, as the previously used one (`v1`) is quite old.

* Don't hard-code the `architecture`, as we now have CI runners with different architectures (both `x64` and `aarch64`). `actions/setup-java` will correctly pick the underlying architecture as the default if one is not specified explicitly, so let's just do that.

* As of `v2`, `setup-java` now requires you to explicitly specify a `distribution`. `v1` was implicitly using the `zulu` distribution, so let's go with that.

Fixes #3183.