### PR TITLE
cryptol-saw-core: Fix definition of `tcMod` in `Cryptol.sawcore`.

### DIFF
--- a/cryptol-saw-core/saw/Cryptol.sawcore
+++ b/cryptol-saw-core/saw/Cryptol.sawcore
@@ -135,18 +135,28 @@ tcMul =
                (\ (y:Nat) -> if0Nat Num y (TCNum 0) TCInf)
                TCInf;
 
+-- | The Cryptol type-level division operation (/).
+-- Note that in Cryptol, division is a partial type function,
+-- where x / y requires fin x and y >= 1 as preconditions.
 tcDiv : Num -> Num -> Num;
 tcDiv =
   binaryNumFun (\ (x:Nat) -> \ (y:Nat) -> divNat x y)
+               -- When x is finite, x / inf = 0, since inf*0 + x = x
                (\ (x:Nat) -> TCNum 0)
+               -- When y is finite, inf / y = inf, since y*inf + 0 = inf
                (\ (y:Nat) -> TCInf)
                -- infinity / infinity = 1
                (TCNum 1);
+
+-- | The Cryptol type-level modulus operation (%).
+-- Note that in Cryptol, modulus is a partial type function,
+-- where x % y requires fin x and y >= 1 as preconditions.
 tcMod : Num -> Num -> Num;
 tcMod =
   binaryNumFun (\ (x:Nat) -> \ (y:Nat) -> modNat x y)
-               (\ (x:Nat) -> TCNum 0)
-               -- infinity % y = 0, since y*infinity + 0 = infinity
+               -- When x is finite, x % inf = x, since inf*0 + x = x
+               (\ (x:Nat) -> TCNum x)
+               -- When y is finite, inf % y = 0, since y*inf + 0 = inf
                (\ (y:Nat) -> TCNum 0)
                -- infinity % infinity = 0
                (TCNum 0);

--- a/otherTests/saw-core-rocq/test_cryptol_primitives.log.good
+++ b/otherTests/saw-core-rocq/test_cryptol_primitives.log.good
@@ -83,7 +83,7 @@ Definition tcDiv : forall (_1 : Num), forall (_2 : Num), Num :=
   binaryNumFun (fun (x : Init.Datatypes.nat) (y : Init.Datatypes.nat) => SAWCorePrelude.divNat x y) (fun (x : Init.Datatypes.nat) => TCNum SAWCoreScaffolding.Zero) (fun (y : Init.Datatypes.nat) => TCInf) (TCNum (Stdlib.PArith.BinPos.Pos.to_nat Stdlib.PArith.BinPos.xH)).
 
 Definition tcMod : forall (_1 : Num), forall (_2 : Num), Num :=
-  binaryNumFun (fun (x : Init.Datatypes.nat) (y : Init.Datatypes.nat) => SAWCorePrelude.modNat x y) (fun (x : Init.Datatypes.nat) => TCNum SAWCoreScaffolding.Zero) (fun (y : Init.Datatypes.nat) => TCNum SAWCoreScaffolding.Zero) (TCNum SAWCoreScaffolding.Zero).
+  binaryNumFun (fun (x : Init.Datatypes.nat) (y : Init.Datatypes.nat) => SAWCorePrelude.modNat x y) (fun (x : Init.Datatypes.nat) => TCNum x) (fun (y : Init.Datatypes.nat) => TCNum SAWCoreScaffolding.Zero) (TCNum SAWCoreScaffolding.Zero).
 
 Definition tcExp : forall (_1 : Num), forall (_2 : Num), Num :=
   binaryNumFun SAWCoreScaffolding.expNat (fun (x : Init.Datatypes.nat) => SAWCorePrelude.natCase (fun (_1 : Init.Datatypes.nat) => Num) (TCNum SAWCoreScaffolding.Zero) (fun (x_minus_1 : Init.Datatypes.nat) => SAWCoreScaffolding.if0Nat Num x_minus_1 (TCNum (Stdlib.PArith.BinPos.Pos.to_nat Stdlib.PArith.BinPos.xH)) TCInf) x) (fun (y : Init.Datatypes.nat) => SAWCoreScaffolding.if0Nat Num y (TCNum (Stdlib.PArith.BinPos.Pos.to_nat Stdlib.PArith.BinPos.xH)) TCInf) TCInf.


### PR DESCRIPTION
Fixes #3161.