### PR TITLE
detect "import submodule" and give proper errors

### DIFF
--- a/crux-mir-comp/src/Mir/Cryptol.hs
+++ b/crux-mir-comp/src/Mir/Cryptol.hs
@@ -241,7 +241,7 @@ loadCryptolFunc col sig modulePath name = do
     let ?fileReader = BS.readFile
     ce <- liftIO (readIORef (mirCryEnv mirState))
     let modName = Cry.textToModName modulePath
-    ce' <- liftIO $ SAW.importCryptolModule sc ce (Right modName) Nothing SAW.PublicAndPrivate Nothing
+    ce' <- liftIO $ SAW.importCryptolModule sc ce (Right modName) Nothing False SAW.PublicAndPrivate Nothing
     liftIO (writeIORef (mirCryEnv mirState) ce')
     -- (m, _ce') <- liftIO $ SAW.loadCryptolModule sc ce (Text.unpack modulePath)
     -- tt <- liftIO $ SAW.extractDefFromCryptolModule m (Text.unpack name)

--- a/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/Cryptol.hs
@@ -322,19 +322,19 @@ data ImportVisibility
 -- avoided; that isn't super clear.
 --
 data CryptolEnv = CryptolEnv
-  { eImports    :: [(ImportVisibility, C.Import)]
-  , eModuleEnv  :: ME.ModuleEnv
+  { eImports     :: [(ImportVisibility, C.Import)]
+  , eModuleEnv   :: ME.ModuleEnv
   , eExtraNaming :: MR.NamingEnv
-  , eExtraVars  :: Map C.Name C.Schema
+  , eExtraVars   :: Map C.Name C.Schema
   , eExtraTySyns :: Map C.Name C.TySyn
-  , eAllVars    :: Map C.Name C.Schema
-  , eTyVars     :: Map Int Term
-  , eTyProps    :: Map C.Prop (Term, [FieldName])
-  , eAllTerms   :: Map C.Name Term
-  , eRefPrims   :: Map C.PrimIdent C.Expr
-  , ePrims      :: Map C.PrimIdent Term
-  , ePrimTypes  :: Map C.PrimIdent Term
-  , eFFITypes   :: Map NameInfo C.FFI
+  , eAllVars     :: Map C.Name C.Schema
+  , eTyVars      :: Map Int Term
+  , eTyProps     :: Map C.Prop (Term, [FieldName])
+  , eAllTerms    :: Map C.Name Term
+  , eRefPrims    :: Map C.PrimIdent C.Expr
+  , ePrims       :: Map C.PrimIdent Term
+  , ePrimTypes   :: Map C.PrimIdent Term
+  , eFFITypes    :: Map NameInfo C.FFI
   }
 
 

--- a/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
@@ -6,7 +6,7 @@ Maintainer  : huffman
 Stability   : provisional
 
 This module contains (most of) the code for managing the Cryptol
-environment and also some of logic for importing into SAWCore.
+environment and also some of the logic for importing into SAWCore.
 
 FUTURE: This module and "Cryptol" should be merged together, shaken
 up, and then maybe or maybe not split apart again following some kind
@@ -126,7 +126,7 @@ import qualified CryptolSAWCore.Pretty as CryPP
 --import SAWScript.REPL.Monad (REPLException(..))
 import CryptolSAWCore.TypedTerm
 import Cryptol.ModuleSystem.Env (ModContextParams(NoParams))
--- import SAWCentral.AST (Located(getVal, locatedPos), Import(..))
+
 
 ---- Key Types -----------------------------------------------------------------
 
@@ -249,18 +249,18 @@ initCryptolEnv sc = do
             , mkImport OnlyPublic preludeReferenceName' (Just preludeReferenceName) Nothing
             , mkImport OnlyPublic arrayName'            Nothing Nothing
             ]
-        , eModuleEnv  = modEnv3
+        , eModuleEnv   = modEnv3
         , eExtraNaming = mempty
-        , eExtraVars  = Map.empty
+        , eExtraVars   = Map.empty
         , eExtraTySyns = Map.empty
-        , eAllVars    = Map.empty
-        , eTyVars     = Map.empty
-        , eTyProps    = Map.empty
-        , eAllTerms   = Map.empty
-        , eRefPrims   = refPrims
-        , ePrims      = Map.empty
-        , ePrimTypes  = Map.empty
-        , eFFITypes   = Map.empty
+        , eAllVars     = Map.empty
+        , eTyVars      = Map.empty
+        , eTyProps     = Map.empty
+        , eAllTerms    = Map.empty
+        , eRefPrims    = refPrims
+        , ePrims       = Map.empty
+        , ePrimTypes   = Map.empty
+        , eFFITypes    = Map.empty
         }
 
   -- Generate SAWCore translations for all values in scope
@@ -421,12 +421,12 @@ computeNamingEnv lm vis =
         -- definitions at the top module:
         (MI.ifsDefines $ MI.ifNames $ ME.lmInterface lm)
 
-
     nmsPublic :: Set MN.Name
     nmsPublic = MI.ifsPublic $ MI.ifNames $ ME.lmInterface lm
 
     nmsPrivate :: Set MN.Name
     nmsPrivate = nmsDefined Set.\\ nmsTopLevels
+
 
 -- | Like Cryptol's 'ME.loadedNominalTypes', except that it only returns
 -- nominal types from non-parameterized modules, which are currently the only
@@ -436,6 +436,7 @@ loadedNonParamNominalTypes menv =
   Map.unions $
     map (MI.ifNominalTypes . MI.ifDefines . ME.lmInterface)
         (ME.lmLoadedModules (ME.meLoadedModules menv))
+
 
 -- Typecheck -------------------------------------------------------------------
 
@@ -499,8 +500,8 @@ data ExtCryptolModule =
 -- | Create the print string for an `ExtCryptolModule`, as used e.g.
 --   by the REPL or by the SAWScript @print@ function.
 --
---  - FIXME: This function, with the ECM_LoadedModule constructor, are
---      a bit ad hoc!  Currently `ExtCryptolModule` is exposed to the
+--  - FIXME: This function, with the ECM_LoadedModule constructor, is
+--      quite ad hoc!  Currently `ExtCryptolModule` is exposed to the
 --      CLI *and* requires a way to show this type to the user (as
 --      implemented here) to support the user interface.  As the state
 --      isn't available when we want to display this value, we compute
@@ -780,6 +781,7 @@ extractDefFromExtCryptolModule sc env_0 ecm name =
         -- unnecessary after addressing Issue #2645 (turning
         -- cryptol_prims into a built-in Cryptol module).
 
+
 ---- Core functions for loading and Translating Modules ------------------------
 
 -- | Load a Cryptol module and translate its contents to SAWCore.
@@ -913,7 +915,7 @@ mkImport :: ImportVisibility
          -> Maybe T.ImportSpec
          -> (ImportVisibility, T.Import)
 mkImport vis nm as imps =
-    let im = P.Import { T.iModule = nm
+    let im = T.Import { T.iModule = nm
                       , T.iAs     = as
                       , T.iSpec   = imps
                       , T.iInst   = Nothing
@@ -921,6 +923,7 @@ mkImport vis nm as imps =
                       }
     in
     (vis, im)
+
 
 ---- Binding -------------------------------------------------------------------
 

--- a/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
@@ -58,38 +58,37 @@ module CryptolSAWCore.CryptolEnv
   )
   where
 
-import Data.ByteString (ByteString)
-import qualified Data.Text as Text
-import Data.Map (Map)
+-- base modules:
+import           Control.Monad(when)
+import           Data.ByteString (ByteString)
 import qualified Data.Map as Map
-import Data.Set (Set)
+import           Data.Map (Map)
+import           Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
-import Data.Maybe (fromMaybe)
-import Data.Text (Text, pack, splitOn)
-import Control.Monad(when)
-import GHC.Stack
+import           Data.Set (Set)
+import qualified Data.Text as Text
+import           Data.Text (Text, pack, splitOn)
+import           GHC.Stack
+import           System.Environment (lookupEnv)
+import           System.Environment.Executable (splitExecutablePath)
+import           System.FilePath ((</>), normalise, joinPath, splitPath, splitSearchPath)
 
-import System.Environment (lookupEnv)
-import System.Environment.Executable (splitExecutablePath)
-import System.FilePath ((</>), normalise, joinPath, splitPath, splitSearchPath)
-
+-- pretty-printer pkg:
 import qualified Prettyprinter as PP
-import Prettyprinter ((<+>))
+import           Prettyprinter ((<+>))
 
-import SAWSupport.Console
-import qualified SAWSupport.Pretty as PPS
-
-import CryptolSAWCore.Panic
-import SAWCore.Name (nameInfo)
-import SAWCore.Recognizer (asConstant)
-import SAWCore.SharedTerm (NameInfo, SharedContext, Term, ppTerm)
-
-import qualified CryptolSAWCore.Cryptol as C
--- These used to live in this file, so import them unqualified for now.
--- XXX: tidy up
-import CryptolSAWCore.Cryptol (ImportVisibility(..), CryptolEnv(..))
-
+-- cryptol pkg:
 import qualified Cryptol.Eval as E
+import qualified Cryptol.ModuleSystem as M
+import qualified Cryptol.ModuleSystem.Base as MB
+import qualified Cryptol.ModuleSystem.Env as ME
+import           Cryptol.ModuleSystem.Env (ModContextParams(NoParams))
+import qualified Cryptol.ModuleSystem.Exports as MEx
+import qualified Cryptol.ModuleSystem.Interface as MI
+import qualified Cryptol.ModuleSystem.Monad as MM
+import qualified Cryptol.ModuleSystem.Name      as MN
+import qualified Cryptol.ModuleSystem.NamingEnv as MN
+import qualified Cryptol.ModuleSystem.Renamer as MR
 import qualified Cryptol.Parser as P
 import qualified Cryptol.Parser.AST as P
 import qualified Cryptol.Parser.ExpandPropGuards as P
@@ -98,34 +97,34 @@ import qualified Cryptol.TypeCheck as T
 import qualified Cryptol.TypeCheck.AST as T
 import qualified Cryptol.TypeCheck.Error as TE
 import qualified Cryptol.TypeCheck.Infer as TI
+import qualified Cryptol.TypeCheck.Interface as TIface
 import qualified Cryptol.TypeCheck.Kind as TK
 import qualified Cryptol.TypeCheck.Monad as TM
-import qualified Cryptol.TypeCheck.Interface as TIface
 import qualified Cryptol.TypeCheck.Solver.SMT as SMT
---import qualified Cryptol.TypeCheck.PP as TP
-
-import qualified Cryptol.ModuleSystem as M
-import qualified Cryptol.ModuleSystem.Base as MB
-import qualified Cryptol.ModuleSystem.Env as ME
-import qualified Cryptol.ModuleSystem.Exports as MEx
-import qualified Cryptol.ModuleSystem.Interface as MI
-import qualified Cryptol.ModuleSystem.Monad as MM
-import qualified Cryptol.ModuleSystem.NamingEnv as MN
-import qualified Cryptol.ModuleSystem.Name as MN
-import qualified Cryptol.ModuleSystem.Renamer as MR
-
 import qualified Cryptol.Utils.Ident as C
-
-import Cryptol.Utils.Ident (Ident, preludeName, arrayName, preludeReferenceName
+import           Cryptol.Utils.Ident
+                           ( Ident, preludeName, arrayName, preludeReferenceName
                            , mkIdent, interactiveName, identText
                            , textToModName
                            , prelPrim)
-import Cryptol.Utils.Logger (quietLogger)
+import           Cryptol.Utils.Logger (quietLogger)
 
+-- local:
+import           CryptolSAWCore.Panic
 import qualified CryptolSAWCore.Pretty as CryPP
---import SAWScript.REPL.Monad (REPLException(..))
-import CryptolSAWCore.TypedTerm
-import Cryptol.ModuleSystem.Env (ModContextParams(NoParams))
+import           CryptolSAWCore.TypedTerm
+
+import           SAWCore.Name (nameInfo)
+import           SAWCore.Recognizer (asConstant)
+import           SAWCore.SharedTerm (NameInfo, SharedContext, Term, ppTerm)
+
+import           SAWSupport.Console
+import qualified SAWSupport.Pretty as PPS
+
+import qualified CryptolSAWCore.Cryptol as C
+import           CryptolSAWCore.Cryptol (ImportVisibility(..), CryptolEnv(..))
+                 -- These used to live in this file, so import them unqualified for now.
+                 -- XXX: tidy up
 
 
 ---- Key Types -----------------------------------------------------------------
@@ -787,9 +786,9 @@ extractDefFromExtCryptolModule sc env_0 ecm name =
 -- | Load a Cryptol module and translate its contents to SAWCore.
 --
 -- There are three paths here:
---    - `importCryptolModule`, which is the back end for SAWScript @import@
+--    - `importCryptolModule`,  which is the back end for SAWScript @import@
 --    - `loadExtCryptolModule`, which is the back end for SAWScript @cryptol_load@
---    - `loadCryptolModule`, which is used for Rocq export and from crux-mir-comp
+--    - `loadCryptolModule`,    which is used for Rocq export and from crux-mir-comp
 --
 -- These can probably be unified.
 --
@@ -892,7 +891,7 @@ updateFFITypes sc m allTerms' eFFITypes' = do
 --  - the module can be qualified or not (per @as@ argument).
 --  - per @vis@ we can import public definitions or *all* (i.e., internal
 --    and public) definitions.
-
+-- 
 importCryptolModule ::
   (?fileReader :: FilePath -> IO ByteString) =>
   SharedContext             {- ^ Shared context for creating terms -} ->

--- a/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
@@ -898,14 +898,16 @@ importCryptolModule ::
   CryptolEnv                {- ^ Extend this environment -} ->
   Either FilePath P.ModName {- ^ Where to find the module -} ->
   Maybe P.ModName           {- ^ Name qualifier -} ->
+  Bool                      {- ^ isSubmodule: True if 'import submodule ...' -} ->
   ImportVisibility          {- ^ What visibility to give symbols from this module -} ->
   Maybe P.ImportSpec        {- ^ What to import -} ->
   IO CryptolEnv
-importCryptolModule sc env src as vis imps =
+importCryptolModule sc env src as _isSubM vis imps =
   do
   (mod', env') <- loadAndTranslateModule sc env src
   let import' = mkImport vis (locatedUnknown (T.mName mod')) as imps
   return $ env' {eImports = import' : eImports env }
+
 
 -- | Create an entry for the `eImports` list in `CryptolEnv`.
 mkImport :: ImportVisibility

--- a/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
@@ -902,11 +902,19 @@ importCryptolModule ::
   ImportVisibility          {- ^ What visibility to give symbols from this module -} ->
   Maybe P.ImportSpec        {- ^ What to import -} ->
   IO CryptolEnv
-importCryptolModule sc env src as _isSubM vis imps =
+importCryptolModule sc env src as False vis imps =
+  -- importing full module:
   do
   (mod', env') <- loadAndTranslateModule sc env src
   let import' = mkImport vis (locatedUnknown (T.mName mod')) as imps
   return $ env' {eImports = import' : eImports env }
+importCryptolModule _sc _env (Right __nm) _as True _vis _imps =
+  -- importing submodule by name:
+  fail $ "`import submodule` is unsupported."
+importCryptolModule _sc _env (Left _)  _as True _vis _imps =
+  -- importing submodule by FilePath: disallowed:
+  fail $ "`import submodule PATHNAME` is not allowed."
+     -- this allowed by parser?
 
 
 -- | Create an entry for the `eImports` list in `CryptolEnv`.

--- a/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
@@ -916,7 +916,6 @@ importCryptolModule _sc _env (Left _)  _as True _vis _imps =
   fail $ "`import submodule PATHNAME` is not allowed."
      -- this allowed by parser?
 
-
 -- | Create an entry for the `eImports` list in `CryptolEnv`.
 mkImport :: ImportVisibility
          -> P.Located C.ModName

--- a/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
@@ -110,21 +110,19 @@ import           Cryptol.Utils.Ident
 import           Cryptol.Utils.Logger (quietLogger)
 
 -- local:
+import qualified CryptolSAWCore.Cryptol as C
+import           CryptolSAWCore.Cryptol (ImportVisibility(..), CryptolEnv(..))
+                 -- These used to live in this file, so import them
+                 -- unqualified for now.
+                 -- XXX: tidy up
 import           CryptolSAWCore.Panic
 import qualified CryptolSAWCore.Pretty as CryPP
 import           CryptolSAWCore.TypedTerm
-
 import           SAWCore.Name (nameInfo)
 import           SAWCore.Recognizer (asConstant)
 import           SAWCore.SharedTerm (NameInfo, SharedContext, Term, ppTerm)
-
 import           SAWSupport.Console
 import qualified SAWSupport.Pretty as PPS
-
-import qualified CryptolSAWCore.Cryptol as C
-import           CryptolSAWCore.Cryptol (ImportVisibility(..), CryptolEnv(..))
-                 -- These used to live in this file, so import them unqualified for now.
-                 -- XXX: tidy up
 
 
 ---- Key Types -----------------------------------------------------------------

--- a/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/CryptolEnv.hs
@@ -58,7 +58,7 @@ module CryptolSAWCore.CryptolEnv
   )
   where
 
--- base modules:
+-- base & standard modules:
 import           Control.Monad(when)
 import           Data.ByteString (ByteString)
 import qualified Data.Map as Map
@@ -397,7 +397,7 @@ computeNamingEnv lm vis =
     envPublic = MN.filterUNames
                   (`Set.member` nmsPublic)
                   envTopLevels
-    
+
   -- Name Sets: --
 
     -- | names in scope at Top level of module
@@ -786,9 +786,9 @@ extractDefFromExtCryptolModule sc env_0 ecm name =
 -- | Load a Cryptol module and translate its contents to SAWCore.
 --
 -- There are three paths here:
---    - `importCryptolModule`,  which is the back end for SAWScript @import@
+--    - `importCryptolModule`, which is the back end for SAWScript @import@
 --    - `loadExtCryptolModule`, which is the back end for SAWScript @cryptol_load@
---    - `loadCryptolModule`,    which is used for Rocq export and from crux-mir-comp
+--    - `loadCryptolModule`, which is used for Rocq export and from crux-mir-comp
 --
 -- These can probably be unified.
 --
@@ -891,7 +891,7 @@ updateFFITypes sc m allTerms' eFFITypes' = do
 --  - the module can be qualified or not (per @as@ argument).
 --  - per @vis@ we can import public definitions or *all* (i.e., internal
 --    and public) definitions.
--- 
+--
 importCryptolModule ::
   (?fileReader :: FilePath -> IO ByteString) =>
   SharedContext             {- ^ Shared context for creating terms -} ->
@@ -910,11 +910,13 @@ importCryptolModule sc env src as False vis imps =
   return $ env' {eImports = import' : eImports env }
 importCryptolModule _sc _env (Right __nm) _as True _vis _imps =
   -- importing submodule by name:
+  -- FIXME: this will be implemented in #2618 (soon).
   fail $ "`import submodule` is unsupported."
 importCryptolModule _sc _env (Left _)  _as True _vis _imps =
   -- importing submodule by FilePath: disallowed:
   fail $ "`import submodule PATHNAME` is not allowed."
-     -- this allowed by parser?
+     -- NOTE: this is allowed by parser (thus we can get here).
+     -- FIXME: Would we want to implement this check in the typechecker?
 
 -- | Create an entry for the `eImports` list in `CryptolEnv`.
 mkImport :: ImportVisibility

--- a/intTests/test_saw_submodule_import/.gitignore
+++ b/intTests/test_saw_submodule_import/.gitignore
@@ -1,0 +1,3 @@
+*.rawlog
+*.log
+*.diff

--- a/intTests/test_saw_submodule_import/A.cry
+++ b/intTests/test_saw_submodule_import/A.cry
@@ -1,0 +1,1 @@
+../test_saw_submodule_access1/A.cry

--- a/intTests/test_saw_submodule_import/B.cry
+++ b/intTests/test_saw_submodule_import/B.cry
@@ -1,0 +1,1 @@
+../test_saw_submodule_access1/B.cry

--- a/intTests/test_saw_submodule_import/C.cry
+++ b/intTests/test_saw_submodule_import/C.cry
@@ -1,0 +1,1 @@
+../test_saw_submodule_access1/C.cry

--- a/intTests/test_saw_submodule_import/D.cry
+++ b/intTests/test_saw_submodule_import/D.cry
@@ -1,0 +1,1 @@
+../test_saw_submodule_access1/D.cry

--- a/intTests/test_saw_submodule_import/Makefile
+++ b/intTests/test_saw_submodule_import/Makefile
@@ -1,0 +1,5 @@
+all: ;
+clean:
+	sh ./test.sh clean
+
+.PHONY: all clean

--- a/intTests/test_saw_submodule_import/test.sh
+++ b/intTests/test_saw_submodule_import/test.sh
@@ -1,0 +1,1 @@
+exec ${TEST_SHELL:-bash} ../support/test-and-diff.sh "$@"

--- a/intTests/test_saw_submodule_import/testGoodImport1.log.good
+++ b/intTests/test_saw_submodule_import/testGoodImport1.log.good
@@ -1,0 +1,2 @@
+Loading file "testGoodImport1.saw"
+done

--- a/intTests/test_saw_submodule_import/testGoodImport1.saw
+++ b/intTests/test_saw_submodule_import/testGoodImport1.saw
@@ -1,0 +1,3 @@
+import "D.cry";
+
+print "done";

--- a/intTests/test_saw_submodule_import/testImportErrors1.log.good
+++ b/intTests/test_saw_submodule_import/testImportErrors1.log.good
@@ -1,0 +1,6 @@
+Loading file "testImportErrors1.saw"
+Stack trace:
+   (builtin) (at top level)
+`import submodule PATHNAME` is not allowed.
+
+FAILED

--- a/intTests/test_saw_submodule_import/testImportErrors1.saw
+++ b/intTests/test_saw_submodule_import/testImportErrors1.saw
@@ -1,0 +1,3 @@
+import submodule "D.cry";
+
+print "done";

--- a/intTests/test_saw_submodule_import/testImportErrors2.log.good
+++ b/intTests/test_saw_submodule_import/testImportErrors2.log.good
@@ -1,0 +1,6 @@
+Loading file "testImportErrors2.saw"
+Stack trace:
+   (builtin) (at top level)
+`import submodule` is unsupported.
+
+FAILED

--- a/intTests/test_saw_submodule_import/testImportErrors2.saw
+++ b/intTests/test_saw_submodule_import/testImportErrors2.saw
@@ -1,0 +1,3 @@
+import submodule D;
+
+print "done";

--- a/otherTests/cryptol-saw-core/CryptolVerifierTC.hs
+++ b/otherTests/cryptol-saw-core/CryptolVerifierTC.hs
@@ -24,15 +24,18 @@ main =
      let ?fileReader = BS.readFile
      cenv0 <- CEnv.initCryptolEnv sc
      putStrLn "Translated Cryptol.cry!"
-     cenv1 <- CEnv.importCryptolModule sc cenv0 (Right N.floatName) Nothing CEnv.OnlyPublic Nothing
+     let importCryptolModule' cenv nm =
+           CEnv.importCryptolModule
+             sc cenv (Right nm) Nothing False CEnv.OnlyPublic Nothing
+     cenv1 <- importCryptolModule' cenv0 N.floatName
      putStrLn "Translated Float.cry!"
-     cenv2 <- CEnv.importCryptolModule sc cenv1 (Right N.arrayName) Nothing CEnv.OnlyPublic Nothing
+     cenv2 <- importCryptolModule' cenv1 N.arrayName
      putStrLn "Translated Array.cry!"
-     cenv3 <- CEnv.importCryptolModule sc cenv2 (Right N.suiteBName) Nothing CEnv.OnlyPublic Nothing
+     cenv3 <- importCryptolModule' cenv2 N.suiteBName
      putStrLn "Translated SuiteB.cry!"
-     cenv4 <- CEnv.importCryptolModule sc cenv3 (Right N.primeECName) Nothing CEnv.OnlyPublic Nothing
+     cenv4 <- importCryptolModule' cenv3 N.primeECName
      putStrLn "Translated PrimeEC.cry!"
-     cenv5 <- CEnv.importCryptolModule sc cenv4 (Right N.preludeReferenceName) Nothing CEnv.OnlyPublic Nothing
+     cenv5 <- importCryptolModule' cenv4 N.preludeReferenceName
      putStrLn "Translated Reference.cry!"
      cenv6 <- CEnv.parseDecls sc cenv5 (CEnv.InputText superclassContents "superclass.cry" 1 1)
      putStrLn "Translated superclass.cry!"

--- a/saw-script/src/SAWScript/AutoMatch/Cryptol.hs
+++ b/saw-script/src/SAWScript/AutoMatch/Cryptol.hs
@@ -53,7 +53,7 @@ getDeclsCryptol path = do
          Right ((_, top), _) ->
             case top of
               AST.TCTopSignature {} ->
-                 liftF $ Failure True "Expected a module but found an intreface" Nothing
+                 liftF $ Failure True "Expected a module but found an interface" Nothing
               AST.TCTopModule AST.Module { mDecls } ->
                 let stdDecls = catMaybes . for (concatMap flattenDeclGroup mDecls) $
                       \(AST.Decl{dName, dSignature, dDefinition}) -> do

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -1060,10 +1060,12 @@ interpretTopStmt printBinds stmt = do
          sc <- getSharedContext
          cenv <- getCryptolEnv
          --showCryptolEnv
-         let mLoc = iModule imp
-             qual = iAs imp
-             spec = iSpec imp
-         cenv' <- io $ CEnv.importCryptolModule sc cenv mLoc qual CEnv.PublicAndPrivate spec
+         let mLoc  = iModule imp
+             qual  = iAs imp
+             spec  = iSpec imp
+             isSub = iIsSubmodule imp
+         cenv' <- io $ CEnv.importCryptolModule
+                         sc cenv mLoc qual isSub CEnv.PublicAndPrivate spec
          setCryptolEnv cenv'
          --showCryptolEnv
 

--- a/saw-server/src/SAWServer/CryptolSetup.hs
+++ b/saw-server/src/SAWServer/CryptolSetup.hs
@@ -42,7 +42,7 @@ cryptolLoadModule (CryptolLoadModuleParams modName) =
      let importSpec = Nothing -- TODO add field to params
      fileReader <- Argo.getFileReader
      let ?fileReader = fileReader
-     cenv' <- liftIO $ try $ CEnv.importCryptolModule sc cenv (Right modName) qual CEnv.PublicAndPrivate importSpec
+     cenv' <- liftIO $ try $ CEnv.importCryptolModule sc cenv (Right modName) qual False CEnv.PublicAndPrivate importSpec
      case cenv' of
        Left (ex :: SomeException) -> Argo.raise $ cryptolError (show ex)
        Right cenv'' ->
@@ -78,7 +78,7 @@ cryptolLoadFile (CryptolLoadFileParams fileName) =
      let importSpec = Nothing -- TODO add field to params
      fileReader <- Argo.getFileReader
      let ?fileReader = fileReader
-     cenv' <- liftIO $ try $ CEnv.importCryptolModule sc cenv (Left fileName) qual CEnv.PublicAndPrivate importSpec
+     cenv' <- liftIO $ try $ CEnv.importCryptolModule sc cenv (Left fileName) qual False CEnv.PublicAndPrivate importSpec
      case cenv' of
        Left (ex :: SomeException) -> Argo.raise $ cryptolError (show ex)
        Right cenv'' ->


### PR DESCRIPTION
Plumb parsing data to the `importCryptolModule` so as to give proper error messages.
(Does not support the `import submodule SUBMODULENAME` yet)

- This is part one of addressing #2618 