### PR TITLE
Add preprocessing pass to `yosys_import` to clean up module names

### DIFF
--- a/intTests/test_yosys_import_parameterized/Makefile
+++ b/intTests/test_yosys_import_parameterized/Makefile
@@ -1,0 +1,14 @@
+YOSYS?=yosys
+
+all: test.json
+
+test.json: test.sv test.ys
+	$(YOSYS) -s test.ys
+
+.PHONY: destroy
+destroy:
+	rm -f *.json
+
+.PHONY: clean
+clean:
+	@true

--- a/intTests/test_yosys_import_parameterized/test.json
+++ b/intTests/test_yosys_import_parameterized/test.json
@@ -1,0 +1,258 @@
+{
+  "creator": "Yosys 0.62 (git sha1 7326bb7d6641500ecb285c291a54a662cb1e76cf, clang++ 17.0.0 -fPIC -O3)",
+  "modules": {
+    "$paramod\\dff\\WIDTH=s32'00000000000000000000000000000110": {
+      "attributes": {
+        "dynports": "00000000000000000000000000000001",
+        "hdlname": "dff",
+        "src": "test.sv:1.1-10.10"
+      },
+      "parameter_default_values": {
+        "WIDTH": "00000000000000000000000000000110"
+      },
+      "ports": {
+        "clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "d": {
+          "direction": "input",
+          "bits": [ 3, 4, 5, 6, 7, 8 ]
+        },
+        "q": {
+          "direction": "output",
+          "bits": [ 9, 10, 11, 12, 13, 14 ]
+        }
+      },
+      "cells": {
+        "$procdff$3": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000110"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "test.sv:6.4-8.7"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 2 ],
+            "D": [ 3, 4, 5, 6, 7, 8 ],
+            "Q": [ 9, 10, 11, 12, 13, 14 ]
+          }
+        }
+      },
+      "netnames": {
+        "clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "test.sv:2.29-2.32"
+          }
+        },
+        "d": {
+          "hide_name": 0,
+          "bits": [ 3, 4, 5, 6, 7, 8 ],
+          "attributes": {
+            "src": "test.sv:3.29-3.30"
+          }
+        },
+        "q": {
+          "hide_name": 0,
+          "bits": [ 9, 10, 11, 12, 13, 14 ],
+          "attributes": {
+            "src": "test.sv:4.29-4.30"
+          }
+        }
+      }
+    },
+    "$paramod\\dff\\WIDTH=s32'00000000000000000000000000001010": {
+      "attributes": {
+        "dynports": "00000000000000000000000000000001",
+        "hdlname": "dff",
+        "src": "test.sv:1.1-10.10"
+      },
+      "parameter_default_values": {
+        "WIDTH": "00000000000000000000000000001010"
+      },
+      "ports": {
+        "clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "d": {
+          "direction": "input",
+          "bits": [ 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
+        },
+        "q": {
+          "direction": "output",
+          "bits": [ 13, 14, 15, 16, 17, 18, 19, 20, 21, 22 ]
+        }
+      },
+      "cells": {
+        "$procdff$4": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000001010"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "test.sv:6.4-8.7"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 2 ],
+            "D": [ 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ],
+            "Q": [ 13, 14, 15, 16, 17, 18, 19, 20, 21, 22 ]
+          }
+        }
+      },
+      "netnames": {
+        "clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "test.sv:2.29-2.32"
+          }
+        },
+        "d": {
+          "hide_name": 0,
+          "bits": [ 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ],
+          "attributes": {
+            "src": "test.sv:3.29-3.30"
+          }
+        },
+        "q": {
+          "hide_name": 0,
+          "bits": [ 13, 14, 15, 16, 17, 18, 19, 20, 21, 22 ],
+          "attributes": {
+            "src": "test.sv:4.29-4.30"
+          }
+        }
+      }
+    },
+    "main": {
+      "attributes": {
+        "hdlname": "main",
+        "top": "00000000000000000000000000000001",
+        "src": "test.sv:12.1-26.10"
+      },
+      "ports": {
+        "clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "x": {
+          "direction": "input",
+          "bits": [ 3, 4, 5, 6, 7, 8 ]
+        },
+        "y": {
+          "direction": "input",
+          "bits": [ 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 ]
+        },
+        "z": {
+          "direction": "output",
+          "bits": [ 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34 ]
+        }
+      },
+      "cells": {
+        "inst1": {
+          "hide_name": 0,
+          "type": "$paramod\\dff\\WIDTH=s32'00000000000000000000000000000110",
+          "parameters": {
+          },
+          "attributes": {
+            "module_not_derived": "00000000000000000000000000000001",
+            "src": "test.sv:21.13-21.46"
+          },
+          "port_directions": {
+            "clk": "input",
+            "d": "input",
+            "q": "output"
+          },
+          "connections": {
+            "clk": [ 2 ],
+            "d": [ 3, 4, 5, 6, 7, 8 ],
+            "q": [ 29, 30, 31, 32, 33, 34 ]
+          }
+        },
+        "inst2": {
+          "hide_name": 0,
+          "type": "$paramod\\dff\\WIDTH=s32'00000000000000000000000000001010",
+          "parameters": {
+          },
+          "attributes": {
+            "module_not_derived": "00000000000000000000000000000001",
+            "src": "test.sv:22.14-22.47"
+          },
+          "port_directions": {
+            "clk": "input",
+            "d": "input",
+            "q": "output"
+          },
+          "connections": {
+            "clk": [ 2 ],
+            "d": [ 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 ],
+            "q": [ 19, 20, 21, 22, 23, 24, 25, 26, 27, 28 ]
+          }
+        }
+      },
+      "netnames": {
+        "clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "test.sv:13.24-13.27"
+          }
+        },
+        "q_x": {
+          "hide_name": 0,
+          "bits": [ 29, 30, 31, 32, 33, 34 ],
+          "attributes": {
+            "src": "test.sv:18.21-18.24"
+          }
+        },
+        "q_y": {
+          "hide_name": 0,
+          "bits": [ 19, 20, 21, 22, 23, 24, 25, 26, 27, 28 ],
+          "attributes": {
+            "src": "test.sv:19.21-19.24"
+          }
+        },
+        "x": {
+          "hide_name": 0,
+          "bits": [ 3, 4, 5, 6, 7, 8 ],
+          "attributes": {
+            "src": "test.sv:14.24-14.25"
+          }
+        },
+        "y": {
+          "hide_name": 0,
+          "bits": [ 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 ],
+          "attributes": {
+            "src": "test.sv:15.24-15.25"
+          }
+        },
+        "z": {
+          "hide_name": 0,
+          "bits": [ 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34 ],
+          "attributes": {
+            "src": "test.sv:16.24-16.25"
+          }
+        }
+      }
+    }
+  }
+}

--- a/intTests/test_yosys_import_parameterized/test.saw
+++ b/intTests/test_yosys_import_parameterized/test.saw
@@ -1,0 +1,15 @@
+enable_experimental;
+
+m <- yosys_import "test.json";
+
+prove_print z3
+  {{ \s -> m.dff_6.out s == s }};
+
+prove_print z3
+  {{ \s -> m.dff_10.out s == s }};
+
+prove_print z3
+  {{ \x y s -> m.main.out (m.main.step {clk = 0, x = x, y = y} s) == {z = s.inst1.q # s.inst2.q} }};
+
+prove_print z3
+  {{ \x y s -> m.main.out (m.main.step {clk = 1, x = x, y = y} s) == {z = x # y} }};

--- a/intTests/test_yosys_import_parameterized/test.sh
+++ b/intTests/test_yosys_import_parameterized/test.sh
@@ -1,0 +1,1 @@
+$SAW test.saw

--- a/intTests/test_yosys_import_parameterized/test.sv
+++ b/intTests/test_yosys_import_parameterized/test.sv
@@ -1,0 +1,26 @@
+module dff #(parameter WIDTH=1)
+  (input logic              clk,
+   input logic [WIDTH-1:0]  d,
+   output logic [WIDTH-1:0] q);
+
+   always_ff @(posedge clk) begin
+      q <= d;
+   end
+
+endmodule // dff
+
+module main
+  (input logic         clk,
+   input logic [5:0]   x,
+   input logic [9:0]   y,
+   output logic [15:0] z);
+
+   wire logic [5:0] q_x;
+   wire logic [9:0] q_y;
+
+   dff #(6) inst1 (.clk(clk), .d(x), .q(q_x));
+   dff #(10) inst2 (.clk(clk), .d(y), .q(q_y));
+
+   assign z = {q_x, q_y};
+
+endmodule // main

--- a/intTests/test_yosys_import_parameterized/test.ys
+++ b/intTests/test_yosys_import_parameterized/test.ys
@@ -1,0 +1,3 @@
+read -sv test.sv
+prep -top main
+write_json test.json

--- a/saw-central/src/SAWCentral/Yosys.hs
+++ b/saw-central/src/SAWCentral/Yosys.hs
@@ -131,7 +131,7 @@ yosysIRToRecordTerm ::
   YosysIR ->
   IO SC.TypedTerm
 yosysIRToRecordTerm sc ir =
-  do env <- convertYosysIR sc ir
+  do env <- convertYosysIR sc (renameCellTypeNames ir)
      record <- cryptolRecord sc $ view convertedModuleTerm <$> env
      SC.mkTypedTerm sc record
 

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -219,6 +219,8 @@ data ClockEnable
   deriving (Eq, Ord)
 
 -- | All supported primitive register cell types.
+-- All register cell types have a numeric parameter WIDTH and a single
+-- output port Q of size WIDTH.
 -- See the Yosys documentation for the cell definitions:
 -- <https://yosyshq.readthedocs.io/projects/yosys/en/latest/cell/word_reg.html>
 data CellTypeRegister

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -31,7 +31,8 @@ module SAWCentral.Yosys.IR (
       cellPortDirections,
       cellConnections,
     Module,
-      moduleAttributes,
+      moduleHdlName,
+      moduleParameters,
       modulePorts,
       moduleCells,
       moduleNetnames,
@@ -44,18 +45,21 @@ module SAWCentral.Yosys.IR (
     cellInputConnections,
     cellOutputConnections,
     cellIsRegister,
-    renameRegisterInstances
+    renameRegisterInstances,
+    renameCellTypeNames
   ) where
 
 import Control.Lens.TH (makeLenses)
 
-import Control.Lens ((^.), set)
+import Control.Lens ((^.), over, set)
 
 import qualified Data.Maybe as Maybe
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
+
+import Numeric.Natural (Natural)
 
 import qualified Data.Aeson as Aeson
 
@@ -412,7 +416,8 @@ instance Aeson.FromJSON Netname where
 
 -- | A single HDL module.
 data Module = Module
-  { _moduleAttributes :: Maybe Aeson.Value -- currently unused
+  { _moduleHdlName :: Maybe Text
+  , _moduleParameters :: Map Text Natural
   , _modulePorts :: Map PortName Port
   , _moduleCells :: Map CellInstName Cell
   , _moduleNetnames :: Map Text Netname
@@ -422,7 +427,11 @@ makeLenses ''Module
 
 instance Aeson.FromJSON Module where
   parseJSON = Aeson.withObject "module" $ \o -> do
-    _moduleAttributes <- o Aeson..:? "attributes"
+    attributes <- Maybe.fromMaybe mempty <$> o Aeson..:? "attributes"
+    _moduleHdlName <- attributes Aeson..:? "hdlname"
+    _moduleParameters <-
+      fmap textBinNat . Maybe.fromMaybe mempty <$>
+      o Aeson..:? "parameter_default_values"
     _modulePorts <- Maybe.fromMaybe mempty <$> o Aeson..:? "ports"
     _moduleCells <- Maybe.fromMaybe mempty <$> o Aeson..:? "cells"
     _moduleNetnames <- Maybe.fromMaybe mempty <$> o Aeson..:? "netnames"
@@ -517,3 +526,53 @@ renameRegisterInstances m = set moduleCells cells' m
              Map.lookup bs netnames
       | otherwise =
           t
+
+-- | If a 'Module' has an @attributes@ section with an @hdlname@
+-- entry, then use it to produce a suitably nice 'CellTypeName'.
+betterModuleName :: Module -> Maybe CellTypeName
+betterModuleName m =
+  do basename <- m ^. moduleHdlName
+     let params = Map.elems (m ^. moduleParameters)
+     pure (Text.intercalate "_" (basename : map (Text.pack . show) params))
+
+-- | Replace machine-generated names of modules with simpler names
+-- based on user-provided names and parameters (if any).
+-- If no suitable name exists, then use function 'cellIdentifier' to
+-- produce a lexically-valid module name.
+renameCellTypeNames :: YosysIR -> YosysIR
+renameCellTypeNames ir = renameYosysIR renaming ir
+  where
+    newName :: CellTypeName -> Module -> CellTypeName
+    newName name m =
+      case betterModuleName m of
+        Just name' -> name'
+        Nothing -> cellIdentifier name
+
+    renaming :: Map CellTypeName CellTypeName
+    renaming = Map.mapWithKey newName (ir ^. yosysModules)
+
+-- | Apply a substitution to the 'CellTypeName's in the given
+-- 'YosysIR'.
+renameYosysIR :: Map CellTypeName CellTypeName -> YosysIR -> YosysIR
+renameYosysIR sub ir = set yosysModules newModules ir
+  where
+    newModules =
+      Map.fromList
+      [ (Maybe.fromMaybe name (Map.lookup name sub), renameModule m)
+      | (name, m) <- Map.toList (ir ^. yosysModules) ]
+
+    renameModule :: Module -> Module
+    renameModule m = over moduleCells (fmap renameCell) m
+
+    renameCell :: Cell -> Cell
+    renameCell c = over cellType renameCellType c
+
+    renameCellType :: CellType -> CellType
+    renameCellType ct =
+      case ct of
+        CellTypeCombinational _ -> ct
+        CellTypeRegister _ -> ct
+        CellTypeUserType name ->
+          maybe ct CellTypeUserType (Map.lookup name sub)
+        CellTypeUnsupportedPrimitive name ->
+          maybe ct CellTypeUserType (Map.lookup name sub)

--- a/saw-central/src/SAWCentral/Yosys/IR.hs
+++ b/saw-central/src/SAWCentral/Yosys/IR.hs
@@ -44,7 +44,7 @@ module SAWCentral.Yosys.IR (
     cellInputConnections,
     cellOutputConnections,
     cellIsRegister,
-    renameDffInstances
+    renameRegisterInstances
   ) where
 
 import Control.Lens.TH (makeLenses)
@@ -480,19 +480,20 @@ cellOutputConnections c = Map.intersection (c ^. cellConnections) out
   where
     out = Map.filter isOutput (c ^. cellPortDirections)
 
--- | Test whether a 'Cell' is a state element ('CellTypeDff' or 'CellTypeFf').
+-- | Test whether a 'Cell' is a stateful register, such as a DFF.
 cellIsRegister :: Cell -> Bool
 cellIsRegister c =
   case c ^. cellType of
     CellTypeRegister _ -> True
     _ -> False
 
--- | Swap out machine-generated names of DFF cells for user-provided
--- names from the netnames section of the module, wherever possible.
+-- | Swap out machine-generated names of register cells for
+-- user-provided names from the netnames section of the module,
+-- wherever possible.
 -- If no suitable name exists in the netnames table, then use function
 -- 'cellIdentifier' to produce a lexically-valid field name.
-renameDffInstances :: Module -> Module
-renameDffInstances m = set moduleCells cells' m
+renameRegisterInstances :: Module -> Module
+renameRegisterInstances m = set moduleCells cells' m
   where
     cells' :: Map CellInstName Cell
     cells' =

--- a/saw-central/src/SAWCentral/Yosys/Netgraph.hs
+++ b/saw-central/src/SAWCentral/Yosys/Netgraph.hs
@@ -500,7 +500,7 @@ convertModule ::
   Module ->
   IO ConvertedModule
 convertModule sc env mname m0 =
-  do let m = renameDffInstances m0
+  do let m = renameRegisterInstances m0
      let ng = moduleNetgraph env m
 
      let inputPorts = moduleInputPorts m

--- a/saw-central/src/SAWCentral/Yosys/State.hs
+++ b/saw-central/src/SAWCentral/Yosys/State.hs
@@ -92,7 +92,7 @@ convertModuleInline ::
   Module ->
   IO YosysSequential
 convertModuleInline sc mname m0 =
-  do let m = renameDffInstances m0
+  do let m = renameRegisterInstances m0
      let ng = moduleNetgraph Map.empty m
 
      -- construct SAWCore and Cryptol types

--- a/saw-central/src/SAWCentral/Yosys/Utils.hs
+++ b/saw-central/src/SAWCentral/Yosys/Utils.hs
@@ -257,6 +257,9 @@ cellIdentifier name
   | otherwise = Text.pack $ zEncodeString $ Text.unpack name
 
 -- | Test whether the string is a valid Cryptol identifier.
+-- TODO: Replace this with a call to a library function if
+-- Cryptol issue 2036 is implemented.
+-- <https://github.com/GaloisInc/cryptol/issues/2036>
 validIdentifier :: Text -> Bool
 validIdentifier x =
   case Text.uncons x of

--- a/saw-central/src/SAWCentral/Yosys/Utils.hs
+++ b/saw-central/src/SAWCentral/Yosys/Utils.hs
@@ -42,7 +42,7 @@ import Control.Monad (forM, foldM)
 import Control.Exception (Exception, throwIO)
 
 import Data.Bifunctor (bimap)
-import Data.Char (digitToInt)
+import Data.Char (digitToInt, isAlpha, isAlphaNum)
 import qualified Data.List as List
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -250,8 +250,23 @@ eqBvRecords sc cty a b =
 -- | Encode the given string such that is a valid Cryptol identifier.
 -- Since Yosys cell names often look like "\42", this makes it much
 -- easier to manipulate state records, which are keyed by cell name.
+-- If the name is already a valid Cryptol identifier, leave it alone.
 cellIdentifier :: CellInstName -> Text
-cellIdentifier = Text.pack . zEncodeString . Text.unpack
+cellIdentifier name
+  | validIdentifier name = name
+  | otherwise = Text.pack $ zEncodeString $ Text.unpack name
+
+-- | Test whether the string is a valid Cryptol identifier.
+validIdentifier :: Text -> Bool
+validIdentifier x =
+  case Text.uncons x of
+    Nothing -> False
+    Just (c, x') -> idFirst c && Text.all idNext x'
+  where
+    idFirst :: Char -> Bool
+    idFirst c = isAlpha c || c == '_'
+    idNext :: Char -> Bool
+    idNext c = isAlphaNum c || c == '_' || c == '\''
 
 textBinNat :: Text -> Natural
 textBinNat = fromIntegral . Text.foldl' (\a x -> digitToInt x + a * 2) 0


### PR DESCRIPTION
Module names for `yosys_import` are now based on the "hdlname" field in the Yosys .json file (which is the user-given name from the source) combined with the list of module parameters, if any.

Fixes #3187.
