### PR TITLE
Implement `Bool#rec` and `Nat#rec` as primitives in all SAWCore simulator backends

### DIFF
--- a/intTests/test_recursor_prims/test.saw
+++ b/intTests/test_recursor_prims/test.saw
@@ -1,11 +1,11 @@
 // Test evaluation of Nat#rec and Bool#rec in all simulator backends
 
-let prove_all prop =
+let prove_all onlybits prop =
   do {
     prove_print w4 prop;
     prove_print z3 prop;
-    prove_print abc prop;
-    prove_print rme prop;
+    if onlybits then do {prove_print abc prop; return ();} else return ();
+    if onlybits then do {prove_print rme prop; return ();} else return ();
     prove_print (quickcheck 10) prop;
   };
 
@@ -17,15 +17,20 @@ let prop1 =
 let prop2 =
   parse_core "\\ (x : Vec 8 Bool) -> boolEq (bvNonzero 8 x) (Nat#rec (\\ (_ : Nat) -> Bool) False (\\ (_ : Pos) -> True) (bvToNat 8 x))";
 
-// Bool#rec with concrete argument
+// Nat#rec with symbolic intToNat argument
 let prop3 =
+  parse_core "\\ (x : Integer) -> boolEq (intLt (natToInt 0) x) (Nat#rec (\\ (_ : Nat) -> Bool) False (\\ (_ : Pos) -> True) (intToNat x))";
+
+// Bool#rec with concrete argument
+let prop4 =
   parse_core "bvEq 8 0x02 (bvNat 8 (Bool#rec (\\ (_ : Bool) -> Nat) 2 3 True))";
 
 // Bool#rec with symbolic argument
-let prop4 =
+let prop5 =
   parse_core "\\ (x : Vec 8 Bool) -> bvEq 8 (bvUDiv 8 x 0x80) (Bool#rec (\\ (_ : Bool) -> Vec 8 Bool) 0x01 0x00 (head 7 Bool x))";
 
-prove_all prop1;
-prove_all prop2;
-prove_all prop3;
-prove_all prop4;
+prove_all true prop1;
+prove_all true prop2;
+prove_all false prop3;
+prove_all true prop4;
+prove_all true prop5;

--- a/intTests/test_recursor_prims/test.saw
+++ b/intTests/test_recursor_prims/test.saw
@@ -1,0 +1,31 @@
+// Test evaluation of Nat#rec and Bool#rec in all simulator backends
+
+let prove_all prop =
+  do {
+    prove_print w4 prop;
+    prove_print z3 prop;
+    prove_print abc prop;
+    prove_print rme prop;
+    prove_print (quickcheck 10) prop;
+  };
+
+// Nat#rec with concrete argument
+let prop1 =
+  parse_core "bvEq 8 (bvNat 8 (Nat#rec (\\ (_ : Nat) -> Nat) 2 (\\ (_ : Pos) -> 3) 0)) 0x02";
+
+// Nat#rec with symbolic bvToNat argument
+let prop2 =
+  parse_core "\\ (x : Vec 8 Bool) -> boolEq (bvNonzero 8 x) (Nat#rec (\\ (_ : Nat) -> Bool) False (\\ (_ : Pos) -> True) (bvToNat 8 x))";
+
+// Bool#rec with concrete argument
+let prop3 =
+  parse_core "bvEq 8 0x02 (bvNat 8 (Bool#rec (\\ (_ : Bool) -> Nat) 2 3 True))";
+
+// Bool#rec with symbolic argument
+let prop4 =
+  parse_core "\\ (x : Vec 8 Bool) -> bvEq 8 (bvUDiv 8 x 0x80) (Bool#rec (\\ (_ : Bool) -> Vec 8 Bool) 0x01 0x00 (head 7 Bool x))";
+
+prove_all prop1;
+prove_all prop2;
+prove_all prop3;
+prove_all prop4;

--- a/intTests/test_recursor_prims/test.sh
+++ b/intTests/test_recursor_prims/test.sh
@@ -1,0 +1,1 @@
+$SAW test.saw

--- a/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
+++ b/saw-core-aig/src/SAWCoreAIG/BitBlast.hs
@@ -27,7 +27,7 @@ import qualified Data.Vector as V
 import Numeric.Natural (Natural)
 
 import SAWCore.FiniteValue (FiniteType(..),FirstOrderType(..),toFiniteType)
-import SAWCore.Name (VarName(..))
+import SAWCore.Name (Name(..), VarName(..))
 import SAWCore.Module (ModuleMap)
 import qualified SAWCore.Simulator as Sim
 import SAWCore.Simulator.Value
@@ -279,6 +279,14 @@ beConstMap be =
   , ("Prelude.expByNat", Prims.expByNatOp (prims be))
   ]
 
+-- | Recursor overrides for the SAWCore simulator.
+recursor :: AIG.IsAIG l g => g s -> Name -> sort -> Maybe (BPrim (l s))
+recursor be nm _sort =
+  case nameInfo nm of
+    ModuleIdentifier "Prelude.Bool" -> Just (Prims.boolRecOp (prims be))
+    ModuleIdentifier "Prelude.Nat" -> Just (Prims.natRecOp (prims be))
+    _ -> Nothing
+
 -- | Lifts a strict mux operation to a lazy mux
 lazyMux :: AIG.IsAIG l g => g s -> (l s -> a -> a -> IO a) -> l s -> IO a -> IO a -> IO a
 lazyMux be muxFn c tm fm
@@ -452,7 +460,7 @@ bitBlastBasic be m addlPrims varMap t = do
   cfg <- Sim.evalGlobal m (Map.union (beConstMap be) (addlPrims be))
          (bitBlastVariable varMap)
          (\_ _ -> Nothing)
-         (\_ _ -> Nothing)
+         (recursor be)
          primHandler
          (Prims.lazyMuxValue (prims be))
   Sim.evalSharedTerm cfg t

--- a/saw-core-sbv/src/SAWCoreSBV/SBV.hs
+++ b/saw-core-sbv/src/SAWCoreSBV/SBV.hs
@@ -237,10 +237,10 @@ constMap =
   ]
 
 -- | Recursor overrides for the SAWCore simulator.
-recursor :: Name -> sort -> Maybe (IO SValue)
+recursor :: Name -> sort -> Maybe SPrim
 recursor nm _sort =
   case nameInfo nm of
-    ModuleIdentifier "Prelude.Stream" -> Just (pure streamRecOp)
+    ModuleIdentifier "Prelude.Stream" -> Just streamRecOp
     _ -> Nothing
 
 ------------------------------------------------------------
@@ -567,12 +567,13 @@ lookupSbvExtra (SStream f r) n =
 -- Stream#rec :
 --   (a : sort 0) -> (p : Stream a -> sort 0) ->
 --   ((f : Nat -> a) -> p (MkStream a f)) -> (str : Stream a) -> p str
-streamRecOp :: SValue
+streamRecOp :: SPrim
 streamRecOp =
-  VFun $ \_a -> pure $
-  VFun $ \_p -> pure $
-  vStrictFun $ \f1 -> pure $
-  vStrictFun $ \xs ->
+  Prims.PrimFun $ \_a ->
+  Prims.PrimFun $ \_p ->
+  Prims.PrimStrict $ \f1 ->
+  Prims.PrimStrict $ \xs ->
+  Prims.Prim $
   do let f = vStrictFun $ \ix -> streamGet xs ix
      apply f1 (ready f)
 

--- a/saw-core-sbv/src/SAWCoreSBV/SBV.hs
+++ b/saw-core-sbv/src/SAWCoreSBV/SBV.hs
@@ -241,6 +241,7 @@ recursor :: Name -> sort -> Maybe SPrim
 recursor nm _sort =
   case nameInfo nm of
     ModuleIdentifier "Prelude.Stream" -> Just streamRecOp
+    ModuleIdentifier "Prelude.Bool" -> Just (Prims.boolRecOp prims)
     _ -> Nothing
 
 ------------------------------------------------------------

--- a/saw-core-sbv/src/SAWCoreSBV/SBV.hs
+++ b/saw-core-sbv/src/SAWCoreSBV/SBV.hs
@@ -242,6 +242,7 @@ recursor nm _sort =
   case nameInfo nm of
     ModuleIdentifier "Prelude.Stream" -> Just streamRecOp
     ModuleIdentifier "Prelude.Bool" -> Just (Prims.boolRecOp prims)
+    ModuleIdentifier "Prelude.Nat" -> Just (Prims.natRecOp prims)
     _ -> Nothing
 
 ------------------------------------------------------------

--- a/saw-core-sbv/src/SAWCoreSBV/SBV.hs
+++ b/saw-core-sbv/src/SAWCoreSBV/SBV.hs
@@ -419,7 +419,7 @@ intToNatOp =
       Nothing ->
         let z  = svInteger KUnbounded 0
             i' = svIte (svLessThan i z) z i
-         in VIntToNat (VInt i')
+         in VIntToNat i'
 
 -- primitive natToInt :: Nat -> Integer;
 natToInt :: Natural -> SWord

--- a/saw-core-what4/src/SAWCoreWhat4/What4.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/What4.hs
@@ -271,10 +271,10 @@ constMap sym =
   ]
 
 -- | Recursor overrides for the SAWCore simulator.
-recursor :: Sym sym => sym -> Name -> sort -> Maybe (IO (SValue sym))
+recursor :: Sym sym => sym -> Name -> sort -> Maybe (SPrim sym)
 recursor sym nm _sort =
   case nameInfo nm of
-    ModuleIdentifier "Prelude.Stream" -> Just (pure (streamRecOp sym))
+    ModuleIdentifier "Prelude.Stream" -> Just (streamRecOp sym)
     _ -> Nothing
 
 -----------------------------------------------------------------------
@@ -606,12 +606,13 @@ lookupSStream _ _ = fail "SAWCoreWhat4.What4.lookupSStream: expected Stream"
 -- Stream#rec :
 --   (a : sort 0) -> (p : Stream a -> sort 0) ->
 --   ((f : Nat -> a) -> p (MkStream a f)) -> (str : Stream a) -> p str
-streamRecOp :: Sym sym => sym -> SValue sym
+streamRecOp :: Sym sym => sym -> SPrim sym
 streamRecOp sym =
-  VFun $ \_a -> pure $
-  VFun $ \_p -> pure $
-  vStrictFun $ \f1 -> pure $
-  vStrictFun $ \xs ->
+  Prims.PrimFun $ \_a ->
+  Prims.PrimFun $ \_p ->
+  Prims.PrimStrict $ \f1 ->
+  Prims.PrimStrict $ \xs ->
+  Prims.Prim $
   do let f = vStrictFun $ \ix -> streamGet sym xs ix
      apply f1 (ready f)
 

--- a/saw-core-what4/src/SAWCoreWhat4/What4.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/What4.hs
@@ -348,7 +348,7 @@ intToNatOp sym =
         do z <- W.intLit sym 0
            pneg <- W.intLt sym i z
            i' <- W.intIte sym pneg z i
-           pure (VIntToNat (VInt i'))
+           pure (VIntToNat i')
 
 -- primitive natToInt :: Nat -> Integer;
 natToInt :: forall sym. Sym sym => sym -> Natural -> IO (SymInteger sym)

--- a/saw-core-what4/src/SAWCoreWhat4/What4.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/What4.hs
@@ -275,6 +275,7 @@ recursor :: Sym sym => sym -> Name -> sort -> Maybe (SPrim sym)
 recursor sym nm _sort =
   case nameInfo nm of
     ModuleIdentifier "Prelude.Stream" -> Just (streamRecOp sym)
+    ModuleIdentifier "Prelude.Bool" -> Just (Prims.boolRecOp (prims sym))
     _ -> Nothing
 
 -----------------------------------------------------------------------

--- a/saw-core-what4/src/SAWCoreWhat4/What4.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/What4.hs
@@ -276,6 +276,7 @@ recursor sym nm _sort =
   case nameInfo nm of
     ModuleIdentifier "Prelude.Stream" -> Just (streamRecOp sym)
     ModuleIdentifier "Prelude.Bool" -> Just (Prims.boolRecOp (prims sym))
+    ModuleIdentifier "Prelude.Nat" -> Just (Prims.natRecOp (prims sym))
     _ -> Nothing
 
 -----------------------------------------------------------------------

--- a/saw-core/src/SAWCore/Simulator.hs
+++ b/saw-core/src/SAWCore/Simulator.hs
@@ -318,7 +318,7 @@ reduceRecursor r elim c_args argstruct = go elim c_args (map snd (ctorArgs argst
   Map Ident (PrimIn Id l) ->
   (VarName -> TValueIn Id l -> MValueIn Id l) ->
   (Name -> TValueIn Id l -> Maybe (MValueIn Id l)) ->
-  (Name -> Sort -> Maybe (MValueIn Id l)) ->
+  (Name -> Sort -> Maybe (PrimIn Id l)) ->
   (Name -> Text -> [ThunkIn Id l] -> MValueIn Id l) ->
   (VBool (WithM Id l) -> MValueIn Id l -> MValueIn Id l -> MValueIn Id l) ->
   Id (SimulatorConfigIn Id l) #-}
@@ -328,7 +328,7 @@ reduceRecursor r elim c_args argstruct = go elim c_args (map snd (ctorArgs argst
   Map Ident (PrimIn IO l) ->
   (VarName -> TValueIn IO l -> MValueIn IO l) ->
   (Name -> TValueIn IO l -> Maybe (MValueIn IO l)) ->
-  (Name -> Sort -> Maybe (MValueIn IO l)) ->
+  (Name -> Sort -> Maybe (PrimIn IO l)) ->
   (Name -> Text -> [ThunkIn IO l] -> MValueIn IO l) ->
   (VBool (WithM IO l) -> MValueIn IO l -> MValueIn IO l -> MValueIn IO l) ->
   IO (SimulatorConfigIn IO l) #-}
@@ -342,7 +342,7 @@ evalGlobal ::
   -- | Overrides for Constant terms (e.g. uninterpreted functions)
   (Name -> TValue l -> Maybe (EvalM l (Value l))) ->
   -- | Overrides for Recursor terms
-  (Name -> Sort -> Maybe (EvalM l (Value l))) ->
+  (Name -> Sort -> Maybe (Prims.Prim l)) ->
   -- | Handler for stuck primitives
   (Name -> Text -> [Thunk l] -> MValue l) ->
   -- | Lazy mux operation
@@ -357,7 +357,7 @@ evalGlobal modmap prims variable constant recursor primHandler lazymux =
   Map Ident (PrimIn Id l) ->
   (Term -> VarName -> TValueIn Id l -> MValueIn Id l) ->
   (Name -> TValueIn Id l -> Maybe (MValueIn Id l)) ->
-  (Name -> Sort -> Maybe (MValueIn Id l)) ->
+  (Name -> Sort -> Maybe (PrimIn Id l)) ->
   (Name -> Text -> [ThunkIn Id l] -> MValueIn Id l) ->
   (VBool l -> MValueIn Id l -> MValueIn Id l -> MValueIn Id l) ->
   Id (SimulatorConfigIn Id l) #-}
@@ -367,7 +367,7 @@ evalGlobal modmap prims variable constant recursor primHandler lazymux =
   Map Ident (PrimIn IO l) ->
   (Term -> VarName -> TValueIn IO l -> MValueIn IO l) ->
   (Name -> TValueIn IO l -> Maybe (MValueIn IO l)) ->
-  (Name -> Sort -> Maybe (MValueIn IO l)) ->
+  (Name -> Sort -> Maybe (PrimIn IO l)) ->
   (Name -> Text -> [ThunkIn IO l] -> MValueIn IO l) ->
   (VBool l -> MValueIn IO l -> MValueIn IO l -> MValueIn IO l) ->
   IO (SimulatorConfigIn IO l) #-}
@@ -383,7 +383,7 @@ evalGlobal' ::
   -- | Overrides for Constant terms (e.g. uninterpreted functions)
   (Name -> TValue l -> Maybe (MValue l)) ->
   -- | Overrides for Recursor terms
-  (Name -> Sort -> Maybe (MValue l)) ->
+  (Name -> Sort -> Maybe (Prims.Prim l)) ->
   -- | Handler for stuck primitives
   (Name -> Text -> [Thunk l] -> MValue l) ->
   -- | Lazy mux operation
@@ -391,7 +391,7 @@ evalGlobal' ::
   EvalM l (SimulatorConfig l)
 evalGlobal' modmap prims variable constant recursor primHandler lazymux =
   do checkPrimitives modmap prims
-     return (SimulatorConfig primitive variable constant' recursor modmap lazymux)
+     return (SimulatorConfig primitive variable constant' recursor' modmap lazymux)
   where
     constant' :: Name -> TValue l -> Maybe (MValue l)
     constant' nm tv =
@@ -412,6 +412,9 @@ evalGlobal' modmap prims variable constant recursor primHandler lazymux =
           case Map.lookup ident prims of
             Just v  -> evalPrim (primHandler nm) v
             Nothing -> panic "evalGlobal'" ["Unimplemented global: " <> identText ident]
+
+    recursor' :: Name -> Sort -> Maybe (MValue l)
+    recursor' nm s = evalPrim (primHandler nm) <$> recursor nm s
 
 -- | Check that all the primitives declared in the given module
 --   are implemented, and that terms with implementations are not

--- a/saw-core/src/SAWCore/Simulator/Concrete.hs
+++ b/saw-core/src/SAWCore/Simulator/Concrete.hs
@@ -341,7 +341,7 @@ streamGet :: IntTrie CValue -> CValue -> CValue
 streamGet xs ix =
   case ix of
     VNat n -> IntTrie.apply xs (toInteger n)
-    VIntToNat (VInt i) -> IntTrie.apply xs i
+    VIntToNat i -> IntTrie.apply xs i
     VBVToNat _ w -> IntTrie.apply xs (unsigned (toWord w))
     n -> panic "streamGet" ["Expected Nat value; found " <> Text.pack (show n)]
 

--- a/saw-core/src/SAWCore/Simulator/Concrete.hs
+++ b/saw-core/src/SAWCore/Simulator/Concrete.hs
@@ -60,6 +60,7 @@ evalSharedTerm m addlPrims varVals t =
     recursor nm _sort =
       case nameInfo nm of
         ModuleIdentifier "Prelude.Stream" -> Just streamRecOp
+        ModuleIdentifier "Prelude.Bool" -> Just (Prims.boolRecOp prims)
         _ -> Nothing
     primHandler nm msg env =
       return $ Prim.userError $ unlines

--- a/saw-core/src/SAWCore/Simulator/Concrete.hs
+++ b/saw-core/src/SAWCore/Simulator/Concrete.hs
@@ -59,7 +59,7 @@ evalSharedTerm m addlPrims varVals t =
         Nothing -> return $ Prim.userError $ "Unimplemented: free variable " ++ show (vnName vn)
     recursor nm _sort =
       case nameInfo nm of
-        ModuleIdentifier "Prelude.Stream" -> Just (pure streamRecOp)
+        ModuleIdentifier "Prelude.Stream" -> Just streamRecOp
         _ -> Nothing
     primHandler nm msg env =
       return $ Prim.userError $ unlines
@@ -346,11 +346,12 @@ streamGet xs ix =
 -- Stream#rec :
 --   (a : sort 0) -> (p : Stream a -> sort 0) ->
 --   ((f : Nat -> a) -> p (MkStream a f)) -> (str : Stream a) -> p str
-streamRecOp :: CValue
+streamRecOp :: CPrim
 streamRecOp =
-  VFun $ \_a -> pure $
-  VFun $ \_p -> pure $
-  vStrictFun $ \f1 -> pure $
-  vStrictFun $ \xs ->
+  Prims.PrimFun $ \_a ->
+  Prims.PrimFun $ \_p ->
+  Prims.PrimStrict $ \f1 ->
+  Prims.PrimStrict $ \xs ->
+  Prims.Prim $
   do let f = vStrictFun $ \ix -> pure (streamGet (toStream xs) ix)
      apply f1 (ready f)

--- a/saw-core/src/SAWCore/Simulator/Concrete.hs
+++ b/saw-core/src/SAWCore/Simulator/Concrete.hs
@@ -61,6 +61,7 @@ evalSharedTerm m addlPrims varVals t =
       case nameInfo nm of
         ModuleIdentifier "Prelude.Stream" -> Just streamRecOp
         ModuleIdentifier "Prelude.Bool" -> Just (Prims.boolRecOp prims)
+        ModuleIdentifier "Prelude.Nat" -> Just (Prims.natRecOp prims)
         _ -> Nothing
     primHandler nm msg env =
       return $ Prim.userError $ unlines

--- a/saw-core/src/SAWCore/Simulator/Prims.hs
+++ b/saw-core/src/SAWCore/Simulator/Prims.hs
@@ -46,7 +46,9 @@ module SAWCore.Simulator.Prims
   , lazyMuxValue
   , muxValue
   , shifter
+  -- * Primitive recursors
   , boolRecOp
+  , natRecOp
   ) where
 
 import Prelude hiding (sequence, mapM)
@@ -332,7 +334,7 @@ constMap bp = Map.fromList
   , ("Prelude.expNat", expNatOp)
   , ("Prelude.widthNat", widthNatOp)
   , ("Prelude.natCase", natCaseOp)
-  , ("Prelude.Nat__rec", natRecOp)
+  , ("Prelude.Nat__rec", nat__RecOp)
   , ("Prelude.equalNat", equalNatOp bp)
   , ("Prelude.ltNat", ltNatOp bp)
   -- Integers
@@ -761,8 +763,8 @@ natCaseOp =
 --   (p Zero) ->
 --   ((n : Nat) -> p n -> p (Succ n)) ->
 --   (n : Nat) -> p n;
-natRecOp :: (VMonadLazy l, Show (Extra l)) => Prim l
-natRecOp =
+nat__RecOp :: (VMonadLazy l, Show (Extra l)) => Prim l
+nat__RecOp =
   constFun $
   primFun $ \z ->
   primFun $ \s ->
@@ -773,6 +775,26 @@ natRecOp =
                 r <- delay (loop (n - 1))
                 applyAll s' [ready (VNat (n - 1)), r]
   in natFun $ \n -> Prim (loop n)
+
+-- Nat#rec :
+--   (p : (Nat -> sort 0)) ->
+--   p 0 ->
+--   ((x : Pos) -> p (NatPos x)) ->
+--   (n : Nat) -> p n
+natRecOp :: (VMonadLazy l, Show (Extra l)) => BasePrims l -> Prim l
+natRecOp bp =
+  constFun $
+  primFun $ \f1 ->
+  strictFun $ \f2 ->
+  unaryNatOp bp id
+  (\n -> if n == 0 then force f1 else apply f2 (ready (VNat n)))
+  (\w x -> -- w :: Int, x :: VWord l, result :: MValue l
+     do z <- bpBvLit bp w 0
+        isZero <- bpBvEq bp x z
+        let m1 = force f1
+        let m2 = apply f2 (ready (VWord x))
+        lazyMuxValue bp isZero m1 m2
+  )
 
 --------------------------------------------------------------------------------
 -- Strings

--- a/saw-core/src/SAWCore/Simulator/Prims.hs
+++ b/saw-core/src/SAWCore/Simulator/Prims.hs
@@ -17,36 +17,36 @@ Portability : non-portable (language extensions)
 -}
 
 module SAWCore.Simulator.Prims
-( Prim(..)
-, BasePrims(..)
-, constMap
-  -- * primitive function constructors
-, primFun
-, strictFun
-, constFun
-, boolFun
-, natFun
-, intFun
-, intModFun
-, tvalFun
-, stringFun
-, wordFun
-, vectorFun
-, Pack
-, Unpack
+  ( Prim(..)
+  , BasePrims(..)
+  , constMap
+    -- * primitive function constructors
+  , primFun
+  , strictFun
+  , constFun
+  , boolFun
+  , natFun
+  , intFun
+  , intModFun
+  , tvalFun
+  , stringFun
+  , wordFun
+  , vectorFun
+  , Pack
+  , Unpack
 
   -- * primitive computations
-, selectV
-, expByNatOp
-, intToNatOp
-, vRotateL
-, vRotateR
-, vShiftL
-, vShiftR
-, lazyMuxValue
-, muxValue
-, shifter
-) where
+  , selectV
+  , expByNatOp
+  , intToNatOp
+  , vRotateL
+  , vRotateR
+  , vShiftL
+  , vShiftR
+  , lazyMuxValue
+  , muxValue
+  , shifter
+  ) where
 
 import Prelude hiding (sequence, mapM)
 

--- a/saw-core/src/SAWCore/Simulator/Prims.hs
+++ b/saw-core/src/SAWCore/Simulator/Prims.hs
@@ -46,6 +46,7 @@ module SAWCore.Simulator.Prims
   , lazyMuxValue
   , muxValue
   , shifter
+  , boolRecOp
   ) where
 
 import Prelude hiding (sequence, mapM)
@@ -397,9 +398,6 @@ constMap bp = Map.fromList
   , ("Prelude.bytesToString", bytesToStringOp bp)
   , ("Prelude.equalString", equalStringOp bp)
 
-  -- Overloaded
-  , ("Prelude.ite", iteOp bp)
-  , ("Prelude.iteDep", iteDepOp bp)
   -- SMT Arrays
   , ("Prelude.Array", arrayTypeOp)
   , ("Prelude.arrayConstant", arrayConstantOp bp)
@@ -1457,31 +1455,21 @@ errorOp =
 ------------------------------------------------------------
 -- Conditionals
 
-iteDepOp :: (HasCallStack, VMonadLazy l, Show (Extra l)) => BasePrims l -> Prim l
-iteDepOp bp =
+boolRecOp :: (HasCallStack, VMonadLazy l, Show (Extra l)) => BasePrims l -> Prim l
+boolRecOp bp =
   primFun $ \_p ->
+  primFun $ \f1 ->
+  primFun $ \f2 ->
   boolFun $ \b ->
-  primFun $ \x ->
-  primFun $ \y ->
   PrimExcept $
     case bpAsBool bp b of
-      Just True  -> lift (force x)
-      Just False -> lift (force y)
-      Nothing    -> throwE "unsupported symbolic operation: iteDep"
-
-iteOp :: (HasCallStack, VMonadLazy l, Show (Extra l)) => BasePrims l -> Prim l
-iteOp bp =
-  tvalFun $ \_tp ->
-  boolFun $ \b ->
-  primFun $ \x ->
-  primFun $ \y ->
-  PrimExcept $
-    case bpAsBool bp b of
-      Just True  -> lift (force x)
-      Just False -> lift (force y)
+      Just True  -> lift (force f1)
+      Just False -> lift (force f2)
       Nothing
-        | bpIsSymbolicEvaluator bp -> lift (lazyMuxValue bp b (force x) (force y))
-        | otherwise -> throwE "iteOp"
+        | bpIsSymbolicEvaluator bp ->
+            lift (lazyMuxValue bp b (force f1) (force f2))
+        | otherwise ->
+            throwE "SAWCore.Simulator.Prims.boolRecOp: unsupported symbolic operation"
 
 lazyMuxValue ::
   (HasCallStack, VMonadLazy l, Show (Extra l)) =>

--- a/saw-core/src/SAWCore/Simulator/Prims.hs
+++ b/saw-core/src/SAWCore/Simulator/Prims.hs
@@ -778,8 +778,8 @@ nat__RecOp =
 
 -- Nat#rec :
 --   (p : (Nat -> sort 0)) ->
---   p 0 ->
---   ((x : Pos) -> p (NatPos x)) ->
+--   (f1 : p 0) ->
+--   (f2 : (x : Pos) -> p (NatPos x)) ->
 --   (n : Nat) -> p n
 natRecOp :: (VMonadLazy l, Show (Extra l)) => BasePrims l -> Prim l
 natRecOp bp =
@@ -1477,6 +1477,11 @@ errorOp =
 ------------------------------------------------------------
 -- Conditionals
 
+-- Bool#rec :
+--   (p : (Bool -> sort 0)) ->
+--   (f1 : p True) ->
+--   (f2 : p False) ->
+--   (b : Bool) -> p b
 boolRecOp :: (HasCallStack, VMonadLazy l, Show (Extra l)) => BasePrims l -> Prim l
 boolRecOp bp =
   primFun $ \_p ->

--- a/saw-core/src/SAWCore/Simulator/Prims.hs
+++ b/saw-core/src/SAWCore/Simulator/Prims.hs
@@ -786,15 +786,23 @@ natRecOp bp =
   constFun $
   primFun $ \f1 ->
   strictFun $ \f2 ->
-  unaryNatOp bp id
-  (\n -> if n == 0 then force f1 else apply f2 (ready (VNat n)))
-  (\w x -> -- w :: Int, x :: VWord l, result :: MValue l
-     do z <- bpBvLit bp w 0
-        isZero <- bpBvEq bp x z
-        let m1 = force f1
-        let m2 = apply f2 (ready (VWord x))
-        lazyMuxValue bp isZero m1 m2
-  )
+  strictFun $ \v ->
+  Prim $
+  do let m1 = force f1
+     let m2 = apply f2 (ready v)
+     case v of
+       VNat n -> if n == 0 then m1 else m2
+       VIntToNat (VInt i) ->
+         do z <- bpNatToInt bp 0
+            isZero <- bpIntEq bp z i
+            lazyMuxValue bp isZero m1 m2
+       VBVToNat w v' ->
+         do x <- toWord (bpPack bp) v'
+            z <- bpBvLit bp w 0
+            isZero <- bpBvEq bp x z
+            lazyMuxValue bp isZero m1 m2
+       _ ->
+         panic "natRecOp" ["Expected Nat: " <> Text.pack (show v)]
 
 --------------------------------------------------------------------------------
 -- Strings

--- a/saw-core/src/SAWCore/Simulator/Prims.hs
+++ b/saw-core/src/SAWCore/Simulator/Prims.hs
@@ -792,7 +792,7 @@ natRecOp bp =
      let m2 = apply f2 (ready v)
      case v of
        VNat n -> if n == 0 then m1 else m2
-       VIntToNat (VInt i) ->
+       VIntToNat i ->
          do z <- bpNatToInt bp 0
             isZero <- bpIntEq bp z i
             lazyMuxValue bp isZero m1 m2

--- a/saw-core/src/SAWCore/Simulator/RME.hs
+++ b/saw-core/src/SAWCore/Simulator/RME.hs
@@ -265,10 +265,10 @@ constMap =
   ]
 
 -- | Recursor overrides for the SAWCore simulator.
-recursor :: Name -> sort -> Maybe (Identity RValue)
+recursor :: Name -> sort -> Maybe RPrim
 recursor nm _sort =
   case nameInfo nm of
-    ModuleIdentifier "Prelude.Stream" -> Just (pure streamRecOp)
+    ModuleIdentifier "Prelude.Stream" -> Just streamRecOp
     _ -> Nothing
 
 -- primitive bvToInt : (n : Nat) -> Vec n Bool -> Integer;
@@ -386,12 +386,13 @@ streamGet xs ix =
 -- Stream#rec :
 --   (a : sort 0) -> (p : Stream a -> sort 0) ->
 --   ((f : Nat -> a) -> p (MkStream a f)) -> (str : Stream a) -> p str
-streamRecOp :: RValue
+streamRecOp :: RPrim
 streamRecOp =
-  VFun $ \_a -> pure $
-  VFun $ \_p -> pure $
-  vStrictFun $ \f1 -> pure $
-  vStrictFun $ \xs ->
+  Prims.PrimFun $ \_a ->
+  Prims.PrimFun $ \_p ->
+  Prims.PrimStrict $ \f1 ->
+  Prims.PrimStrict $ \xs ->
+  Prims.Prim $
   do let f = vStrictFun $ \ix -> streamGet xs ix
      apply f1 (ready f)
 

--- a/saw-core/src/SAWCore/Simulator/RME.hs
+++ b/saw-core/src/SAWCore/Simulator/RME.hs
@@ -270,6 +270,7 @@ recursor nm _sort =
   case nameInfo nm of
     ModuleIdentifier "Prelude.Stream" -> Just streamRecOp
     ModuleIdentifier "Prelude.Bool" -> Just (Prims.boolRecOp prims)
+    ModuleIdentifier "Prelude.Nat" -> Just (Prims.natRecOp prims)
     _ -> Nothing
 
 -- primitive bvToInt : (n : Nat) -> Vec n Bool -> Integer;

--- a/saw-core/src/SAWCore/Simulator/RME.hs
+++ b/saw-core/src/SAWCore/Simulator/RME.hs
@@ -269,6 +269,7 @@ recursor :: Name -> sort -> Maybe RPrim
 recursor nm _sort =
   case nameInfo nm of
     ModuleIdentifier "Prelude.Stream" -> Just streamRecOp
+    ModuleIdentifier "Prelude.Bool" -> Just (Prims.boolRecOp prims)
     _ -> Nothing
 
 -- primitive bvToInt : (n : Nat) -> Vec n Bool -> Integer;

--- a/saw-core/src/SAWCore/Simulator/Value.hs
+++ b/saw-core/src/SAWCore/Simulator/Value.hs
@@ -114,7 +114,7 @@ data Value l
     -- are always represented with 'VBool'.
   | VWord (VWord l)
   | VBVToNat !Int (Value l) -- TODO: don't use @Int@ for this, use @Natural@
-  | VIntToNat (Value l)
+  | VIntToNat (VInt l)
   | VNat !Natural
     -- ^ While SAWCore types @Nat@ and @Pos@ are data types, values of
     -- those types are never represented as 'VCtorApp' or 'VCtorMux';
@@ -219,7 +219,7 @@ instance Show (Extra l) => Show (Value l) where
       VBool _        -> showString "<<boolean>>"
       VWord _        -> showString "<<bitvector>>"
       VBVToNat n x   -> showString "bvToNat " . shows n . showString " " . showParen True (shows x)
-      VIntToNat x    -> showString "intToNat " . showParen True (shows x)
+      VIntToNat _    -> showString "<<intToNat>>"
       VNat n         -> shows n
       VInt _         -> showString "<<integer>>"
       VIntMod n _    -> showString ("<<Z " ++ show n ++ ">>")


### PR DESCRIPTION
Module `SAWCore.Simulator.Prims` now exports primitives `boolRecOp` and `natRecOp`, which are used to implement the recursors for the `Bool` and `Nat` types in all of the SAWCore simulator backends (Concrete, RME, What4 and SBV).

Fixes #3063.