### PR TITLE
Rework uninterpreted functions.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@ This release supports [version
 
 ## Bug Fixes
 
+* Avoid exponential blow-up when generating uninterpreted functions.
+
 * SAW no longer spuriously rejects `mir_array_value`s that use a signed integer
   type (e.g., `mir_i32`) as an element type.
 

--- a/crux-mir-comp/test/symb_eval/cryptol/uninterp_big_array.cry
+++ b/crux-mir-comp/test/symb_eval/cryptol/uninterp_big_array.cry
@@ -1,0 +1,14 @@
+module test::symb_eval::cryptol::uninterp_big_array where
+
+tick : {n} [n][64] -> [64] -> [n][64]
+tick ns acc = update ns acc (1 + ns @ x)
+
+spec: {m,n} (fin m) => [n][64] -> [m][64] -> [n][64]
+spec = foldl tick
+
+
+f : [8] -> ()
+f _ = ()
+
+x : [8]
+x = 0

--- a/crux-mir-comp/test/symb_eval/cryptol/uninterp_big_array.good
+++ b/crux-mir-comp/test/symb_eval/cryptol/uninterp_big_array.good
@@ -1,0 +1,7 @@
+test uninterp_big_array/<DISAMB>::count[0]::test_issue_3166[0]: starting `test_f`
+ok
+test uninterp_big_array/<DISAMB>::test_issue_3195[0]: starting `count_check`
+finished `count_check`
+ok
+
+[Crux] Overall status: Valid.

--- a/crux-mir-comp/test/symb_eval/cryptol/uninterp_big_array.rs
+++ b/crux-mir-comp/test/symb_eval/cryptol/uninterp_big_array.rs
@@ -1,0 +1,56 @@
+extern crate crucible;
+use crucible::{
+    crucible_assert, crucible_assume, cryptol::uninterp, override_, print_str, Symbolic as _,
+};
+const N: usize = 1024;
+
+mod cry {
+    use crucible::cryptol;
+    cryptol! {
+        path "test::symb_eval::cryptol::uninterp_big_array";
+        pub(super) fn tick<const M: usize>(ns: [u64; M], x: usize) -> [u64; M] = "tick`{{{M}}}";
+        pub(super) fn spec<const M: usize, const N: usize>(init: [u64; N], ixes: [usize; M]) -> [u64; N] = "spec`{{ {M},{N} }}";
+        pub(super) fn f(x: u8) -> () = "f";
+        pub fn x() -> u8 = "x";
+    }
+}
+
+
+
+fn tick(ns: &mut [u64; N], x: usize) {
+    ns[x] = ns[x].wrapping_add(1);
+}
+
+fn cry_tick(ns: &mut [u64; N], x: usize) {
+    *ns = cry::tick(*ns, x);
+}
+
+fn count(ns: &mut [u64; N], xs: &[usize]) {
+    for &x in xs {
+        tick(ns, x)
+    }
+
+#[crux::test]
+fn test_issue_3166() {
+    print_str("starting `test_f`");
+
+    uninterp("x");
+    cry::f(cry::x());
+}}
+
+
+#[crux::test]
+fn test_issue_3195() {
+    print_str("starting `count_check`");
+
+    uninterp("Tick::tick");
+    override_(tick, cry_tick);
+
+    let vs = <[u64; N]>::symbolic("ns");
+    let mut ns = vs;
+    let xs = <[usize; 3]>::symbolic_where("xs", |&xs| xs.iter().all(|&x| x < N));
+
+    count(&mut ns, &xs);
+    crucible_assert!(ns==cry::spec(vs,xs));
+    print_str("finished `count_check`");
+}

--- a/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/X86.hs
@@ -264,12 +264,12 @@ cryptolUninterpreted ::
   Text ->
   SharedContext ->
   [Term] ->
-  m Term
+  m UninterpResult
 cryptolUninterpreted path func env nm sc xs =
   case lookupIn nm $ eAllTerms env of
     Left _err -> throwX86func path func $
         "Failed to look up Cryptol name \"" <> nm <> "\" in Cryptol environment"
-    Right t -> liftIO $ scApplyAll sc t xs
+    Right t -> UninterpOne <$> liftIO (scApplyAll sc t xs)
 
 llvmPointerBlock :: C.LLVM.LLVMPtr sym w -> W4.SymNat sym
 llvmPointerBlock = fst . C.LLVM.llvmPointerView

--- a/saw-core-what4/src/SAWCoreWhat4/Common.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/Common.hs
@@ -1,0 +1,128 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ConstraintKinds#-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module SAWCoreWhat4.Common (module SAWCoreWhat4.Common) where
+
+import Data.IORef
+import Data.Kind (Type)
+import Data.Map (Map)
+import Numeric.Natural (Natural)
+
+-- saw-core
+import SAWCore.SharedTerm
+import SAWCore.FiniteValue (FirstOrderType(..))
+import qualified SAWCore.Simulator.Prims as Prims
+import SAWCore.Simulator.Value
+
+
+
+-- what4
+import           What4.Interface(Pred,SymInteger,IsSymExprBuilder)
+import qualified What4.Interface as W
+import           What4.SWord (SWord(..))
+
+-- parameterized-utils
+import qualified Data.Parameterized.Context as Ctx
+import Data.Parameterized.Some
+
+-- saw-core-what4
+import SAWCoreWhat4.FirstOrder
+
+---------------------------------------------------------------------
+-- empty datatype to index (open) type families
+-- for this backend
+data What4 (sym :: Type)
+
+-- | A What4 symbolic array where the domain and co-domain types do not appear
+--   in the type
+data SArray sym where
+  SArray ::
+    W.IsExpr (W.SymExpr sym) =>
+    W.SymArray sym (Ctx.EmptyCtx Ctx.::> itp) etp ->
+    SArray sym
+
+-- type abbreviations for uniform naming
+type SBool sym = Pred sym
+type SInt  sym = SymInteger sym
+
+type instance EvalM (What4 sym) = IO
+type instance VBool (What4 sym) = SBool sym
+type instance VWord (What4 sym) = SWord sym
+type instance VInt  (What4 sym) = SInt  sym
+type instance VArray (What4 sym) = SArray sym
+type instance Extra (What4 sym) = What4Extra sym
+
+type SValue sym = Value (What4 sym)
+type SPrim sym  = Prims.Prim (What4 sym)
+
+-- Constraint
+type Sym sym = IsSymExprBuilder sym
+
+---------------------------------------------------------------------
+
+data What4Extra sym =
+  SStream (Natural -> IO (SValue sym)) (IORef (Map Natural (SValue sym)))
+
+instance Show (What4Extra sym) where
+  show (SStream _ _) = "<SStream>"
+
+
+instance Show (SArray sym) where
+  show (SArray arr) = show $ W.printSymExpr arr
+
+--
+-- Convert a saw-core type expression to a FirstOrder type expression
+--
+vAsFirstOrderType :: IsSymExprBuilder sym => TValue (What4 sym) -> Maybe FirstOrderType
+vAsFirstOrderType v = asFirstOrderTypeTValue v
+
+valueAsBaseType :: IsSymExprBuilder sym => TValue (What4 sym) -> Maybe (Some W.BaseTypeRepr)
+valueAsBaseType v = fotToBaseType =<< vAsFirstOrderType v
+
+termOfTValue :: SharedContext -> TValue (What4 sym) -> IO Term
+termOfTValue sc val =
+  case val of
+    VBoolType -> scBoolType sc
+    VIntType -> scIntegerType sc
+    VRationalType -> scRationalType sc
+    VVecType n a ->
+      do n' <- scNat sc n
+         a' <- termOfTValue sc a
+         scVecType sc n' a'
+    VDataType (ModuleIdentifier "Prelude.UnitType") [] []
+      -> scUnitType sc
+    VDataType (ModuleIdentifier "Prelude.PairType") [TValue a, TValue b] []
+      -> do a' <- termOfTValue sc a
+            b' <- termOfTValue sc b
+            scPairType sc a' b'
+    VDataType (ModuleIdentifier "Prelude.EmptyType") [] []
+      -> scRecordType sc []
+    VDataType (ModuleIdentifier "Prelude.RecordType")
+      [VString fname, TValue a, TValue b] []
+      -> do fname' <- scString sc fname
+            a' <- termOfTValue sc a
+            b' <- termOfTValue sc b
+            scGlobalApply sc "Prelude.RecordType" [fname', a', b']
+    _ -> fail $ "termOfTValue: " ++ show val
+
+termOfSValue :: SharedContext -> SValue sym -> IO Term
+termOfSValue sc val =
+  case val of
+    VCtorApp 0 _ []
+      -> scUnitValue sc
+    VNat n
+      -> scNat sc n
+    TValue tv -> termOfTValue sc tv
+    _ -> fail $ "termOfSValue: " ++ show val

--- a/saw-core-what4/src/SAWCoreWhat4/Common.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/Common.hs
@@ -13,7 +13,20 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
 
-module SAWCoreWhat4.Common (module SAWCoreWhat4.Common) where
+module SAWCoreWhat4.Common
+  ( What4
+  , SArray(..)
+  , SBool
+  , SInt
+  , SValue
+  , SPrim
+  , Sym
+  , What4Extra(..)
+  , vAsFirstOrderType
+  , valueAsBaseType
+  , termOfTValue
+  , termOfSValue
+  ) where
 
 import Data.IORef
 import Data.Kind (Type)

--- a/saw-core-what4/src/SAWCoreWhat4/ReturnTrip.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/ReturnTrip.hs
@@ -13,6 +13,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds #-}
 
 module SAWCoreWhat4.ReturnTrip
   ( SAWCoreExprBuilder
@@ -27,6 +29,7 @@ module SAWCoreWhat4.ReturnTrip
   , toSC
   , sawCreateVar
   , sawRegisterSymFunInterp
+  , UninterpResult(..)
   , getInputs
   ) where
 
@@ -49,6 +52,8 @@ import qualified Data.Sequence as Seq
 import           Data.Word(Word64)
 import           Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Vector as V
+import           Numeric.Natural(Natural)
 
 import           What4.BaseTypes
 import qualified What4.Config as W4Cfg
@@ -85,7 +90,7 @@ data SAWCoreState n
       -- ^ a record of all the symbolic input variables created so far,
       --   in the order they were created
 
-    , saw_symMap :: IORef (Map Word64 (SC.SharedContext -> [SC.Term] -> IO SC.Term))
+    , saw_symMap :: IORef (Map Word64 (SC.SharedContext -> [SC.Term] -> IO UninterpResult))
       -- ^ What to do with uninterpreted functions.
       -- The key is the "indexValue" of the "symFunId" for the function
 
@@ -98,6 +103,14 @@ data SAWCoreState n
       -- SAWCore terms and What4 variables.
 
     }
+
+data UninterpResult =
+    UninterpOne SC.Term
+    -- ^ Single uninterpreted value
+
+  | UninterpMany Natural SC.Term (V.Vector SC.Term)
+    -- ^ Array of uninterpreted values, indexed by bit-vectors.
+    -- Fields: bit-width of index, type of element, element values
 
 newSAWCoreState ::
   SC.SharedContext ->
@@ -124,9 +137,40 @@ sawCoreSharedContext sym = saw_sc $ sawCoreState sym
 data SAWExpr (bt :: BaseType) where
   SAWExpr :: !SC.Term -> SAWExpr bt
 
+  UninterpArraySAWExpr :: Natural -> SC.Term -> !(V.Vector SC.Term) -> SAWExpr (BaseArrayType i a)
+  -- ^ An array produced by the interpretation of an uninterpreted function.
+  -- These can be fairly large, and we usually just need to index them with
+  -- a constant, so we have this special case to avoid having to make an
+  -- actual array with many calls to update array, just to lookup something
+  -- with a constant.  See `SAWCoreWhat4.Uninterp` for details.
+
   -- This is a term that represents an integer, but has an
   -- implicit integer-to-real conversion.
   IntToRealSAWExpr :: !(SAWExpr BaseIntegerType) -> SAWExpr BaseRealType
+
+
+-- | Generate an actual array term out of a vector.
+-- The array is indexed by bit-vectors of the given width.
+scArrayFromElems ::
+  SC.SharedContext ->
+  Natural           {- ^ Bit-width of index type -} ->
+  SC.Term           {- ^ Type of elements -} ->
+  V.Vector SC.Term  {- ^ Element values -} -> IO SC.Term
+scArrayFromElems sc w elT xs =
+  case V.uncons xs of
+    Just (x,ys) ->
+      do
+        ixT <- SC.scBitvector sc w
+        k   <- SC.scArrayConstant sc ixT elT x
+        let upd (n,arr) t =
+              do
+                i <- SC.scBvLit sc w n
+                a <- SC.scArrayUpdate sc ixT elT arr i t
+                pure (n+1,a)
+        snd <$> foldM upd (1,k) ys
+
+    Nothing     -> panic "materializeArray" ["Empty"]
+
 
 getInputs :: SAWCoreState n -> IO (Seq (SC.VarName, SC.Term))
 getInputs st = readIORef (saw_inputs st)
@@ -205,7 +249,7 @@ bindSAWTerm sym st bt t = do
 sawRegisterSymFunInterp ::
   SAWCoreState n ->
   B.ExprSymFn n args ret ->
-  (SC.SharedContext -> [SC.Term] -> IO SC.Term) ->
+  (SC.SharedContext -> [SC.Term] -> IO UninterpResult) ->
   IO ()
 sawRegisterSymFunInterp st f i =
   modifyIORef (saw_symMap st) (Map.insert (indexValue (B.symFnId f)) i)
@@ -384,8 +428,8 @@ scEq sym sc tp x y =
     BaseIntegerRepr -> scIntEq sc x y
     BaseArrayRepr idxTypes range
       | Ctx.Empty Ctx.:> idx_type <- idxTypes ->
-        do let SAWExpr x' = x
-           let SAWExpr y' = y
+        do x' <- termOfSAWExpr sym sc x
+           y' <- termOfSAWExpr sym sc y
            sc_idx_type <- baseSCType sym sc idx_type
            sc_elm_type <- baseSCType sym sc range
            SAWExpr <$> SC.scArrayEq sc sc_idx_type sc_elm_type x' y'
@@ -469,11 +513,14 @@ termOfSAWExpr ::
   sym ->
   SC.SharedContext ->
   SAWExpr tp -> IO SC.Term
-termOfSAWExpr sym _sc expr =
+termOfSAWExpr sym sc expr =
   case expr of
     SAWExpr t -> return t
+    UninterpArraySAWExpr w t els -> scArrayFromElems sc w t els
     IntToRealSAWExpr _
       -> unsupported sym "SAW backend does not support real values"
+
+
 
 applyExprSymFn ::
   forall n st fs args ret.
@@ -492,7 +539,14 @@ applyExprSymFn sym st sc fn args =
                     ]
          Just mk -> return mk
      ts <- evaluateAsgn args
-     SAWExpr <$> mk sc (reverse ts)
+     res <- mk sc (reverse ts)
+     pure $
+       case res of
+         UninterpOne a -> SAWExpr a
+         UninterpMany w t vs ->
+           case B.symFnReturnType fn of
+             BaseArrayRepr _ _ -> UninterpArraySAWExpr w t vs
+             _ -> undefined
   where
     evaluateAsgn :: Ctx.Assignment SAWExpr args' -> IO [SC.Term]
     evaluateAsgn Ctx.Empty = return []
@@ -799,15 +853,28 @@ evaluateExpr sym st sc cache = f Map.empty
                sc_elm <- f env v
                SAWExpr <$> SC.scArrayConstant sc sc_idx_type sc_elm_type sc_elm
           | otherwise -> unimplemented "multidimensional ConstantArray"
-
+        
         B.SelectArray range arr indexTerms
           | Ctx.Empty Ctx.:> idx <- indexTerms
           , idx_type <- exprType idx ->
             do sc_idx_type <- baseSCType sym sc idx_type
                sc_elm_type <- baseSCType sym sc range
-               sc_arr <- f env arr
-               sc_idx <- f env idx
-               SAWExpr <$> SC.scArrayLookup sc sc_idx_type sc_elm_type sc_arr sc_idx
+
+               arrT <- eval env arr
+               case arrT of
+
+                -- Special case for when reinterpreting uninterpreted functions
+                 UninterpArraySAWExpr _ _ vs
+                   | BaseBVRepr _ <- idx_type
+                   , Just conc <- asBV idx
+                   , Just t <- vs V.!? fromIntegral (BV.asNatural conc) ->
+                     pure (SAWExpr t)
+
+                 saw ->
+                  do
+                    sc_arr <- termOfSAWExpr sym sc saw
+                    sc_idx <- f env idx
+                    SAWExpr <$> SC.scArrayLookup sc sc_idx_type sc_elm_type sc_arr sc_idx
           | otherwise -> unimplemented "multidimensional SelectArray"
 
         B.UpdateArray range indexTypes arr indexTerms v

--- a/saw-core-what4/src/SAWCoreWhat4/ReturnTrip.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/ReturnTrip.hs
@@ -110,7 +110,11 @@ data UninterpResult =
 
   | UninterpMany Natural SC.Term (V.Vector SC.Term)
     -- ^ Array of uninterpreted values, indexed by bit-vectors.
-    -- Fields: bit-width of index, type of element, element values
+    -- Fields: bit-width of index, type of element, element values.
+    -- The vector should have at least one element in it, but need
+    -- not contain all 2^N elements---the first element is used
+    -- as the value for the other fields, although the code in
+    -- uninterp should never access them.
 
 newSAWCoreState ::
   SC.SharedContext ->
@@ -155,7 +159,8 @@ scArrayFromElems ::
   SC.SharedContext ->
   Natural           {- ^ Bit-width of index type -} ->
   SC.Term           {- ^ Type of elements -} ->
-  V.Vector SC.Term  {- ^ Element values -} -> IO SC.Term
+  V.Vector SC.Term  {- ^ Element values -} ->
+  IO SC.Term
 scArrayFromElems sc w elT xs =
   case V.uncons xs of
     Just (x,ys) ->
@@ -169,7 +174,7 @@ scArrayFromElems sc w elT xs =
                 pure (n+1,a)
         snd <$> foldM upd (1,k) ys
 
-    Nothing     -> panic "materializeArray" ["Empty"]
+    Nothing     -> panic "srArrayFromElems" ["Empty"]
 
 
 getInputs :: SAWCoreState n -> IO (Seq (SC.VarName, SC.Term))
@@ -546,7 +551,7 @@ applyExprSymFn sym st sc fn args =
          UninterpMany w t vs ->
            case B.symFnReturnType fn of
              BaseArrayRepr _ _ -> UninterpArraySAWExpr w t vs
-             _ -> undefined
+             _ -> panic "applyExpSymFn" ["`UninterpMany`, but type is not array"]
   where
     evaluateAsgn :: Ctx.Assignment SAWExpr args' -> IO [SC.Term]
     evaluateAsgn Ctx.Empty = return []
@@ -863,7 +868,9 @@ evaluateExpr sym st sc cache = f Map.empty
                arrT <- eval env arr
                case arrT of
 
-                -- Special case for when reinterpreting uninterpreted functions
+                -- Special case for when reinterpreting uninterpreted functions.
+                -- Thechnically, this is just an optimization (i.e., we could
+                -- have just made the array), but likely pretty important one.
                  UninterpArraySAWExpr _ _ vs
                    | BaseBVRepr _ <- idx_type
                    , Just conc <- asBV idx

--- a/saw-core-what4/src/SAWCoreWhat4/ReturnTrip.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/ReturnTrip.hs
@@ -869,7 +869,7 @@ evaluateExpr sym st sc cache = f Map.empty
                case arrT of
 
                 -- Special case for when reinterpreting uninterpreted functions.
-                -- Thechnically, this is just an optimization (i.e., we could
+                -- Technically, this is just an optimization (i.e., we could
                 -- have just made the array), but likely pretty important one.
                  UninterpArraySAWExpr _ _ vs
                    | BaseBVRepr _ <- idx_type

--- a/saw-core-what4/src/SAWCoreWhat4/Uninterp.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/Uninterp.hs
@@ -106,10 +106,10 @@ f_bool x = (f x).1
 g_u8 x0 x1 .. x1023 = [ fx @ 0, fx @ f1, ... fx @ 1023 ]
   where fx = f [ x0, x1 .., x1023 ]
 
-Note1: the sharing in this examples (the `where` clause) happens
+Note 1: the sharing in this examples (the `where` clause) happens
 automatically due to sharing inherent in SAW Core terms.
 
-Note2: we also need to reconstruct the arguments to the original functions
+Note 2: we also need to reconstruct the arguments to the original functions
 from their components before calling (e.g., as in `g_u8`).
 
 We use the type `ArgTerm` to help us create the interpretation.  The
@@ -118,6 +118,10 @@ function out of their pieces (e.g., put together the 1024 parameters into
 a single vector), while the selectors are used to connect a part of the
 result of the original function, to the relevant uninterpreted bit.
 
+Note 3: Since this code is used for making symbolic variables as well as
+uninterpreted functions, there's a special case for terms that started as
+SAW Core *variables* rather than SAW Core *constant*, and don't have any
+arguments---these use `bindSAWTerm` instead of `sawRegisterSymFunInterp`.
 -}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -144,7 +148,7 @@ import qualified Data.BitVector.Sized as BV
 
 import Data.Traversable as T
 import Control.Monad ((<=<), foldM, unless)
-import Control.Monad.State as ST (MonadState(..), get, put, StateT(..), lift)
+import Control.Monad.State as ST (MonadState(..), evalStateT, get, put, StateT(..), lift)
 import Numeric.Natural (Natural)
 
 -- saw-core
@@ -201,20 +205,25 @@ data Arr sym tc = forall args res. Arr {
 -- | Indicates if we need to map What4 terms back to SAW.
 data ReturnTrip sym =
     NoReturnTrip sym
+    -- ^ No need to reinterpret terms back into SAW Core.
+
   | forall n st fs. (sym ~ B.ExprBuilder n st fs ) =>
-    DoReturnTrip sym (SAWCoreState n) SharedContext ArgTerm
+    DoReturnTrip sym Bool (SAWCoreState n) SharedContext ArgTerm
+    -- ^ We should reinterpret terms back into SAW Core.
+    -- The boolean flag indicates that this is a symbolic variable
+    -- (instead of constant), which has special handling without arguments.
   
 withSym :: IsSymExprBuilder sym => ReturnTrip sym -> (sym -> a) -> a
 withSym xs k =
   case xs of
     NoReturnTrip sym -> k sym
-    DoReturnTrip sym _ _ _ -> k sym
+    DoReturnTrip sym _ _ _ _ -> k sym
 
 mapArgTerm :: (ArgTerm -> ArgTerm) -> ReturnTrip sym -> ReturnTrip sym
 mapArgTerm f saw =
   case saw of
     NoReturnTrip sym -> NoReturnTrip sym
-    DoReturnTrip sym st sc t -> DoReturnTrip sym st sc (f t)
+    DoReturnTrip sym isVar st sc t -> DoReturnTrip sym isVar st sc (f t)
 
 
 
@@ -238,15 +247,13 @@ parseUninterpretedSAW ::
   SAWCoreState n            {- ^ Register interpretations for terms here -} ->
   SharedContext             {- ^ Use this to build SAW Core terms -} ->
   IORef (SymFnCache (B.ExprBuilder n st fs)) {- ^ Cache of known uninterpreted functions -} ->
+  Bool                      {- ^ Is the original term a variable (True), or constant (False) -} ->
   Term                      {- ^ Original term -} ->
   UnintApp (SymExpr (B.ExprBuilder n st fs)) {- ^ Type of the function's result -} ->
   TValue (What4 (B.ExprBuilder n st fs)) {- ^ Type of the function's result. -} ->
   IO (SValue (B.ExprBuilder n st fs))
-parseUninterpretedSAW sym st sc ref term app t =
-  do
-    s <- ppTerm sc term
-    putStrLn ("PARSE UNINTERPRETED SAW: " ++ s)
-    parseUninterpretedTop (DoReturnTrip sym st sc (ArgTermConst term)) ref app t
+parseUninterpretedSAW sym st sc ref isVar term app t =
+  parseUninterpretedTop (DoReturnTrip sym isVar st sc (ArgTermConst term)) ref app t
 
 parseUninterpretedTop ::
   forall sym.
@@ -256,22 +263,25 @@ parseUninterpretedTop ::
   UnintApp (SymExpr sym)      {- ^ Name of function and its arguments -} ->
   TValue (What4 sym)          {- ^ Type of the function's result -} ->
   IO (SValue sym)             {- ^ The symbolic value for the call to the uninterpreted function -}
+
+-- This case deals with symbolic variable with no parameters.  The round
+-- trip for these works differently (see `mkUninterpreted`),
+-- and since they have no arguments, we don't need to do the array caching.
+parseUninterpretedTop rt@(DoReturnTrip _ True _ _ _) ref app@(UnintApp _ _ argTys) ty =
+  case testEquality Ctx.empty argTys of
+    Just Refl -> evalStateT (parseUninterpreted' rt ref app ty) MapF.empty
+    Nothing   -> fail "At present, we do not support symbolic variables with parameters"
+    
 parseUninterpretedTop saw ref app ty =
   do
-    count <- withSym saw (\sym ->
+    count <-
+      withSym saw (\sym ->
       MapF.traverseWithKey (mkUnint sym ref app) (countUninterpreted 1 MapF.empty ty))
     (val,st) <- runStateT (parseUninterpreted' saw ref app ty) count
     case saw of
       NoReturnTrip _ -> pure ()
-      DoReturnTrip sym sawSt sc _ -> MapF.traverseWithKey_ register st
+      DoReturnTrip sym _ sawSt sc _ -> MapF.traverseWithKey_ register st
         where
-        {- NOTE: Previously we had a special case for 0 arity functions, which
-            didn't generate an uninterpreted symbol, and instead did this:
-               bindSAWTerm sym sawSt ret =<< reconstructArgTerm trm sc []
-            I am not 100% sure, but I suspect it might have been the cause
-            for #3166.  Currently, we treat uninterpreted symbols uniformly,
-            no matter how many arguments they have. -}
-
         register :: BaseTypeRepr t -> Arr sym t -> IO ()
         register k (Arr fn ixW _ vs) =
           do
@@ -427,10 +437,10 @@ parseUninterpreted' saw ref app ty =
           saw' <-
             case saw of
               NoReturnTrip sym -> pure (NoReturnTrip sym)
-              DoReturnTrip sym st sc trm ->
+              DoReturnTrip sym isVar st sc trm ->
                 do newArg <- mkArgTerm sc t1 x'
                    let newTerm = ArgTermApply trm newArg
-                   pure (DoReturnTrip sym st sc newTerm)
+                   pure (DoReturnTrip sym isVar st sc newTerm)
 
           parseUninterpretedTop saw' ref app' t2
 
@@ -467,13 +477,13 @@ parseUninterpreted' saw ref app ty =
         VVector <$>
         case saw of
           NoReturnTrip _ -> V.replicateM (fromIntegral n) (ready <$> parseUninterpreted' saw ref app et)
-          DoReturnTrip sym st sc arg ->
+          DoReturnTrip sym isVar st sc arg ->
             do
               elTy <- lift (termOfTValue sc et)
               V.generateM (fromIntegral n) (\i ->
                 do
                   let newArg = ArgTermAt n elTy arg (fromIntegral i) 
-                  el <- parseUninterpreted' (DoReturnTrip sym st sc newArg) ref app et
+                  el <- parseUninterpreted' (DoReturnTrip sym isVar st sc newArg) ref app et
                   pure (ready el)
                 )
           
@@ -509,14 +519,22 @@ parseUninterpreted' saw ref app ty =
     do
       mp <- get
       case MapF.lookup tyr mp of
+
+        -- This happens when we are translating a symbolic variable with
+        -- no arguments (see `parseUninterpretedTop`, first case)
+        Nothing
+          | DoReturnTrip sym True st sc arg <- saw ->
+            lift (bindSAWTerm sym st tyr =<< reconstructArgTerm arg sc [])
+            
         Just (Arr fn w (x : xs) atms) ->
           do
             let newTerm =
                   case argTerm of
                     NoReturnTrip _     -> []
-                    DoReturnTrip _ _ _ t -> t : atms
+                    DoReturnTrip _ _ _ _ t -> t : atms
             put (MapF.insert tyr (Arr fn w xs newTerm) mp)
             pure x
+
         _ -> panic "mkUninterpreted" ["Not enough uninterpreted results"]
 
 

--- a/saw-core-what4/src/SAWCoreWhat4/Uninterp.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/Uninterp.hs
@@ -177,136 +177,6 @@ import SAWCoreWhat4.Panic
 import SAWCoreWhat4.ReturnTrip
 
 
-
---------------------------------------------------------------------------------
-
--- | A value of type @UnintApp f@ represents an uninterpreted function
--- with the given 'String' name, applied to a list of argument values
--- paired with a representation of their types. The context of
--- argument types is existentially quantified.
-data UnintApp f =
-  forall args. UnintApp String (Assignment f args) (Assignment BaseTypeRepr args)
-
--- | Extract the string from an 'UnintApp'.
-stringOfUnintApp :: UnintApp f -> String
-stringOfUnintApp (UnintApp s _ _) = s
-
--- | Make an 'UnintApp' with the given name and no arguments.
-mkUnintApp :: String -> UnintApp f
-mkUnintApp nm = UnintApp nm Ctx.empty Ctx.empty
-
--- | Add a suffix to the function name of an 'UnintApp'.  This is used
--- to modify the function name for different polymorphic instantiations,
--- for example.
-suffixUnintApp :: String -> UnintApp f -> UnintApp f
-suffixUnintApp s (UnintApp nm args tys) = UnintApp (nm ++ s) args tys
-
--- | Extend an 'UnintApp' with an additional argument.
-extendUnintApp :: UnintApp f -> f ty -> BaseTypeRepr ty -> UnintApp f
-extendUnintApp (UnintApp nm xs tys) x ty =
-  UnintApp nm (Ctx.extend xs x) (Ctx.extend tys ty)
-
--- | Flatten an 'SValue' to a sequence of components, each of which is
--- a symbolic value of a base type (e.g. word or boolean), and add
--- them to the list of arguments of the given 'UnintApp'. If the
--- 'SValue' contains any values built from data constructors, then
--- encode them as suffixes on the function name of the 'UnintApp'.
-applyUnintApp ::
-  forall sym.
-  (W.IsExprBuilder sym) =>
-  sym ->
-  UnintApp (SymExpr sym) ->
-  SValue sym ->
-  IO (UnintApp (SymExpr sym))
-applyUnintApp sym app0 v =
-  case v of
-    VVector xv                -> foldM (applyUnintApp sym) app0 =<< traverse force xv
-    VBool sb                  -> return (extendUnintApp app0 sb BaseBoolRepr)
-    VInt si                   -> return (extendUnintApp app0 si BaseIntegerRepr)
-    VIntMod 0 si              -> return (extendUnintApp app0 si BaseIntegerRepr)
-    VIntMod n si              -> do n' <- W.intLit sym (toInteger n)
-                                    si' <- W.intMod sym si n'
-                                    return (extendUnintApp app0 si' BaseIntegerRepr)
-    VRational numer denom     -> do app1 <- applyUnintApp sym app0 (VInt numer)
-                                    app2 <- applyUnintApp sym app1 (VInt denom)
-                                    pure app2
-    VWord (DBV sw)            -> return (extendUnintApp app0 sw (W.exprType sw))
-    VArray (SArray sa)        -> return (extendUnintApp app0 sa (W.exprType sa))
-    VWord ZBV                 -> return app0
-    VCtorApp 0 _ []           -> return app0
-    VCtorApp 0 _ [x, y]       -> do app1 <- applyUnintApp sym app0 =<< force x
-                                    app2 <- applyUnintApp sym app1 =<< force y
-                                    return app2
-    VCtorApp n _ xs           -> foldM (applyUnintApp sym) app' =<< traverse force xs
-                                   where app' = suffixUnintApp ("_" ++ show n) app0
-    VNat n                    -> return (suffixUnintApp ("_" ++ show n) app0)
-    VBVToNat w v'             -> applyUnintApp sym app' v'
-                                   where app' = suffixUnintApp ("_" ++ show w) app0
-    TValue (suffixTValue -> Just s)
-                              -> return (suffixUnintApp s app0)
-    VFun {} ->
-      fail $
-      "Cannot create uninterpreted higher-order function " ++
-      show (stringOfUnintApp app0)
-    _ ->
-      fail $
-      "Cannot create uninterpreted function " ++
-      show (stringOfUnintApp app0) ++
-      " with argument " ++ show v
-
---------------------------------------------------------------------------------
-
--- | Track how many uninterpreted results we need for each base type.
-newtype UnintCount (tc :: BaseType) = UnintCount Natural 
-
--- | Count how many uninterpreted symbols we need to represent a value
--- of the given type.  Note that this function should match exactly what
--- is needed by `parseUninterpreted'`.
-countUninterpreted ::
-  IsSymExprBuilder sym =>
-  Natural -> MapF BaseTypeRepr UnintCount -> TValue (What4 sym) -> MapF BaseTypeRepr UnintCount
-countUninterpreted scale count ty =
-  case ty of
-    VPiType {}      -> count
-    VBoolType       -> add BaseBoolRepr count
-    VIntType        -> add BaseIntegerRepr count
-    VIntModType {}  -> add BaseIntegerRepr count
-    VRationalType   -> add BaseIntegerRepr (add BaseIntegerRepr count)
-    VVecType n VBoolType ->
-      case somePosNat n of
-        Just (Some (PosNat w)) -> add (BaseBVRepr w) count
-        _                      -> count
-
-    VVecType n et ->
-      if n == 0 then count else countUninterpreted (n * scale) count et
-
-    VArrayType ity ety
-      | Just (Some idx_repr) <- valueAsBaseType ity
-      , Just (Some elm_repr) <- valueAsBaseType ety
-      -> add (BaseArrayRepr (Ctx.Empty Ctx.:> idx_repr) elm_repr) count
-
-    VDataType (ModuleIdentifier "Prelude.UnitType") [] [] -> count
-
-    VDataType (ModuleIdentifier "Prelude.PairType") [TValue ty1, TValue ty2] [] ->
-      countUninterpreted scale (countUninterpreted scale count ty1) ty2
-
-    VDataType (ModuleIdentifier "Prelude.RecordType")
-      [VString _fname, TValue ty1, TValue ty2] [] ->
-      countUninterpreted scale (countUninterpreted scale count ty1) ty2
-
-    _ -> count
-  where
-  add ::
-    BaseTypeRepr tc ->
-    MapF BaseTypeRepr UnintCount ->
-    MapF BaseTypeRepr UnintCount
-  add bt =
-    MapF.insertWith
-      (\(UnintCount x) (UnintCount y) -> UnintCount (x + y))
-      bt (UnintCount scale)
-
-
-
 -- | Uninterpreted function results for each base type.
 type UnintState sym = MapF BaseTypeRepr (Arr sym)
 
@@ -327,6 +197,26 @@ data Arr sym tc = forall args res. Arr {
   -- Note that these are in reverse order---every time we take a thing
   -- from `arrSymExprs`, we cons a new thing onto here.
 }
+
+-- | Indicates if we need to map What4 terms back to SAW.
+data ReturnTrip sym =
+    NoReturnTrip sym
+  | forall n st fs. (sym ~ B.ExprBuilder n st fs ) =>
+    DoReturnTrip sym (SAWCoreState n) SharedContext ArgTerm
+  
+withSym :: IsSymExprBuilder sym => ReturnTrip sym -> (sym -> a) -> a
+withSym xs k =
+  case xs of
+    NoReturnTrip sym -> k sym
+    DoReturnTrip sym _ _ _ -> k sym
+
+mapArgTerm :: (ArgTerm -> ArgTerm) -> ReturnTrip sym -> ReturnTrip sym
+mapArgTerm f saw =
+  case saw of
+    NoReturnTrip sym -> NoReturnTrip sym
+    DoReturnTrip sym st sc t -> DoReturnTrip sym st sc (f t)
+
+
 
 -- | Generate a call to an uninterpreted function, without reinterpreting
 -- back into SAW Core.
@@ -395,6 +285,57 @@ parseUninterpretedTop saw ref app ty =
 
     pure val
     
+
+-- | Track how many uninterpreted results we need for each base type.
+newtype UnintCount (tc :: BaseType) = UnintCount Natural 
+
+-- | Count how many uninterpreted symbols we need to represent a value
+-- of the given type.  Note that this function should match exactly what
+-- is needed by `parseUninterpreted'`.
+countUninterpreted ::
+  IsSymExprBuilder sym =>
+  Natural -> MapF BaseTypeRepr UnintCount -> TValue (What4 sym) -> MapF BaseTypeRepr UnintCount
+countUninterpreted scale count ty =
+  case ty of
+    VPiType {}      -> count
+    VBoolType       -> add BaseBoolRepr count
+    VIntType        -> add BaseIntegerRepr count
+    VIntModType {}  -> add BaseIntegerRepr count
+    VRationalType   -> add BaseIntegerRepr (add BaseIntegerRepr count)
+    VVecType n VBoolType ->
+      case somePosNat n of
+        Just (Some (PosNat w)) -> add (BaseBVRepr w) count
+        _                      -> count
+
+    VVecType n et ->
+      if n == 0 then count else countUninterpreted (n * scale) count et
+
+    VArrayType ity ety
+      | Just (Some idx_repr) <- valueAsBaseType ity
+      , Just (Some elm_repr) <- valueAsBaseType ety
+      -> add (BaseArrayRepr (Ctx.Empty Ctx.:> idx_repr) elm_repr) count
+
+    VDataType (ModuleIdentifier "Prelude.UnitType") [] [] -> count
+
+    VDataType (ModuleIdentifier "Prelude.PairType") [TValue ty1, TValue ty2] [] ->
+      countUninterpreted scale (countUninterpreted scale count ty1) ty2
+
+    VDataType (ModuleIdentifier "Prelude.RecordType")
+      [VString _fname, TValue ty1, TValue ty2] [] ->
+      countUninterpreted scale (countUninterpreted scale count ty1) ty2
+
+    _ -> count
+  where
+  add ::
+    BaseTypeRepr tc ->
+    MapF BaseTypeRepr UnintCount ->
+    MapF BaseTypeRepr UnintCount
+  add bt =
+    MapF.insertWith
+      (\(UnintCount x) (UnintCount y) -> UnintCount (x + y))
+      bt (UnintCount scale)
+
+
 
 
 
@@ -465,23 +406,6 @@ mkUnint sym ref (UnintApp nm args tys) ret (UnintCount tot)
   suff_asgn i = intercalate "_and" (V.toList (Ctx.toVector i suff))
 
 
--- | Indicates if we need to map What4 terms back to SAW.
-data ReturnTrip sym =
-    NoReturnTrip sym
-  | forall n st fs. (sym ~ B.ExprBuilder n st fs ) =>
-    DoReturnTrip sym (SAWCoreState n) SharedContext ArgTerm
-  
-withSym :: IsSymExprBuilder sym => ReturnTrip sym -> (sym -> a) -> a
-withSym xs k =
-  case xs of
-    NoReturnTrip sym -> k sym
-    DoReturnTrip sym _ _ _ -> k sym
-
-mapArgTerm :: (ArgTerm -> ArgTerm) -> ReturnTrip sym -> ReturnTrip sym
-mapArgTerm f saw =
-  case saw of
-    NoReturnTrip sym -> NoReturnTrip sym
-    DoReturnTrip sym st sc t -> DoReturnTrip sym st sc (f t)
 
 parseUninterpreted' ::
   forall sym.
@@ -594,6 +518,88 @@ parseUninterpreted' saw ref app ty =
             put (MapF.insert tyr (Arr fn w xs newTerm) mp)
             pure x
         _ -> panic "mkUninterpreted" ["Not enough uninterpreted results"]
+
+
+
+--------------------------------------------------------------------------------
+-- Symbolic function and its arguments.
+
+-- | A value of type @UnintApp f@ represents an uninterpreted function
+-- with the given 'String' name, applied to a list of argument values
+-- paired with a representation of their types. The context of
+-- argument types is existentially quantified.
+data UnintApp f =
+  forall args. UnintApp String (Assignment f args) (Assignment BaseTypeRepr args)
+
+-- | Extract the string from an 'UnintApp'.
+stringOfUnintApp :: UnintApp f -> String
+stringOfUnintApp (UnintApp s _ _) = s
+
+-- | Make an 'UnintApp' with the given name and no arguments.
+mkUnintApp :: String -> UnintApp f
+mkUnintApp nm = UnintApp nm Ctx.empty Ctx.empty
+
+-- | Add a suffix to the function name of an 'UnintApp'.  This is used
+-- to modify the function name for different polymorphic instantiations,
+-- for example.
+suffixUnintApp :: String -> UnintApp f -> UnintApp f
+suffixUnintApp s (UnintApp nm args tys) = UnintApp (nm ++ s) args tys
+
+-- | Extend an 'UnintApp' with an additional argument.
+extendUnintApp :: UnintApp f -> f ty -> BaseTypeRepr ty -> UnintApp f
+extendUnintApp (UnintApp nm xs tys) x ty =
+  UnintApp nm (Ctx.extend xs x) (Ctx.extend tys ty)
+
+-- | Flatten an 'SValue' to a sequence of components, each of which is
+-- a symbolic value of a base type (e.g. word or boolean), and add
+-- them to the list of arguments of the given 'UnintApp'. If the
+-- 'SValue' contains any values built from data constructors, then
+-- encode them as suffixes on the function name of the 'UnintApp'.
+applyUnintApp ::
+  forall sym.
+  (W.IsExprBuilder sym) =>
+  sym ->
+  UnintApp (SymExpr sym) ->
+  SValue sym ->
+  IO (UnintApp (SymExpr sym))
+applyUnintApp sym app0 v =
+  case v of
+    VVector xv                -> foldM (applyUnintApp sym) app0 =<< traverse force xv
+    VBool sb                  -> return (extendUnintApp app0 sb BaseBoolRepr)
+    VInt si                   -> return (extendUnintApp app0 si BaseIntegerRepr)
+    VIntMod 0 si              -> return (extendUnintApp app0 si BaseIntegerRepr)
+    VIntMod n si              -> do n' <- W.intLit sym (toInteger n)
+                                    si' <- W.intMod sym si n'
+                                    return (extendUnintApp app0 si' BaseIntegerRepr)
+    VRational numer denom     -> do app1 <- applyUnintApp sym app0 (VInt numer)
+                                    app2 <- applyUnintApp sym app1 (VInt denom)
+                                    pure app2
+    VWord (DBV sw)            -> return (extendUnintApp app0 sw (W.exprType sw))
+    VArray (SArray sa)        -> return (extendUnintApp app0 sa (W.exprType sa))
+    VWord ZBV                 -> return app0
+    VCtorApp 0 _ []           -> return app0
+    VCtorApp 0 _ [x, y]       -> do app1 <- applyUnintApp sym app0 =<< force x
+                                    app2 <- applyUnintApp sym app1 =<< force y
+                                    return app2
+    VCtorApp n _ xs           -> foldM (applyUnintApp sym) app' =<< traverse force xs
+                                   where app' = suffixUnintApp ("_" ++ show n) app0
+    VNat n                    -> return (suffixUnintApp ("_" ++ show n) app0)
+    VBVToNat w v'             -> applyUnintApp sym app' v'
+                                   where app' = suffixUnintApp ("_" ++ show w) app0
+    TValue (suffixTValue -> Just s)
+                              -> return (suffixUnintApp s app0)
+    VFun {} ->
+      fail $
+      "Cannot create uninterpreted higher-order function " ++
+      show (stringOfUnintApp app0)
+    _ ->
+      fail $
+      "Cannot create uninterpreted function " ++
+      show (stringOfUnintApp app0) ++
+      " with argument " ++ show v
+
+
+
 
 --------------------------------------------------------------------------------
 -- `ArgTerms` are used to remember the mappings between low-level symbolic

--- a/saw-core-what4/src/SAWCoreWhat4/Uninterp.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/Uninterp.hs
@@ -1,7 +1,9 @@
 {- |
 Given a constant of type `T`, construct an uninterpreted
 constant with that type.  The type `T` is *not* limited to What4 BaseTypes or
-FirstOrderTypes, and we support polymorphic and function types.ons.
+FirstOrderTypes, and we support polymorphic and function types.
+Note that this is used for both uninterpreted functions and when we create
+symbolic variables.
 
 The Algorithm for Uninterpreted Functions
 =========================================
@@ -61,7 +63,7 @@ but is crucial for the correct behavior of the algorithm.
 
 The `UnintApp` type is used to collect the arguments to a function, and also
 compute the root name for the function.   For ordinary (non-dependent) 
-function applications we just collect the arguments in the `UninApp`.  However,
+function applications we just collect the arguments in the `UnintApp`.  However,
 for dependent applications (e.g., to handle a size polymorphic function),
 we instead modify the root name of the function.  This means that different
 size instantiations of the functions end up with different uninterpreted
@@ -87,8 +89,8 @@ Reinterpreting Terms Back Back to SAW Core (ArgTerm)
 ====================================================
 
 Also we have two cases to consider:
-  1. When translating to the solver (`parseUninterpred`)
-  2. When doing symbolic simulation for SAW (`parseUninterpredSAW`).
+  1. When translating to the solver (`parseUninterpreted`)
+  2. When doing symbolic simulation for SAW (`parseUninterpretedSAW`).
 
 The difference between the two is that in case (2) we need to also be able
 to go back from the symbolic expressions to a semantically equivalent SAW
@@ -96,7 +98,7 @@ Core term.  To do this, we need to provide interpretations for all the functions
 that were left as uninterpreted during the original translation.  For example,
 we'd need to register the following interpretations for the examples above:
 
-f_bv8 x = [ fst @ 0, fst @ 1, fst @ 2, fst @ 3 ]
+f_bv8 x = [ tup1 @ 0, tup1 @ 1, tup1 @ 2, tup1 @ 3 ]
   where tup1 = (f x).0
 
 f_bool x = (f x).1
@@ -336,7 +338,7 @@ parseUninterpreted ::
   UnintApp (SymExpr sym)      {- ^ Name of function and its arguments -} ->
   TValue (What4 sym)          {- ^ Type of the function's result -} ->
   IO (SValue sym)             {- ^ The symbolic value for the call to the uninterpreted function -}
-parseUninterpreted sym = parseUninterpretedTop (NoSAW sym)
+parseUninterpreted sym a b c = parseUninterpretedTop (NoReturnTrip sym) a b c
 
 -- | Generate a call to an uninterpreted function, and also register mapping
 -- back into SAW Core.
@@ -351,12 +353,15 @@ parseUninterpretedSAW ::
   TValue (What4 (B.ExprBuilder n st fs)) {- ^ Type of the function's result. -} ->
   IO (SValue (B.ExprBuilder n st fs))
 parseUninterpretedSAW sym st sc ref term app t =
-  parseUninterpretedTop (SAW sym st sc (ArgTermConst term)) ref app t
+  do
+    s <- ppTerm sc term
+    putStrLn ("PARSE UNINTERPRETED SAW: " ++ s)
+    parseUninterpretedTop (DoReturnTrip sym st sc (ArgTermConst term)) ref app t
 
 parseUninterpretedTop ::
   forall sym.
   (IsSymExprBuilder sym) =>
-  SAW sym ->
+  ReturnTrip sym ->
   IORef (SymFnCache sym)      {- ^ Cache of known uninterpreted functions -} ->
   UnintApp (SymExpr sym)      {- ^ Name of function and its arguments -} ->
   TValue (What4 sym)          {- ^ Type of the function's result -} ->
@@ -367,12 +372,12 @@ parseUninterpretedTop saw ref app ty =
       MapF.traverseWithKey (mkUnint sym ref app) (countUninterpreted 1 MapF.empty ty))
     (val,st) <- runStateT (parseUninterpreted' saw ref app ty) count
     case saw of
-      NoSAW _ -> pure ()
-      SAW sym sawSt sc _ -> MapF.traverseWithKey_ register st
+      NoReturnTrip _ -> pure ()
+      DoReturnTrip sym sawSt sc _ -> MapF.traverseWithKey_ register st
         where
         {- NOTE: Previously we had a special case for 0 arity functions, which
             didn't generate an uninterpreted symbol, and instead did this:
-               bindSAWTerm sym st ret =<< reconstructArgTerm trm sc []
+               bindSAWTerm sym sawSt ret =<< reconstructArgTerm trm sc []
             I am not 100% sure, but I suspect it might have been the cause
             for #3166.  Currently, we treat uninterpreted symbols uniformly,
             no matter how many arguments they have. -}
@@ -460,27 +465,28 @@ mkUnint sym ref (UnintApp nm args tys) ret (UnintCount tot)
   suff_asgn i = intercalate "_and" (V.toList (Ctx.toVector i suff))
 
 
-data SAW sym =
-    NoSAW sym
+-- | Indicates if we need to map What4 terms back to SAW.
+data ReturnTrip sym =
+    NoReturnTrip sym
   | forall n st fs. (sym ~ B.ExprBuilder n st fs ) =>
-    SAW sym (SAWCoreState n) SharedContext ArgTerm
+    DoReturnTrip sym (SAWCoreState n) SharedContext ArgTerm
   
-withSym :: IsSymExprBuilder sym => SAW sym -> (sym -> a) -> a
+withSym :: IsSymExprBuilder sym => ReturnTrip sym -> (sym -> a) -> a
 withSym xs k =
   case xs of
-    NoSAW sym -> k sym
-    SAW sym _ _ _ -> k sym
+    NoReturnTrip sym -> k sym
+    DoReturnTrip sym _ _ _ -> k sym
 
-mapArgTerm :: (ArgTerm -> ArgTerm) -> SAW sym -> SAW sym
+mapArgTerm :: (ArgTerm -> ArgTerm) -> ReturnTrip sym -> ReturnTrip sym
 mapArgTerm f saw =
   case saw of
-    NoSAW sym -> NoSAW sym
-    SAW sym st sc t -> SAW sym st sc (f t)
+    NoReturnTrip sym -> NoReturnTrip sym
+    DoReturnTrip sym st sc t -> DoReturnTrip sym st sc (f t)
 
 parseUninterpreted' ::
   forall sym.
   (IsSymExprBuilder sym) =>
-  SAW sym ->
+  ReturnTrip sym ->
   IORef (SymFnCache sym) ->
   UnintApp (SymExpr sym) ->
   TValue (What4 sym) ->
@@ -496,11 +502,11 @@ parseUninterpreted' saw ref app ty =
 
           saw' <-
             case saw of
-              NoSAW sym -> pure (NoSAW sym)
-              SAW sym st sc trm ->
+              NoReturnTrip sym -> pure (NoReturnTrip sym)
+              DoReturnTrip sym st sc trm ->
                 do newArg <- mkArgTerm sc t1 x'
                    let newTerm = ArgTermApply trm newArg
-                   pure (SAW sym st sc newTerm)
+                   pure (DoReturnTrip sym st sc newTerm)
 
           parseUninterpretedTop saw' ref app' t2
 
@@ -536,14 +542,14 @@ parseUninterpreted' saw ref app ty =
       | n > 0 ->
         VVector <$>
         case saw of
-          NoSAW _ -> V.replicateM (fromIntegral n) (ready <$> parseUninterpreted' saw ref app et)
-          SAW sym st sc arg ->
+          NoReturnTrip _ -> V.replicateM (fromIntegral n) (ready <$> parseUninterpreted' saw ref app et)
+          DoReturnTrip sym st sc arg ->
             do
               elTy <- lift (termOfTValue sc et)
               V.generateM (fromIntegral n) (\i ->
                 do
                   let newArg = ArgTermAt n elTy arg (fromIntegral i) 
-                  el <- parseUninterpreted' (SAW sym st sc newArg) ref app et
+                  el <- parseUninterpreted' (DoReturnTrip sym st sc newArg) ref app et
                   pure (ready el)
                 )
           
@@ -574,7 +580,7 @@ parseUninterpreted' saw ref app ty =
 
   -- Get the next symbolic term of this type, and also record its interpretation
   -- back into SAW Core (if we need to do so).
-  mkUninterpreted :: BaseTypeRepr t -> SAW sym -> StateT (UnintState sym) IO (SymExpr sym t)
+  mkUninterpreted :: BaseTypeRepr t -> ReturnTrip sym -> StateT (UnintState sym) IO (SymExpr sym t)
   mkUninterpreted tyr argTerm =
     do
       mp <- get
@@ -583,8 +589,8 @@ parseUninterpreted' saw ref app ty =
           do
             let newTerm =
                   case argTerm of
-                    NoSAW _     -> []
-                    SAW _ _ _ t -> t : atms
+                    NoReturnTrip _     -> []
+                    DoReturnTrip _ _ _ t -> t : atms
             put (MapF.insert tyr (Arr fn w xs newTerm) mp)
             pure x
         _ -> panic "mkUninterpreted" ["Not enough uninterpreted results"]

--- a/saw-core-what4/src/SAWCoreWhat4/Uninterp.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/Uninterp.hs
@@ -1,0 +1,830 @@
+{- |
+Given a constant of type `T`, construct an uninterpreted
+constant with that type.  The type `T` is *not* limited to What4 BaseTypes or
+FirstOrderTypes, and we support polymorphic and function types.ons.
+
+The Algorithm for Uninterpreted Functions
+=========================================
+
+Our strategy is to generate a separate uninterpreted function for each
+base type that is mentioned in the result of the original uninterpreted
+function.  If we need more than one value of a type, then we return an
+*array* of values, and the actual results of the original function are
+obtained by selecting elements of this array.
+
+For example, consider a function `f: [16] -> ([4][8],Bool)`.
+A call `f x` will be translated like this:
+
+  f_bv8:  [16] -> Array [2] [8]   // Uninterpreted
+  f_bool: [16] -> Bool            // Uninterpreted
+  w8s   = f_bv8 x                 // This has some auto-generated name
+  bools = f_bool x                // This has some auto-generated name
+
+Value for `f x`:
+  ([ w8s ! 0, w8s ! 1, w8s ! 2, w8s ! 3 ], bools)
+
+The reason we do this is to reduce the size of terms in examples like this:
+
+  g: [1024][8] -> [1024][8]
+
+`g` becomes a function of 1024 [8] arguments.  With the naive translation
+we'd end up with:
+
+  g_0 a0 .. a1023
+  g_1 a0 .. a1023
+  ..
+  g_1023 a0 .. a1023  
+
+Note that this has 1024 * 1024 terms.  With the array translation, we
+should end up with:
+
+  arr = g_u8 a0 .. a0123
+  el0 = arr @ 0
+  el1 = arr @ 1
+  ..
+  el1023 = arr @ 1023
+
+This is of size 1024 + 1024, which is much smaller.
+
+
+Handling Functions and Polymorphism (UnintApp, SymFnCache)
+==========================================================
+
+When working with a function type (`Pi`), we don't generate uninterpreted
+functions immediately.  Instead, we generate a Haskell function that collects
+the arguments and only generates the uninterpreted function when they are
+all available (see `VFun`) (i.e., the first time the uninterpreted function
+is called).   Once the functions are generated they are stored in a cache
+(see `SymFnCache`), so that future calls to the same function do not generate
+new uninterpreted symbols, but reuse the old ones.  This is not an optimization,
+but is crucial for the correct behavior of the algorithm.
+
+The `UnintApp` type is used to collect the arguments to a function, and also
+compute the root name for the function.   For ordinary (non-dependent) 
+function applications we just collect the arguments in the `UninApp`.  However,
+for dependent applications (e.g., to handle a size polymorphic function),
+we instead modify the root name of the function.  This means that different
+size instantiations of the functions end up with different uninterpreted
+function instances.   Here's an example:
+
+sum : {n} (fin n) => [n][8] -> [8]
+xs: [16][8]
+ys: [32][8]
+
+`sum xs` will result in something like this:
+
+sum_16_bv8: [8] -> [8] ..  [8] -> [8]     /* Has 16 arguments */
+sum_16_bv8 (xs @ 0) (xs @ 1) .. (xs @ 15)
+
+otoh, `sum ys` will result in something like this:
+sum_32_bv8: [8] -> [8] ..  [8] -> [8]     /* Has 32 arguments */
+sum_32_bv8 (ys @ 0) (ys @ 1) .. (ys @ 31)
+
+See `applyUnintApp` for the full details.
+
+
+Reinterpreting Terms Back Back to SAW Core (ArgTerm)
+====================================================
+
+Also we have two cases to consider:
+  1. When translating to the solver (`parseUninterpred`)
+  2. When doing symbolic simulation for SAW (`parseUninterpredSAW`).
+
+The difference between the two is that in case (2) we need to also be able
+to go back from the symbolic expressions to a semantically equivalent SAW
+Core term.  To do this, we need to provide interpretations for all the functions
+that were left as uninterpreted during the original translation.  For example,
+we'd need to register the following interpretations for the examples above:
+
+f_bv8 x = [ fst @ 0, fst @ 1, fst @ 2, fst @ 3 ]
+  where tup1 = (f x).0
+
+f_bool x = (f x).1
+
+g_u8 x0 x1 .. x1023 = [ fx @ 0, fx @ f1, ... fx @ 1023 ]
+  where fx = f [ x0, x1 .., x1023 ]
+
+Note1: the sharing in this examples (the `where` clause) happens
+automatically due to sharing inherent in SAW Core terms.
+
+Note2: we also need to reconstruct the arguments to the original functions
+from their components before calling (e.g., as in `g_u8`).
+
+We use the type `ArgTerm` to help us create the interpretation.  The
+constructors in `ArgTerm` are used to reassemble the arguments to the original
+function out of their pieces (e.g., put together the 1024 parameters into
+a single vector), while the selectors are used to connect a part of the
+result of the original function, to the relevant uninterpreted bit.
+
+-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
+module SAWCoreWhat4.Uninterp (
+  parseUninterpreted,
+  parseUninterpretedSAW,
+  mkUnintApp,
+  SymFnCache
+) where
+
+
+import Data.Bits
+import Data.IORef
+import Data.List (intercalate)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import qualified Data.Vector as V
+import qualified Data.BitVector.Sized as BV
+
+import Data.Traversable as T
+import Control.Monad ((<=<), foldM, unless)
+import Control.Monad.State as ST (MonadState(..), get, put, StateT(..), lift)
+import Numeric.Natural (Natural)
+
+-- saw-core
+import SAWCore.SharedTerm
+import SAWCore.Simulator.Value
+import SAWCore.Module (ResolvedName(..), ctorName, dtCtors, lookupVarIndexInMap)
+import SAWCore.Term.Functor (FieldName)
+
+-- what4
+import qualified What4.Expr.Builder as B
+import           What4.Interface(SymExpr,SymFnWrapper(..),IsSymExprBuilder)
+import qualified What4.Interface as W
+import           What4.BaseTypes
+import           What4.SWord (SWord(..))
+
+-- parameterized-utils
+import qualified Data.Parameterized.Context as Ctx
+import Data.Parameterized.Map (MapF)
+import qualified Data.Parameterized.Map as MapF
+import Data.Parameterized.Context (Assignment)
+import Data.Parameterized.Some
+
+-- saw-core
+import SAWCore.Name (toAbsoluteName, toQualName)
+
+-- saw-core-what4
+import SAWCoreWhat4.Common
+import SAWCoreWhat4.PosNat
+import SAWCoreWhat4.Panic
+import SAWCoreWhat4.ReturnTrip
+
+
+
+--------------------------------------------------------------------------------
+
+-- | A value of type @UnintApp f@ represents an uninterpreted function
+-- with the given 'String' name, applied to a list of argument values
+-- paired with a representation of their types. The context of
+-- argument types is existentially quantified.
+data UnintApp f =
+  forall args. UnintApp String (Assignment f args) (Assignment BaseTypeRepr args)
+
+-- | Extract the string from an 'UnintApp'.
+stringOfUnintApp :: UnintApp f -> String
+stringOfUnintApp (UnintApp s _ _) = s
+
+-- | Make an 'UnintApp' with the given name and no arguments.
+mkUnintApp :: String -> UnintApp f
+mkUnintApp nm = UnintApp nm Ctx.empty Ctx.empty
+
+-- | Add a suffix to the function name of an 'UnintApp'.  This is used
+-- to modify the function name for different polymorphic instantiations,
+-- for example.
+suffixUnintApp :: String -> UnintApp f -> UnintApp f
+suffixUnintApp s (UnintApp nm args tys) = UnintApp (nm ++ s) args tys
+
+-- | Extend an 'UnintApp' with an additional argument.
+extendUnintApp :: UnintApp f -> f ty -> BaseTypeRepr ty -> UnintApp f
+extendUnintApp (UnintApp nm xs tys) x ty =
+  UnintApp nm (Ctx.extend xs x) (Ctx.extend tys ty)
+
+-- | Flatten an 'SValue' to a sequence of components, each of which is
+-- a symbolic value of a base type (e.g. word or boolean), and add
+-- them to the list of arguments of the given 'UnintApp'. If the
+-- 'SValue' contains any values built from data constructors, then
+-- encode them as suffixes on the function name of the 'UnintApp'.
+applyUnintApp ::
+  forall sym.
+  (W.IsExprBuilder sym) =>
+  sym ->
+  UnintApp (SymExpr sym) ->
+  SValue sym ->
+  IO (UnintApp (SymExpr sym))
+applyUnintApp sym app0 v =
+  case v of
+    VVector xv                -> foldM (applyUnintApp sym) app0 =<< traverse force xv
+    VBool sb                  -> return (extendUnintApp app0 sb BaseBoolRepr)
+    VInt si                   -> return (extendUnintApp app0 si BaseIntegerRepr)
+    VIntMod 0 si              -> return (extendUnintApp app0 si BaseIntegerRepr)
+    VIntMod n si              -> do n' <- W.intLit sym (toInteger n)
+                                    si' <- W.intMod sym si n'
+                                    return (extendUnintApp app0 si' BaseIntegerRepr)
+    VRational numer denom     -> do app1 <- applyUnintApp sym app0 (VInt numer)
+                                    app2 <- applyUnintApp sym app1 (VInt denom)
+                                    pure app2
+    VWord (DBV sw)            -> return (extendUnintApp app0 sw (W.exprType sw))
+    VArray (SArray sa)        -> return (extendUnintApp app0 sa (W.exprType sa))
+    VWord ZBV                 -> return app0
+    VCtorApp 0 _ []           -> return app0
+    VCtorApp 0 _ [x, y]       -> do app1 <- applyUnintApp sym app0 =<< force x
+                                    app2 <- applyUnintApp sym app1 =<< force y
+                                    return app2
+    VCtorApp n _ xs           -> foldM (applyUnintApp sym) app' =<< traverse force xs
+                                   where app' = suffixUnintApp ("_" ++ show n) app0
+    VNat n                    -> return (suffixUnintApp ("_" ++ show n) app0)
+    VBVToNat w v'             -> applyUnintApp sym app' v'
+                                   where app' = suffixUnintApp ("_" ++ show w) app0
+    TValue (suffixTValue -> Just s)
+                              -> return (suffixUnintApp s app0)
+    VFun {} ->
+      fail $
+      "Cannot create uninterpreted higher-order function " ++
+      show (stringOfUnintApp app0)
+    _ ->
+      fail $
+      "Cannot create uninterpreted function " ++
+      show (stringOfUnintApp app0) ++
+      " with argument " ++ show v
+
+--------------------------------------------------------------------------------
+
+-- | Track how many uninterpreted results we need for each base type.
+newtype UnintCount (tc :: BaseType) = UnintCount Natural 
+
+-- | Count how many uninterpreted symbols we need to represent a value
+-- of the given type.  Note that this function should match exactly what
+-- is needed by `parseUninterpreted'`.
+countUninterpreted ::
+  IsSymExprBuilder sym =>
+  Natural -> MapF BaseTypeRepr UnintCount -> TValue (What4 sym) -> MapF BaseTypeRepr UnintCount
+countUninterpreted scale count ty =
+  case ty of
+    VPiType {}      -> count
+    VBoolType       -> add BaseBoolRepr count
+    VIntType        -> add BaseIntegerRepr count
+    VIntModType {}  -> add BaseIntegerRepr count
+    VRationalType   -> add BaseIntegerRepr (add BaseIntegerRepr count)
+    VVecType n VBoolType ->
+      case somePosNat n of
+        Just (Some (PosNat w)) -> add (BaseBVRepr w) count
+        _                      -> count
+
+    VVecType n et ->
+      if n == 0 then count else countUninterpreted (n * scale) count et
+
+    VArrayType ity ety
+      | Just (Some idx_repr) <- valueAsBaseType ity
+      , Just (Some elm_repr) <- valueAsBaseType ety
+      -> add (BaseArrayRepr (Ctx.Empty Ctx.:> idx_repr) elm_repr) count
+
+    VDataType (ModuleIdentifier "Prelude.UnitType") [] [] -> count
+
+    VDataType (ModuleIdentifier "Prelude.PairType") [TValue ty1, TValue ty2] [] ->
+      countUninterpreted scale (countUninterpreted scale count ty1) ty2
+
+    VDataType (ModuleIdentifier "Prelude.RecordType")
+      [VString _fname, TValue ty1, TValue ty2] [] ->
+      countUninterpreted scale (countUninterpreted scale count ty1) ty2
+
+    _ -> count
+  where
+  add ::
+    BaseTypeRepr tc ->
+    MapF BaseTypeRepr UnintCount ->
+    MapF BaseTypeRepr UnintCount
+  add bt =
+    MapF.insertWith
+      (\(UnintCount x) (UnintCount y) -> UnintCount (x + y))
+      bt (UnintCount scale)
+
+
+
+-- | Uninterpreted function results for each base type.
+type UnintState sym = MapF BaseTypeRepr (Arr sym)
+
+-- | Uninterpreted function results for a particular base type.
+-- The length of the lists should match the @UnintCount tc@ for the type.
+data Arr sym tc = forall args res. Arr {
+  arrFn :: W.SymFn sym args res,
+  -- ^ The uninterpreted function name.
+
+  arrIndexWidth :: !Natural,
+  -- ^ How many bits to use for the array index.
+
+  arrSymExprs  :: [SymExpr sym tc],
+  -- ^ Available symbolic expressions
+
+  arrFromSym   :: [ArgTerm]
+  -- ^ How to map `n`-th symbolic expression back into a SAW Core term.
+  -- Note that these are in reverse order---every time we take a thing
+  -- from `arrSymExprs`, we cons a new thing onto here.
+}
+
+-- | Generate a call to an uninterpreted function, without reinterpreting
+-- back into SAW Core.
+parseUninterpreted ::
+  forall sym.
+  (IsSymExprBuilder sym) =>
+  sym                         {- ^ How to make symbolic expressions -} ->
+  IORef (SymFnCache sym)      {- ^ Cache of known uninterpreted functions -} ->
+  UnintApp (SymExpr sym)      {- ^ Name of function and its arguments -} ->
+  TValue (What4 sym)          {- ^ Type of the function's result -} ->
+  IO (SValue sym)             {- ^ The symbolic value for the call to the uninterpreted function -}
+parseUninterpreted sym = parseUninterpretedTop (NoSAW sym)
+
+-- | Generate a call to an uninterpreted function, and also register mapping
+-- back into SAW Core.
+parseUninterpretedSAW ::
+  forall n st fs.
+  B.ExprBuilder n st fs     {- ^ How to make symbolic expressions -} ->
+  SAWCoreState n            {- ^ Register interpretations for terms here -} ->
+  SharedContext             {- ^ Use this to build SAW Core terms -} ->
+  IORef (SymFnCache (B.ExprBuilder n st fs)) {- ^ Cache of known uninterpreted functions -} ->
+  Term                      {- ^ Original term -} ->
+  UnintApp (SymExpr (B.ExprBuilder n st fs)) {- ^ Type of the function's result -} ->
+  TValue (What4 (B.ExprBuilder n st fs)) {- ^ Type of the function's result. -} ->
+  IO (SValue (B.ExprBuilder n st fs))
+parseUninterpretedSAW sym st sc ref term app t =
+  parseUninterpretedTop (SAW sym st sc (ArgTermConst term)) ref app t
+
+parseUninterpretedTop ::
+  forall sym.
+  (IsSymExprBuilder sym) =>
+  SAW sym ->
+  IORef (SymFnCache sym)      {- ^ Cache of known uninterpreted functions -} ->
+  UnintApp (SymExpr sym)      {- ^ Name of function and its arguments -} ->
+  TValue (What4 sym)          {- ^ Type of the function's result -} ->
+  IO (SValue sym)             {- ^ The symbolic value for the call to the uninterpreted function -}
+parseUninterpretedTop saw ref app ty =
+  do
+    count <- withSym saw (\sym ->
+      MapF.traverseWithKey (mkUnint sym ref app) (countUninterpreted 1 MapF.empty ty))
+    (val,st) <- runStateT (parseUninterpreted' saw ref app ty) count
+    case saw of
+      NoSAW _ -> pure ()
+      SAW sym sawSt sc _ -> MapF.traverseWithKey_ register st
+        where
+        {- NOTE: Previously we had a special case for 0 arity functions, which
+            didn't generate an uninterpreted symbol, and instead did this:
+               bindSAWTerm sym st ret =<< reconstructArgTerm trm sc []
+            I am not 100% sure, but I suspect it might have been the cause
+            for #3166.  Currently, we treat uninterpreted symbols uniformly,
+            no matter how many arguments they have. -}
+
+        register :: BaseTypeRepr t -> Arr sym t -> IO ()
+        register k (Arr fn ixW _ vs) =
+          do
+            elTy <- baseSCType sym sc k
+            sawRegisterSymFunInterp sawSt fn $ \sc' ts ->
+              do
+                terms <- mapM (\ate -> reconstructArgTerm ate sc' ts) (reverse vs)
+                case terms of
+                  [t] -> pure (UninterpOne t)
+                  _   -> pure (UninterpMany ixW elTy (V.fromList terms))
+
+    pure val
+    
+
+
+
+-- | Generate the uninterpreted functions.
+mkUnint ::
+  forall sym tc.
+  (IsSymExprBuilder sym) =>
+  sym                         {- ^ How to make symbolic expressions -} ->
+  IORef (SymFnCache sym)      {- ^ Cache of known uninterpreted functions -} ->
+  UnintApp (SymExpr sym)      {- ^ Name of function and its arguments -} ->
+  BaseTypeRepr tc             {- ^ Type of value -} ->
+  UnintCount tc               {- ^ How many values we need -} ->
+  IO (Arr sym tc)
+mkUnint sym ref (UnintApp nm args tys) ret (UnintCount tot)
+  | let lim = tot - 1
+  , let wn = width lim
+  , Just (Some w) <- someNat wn =
+    case isZeroOrGT1 w of
+
+      -- We need only a single symbolic value (i.e., 0-bit index)
+      Left Refl ->
+        do
+          fn <- mkSymFn sym ref (nm ++ suff ret) tys ret
+          el <- W.applySymFn sym fn args
+          pure (Arr { arrFn = fn, arrIndexWidth = wn, arrSymExprs = [el], arrFromSym = [] })
+
+      -- We need multiple symbolic values of this type, result is array
+      Right LeqProof ->
+        do
+          fn <- mkSymFn sym ref (nm ++ suff ret) tys (BaseArrayRepr (Ctx.singleton (BaseBVRepr w)) ret)
+          arr <- W.applySymFn sym fn args
+          els <- forM [ 0 .. lim ] $ \i ->
+            do
+              ind <- W.bvLit sym w (BV.mkBV w (fromIntegral i))
+              W.arrayLookup sym arr (Ctx.singleton ind)
+          pure (Arr { arrFn = fn, arrIndexWidth = wn, arrSymExprs = els, arrFromSym = [] })
+
+  | otherwise =
+    panic "parseUninterpreted" ["`someNat` returned `Nothing` for `Natural`"]
+
+  where
+  -- | Compute the number of bits required to represent the given integer,
+  -- used to index the array of uninterpreted values.
+  width :: Natural -> Natural
+  width x = go 0 x
+    where
+    go s 0 = s
+    go s n = let s' = s + 1 in s' `seq` go s' (n `shiftR` 1)
+
+  -- Type suffixes for uninterpreted functions of each base type.
+  suff :: BaseTypeRepr a -> String
+  suff t =
+    case t of
+      BaseBoolRepr -> "_bool"
+      BaseIntegerRepr -> "_int"
+      BaseRealRepr -> "_real"
+      BaseComplexRepr -> "_complex"
+      BaseBVRepr w -> "_bv" ++ show w
+      BaseFloatRepr (FloatingPointPrecisionRepr x y) -> "_float_" ++ show x ++ "_" ++ show y
+      BaseStringRepr w -> "_str" ++ strw
+        where strw = case w of
+                       Char8Repr -> "8"
+                       Char16Repr -> "16"
+                       UnicodeRepr -> "U"
+      BaseArrayRepr i e -> "_fun" ++ suff_asgn i ++ "_to" ++ suff e
+      BaseStructRepr flds -> "_struct" ++ suff_asgn flds ++ "_end"
+
+  suff_asgn i = intercalate "_and" (V.toList (Ctx.toVector i suff))
+
+
+data SAW sym =
+    NoSAW sym
+  | forall n st fs. (sym ~ B.ExprBuilder n st fs ) =>
+    SAW sym (SAWCoreState n) SharedContext ArgTerm
+  
+withSym :: IsSymExprBuilder sym => SAW sym -> (sym -> a) -> a
+withSym xs k =
+  case xs of
+    NoSAW sym -> k sym
+    SAW sym _ _ _ -> k sym
+
+mapArgTerm :: (ArgTerm -> ArgTerm) -> SAW sym -> SAW sym
+mapArgTerm f saw =
+  case saw of
+    NoSAW sym -> NoSAW sym
+    SAW sym st sc t -> SAW sym st sc (f t)
+
+parseUninterpreted' ::
+  forall sym.
+  (IsSymExprBuilder sym) =>
+  SAW sym ->
+  IORef (SymFnCache sym) ->
+  UnintApp (SymExpr sym) ->
+  TValue (What4 sym) ->
+  StateT (UnintState sym) IO (SValue sym)
+parseUninterpreted' saw ref app ty =
+  case ty of
+    VPiType t1 body ->
+      pure $ VFun $ \x ->
+        do
+          x'   <- force x
+          app' <- withSym saw (\sym -> applyUnintApp sym app x')
+          t2   <- applyPiBody body (ready x')
+
+          saw' <-
+            case saw of
+              NoSAW sym -> pure (NoSAW sym)
+              SAW sym st sc trm ->
+                do newArg <- mkArgTerm sc t1 x'
+                   let newTerm = ArgTermApply trm newArg
+                   pure (SAW sym st sc newTerm)
+
+          parseUninterpretedTop saw' ref app' t2
+
+    VBoolType
+      -> VBool <$> mkUninterpreted BaseBoolRepr saw
+
+    VIntType
+      -> VInt <$> mkUninterpreted BaseIntegerRepr saw
+
+    VIntModType n
+      -> VIntMod n <$> mkUninterpreted BaseIntegerRepr (mapArgTerm (ArgTermFromIntMod n) saw)
+
+    VRationalType ->
+      do
+        -- See:
+        -- https://github.com/GaloisInc/saw-script/issues/3206
+        -- https://github.com/GaloisInc/what4/issues/364 
+        -- Note that the `bad` would only matter if we use a rational in the
+        -- result of an uninterpreted function, and we need to import the
+        -- resulting What4 term back into What4
+        let bad = ArgTermErr ("Rationals in the results of uninterpreted functions are unsupported")
+        numer <- mkUninterpreted BaseIntegerRepr (mapArgTerm (\_ -> bad) saw)
+        -- TODO(#2433): Assert that the denominator is non-zero.
+        denom <- mkUninterpreted BaseIntegerRepr (mapArgTerm (\_ -> bad) saw)
+        pure $ VRational numer denom
+
+    VVecType n VBoolType ->
+      case somePosNat n of
+        Just (Some (PosNat w)) -> VWord . DBV <$> mkUninterpreted (BaseBVRepr w) saw
+        _                      -> pure (VWord ZBV)
+
+    VVecType n et
+      | n > 0 ->
+        VVector <$>
+        case saw of
+          NoSAW _ -> V.replicateM (fromIntegral n) (ready <$> parseUninterpreted' saw ref app et)
+          SAW sym st sc arg ->
+            do
+              elTy <- lift (termOfTValue sc et)
+              V.generateM (fromIntegral n) (\i ->
+                do
+                  let newArg = ArgTermAt n elTy arg (fromIntegral i) 
+                  el <- parseUninterpreted' (SAW sym st sc newArg) ref app et
+                  pure (ready el)
+                )
+          
+    VArrayType ity ety
+      | Just (Some idx_repr) <- valueAsBaseType ity
+      , Just (Some elm_repr) <- valueAsBaseType ety
+      -> (VArray . SArray) <$>
+          mkUninterpreted (BaseArrayRepr (Ctx.Empty Ctx.:> idx_repr) elm_repr) saw
+
+    VDataType (ModuleIdentifier "Prelude.UnitType") [] []
+      -> pure vUnit
+
+    VDataType (ModuleIdentifier "Prelude.PairType") [TValue ty1, TValue ty2] []
+      -> do x1 <- parseUninterpreted' (mapArgTerm ArgTermPairLeft saw) ref app ty1
+            x2 <- parseUninterpreted' (mapArgTerm ArgTermPairRight saw) ref app ty2
+            pure (vPair (ready x1) (ready x2))
+
+    VDataType (ModuleIdentifier "Prelude.EmptyType") [] []
+      -> pure vEmptyRecord
+    VDataType (ModuleIdentifier "Prelude.RecordType")
+      [VString fname, TValue ty1, TValue ty2] []
+      -> do x1 <- parseUninterpreted' (mapArgTerm (`ArgTermRecordSelect` fname) saw) ref app ty1
+            x2 <- parseUninterpreted' saw ref app ty2
+            pure (vRecordValue (ready x1) (ready x2))
+
+    _ -> fail $ "could not create uninterpreted symbol of type " ++ show ty
+  where
+
+  -- Get the next symbolic term of this type, and also record its interpretation
+  -- back into SAW Core (if we need to do so).
+  mkUninterpreted :: BaseTypeRepr t -> SAW sym -> StateT (UnintState sym) IO (SymExpr sym t)
+  mkUninterpreted tyr argTerm =
+    do
+      mp <- get
+      case MapF.lookup tyr mp of
+        Just (Arr fn w (x : xs) atms) ->
+          do
+            let newTerm =
+                  case argTerm of
+                    NoSAW _     -> []
+                    SAW _ _ _ t -> t : atms
+            put (MapF.insert tyr (Arr fn w xs newTerm) mp)
+            pure x
+        _ -> panic "mkUninterpreted" ["Not enough uninterpreted results"]
+
+--------------------------------------------------------------------------------
+-- `ArgTerms` are used to remember the mappings between low-level symbolic
+-- terms and SAW core terms. 
+
+
+-- | An 'ArgTerm' is a description of how to reassemble a saw-core
+-- term from a list of the atomic components it is composed of.
+data ArgTerm
+  = ArgTermVar
+  | ArgTermBVZero -- ^ scBvNat 0 0
+  | ArgTermToIntMod Natural ArgTerm -- ^ toIntMod n x
+  | ArgTermFromIntMod Natural ArgTerm -- ^ fromIntMod n x
+  | ArgTermRational ArgTerm ArgTerm -- ^ numerator, denominator
+  | ArgTermVector Term [ArgTerm] -- ^ element type, elements
+  | ArgTermUnit
+  | ArgTermPair ArgTerm ArgTerm
+  | ArgTermEmpty
+  | ArgTermRecord FieldName ArgTerm ArgTerm
+  | ArgTermRecordSelect ArgTerm FieldName
+  | ArgTermConst Term
+  | ArgTermApply ArgTerm ArgTerm
+  | ArgTermAt Natural Term ArgTerm Natural
+    -- ^ length, element type, list, index
+  | ArgTermPairLeft ArgTerm
+  | ArgTermPairRight ArgTerm
+  | ArgTermBVToNat Natural ArgTerm
+  | ArgTermErr String
+    deriving Show
+
+-- | Reassemble a saw-core term from an 'ArgTerm' and a list of parts.
+-- The length of the list should be equal to the number of
+-- 'ArgTermVar' constructors in the 'ArgTerm'.
+reconstructArgTerm :: ArgTerm -> SharedContext -> [Term] -> IO Term
+reconstructArgTerm atrm sc ts =
+  do (t, unused) <- parse atrm ts
+     unless (null unused) $ fail "reconstructArgTerm: too many function arguments"
+     return t
+  where
+    parse :: ArgTerm -> [Term] -> IO (Term, [Term])
+    parse at ts0 =
+      case at of
+        ArgTermVar ->
+          case ts0 of
+            x : ts1 -> return (x, ts1)
+            [] -> fail "reconstructArgTerm: too few function arguments"
+        ArgTermBVZero ->
+          do z <- scNat sc 0
+             x <- scBvNat sc z z
+             return (x, ts0)
+        ArgTermToIntMod n at1 ->
+          do n' <- scNat sc n
+             (x1, ts1) <- parse at1 ts0
+             x <- scToIntMod sc n' x1
+             pure (x, ts1)
+        ArgTermFromIntMod n at1 ->
+          do n' <- scNat sc n
+             (x1, ts1) <- parse at1 ts0
+             x <- scFromIntMod sc n' x1
+             pure (x, ts1)
+        ArgTermRational numer denom ->
+          do (numer', ts1) <- parse numer ts0
+             (denom', ts2) <- parse denom ts1
+             rat <- scRational sc numer' denom'
+             pure (rat, ts2)
+        ArgTermVector ty ats ->
+          do (xs, ts1) <- parseList ats ts0
+             x <- scVectorReduced sc ty xs
+             return (x, ts1)
+        ArgTermUnit ->
+          do x <- scUnitValue sc
+             return (x, ts0)
+        ArgTermPair at1 at2 ->
+          do (x1, ts1) <- parse at1 ts0
+             (x2, ts2) <- parse at2 ts1
+             x <- scPairValue sc x1 x2
+             return (x, ts2)
+        ArgTermEmpty ->
+          do x <- scRecordValue sc []
+             pure (x, ts0)
+        ArgTermRecord fname at1 at2 ->
+          do s <- scString sc fname
+             (x1, ts1) <- parse at1 ts0
+             (x2, ts2) <- parse at2 ts1
+             ty1 <- scTypeOf sc x1
+             ty2 <- scTypeOf sc x2
+             x <- scGlobalApply sc "Prelude.RecordValue" [s, ty1, ty2, x1, x2]
+             pure (x, ts2)
+        ArgTermRecordSelect at1 fname ->
+          do (x1, ts1) <- parse at1 ts0
+             x <- scRecordSelect sc x1 fname
+             pure (x, ts1)
+        ArgTermConst x ->
+          do return (x, ts0)
+        ArgTermApply at1 at2 ->
+          do (x1, ts1) <- parse at1 ts0
+             (x2, ts2) <- parse at2 ts1
+             x <- scApply sc x1 x2
+             return (x, ts2)
+        ArgTermAt n ty at1 i ->
+          do n' <- scNat sc n
+             (x1, ts1) <- parse at1 ts0
+             i' <- scNat sc i
+             x <- scAt sc n' ty x1 i'
+             return (x, ts1)
+        ArgTermPairLeft at1 ->
+          do (x1, ts1) <- parse at1 ts0
+             x <- scPairLeft sc x1
+             return (x, ts1)
+        ArgTermPairRight at1 ->
+          do (x1, ts1) <- parse at1 ts0
+             x <- scPairRight sc x1
+             return (x, ts1)
+        ArgTermBVToNat w at1 ->
+          do (x1, ts1) <- parse at1 ts0
+             x <- scBvToNat sc w x1
+             pure (x, ts1)
+        ArgTermErr msg -> fail msg
+
+    parseList :: [ArgTerm] -> [Term] -> IO ([Term], [Term])
+    parseList [] ts0 = return ([], ts0)
+    parseList (at : ats) ts0 =
+      do (x, ts1) <- parse at ts0
+         (xs, ts2) <- parseList ats ts1
+         return (x : xs, ts2)
+
+-- | Given a type and value encoded as 'SValue's, construct an
+-- 'ArgTerm' that builds a term of that type from local variables with
+-- base types. The number of 'ArgTermVar' constructors should match
+-- the number of arguments appended by 'applyUnintApp'.
+mkArgTerm :: forall sym. SharedContext -> TValue (What4 sym) -> SValue sym -> IO ArgTerm
+mkArgTerm sc ty val =
+  case (ty, val) of
+    (VBoolType, VBool _) -> return ArgTermVar
+    (VIntType, VInt _)   -> return ArgTermVar
+    (_, VWord ZBV)       -> return ArgTermBVZero     -- 0-width bitvector is a constant
+    (_, VWord (DBV _))   -> return ArgTermVar
+    (_, VArray{})        -> return ArgTermVar
+    (VIntModType n, VIntMod _ _) -> pure (ArgTermToIntMod n ArgTermVar)
+    (VRationalType, VRational numer denom) ->
+      do numer' <- mkArgTerm @sym sc VIntType (VInt numer)
+         denom' <- mkArgTerm @sym sc VIntType (VInt denom)
+         pure (ArgTermRational numer' denom')
+
+    (VVecType _ ety, VVector vv) ->
+      do vs <- traverse force (V.toList vv)
+         xs <- traverse (mkArgTerm sc ety) vs
+         ety' <- termOfTValue sc ety
+         return (ArgTermVector ety' xs)
+
+    (VDataType (ModuleIdentifier "Prelude.UnitType") [] [],
+     VCtorApp 0 _ [])
+                         -> return ArgTermUnit
+    (VDataType (ModuleIdentifier "Prelude.PairType") [TValue ty1, TValue ty2] [],
+     VCtorApp 0 _ [v1, v2]) ->
+      do x1 <- mkArgTerm sc ty1 =<< force v1
+         x2 <- mkArgTerm sc ty2 =<< force v2
+         return (ArgTermPair x1 x2)
+
+    (VDataType (ModuleIdentifier "Prelude.EmptyType") [] [],
+     VCtorApp 0 _ []) ->
+      pure ArgTermEmpty
+    (VDataType _nm [VString fname, TValue ty1, TValue ty2] [],
+     VCtorApp 0 _ [v1, v2]) ->
+      do x1 <- mkArgTerm sc ty1 =<< force v1
+         x2 <- mkArgTerm sc ty2 =<< force v2
+         pure (ArgTermRecord fname x1 x2)
+
+    (VDataType nmi ps _, VCtorApp n _ vv) ->
+      do mvi <- scResolveQualName sc (toQualName nmi)
+         vi <-
+           case mvi of
+             Just vi -> pure vi
+             Nothing -> panic "mkArgTerm" ["Data type name not found: " <> toAbsoluteName nmi]
+         mm <- scGetModuleMap sc
+         dt <-
+           case lookupVarIndexInMap vi mm of
+             Just (ResolvedDataType dt) -> pure dt
+             _ -> panic "mkArgTerm" ["Data type not found: " <> toAbsoluteName nmi]
+         let ctor = dtCtors dt !! n
+         ps' <- traverse (termOfSValue sc) ps
+         vv' <- traverse (termOfSValue sc <=< force) vv
+         x   <- scConstApply sc (ctorName ctor) (ps' ++ vv')
+         return (ArgTermConst x)
+
+    (_, TValue tval) ->
+      do x <- termOfTValue sc tval
+         pure (ArgTermConst x)
+
+    (_, VNat n) ->
+      do x <- scNat sc n
+         pure (ArgTermConst x)
+
+    (_, VBVToNat w v) ->
+      do let w' = fromIntegral w -- FIXME: make w :: Natural to avoid fromIntegral
+         x <- mkArgTerm sc (VVecType w' VBoolType) v
+         pure (ArgTermBVToNat w' x)
+
+    _ -> fail $ "could not create uninterpreted function argument of type " ++ show ty
+
+
+
+--------------------------------------------------------------------------------
+-- Uninterpreted function cache
+
+type SymFnCache sym =
+  Map W.SolverSymbol (MapF (Assignment BaseTypeRepr) (SymFnWrapper sym))
+
+lookupSymFn ::
+  W.SolverSymbol -> Assignment BaseTypeRepr args -> BaseTypeRepr ty ->
+  SymFnCache sym -> Maybe (W.SymFn sym args ty)
+lookupSymFn s args ty cache =
+  do m <- Map.lookup s cache
+     SymFnWrapper fn <- MapF.lookup (Ctx.extend args ty) m
+     return fn
+
+insertSymFn ::
+  W.SolverSymbol -> Assignment BaseTypeRepr args -> BaseTypeRepr ty ->
+  W.SymFn sym args ty -> SymFnCache sym -> SymFnCache sym
+insertSymFn s args ty fn = Map.alter upd s
+  where
+    upd Nothing = Just (MapF.singleton (Ctx.extend args ty) (SymFnWrapper fn))
+    upd (Just m) = Just (MapF.insert (Ctx.extend args ty) (SymFnWrapper fn) m)
+
+mkSymFn ::
+  forall sym args ret. (IsSymExprBuilder sym) =>
+  sym -> IORef (SymFnCache sym) ->
+  String -> Assignment BaseTypeRepr args -> BaseTypeRepr ret ->
+  IO (W.SymFn sym args ret)
+mkSymFn sym ref nm args ret =
+  do let s = W.safeSymbol nm
+     cache <- readIORef ref
+     case lookupSymFn s args ret cache of
+       Just fn -> pure fn
+       Nothing ->
+         do fn <- W.freshTotalUninterpFn sym s args ret
+            writeIORef ref (insertSymFn s args ret fn cache)
+            pure fn
+--------------------------------------------------------------------------------
+

--- a/saw-core-what4/src/SAWCoreWhat4/What4.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/What4.hs
@@ -45,16 +45,12 @@ module SAWCoreWhat4.What4
   , symExprToValue
   ) where
 
-
-
 import qualified Control.Arrow as A
 
 import Data.Bits
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import Data.IORef
-import Data.Kind (Type)
-import Data.List (genericTake,intercalate)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Ratio ((%))
@@ -63,10 +59,9 @@ import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Vector (Vector)
 import qualified Data.Vector as V
-import qualified Data.BitVector.Sized as BV
 
 import Data.Traversable as T
-import Control.Monad ((<=<), foldM, unless)
+import Control.Monad (foldM)
 import Control.Monad.State as ST (MonadState(..), get, put, StateT(..), evalStateT, modify)
 import Control.Monad.Trans.Class (MonadTrans(..))
 import Numeric.Natural (Natural)
@@ -79,14 +74,14 @@ import SAWCore.SATQuery
 import SAWCore.SharedTerm
 import SAWCore.Simulator.Value
 import SAWCore.FiniteValue (FirstOrderType(..), FirstOrderValue(..))
-import SAWCore.Module (ModuleMap, ResolvedName(..), ctorName, dtCtors, lookupVarIndexInMap)
-import SAWCore.Name (Name(..), VarName(..), toAbsoluteName, toShortName, toQualName)
+import SAWCore.Module (ModuleMap)
+import SAWCore.Name (Name(..), VarName(..), toShortName)
 import SAWCore.Term.Functor (FieldName)
 
 -- what4
 import qualified What4.Expr.Builder as B
 import           What4.Expr.GroundEval
-import           What4.Interface(SymExpr,Pred,SymInteger, IsExpr, SymFnWrapper(..),
+import           What4.Interface(SymExpr,Pred,SymInteger, IsExpr,
                                  IsExprBuilder,IsSymExprBuilder, BoundVar)
 import qualified What4.Interface as W
 import           What4.BaseTypes
@@ -95,54 +90,15 @@ import           What4.SWord (SWord(..))
 
 -- parameterized-utils
 import qualified Data.Parameterized.Context as Ctx
-import Data.Parameterized.Map (MapF)
-import qualified Data.Parameterized.Map as MapF
-import Data.Parameterized.Context (Assignment)
 import Data.Parameterized.Some
 
 -- saw-core-what4
+import SAWCoreWhat4.Common
 import SAWCoreWhat4.PosNat
 import SAWCoreWhat4.FirstOrder
 import SAWCoreWhat4.Panic
 import SAWCoreWhat4.ReturnTrip
-
----------------------------------------------------------------------
--- empty datatype to index (open) type families
--- for this backend
-data What4 (sym :: Type)
-
--- | A What4 symbolic array where the domain and co-domain types do not appear
---   in the type
-data SArray sym where
-  SArray ::
-    W.IsExpr (W.SymExpr sym) =>
-    W.SymArray sym (Ctx.EmptyCtx Ctx.::> itp) etp ->
-    SArray sym
-
--- type abbreviations for uniform naming
-type SBool sym = Pred sym
-type SInt  sym = SymInteger sym
-
-type instance EvalM (What4 sym) = IO
-type instance VBool (What4 sym) = SBool sym
-type instance VWord (What4 sym) = SWord sym
-type instance VInt  (What4 sym) = SInt  sym
-type instance VArray (What4 sym) = SArray sym
-type instance Extra (What4 sym) = What4Extra sym
-
-type SValue sym = Value (What4 sym)
-type SPrim sym  = Prims.Prim (What4 sym)
-
--- Constraint
-type Sym sym = IsSymExprBuilder sym
-
----------------------------------------------------------------------
-
-data What4Extra sym =
-  SStream (Natural -> IO (SValue sym)) (IORef (Map Natural (SValue sym)))
-
-instance Show (What4Extra sym) where
-  show (SStream _ _) = "<SStream>"
+import SAWCoreWhat4.Uninterp
 
 ---------------------------------------------------------------------
 --
@@ -666,9 +622,6 @@ selectV sym merger maxValue valueFn vx =
       p <- SW.bvAtLE sym vx (toInteger j)
       merger p (impl j (y `setBit` j)) (impl j y) where j = i - 1
 
-instance Show (SArray sym) where
-  show (SArray arr) = show $ W.printSymExpr arr
-
 arrayConstant ::
   W.IsSymExprBuilder sym =>
   sym ->
@@ -902,338 +855,11 @@ w4SolveBasic sym sc addlPrims varMap ref unintSet t =
      Sim.evalSharedTerm cfg t
 
 
-----------------------------------------------------------------------
--- Uninterpreted function cache
-
-{-
-data SymFnWrapper sym :: Ctx.Ctx BaseType -> Type where
-  SymFnWrapper :: !(W.SymFn sym args ret) -> SymFnWrapper sym (args Ctx.::> ret)
--}
-type SymFnCache sym = Map W.SolverSymbol (MapF (Assignment BaseTypeRepr) (SymFnWrapper sym))
-
-lookupSymFn ::
-  W.SolverSymbol -> Assignment BaseTypeRepr args -> BaseTypeRepr ty ->
-  SymFnCache sym -> Maybe (W.SymFn sym args ty)
-lookupSymFn s args ty cache =
-  do m <- Map.lookup s cache
-     SymFnWrapper fn <- MapF.lookup (Ctx.extend args ty) m
-     return fn
-
-insertSymFn ::
-  W.SolverSymbol -> Assignment BaseTypeRepr args -> BaseTypeRepr ty ->
-  W.SymFn sym args ty -> SymFnCache sym -> SymFnCache sym
-insertSymFn s args ty fn = Map.alter upd s
-  where
-    upd Nothing = Just (MapF.singleton (Ctx.extend args ty) (SymFnWrapper fn))
-    upd (Just m) = Just (MapF.insert (Ctx.extend args ty) (SymFnWrapper fn) m)
-
-mkSymFn ::
-  forall sym args ret. (IsSymExprBuilder sym) =>
-  sym -> IORef (SymFnCache sym) ->
-  String -> Assignment BaseTypeRepr args -> BaseTypeRepr ret ->
-  IO (W.SymFn sym args ret)
-mkSymFn sym ref nm args ret =
-  do let s = W.safeSymbol nm
-     cache <- readIORef ref
-     case lookupSymFn s args ret cache of
-       Just fn -> return fn
-       Nothing ->
-         do fn <- W.freshTotalUninterpFn sym s args ret
-            writeIORef ref (insertSymFn s args ret fn cache)
-            return fn
-
-----------------------------------------------------------------------
--- Given a constant nm of (saw-core) type ty, construct an uninterpreted
--- constant with that type.
--- Importantly: The types of these uninterpreted values are *not*
--- limited to What4 BaseTypes or FirstOrderTypes.
-
-{- NOTE: How we generate uninterpreted functions
-
-Our strategy is to generate a separate uninterpreted function for each
-base type that is mentioned in the result of the original uninterpreted
-function.  If we need more than one value of a type, then we return an
-*array* of values, and the actual results of the original function are
-obtained by selecting elements of this array.
-
-For example, consider a function `f: [16] -> ([4][8],Bool)`.
-A call `f x` will be translated like this:
-
-  f_bv8:  [16] -> Array [2] [8]   // Uninterpreted
-  f_bool: [16] -> Bool            // Uninterpreted
-  w8s   = f_bv8 x                 // This has some auto-generated name
-  bools = f_bool x                // This has some auto-generated name
-
-Value for `f x`:
-  ([ w8s ! 0, w8s ! 1, w8s ! 2, w8s ! 3 ], bools)
--}
 
 
 
--- | Track how many uninterpreted results we need for each base type.
-newtype UnintCount (tc :: BaseType) = UnintCount Natural
-
--- | Uninterpreted function results for each base type.
-type UnintState sym = MapF BaseTypeRepr (Arr sym)
-
--- | Uninterpreted function results for a particular base type.
--- The length of the lists should match the @UnintCount tc@ for the type.
-newtype Arr sym tc = Arr [SymExpr sym tc]
-
--- | Generate a call to an uninterpreted function.
-parseUninterpreted ::
-  forall sym.
-  (IsSymExprBuilder sym) =>
-  sym                         {- ^ How to make symbolic expressions -} ->
-  IORef (SymFnCache sym)      {- ^ Cache of known uninterpreted functions -} ->
-  UnintApp (SymExpr sym)      {- ^ Name of function and its arguments -} ->
-  TValue (What4 sym)          {- ^ Type of the function's result -} ->
-  IO (SValue sym)             {- ^ The symbolic value for the call to the uninterpreted function -}
-parseUninterpreted sym ref app@(UnintApp nm args tys) ty =
-  do
-    un <- MapF.traverseWithKey mkUnint (countUninterpreted 1 MapF.empty ty)
-    evalStateT (parseUninterpreted' sym ref app ty) un
-  where
-  mkUnint :: BaseTypeRepr tc -> UnintCount tc -> IO (Arr sym tc)
-  mkUnint ret (UnintCount n)
-    | let lim = n - 1
-    , Just (Some w) <- someNat (width lim) =
-      case isZeroOrGT1 w of
-        Left Refl ->
-          do
-            fn <- mkSymFn sym ref (nm ++ suff ret) tys ret
-            el <- W.applySymFn sym fn args
-            pure (Arr [el])
-        Right LeqProof ->
-          do
-            fn   <- mkSymFn sym ref (nm ++ suff ret) tys (BaseArrayRepr (Ctx.singleton (BaseBVRepr w)) ret)
-            arr  <- W.applySymFn sym fn args
-            els <- forM [ 0 .. lim ] $ \i ->
-              do
-                ind <- W.bvLit sym w (BV.mkBV w (fromIntegral i))
-                W.arrayLookup sym arr (Ctx.singleton ind)
-            pure (Arr els)
-    | otherwise = panic "parseUninterpreted" ["`someNat` returned `Nothing` for `Natural`"]
-
-  -- | Compute the number of bits required to represent the given integer.
-  width :: Natural -> Natural
-  width x = go 0 x
-    where
-      go s 0 = s
-      go s n = let s' = s + 1 in s' `seq` go s' (n `shiftR` 1)
-
-  -- Type suffixes for uninterpreted functions of each base type.
-  suff :: BaseTypeRepr a -> String
-  suff t =
-    case t of
-      BaseBoolRepr -> "_bool"
-      BaseIntegerRepr -> "_int"
-      BaseRealRepr -> "_real"
-      BaseComplexRepr -> "_complex"
-      BaseBVRepr w -> "_bv" ++ show w
-      BaseFloatRepr (FloatingPointPrecisionRepr x y) -> "_float_" ++ show x ++ "_" ++ show y
-      BaseStringRepr w -> "_str" ++ strw
-        where strw = case w of
-                       Char8Repr -> "8"
-                       Char16Repr -> "16"
-                       UnicodeRepr -> "U"
-      BaseArrayRepr i e -> "_fun" ++ suff_asgn i ++ "_to" ++ suff e
-      BaseStructRepr flds -> "_struct" ++ suff_asgn flds ++ "_end"
-
-  suff_asgn i = intercalate "_and" (V.toList (Ctx.toVector i suff))
 
 
-
--- | Count how many uninterpreted symbols we need to represent a value
--- of the given type.  Note that this function should match exactly what
--- is needed by `parseUninterpreted'`.
-countUninterpreted ::
-  IsSymExprBuilder sym =>
-  Natural -> MapF BaseTypeRepr UnintCount -> TValue (What4 sym) -> MapF BaseTypeRepr UnintCount
-countUninterpreted scale count ty =
-  case ty of
-    VPiType {}      -> count
-    VBoolType       -> add BaseBoolRepr count
-    VIntType        -> add BaseIntegerRepr count
-    VIntModType {}  -> add BaseIntegerRepr count
-    VRationalType   -> add BaseIntegerRepr (add BaseIntegerRepr count)
-    VVecType n VBoolType ->
-      case somePosNat n of
-        Just (Some (PosNat w)) -> add (BaseBVRepr w) count
-        _                      -> count
-
-    VVecType n et -> if n == 0 then count else countUninterpreted (n * scale) count et
-
-    VArrayType ity ety
-      | Just (Some idx_repr) <- valueAsBaseType ity
-      , Just (Some elm_repr) <- valueAsBaseType ety
-      -> add (BaseArrayRepr (Ctx.Empty Ctx.:> idx_repr) elm_repr) count
-
-    VDataType (ModuleIdentifier "Prelude.UnitType") [] [] -> count
-
-    VDataType (ModuleIdentifier "Prelude.PairType") [TValue ty1, TValue ty2] [] ->
-      countUninterpreted scale (countUninterpreted scale count ty1) ty2
-
-    VDataType (ModuleIdentifier "Prelude.RecordType")
-      [VString _fname, TValue ty1, TValue ty2] [] ->
-      countUninterpreted scale (countUninterpreted scale count ty1) ty2
-
-    _ -> count
-  where
-  add ::
-    BaseTypeRepr tc ->
-    MapF BaseTypeRepr UnintCount ->
-    MapF BaseTypeRepr UnintCount
-  add bt =
-    MapF.insertWith
-      (\(UnintCount x) (UnintCount y) -> UnintCount (x + y))
-      bt (UnintCount scale)
-
--- Note that this doesn't really use IO, except for the `fail`.
-parseUninterpreted' ::
-  forall sym.
-  (IsSymExprBuilder sym) =>
-  sym ->
-  IORef (SymFnCache sym) ->
-  UnintApp (SymExpr sym) ->
-  TValue (What4 sym) ->
-  StateT (UnintState sym) IO (SValue sym)
-parseUninterpreted' sym ref app ty =
-  case ty of
-    VPiType _ body
-      -> pure $ VFun $ \x ->
-           do x' <- force x
-              app' <- applyUnintApp sym app x'
-              t2 <- applyPiBody body (ready x')
-              parseUninterpreted sym ref app' t2
-
-    VBoolType
-      -> VBool <$> mkUninterpreted BaseBoolRepr
-
-    VIntType
-      -> VInt  <$> mkUninterpreted BaseIntegerRepr
-
-    VIntModType n
-      -> VIntMod n <$> mkUninterpreted BaseIntegerRepr
-
-    VRationalType
-      -> do numer <- mkUninterpreted BaseIntegerRepr
-            -- TODO(#2433): Assert that the denominator is non-zero.
-            denom <- mkUninterpreted BaseIntegerRepr
-            pure $ VRational numer denom
-
-    VVecType n VBoolType ->
-      case somePosNat n of
-        Just (Some (PosNat w)) -> VWord . DBV <$> mkUninterpreted (BaseBVRepr w)
-        _                      -> pure (VWord ZBV)
-
-    VVecType n et ->
-      VVector <$> V.replicateM (fromIntegral n) (ready <$> parseUninterpreted' sym ref app et)
-
-    VArrayType ity ety
-      | Just (Some idx_repr) <- valueAsBaseType ity
-      , Just (Some elm_repr) <- valueAsBaseType ety
-      -> (VArray . SArray) <$>
-          mkUninterpreted (BaseArrayRepr (Ctx.Empty Ctx.:> idx_repr) elm_repr)
-
-    VDataType (ModuleIdentifier "Prelude.UnitType") [] []
-      -> pure vUnit
-
-    VDataType (ModuleIdentifier "Prelude.PairType") [TValue ty1, TValue ty2] []
-      -> do x1 <- parseUninterpreted' sym ref app ty1
-            x2 <- parseUninterpreted' sym ref app ty2
-            pure (vPair (ready x1) (ready x2))
-
-    VDataType (ModuleIdentifier "Prelude.EmptyType") [] []
-      -> pure vEmptyRecord
-    VDataType (ModuleIdentifier "Prelude.RecordType")
-      [VString _fname, TValue ty1, TValue ty2] []
-      -> do x1 <- parseUninterpreted' sym ref app ty1
-            x2 <- parseUninterpreted' sym ref app ty2
-            pure (vRecordValue (ready x1) (ready x2))
-
-    _ -> fail $ "could not create uninterpreted symbol of type " ++ show ty
-  where
-  mkUninterpreted :: BaseTypeRepr t -> StateT (UnintState sym) IO (SymExpr sym t)
-  mkUninterpreted tyr =
-    do mp <- get
-       case MapF.lookup tyr mp of
-         Just (Arr (x : xs)) -> put (MapF.insert tyr (Arr xs) mp) >> pure x
-         _ -> panic "mkUninterpreted" ["Not enough uninterpreted results"]
-
-
-
--- | A value of type @UnintApp f@ represents an uninterpreted function
--- with the given 'String' name, applied to a list of argument values
--- paired with a representation of their types. The context of
--- argument types is existentially quantified.
-data UnintApp f =
-  forall args. UnintApp String (Assignment f args) (Assignment BaseTypeRepr args)
-
--- | Extract the string from an 'UnintApp'.
-stringOfUnintApp :: UnintApp f -> String
-stringOfUnintApp (UnintApp s _ _) = s
-
--- | Make an 'UnintApp' with the given name and no arguments.
-mkUnintApp :: String -> UnintApp f
-mkUnintApp nm = UnintApp nm Ctx.empty Ctx.empty
-
--- | Add a suffix to the function name of an 'UnintApp'.
-suffixUnintApp :: String -> UnintApp f -> UnintApp f
-suffixUnintApp s (UnintApp nm args tys) = UnintApp (nm ++ s) args tys
-
--- | Extend an 'UnintApp' with an additional argument.
-extendUnintApp :: UnintApp f -> f ty -> BaseTypeRepr ty -> UnintApp f
-extendUnintApp (UnintApp nm xs tys) x ty =
-  UnintApp nm (Ctx.extend xs x) (Ctx.extend tys ty)
-
--- | Flatten an 'SValue' to a sequence of components, each of which is
--- a symbolic value of a base type (e.g. word or boolean), and add
--- them to the list of arguments of the given 'UnintApp'. If the
--- 'SValue' contains any values built from data constructors, then
--- encode them as suffixes on the function name of the 'UnintApp'.
-applyUnintApp ::
-  forall sym.
-  (W.IsExprBuilder sym) =>
-  sym ->
-  UnintApp (SymExpr sym) ->
-  SValue sym ->
-  IO (UnintApp (SymExpr sym))
-applyUnintApp sym app0 v =
-  case v of
-    VVector xv                -> foldM (applyUnintApp sym) app0 =<< traverse force xv
-    VBool sb                  -> return (extendUnintApp app0 sb BaseBoolRepr)
-    VInt si                   -> return (extendUnintApp app0 si BaseIntegerRepr)
-    VIntMod 0 si              -> return (extendUnintApp app0 si BaseIntegerRepr)
-    VIntMod n si              -> do n' <- W.intLit sym (toInteger n)
-                                    si' <- W.intMod sym si n'
-                                    return (extendUnintApp app0 si' BaseIntegerRepr)
-    VRational numer denom     -> do app1 <- applyUnintApp sym app0 (VInt numer)
-                                    app2 <- applyUnintApp sym app1 (VInt denom)
-                                    pure app2
-    VWord (DBV sw)            -> return (extendUnintApp app0 sw (W.exprType sw))
-    VArray (SArray sa)        -> return (extendUnintApp app0 sa (W.exprType sa))
-    VWord ZBV                 -> return app0
-    VCtorApp 0 _ []           -> return app0
-    VCtorApp 0 _ [x, y]       -> do app1 <- applyUnintApp sym app0 =<< force x
-                                    app2 <- applyUnintApp sym app1 =<< force y
-                                    return app2
-    VCtorApp n _ xs           -> foldM (applyUnintApp sym) app' =<< traverse force xs
-                                   where app' = suffixUnintApp ("_" ++ show n) app0
-    VNat n                    -> return (suffixUnintApp ("_" ++ show n) app0)
-    VBVToNat w v'             -> applyUnintApp sym app' v'
-                                   where app' = suffixUnintApp ("_" ++ show w) app0
-    TValue (suffixTValue -> Just s)
-                              -> return (suffixUnintApp s app0)
-    VFun {} ->
-      fail $
-      "Cannot create uninterpreted higher-order function " ++
-      show (stringOfUnintApp app0)
-    _ ->
-      fail $
-      "Cannot create uninterpreted function " ++
-      show (stringOfUnintApp app0) ++
-      " with argument " ++ show v
 
 
 ------------------------------------------------------------
@@ -1379,14 +1005,9 @@ argTypes v =
 
     loop _ = return []
 
---
--- Convert a saw-core type expression to a FirstOrder type expression
---
-vAsFirstOrderType :: IsSymExprBuilder sym => TValue (What4 sym) -> Maybe FirstOrderType
-vAsFirstOrderType v = asFirstOrderTypeTValue v
 
-valueAsBaseType :: IsSymExprBuilder sym => TValue (What4 sym) -> Maybe (Some W.BaseTypeRepr)
-valueAsBaseType v = fotToBaseType =<< vAsFirstOrderType v
+
+
 
 ------------------------------------------------------------------------------
 
@@ -1710,7 +1331,7 @@ w4EvalBasic sym st sc m addlPrims varCons ref unintSet t =
   do let variable tf (VarName ix nm) ty
            | Just v <- IntMap.lookup ix varCons = pure v
            | otherwise =
-           do trm <- ArgTermConst <$> scTermF sc tf
+           do trm <- scTermF sc tf
               parseUninterpretedSAW sym st sc ref trm
                  (mkUnintApp (Text.unpack nm ++ "_" ++ show ix)) ty
      let variable' tp vn ty = variable (Variable vn tp) vn ty
@@ -1723,336 +1344,6 @@ w4EvalBasic sym st sc m addlPrims varCons ref unintSet t =
      let mux = Prims.lazyMuxValue (prims sym)
      cfg <-
        Sim.evalGlobal' m (constMap sym `Map.union` addlPrims)
-       variable' uninterpreted (recursor sym) primHandler mux
+                        variable' uninterpreted (recursor sym) primHandler mux
      Sim.evalSharedTerm cfg t
 
--- | Given a constant nm of (saw-core) type ty, construct an
--- uninterpreted constant with that type. The 'Term' argument should
--- be an open term, which should have the designated return type when
--- the local variables have the corresponding types from the
--- 'Assignment'.
-parseUninterpretedSAW ::
-  forall n st fs.
-  B.ExprBuilder n st fs ->
-  SAWCoreState n ->
-  SharedContext ->
-  IORef (SymFnCache (B.ExprBuilder n st fs)) ->
-  ArgTerm {- ^ representation of function applied to arguments -} ->
-  UnintApp (SymExpr (B.ExprBuilder n st fs)) ->
-  TValue (What4 (B.ExprBuilder n st fs)) {- ^ return type -} ->
-  IO (SValue (B.ExprBuilder n st fs))
-parseUninterpretedSAW sym st sc ref trm app ty =
-  case ty of
-    VPiType t1 body
-      -> pure $ VFun $ \x ->
-           do x' <- force x
-              app' <- applyUnintApp sym app x'
-              arg <- mkArgTerm sc t1 x'
-              let trm' = ArgTermApply trm arg
-              t2 <- applyPiBody body (ready x')
-              parseUninterpretedSAW sym st sc ref trm' app' t2
-
-    VBoolType
-      -> VBool <$> mkUninterpretedSAW sym st sc ref trm app BaseBoolRepr
-
-    VIntType
-      -> VInt  <$> mkUninterpretedSAW sym st sc ref trm app BaseIntegerRepr
-
-    VIntModType n
-      -> VIntMod n <$> mkUninterpretedSAW sym st sc ref (ArgTermFromIntMod n trm) app BaseIntegerRepr
-
-    VRationalType
-      -> do numer <- mkUninterpretedSAW sym st sc ref trm (suffixUnintApp "_numer" app) BaseIntegerRepr
-            -- TODO(#2433): Assert that the denominator is non-zero.
-            denom <- mkUninterpretedSAW sym st sc ref trm (suffixUnintApp "_denom" app) BaseIntegerRepr
-            pure $ VRational numer denom
-
-    -- 0 width bitvector is a constant
-    VVecType 0 VBoolType
-      -> return $ VWord ZBV
-
-    VVecType n VBoolType
-      | Just (Some (PosNat w)) <- somePosNat n
-      -> (VWord . DBV) <$> mkUninterpretedSAW sym st sc ref trm app (BaseBVRepr w)
-
-    VVecType n ety | n >= 0
-      ->  do ety' <- termOfTValue sc ety
-             let mkElem i =
-                   do let trm' = ArgTermAt n ety' trm i
-                      let app' = suffixUnintApp ("_a" ++ show i) app
-                      parseUninterpretedSAW sym st sc ref trm' app' ety
-             xs <- traverse mkElem (genericTake n [0 ..])
-             return (VVector (V.fromList (map ready xs)))
-
-    VArrayType ity ety
-      | Just (Some idx_repr) <- valueAsBaseType ity
-      , Just (Some elm_repr) <- valueAsBaseType ety
-      -> (VArray . SArray) <$>
-          mkUninterpretedSAW sym st sc ref trm app (BaseArrayRepr (Ctx.Empty Ctx.:> idx_repr) elm_repr)
-
-    VDataType (ModuleIdentifier "Prelude.UnitType") [] []
-      -> pure vUnit
-
-    VDataType (ModuleIdentifier "Prelude.PairType") [TValue ty1, TValue ty2] []
-      -> do let trm1 = ArgTermPairLeft trm
-            let trm2 = ArgTermPairRight trm
-            x1 <- parseUninterpretedSAW sym st sc ref trm1 (suffixUnintApp "_L" app) ty1
-            x2 <- parseUninterpretedSAW sym st sc ref trm2 (suffixUnintApp "_R" app) ty2
-            return (vPair (ready x1) (ready x2))
-
-    VDataType (ModuleIdentifier "Prelude.EmptyType") [] []
-      -> pure vEmptyRecord
-    VDataType (ModuleIdentifier "Prelude.RecordType")
-      [VString fname, TValue ty1, TValue ty2] []
-      -> do let trm1 = ArgTermRecordSelect trm fname
-            let suffix = "_" ++ Text.unpack fname
-            x1 <- parseUninterpretedSAW sym st sc ref trm1 (suffixUnintApp suffix app) ty1
-            x2 <- parseUninterpretedSAW sym st sc ref trm app ty2
-            pure (vRecordValue (ready x1) (ready x2))
-
-    _ -> fail $ "could not create uninterpreted symbol of type " ++ show ty
-
-mkUninterpretedSAW ::
-  forall n st fs t.
-  B.ExprBuilder n st fs ->
-  SAWCoreState n ->
-  SharedContext ->
-  IORef (SymFnCache (B.ExprBuilder n st fs)) ->
-  ArgTerm ->
-  UnintApp (SymExpr (B.ExprBuilder n st fs)) ->
-  BaseTypeRepr t ->
-  IO (SymExpr (B.ExprBuilder n st fs) t)
-mkUninterpretedSAW sym st sc ref trm (UnintApp nm args tys) ret
-  | Just Refl <- testEquality Ctx.empty tys =
-    bindSAWTerm sym st ret =<< reconstructArgTerm trm sc []
-  | otherwise =
-  do fn <- mkSymFn sym ref nm tys ret
-     sawRegisterSymFunInterp st fn (reconstructArgTerm trm)
-     W.applySymFn sym fn args
-
--- | An 'ArgTerm' is a description of how to reassemble a saw-core
--- term from a list of the atomic components it is composed of.
-data ArgTerm
-  = ArgTermVar
-  | ArgTermBVZero -- ^ scBvNat 0 0
-  | ArgTermToIntMod Natural ArgTerm -- ^ toIntMod n x
-  | ArgTermFromIntMod Natural ArgTerm -- ^ fromIntMod n x
-  | ArgTermRational ArgTerm ArgTerm -- ^ numerator, denominator
-  | ArgTermVector Term [ArgTerm] -- ^ element type, elements
-  | ArgTermUnit
-  | ArgTermPair ArgTerm ArgTerm
-  | ArgTermEmpty
-  | ArgTermRecord FieldName ArgTerm ArgTerm
-  | ArgTermRecordSelect ArgTerm FieldName
-  | ArgTermConst Term
-  | ArgTermApply ArgTerm ArgTerm
-  | ArgTermAt Natural Term ArgTerm Natural
-    -- ^ length, element type, list, index
-  | ArgTermPairLeft ArgTerm
-  | ArgTermPairRight ArgTerm
-  | ArgTermBVToNat Natural ArgTerm
-
--- | Reassemble a saw-core term from an 'ArgTerm' and a list of parts.
--- The length of the list should be equal to the number of
--- 'ArgTermVar' constructors in the 'ArgTerm'.
-reconstructArgTerm :: ArgTerm -> SharedContext -> [Term] -> IO Term
-reconstructArgTerm atrm sc ts =
-  do (t, unused) <- parse atrm ts
-     unless (null unused) $ fail "reconstructArgTerm: too many function arguments"
-     return t
-  where
-    parse :: ArgTerm -> [Term] -> IO (Term, [Term])
-    parse at ts0 =
-      case at of
-        ArgTermVar ->
-          case ts0 of
-            x : ts1 -> return (x, ts1)
-            [] -> fail "reconstructArgTerm: too few function arguments"
-        ArgTermBVZero ->
-          do z <- scNat sc 0
-             x <- scBvNat sc z z
-             return (x, ts0)
-        ArgTermToIntMod n at1 ->
-          do n' <- scNat sc n
-             (x1, ts1) <- parse at1 ts0
-             x <- scToIntMod sc n' x1
-             pure (x, ts1)
-        ArgTermFromIntMod n at1 ->
-          do n' <- scNat sc n
-             (x1, ts1) <- parse at1 ts0
-             x <- scFromIntMod sc n' x1
-             pure (x, ts1)
-        ArgTermRational numer denom ->
-          do (numer', ts1) <- parse numer ts0
-             (denom', ts2) <- parse denom ts1
-             rat <- scRational sc numer' denom'
-             pure (rat, ts2)
-        ArgTermVector ty ats ->
-          do (xs, ts1) <- parseList ats ts0
-             x <- scVectorReduced sc ty xs
-             return (x, ts1)
-        ArgTermUnit ->
-          do x <- scUnitValue sc
-             return (x, ts0)
-        ArgTermPair at1 at2 ->
-          do (x1, ts1) <- parse at1 ts0
-             (x2, ts2) <- parse at2 ts1
-             x <- scPairValue sc x1 x2
-             return (x, ts2)
-        ArgTermEmpty ->
-          do x <- scRecordValue sc []
-             pure (x, ts0)
-        ArgTermRecord fname at1 at2 ->
-          do s <- scString sc fname
-             (x1, ts1) <- parse at1 ts0
-             (x2, ts2) <- parse at2 ts1
-             ty1 <- scTypeOf sc x1
-             ty2 <- scTypeOf sc x2
-             x <- scGlobalApply sc "Prelude.RecordValue" [s, ty1, ty2, x1, x2]
-             pure (x, ts2)
-        ArgTermRecordSelect at1 fname ->
-          do (x1, ts1) <- parse at1 ts0
-             x <- scRecordSelect sc x1 fname
-             pure (x, ts1)
-        ArgTermConst x ->
-          do return (x, ts0)
-        ArgTermApply at1 at2 ->
-          do (x1, ts1) <- parse at1 ts0
-             (x2, ts2) <- parse at2 ts1
-             x <- scApply sc x1 x2
-             return (x, ts2)
-        ArgTermAt n ty at1 i ->
-          do n' <- scNat sc n
-             (x1, ts1) <- parse at1 ts0
-             i' <- scNat sc i
-             x <- scAt sc n' ty x1 i'
-             return (x, ts1)
-        ArgTermPairLeft at1 ->
-          do (x1, ts1) <- parse at1 ts0
-             x <- scPairLeft sc x1
-             return (x, ts1)
-        ArgTermPairRight at1 ->
-          do (x1, ts1) <- parse at1 ts0
-             x <- scPairRight sc x1
-             return (x, ts1)
-        ArgTermBVToNat w at1 ->
-          do (x1, ts1) <- parse at1 ts0
-             x <- scBvToNat sc w x1
-             pure (x, ts1)
-
-    parseList :: [ArgTerm] -> [Term] -> IO ([Term], [Term])
-    parseList [] ts0 = return ([], ts0)
-    parseList (at : ats) ts0 =
-      do (x, ts1) <- parse at ts0
-         (xs, ts2) <- parseList ats ts1
-         return (x : xs, ts2)
-
--- | Given a type and value encoded as 'SValue's, construct an
--- 'ArgTerm' that builds a term of that type from local variables with
--- base types. The number of 'ArgTermVar' constructors should match
--- the number of arguments appended by 'applyUnintApp'.
-mkArgTerm :: forall sym. SharedContext -> TValue (What4 sym) -> SValue sym -> IO ArgTerm
-mkArgTerm sc ty val =
-  case (ty, val) of
-    (VBoolType, VBool _) -> return ArgTermVar
-    (VIntType, VInt _)   -> return ArgTermVar
-    (_, VWord ZBV)       -> return ArgTermBVZero     -- 0-width bitvector is a constant
-    (_, VWord (DBV _))   -> return ArgTermVar
-    (_, VArray{})        -> return ArgTermVar
-    (VIntModType n, VIntMod _ _) -> pure (ArgTermToIntMod n ArgTermVar)
-    (VRationalType, VRational numer denom) ->
-      do numer' <- mkArgTerm @sym sc VIntType (VInt numer)
-         denom' <- mkArgTerm @sym sc VIntType (VInt denom)
-         pure (ArgTermRational numer' denom')
-
-    (VVecType _ ety, VVector vv) ->
-      do vs <- traverse force (V.toList vv)
-         xs <- traverse (mkArgTerm sc ety) vs
-         ety' <- termOfTValue sc ety
-         return (ArgTermVector ety' xs)
-
-    (VDataType (ModuleIdentifier "Prelude.UnitType") [] [],
-     VCtorApp 0 _ [])
-                         -> return ArgTermUnit
-    (VDataType (ModuleIdentifier "Prelude.PairType") [TValue ty1, TValue ty2] [],
-     VCtorApp 0 _ [v1, v2]) ->
-      do x1 <- mkArgTerm sc ty1 =<< force v1
-         x2 <- mkArgTerm sc ty2 =<< force v2
-         return (ArgTermPair x1 x2)
-
-    (VDataType (ModuleIdentifier "Prelude.EmptyType") [] [],
-     VCtorApp 0 _ []) ->
-      pure ArgTermEmpty
-    (VDataType _nm [VString fname, TValue ty1, TValue ty2] [],
-     VCtorApp 0 _ [v1, v2]) ->
-      do x1 <- mkArgTerm sc ty1 =<< force v1
-         x2 <- mkArgTerm sc ty2 =<< force v2
-         pure (ArgTermRecord fname x1 x2)
-
-    (VDataType nmi ps _, VCtorApp n _ vv) ->
-      do mvi <- scResolveQualName sc (toQualName nmi)
-         vi <-
-           case mvi of
-             Just vi -> pure vi
-             Nothing -> panic "mkArgTerm" ["Data type name not found: " <> toAbsoluteName nmi]
-         mm <- scGetModuleMap sc
-         dt <-
-           case lookupVarIndexInMap vi mm of
-             Just (ResolvedDataType dt) -> pure dt
-             _ -> panic "mkArgTerm" ["Data type not found: " <> toAbsoluteName nmi]
-         let ctor = dtCtors dt !! n
-         ps' <- traverse (termOfSValue sc) ps
-         vv' <- traverse (termOfSValue sc <=< force) vv
-         x   <- scConstApply sc (ctorName ctor) (ps' ++ vv')
-         return (ArgTermConst x)
-
-    (_, TValue tval) ->
-      do x <- termOfTValue sc tval
-         pure (ArgTermConst x)
-
-    (_, VNat n) ->
-      do x <- scNat sc n
-         pure (ArgTermConst x)
-
-    (_, VBVToNat w v) ->
-      do let w' = fromIntegral w -- FIXME: make w :: Natural to avoid fromIntegral
-         x <- mkArgTerm sc (VVecType w' VBoolType) v
-         pure (ArgTermBVToNat w' x)
-
-    _ -> fail $ "could not create uninterpreted function argument of type " ++ show ty
-
-termOfTValue :: SharedContext -> TValue (What4 sym) -> IO Term
-termOfTValue sc val =
-  case val of
-    VBoolType -> scBoolType sc
-    VIntType -> scIntegerType sc
-    VRationalType -> scRationalType sc
-    VVecType n a ->
-      do n' <- scNat sc n
-         a' <- termOfTValue sc a
-         scVecType sc n' a'
-    VDataType (ModuleIdentifier "Prelude.UnitType") [] []
-      -> scUnitType sc
-    VDataType (ModuleIdentifier "Prelude.PairType") [TValue a, TValue b] []
-      -> do a' <- termOfTValue sc a
-            b' <- termOfTValue sc b
-            scPairType sc a' b'
-    VDataType (ModuleIdentifier "Prelude.EmptyType") [] []
-      -> scRecordType sc []
-    VDataType (ModuleIdentifier "Prelude.RecordType")
-      [VString fname, TValue a, TValue b] []
-      -> do fname' <- scString sc fname
-            a' <- termOfTValue sc a
-            b' <- termOfTValue sc b
-            scGlobalApply sc "Prelude.RecordType" [fname', a', b']
-    _ -> fail $ "termOfTValue: " ++ show val
-
-termOfSValue :: SharedContext -> SValue sym -> IO Term
-termOfSValue sc val =
-  case val of
-    VCtorApp 0 _ []
-      -> scUnitValue sc
-    VNat n
-      -> scNat sc n
-    TValue tv -> termOfTValue sc tv
-    _ -> fail $ "termOfSValue: " ++ show val

--- a/saw-core-what4/src/SAWCoreWhat4/What4.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/What4.hs
@@ -1332,7 +1332,11 @@ w4EvalBasic sym st sc m addlPrims varCons ref unintSet t =
            | Just v <- IntMap.lookup ix varCons = pure v
            | otherwise =
            do trm <- scTermF sc tf
-              parseUninterpretedSAW sym st sc ref trm
+              let isVar = case tf of
+                            Variable {} -> True
+                            Constant {} -> False
+                            _ -> panic "w4EvalBasic" ["Unexpected term in `variable`"]
+              parseUninterpretedSAW sym st sc ref isVar trm
                  (mkUnintApp (Text.unpack nm ++ "_" ++ show ix)) ty
      let variable' tp vn ty = variable (Variable vn tp) vn ty
      let uninterpreted nm ty

--- a/saw.cabal
+++ b/saw.cabal
@@ -413,11 +413,13 @@ library saw-core-what4
 
   hs-source-dirs: saw-core-what4/src
   exposed-modules:
+    SAWCoreWhat4.Common
     SAWCoreWhat4.What4
     SAWCoreWhat4.FirstOrder
     SAWCoreWhat4.PosNat
     SAWCoreWhat4.Position
     SAWCoreWhat4.ReturnTrip
+    SAWCoreWhat4.Uninterp
   other-modules:
     SAWCoreWhat4.Panic
 


### PR DESCRIPTION
Factors out uninterpreted code into a separate modules, and reworks the code to use the same code path for both the rount-trip and non-round-trip variants of the code.

This allows us to use the sharing uninterpreted functions implementation in both cases, which fixes #3195.

The code seems to have also fixed #3166, I think, because we don't have a special case for 0 arity functions.