### PR TITLE
`cryptol-saw-core`: Expand PropGuards when loading `let {{ ... }}` blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,9 @@ This release supports [version
 * LLVM module importing now supports `DISubrangeType` (metadata ID 48) and
   `DIFixedPointType` (metadata ID 49) elements.
 
+* SAW no longer panics when defining Cryptol functions using numeric
+  constraint guards in `let {{ ... }}` blocks.
+
 # 1.5 -- 2026-01-31
 
 This release supports [version

--- a/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
@@ -1335,7 +1335,7 @@ defaultEvalOpts = E.EvalOpts quietLogger E.defaultPPOpts
 -- | Process an `M.ModuleRes` (result of a `MM.ModuleM` computation)
 --   Print errors and warnings.
 --
---   Suppress warnings about defaulting types. 
+--   Suppress warnings about defaulting types.
 --
 moduleCmdResult :: M.ModuleRes a -> IO (a, ME.ModuleEnv)
 moduleCmdResult (res, ws) = do

--- a/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
@@ -92,6 +92,7 @@ import CryptolSAWCore.Cryptol (ImportVisibility(..), CryptolEnv(..))
 import qualified Cryptol.Eval as E
 import qualified Cryptol.Parser as P
 import qualified Cryptol.Parser.AST as P
+import qualified Cryptol.Parser.ExpandPropGuards as P
 import qualified Cryptol.Parser.Position as P
 import qualified Cryptol.TypeCheck as T
 import qualified Cryptol.TypeCheck.AST as T
@@ -1175,8 +1176,13 @@ parseDecls sc env input = do
     -- Eliminate patterns
     (npdecls :: [P.Decl P.PName]) <- MM.interactive (MB.noPat decls)
 
+    -- Expand PropGuards
+    epgDecls <- case P.runExpandPropGuardsM (concat <$> mapM P.expandDecl npdecls) of
+      Left err -> MM.expandPropGuardsError err
+      Right e' -> pure e'
+
     -- Convert from 'Decl' to 'TopDecl' so that types will be generalized
-    let topdecls = [ P.Decl (P.TopLevel P.Public Nothing d) | d <- npdecls ]
+    let topdecls = [ P.Decl (P.TopLevel P.Public Nothing d) | d <- epgDecls ]
 
     -- Resolve names
     (_nenv, rdecls) <- MM.interactive (MB.rename interactiveName (getNamingEnv env) (MR.renameTopDecls interactiveName topdecls))

--- a/intTests/test3199/Test.cry
+++ b/intTests/test3199/Test.cry
@@ -1,0 +1,6 @@
+module Test where
+
+g : {n} [n][8] -> Bit
+g x
+  | n < 2 => reverse x == x
+  | n >= 2 => True

--- a/intTests/test3199/test.saw
+++ b/intTests/test3199/test.saw
@@ -1,0 +1,9 @@
+import "Test.cry";
+
+let
+{{
+f : {n} [n][8] -> Bit
+f x
+  | n < 2 => reverse x == x
+  | n >= 2 => True
+}};

--- a/intTests/test3199/test.sh
+++ b/intTests/test3199/test.sh
@@ -1,0 +1,3 @@
+set -e
+
+$SAW test.saw


### PR DESCRIPTION
`cryptol-saw-core` has multiple code paths for loading Cryptol functions into SAWCore. Two notable ones are:

1. The code path that is used when importing `.cry` files.
2. The code path that is used when loading functions defined inside of `let {{ ... }}` blocks.

The former code path uses the Cryptol API to typecheck a `.cry` file, which ensures that functions using numeric constraint guards (i.e., PropGuards) are expanded properly. (See `Cryptol.Parser.ExpandPropGuards` for an explanantion of what expanding PropGuards is all about.)

The latter code path, on the other hand, was using custom logic for loading Cryptol declarations that did _not_ expand PropGuards. This lead to Cryptol panicking later in the pipeline, as seen in https://github.com/GaloisInc/saw-script/issues/3199. The solution is to fix up this latter code path to behave more like the former and expand PropGuards right before renaming.

Fixes https://github.com/GaloisInc/saw-script/issues/3199.