### PR TITLE
Add more general alternative to `add_prelude_eqs`/`add_cryptol_eqs`

### DIFF
--- a/doc/saw-user-manual/transforming-term-values.md
+++ b/doc/saw-user-manual/transforming-term-values.md
@@ -163,6 +163,9 @@ to the given `Simpset`.
 - `add_prelude_defs : [String] -> Simpset -> Simpset` adds unfolding
 rules from the SAWCore `Prelude` module to a `Simpset`.
 
+- `core_thm : String -> Theorem` parses a SAWCore term of type `Prop`
+from the SAWCore `Prelude` or any other loaded SAWCore module.
+
 - `add_core_thms : [String] -> Simpset -> Simpset` adds equality-typed
 terms from the SAWCore `Prelude` or any other loaded SAWCore module to
 a `Simpset`.

--- a/doc/saw-user-manual/transforming-term-values.md
+++ b/doc/saw-user-manual/transforming-term-values.md
@@ -160,15 +160,12 @@ but does not include any of the terms of equality type.
 rules for functions with the given names from the SAWCore `Cryptol` module
 to the given `Simpset`.
 
-- `add_cryptol_eqs : [String] -> Simpset -> Simpset` adds the terms of
-equality type with the given names from the SAWCore `Cryptol` module to
-the given `Simpset`.
-
 - `add_prelude_defs : [String] -> Simpset -> Simpset` adds unfolding
 rules from the SAWCore `Prelude` module to a `Simpset`.
 
-- `add_prelude_eqs : [String] -> Simpset -> Simpset` adds equality-typed
-terms from the SAWCore `Prelude` module to a `Simpset`.
+- `add_core_thms : [String] -> Simpset -> Simpset` adds equality-typed
+terms from the SAWCore `Prelude` or any other loaded SAWCore module to
+a `Simpset`.
 
 Finally, it's possible to construct a theorem from an arbitrary SAWCore
 expression (rather than a Cryptol expression), using the `core_axiom`

--- a/examples/aes/aes.saw
+++ b/examples/aes/aes.saw
@@ -52,7 +52,7 @@ print "Verifying that InvSubBytes inverts SubBytes";
 invert_SubBytes <- prove_print
     do {
         unfolding ["InvSubBytes", "SubBytes"];
-        simplify (add_prelude_eqs ["map_map"] (addsimps [invert_SBox] ss0));
+        simplify (addsimps [core_thm "map_map", invert_SBox] ss0);
         rme;
     }
     {{ \s -> InvSubBytes (SubBytes s) == s }};

--- a/examples/ecdsa/ecdsa.saw
+++ b/examples/ecdsa/ecdsa.saw
@@ -285,14 +285,14 @@ let field_sub_def = {{ p384_field::p384_field_sub }};
 
 print "Proving and registering rewrite rules.";
 let cry_ss = cryptol_ss ();
-let ss0 = add_prelude_eqs [ "bvShiftL_bvShl"
-                          , "bvShiftR_bvShr"
-                          ] cry_ss;
+let ss0 = add_core_thms [ "bvShiftL_bvShl"
+                        , "bvShiftR_bvShr"
+                        ] cry_ss;
 
 let assume_rule t = prove_print (admit "assume rule") (rewrite ss0 t);
 let prove_rule t = prove_print yices (rewrite ss0 t);
 
-let ss1 = add_prelude_eqs
+let ss1 = add_core_thms
   [ "ite_not"
   , "ite_nest1"
   , "ite_nest2"
@@ -309,7 +309,7 @@ let ss1 = add_prelude_eqs
   , "implies_True1", "implies_False1"
   , "not_True", "not_False"
   ] ss0; //(add_prelude_defs ["implies"] ss0);
-let ss2 = add_cryptol_eqs [] ss1;
+let ss2 = add_core_thms [] ss1;
 
 
 ite24 <- prove_rule {{
@@ -761,7 +761,7 @@ mul_inner_ov <- method "mul_inner" []
     jvm_return (jvm_term {{ res.mji_d }});
   }
   do {
-    simplify (add_prelude_eqs ["and_True1", "and_True2"] empty_ss);
+    simplify (add_core_thms ["and_True1", "and_True2"] empty_ss);
     yices;
   };
 
@@ -778,7 +778,7 @@ mul_ov <- method "mul" [mul_inner_ov]
   do {
     simplify
       (addsimps [at24, ec_split_join_768]
-      (add_prelude_eqs
+      (add_core_thms
         [ "and_True1", "and_True2"
         , "and_False1", "and_False2"
         , "or_False1", "or_False2"
@@ -802,7 +802,7 @@ sq_inner1_ov <- method "sq_inner1" []
     jvm_return (jvm_term {{ res.mji_d }});
   }
   do {
-    simplify (add_prelude_eqs ["and_True1", "and_True2"] empty_ss);
+    simplify (add_core_thms ["and_True1", "and_True2"] empty_ss);
     z3;
   };
 
@@ -820,7 +820,7 @@ sq_inner2_ov <- method "sq_inner2" []
     jvm_return (jvm_term {{ res.mji_d }});
   }
   do {
-    simplify (add_prelude_eqs ["and_True1", "and_True2"] empty_ss);
+    simplify (add_core_thms ["and_True1", "and_True2"] empty_ss);
     z3;
   };
 

--- a/intTests/test1646/test15.log.good
+++ b/intTests/test1646/test15.log.good
@@ -5,6 +5,7 @@ y : rebindable Int
 
 abc : ProofScript ()
 abstract_symbolic : Term -> Term
+add_core_thms : [String] -> Simpset -> Simpset
 add_cryptol_defs : [String] -> Simpset -> Simpset
 add_cryptol_eqs : [String] -> Simpset -> Simpset
 add_prelude_defs : [String] -> Simpset -> Simpset

--- a/intTests/test_fold_rewrite_proof/tupletest.saw
+++ b/intTests/test_fold_rewrite_proof/tupletest.saw
@@ -2,7 +2,7 @@ enable_experimental;
 
 let use_lemmas lemmas =
     simplify (addsimps lemmas
-              (add_prelude_eqs ["foldl_cons","foldl_nil","head_gen","tail_gen"] (cryptol_ss())));
+              (add_core_thms ["foldl_cons","foldl_nil","head_gen","tail_gen"] (cryptol_ss())));
 
 let proveit p script =
   do {
@@ -20,7 +20,7 @@ proveit {{ foldFunctionInverse }} do {
               , "foldFunction'"
               ];
     goal_normalize ["fnc", "fnc'"];
-    simplify (add_prelude_eqs ["foldl_cons","foldl_nil",
-                               "head_gen","tail_gen"] (cryptol_ss()));
+    simplify (add_core_thms ["foldl_cons","foldl_nil",
+                             "head_gen","tail_gen"] (cryptol_ss()));
     z3;
 };

--- a/intTests/test_sawcore_qualify/test.saw
+++ b/intTests/test_sawcore_qualify/test.saw
@@ -161,7 +161,7 @@ let x_y_app_x_y = term_apply (lambda x_y x_y) [x_y];
 parse_as "(\\(y : Bool) -> y) !?\"x&&y\"@fresh" x_y_app_x_y;
 
 // loose variables are not let-bound when printing rules
-print (add_prelude_eqs ["not_not"] empty_ss);
+print (add_core_thms ["not_not"] empty_ss);
 
 
 // generated let-bindings never clash with bound variable names or each other

--- a/intTests/test_search/search02.log.good
+++ b/intTests/test_search/search02.log.good
@@ -1,6 +1,7 @@
 --------------------------------
 -- (a -> a)
 abstract_symbolic : Term -> Term
+add_core_thms : [String] -> Simpset -> Simpset
 add_cryptol_defs : [String] -> Simpset -> Simpset
 add_cryptol_eqs : [String] -> Simpset -> Simpset
 add_prelude_defs : [String] -> Simpset -> Simpset

--- a/intTests/test_search/search02.log.good
+++ b/intTests/test_search/search02.log.good
@@ -3,9 +3,13 @@
 abstract_symbolic : Term -> Term
 add_core_thms : [String] -> Simpset -> Simpset
 add_cryptol_defs : [String] -> Simpset -> Simpset
-add_cryptol_eqs : [String] -> Simpset -> Simpset
+add_cryptol_eqs :
+   [String] -> Simpset -> Simpset
+   (DEPRECATED AND WILL WARN)
 add_prelude_defs : [String] -> Simpset -> Simpset
-add_prelude_eqs : [String] -> Simpset -> Simpset
+add_prelude_eqs :
+   [String] -> Simpset -> Simpset
+   (DEPRECATED AND WILL WARN)
 addsimp : Theorem -> Simpset -> Simpset
 addsimp_shallow : Theorem -> Simpset -> Simpset
 addsimps : [Theorem] -> Simpset -> Simpset

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -144,6 +144,7 @@ module SAWCentral.Builtins (
     satPrintPrim,
     quickCheckPrintPrim,
     cryptolSimpset,
+    add_core_thms,
     addPreludeEqs,
     addCryptolEqs,
     add_prelude_defs,
@@ -1541,6 +1542,11 @@ cryptolSimpset :: TopLevel SV.SAWSimpset
 cryptolSimpset =
   do sc <- getSharedContext
      io $ Cryptol.mkCryptolSimpset sc
+
+add_core_thms :: [Text] -> SV.SAWSimpset -> TopLevel SV.SAWSimpset
+add_core_thms names ss =
+  do thms <- traverse core_thm names
+     addsimps thms ss
 
 addPreludeEqs :: [Text] -> SV.SAWSimpset -> TopLevel SV.SAWSimpset
 addPreludeEqs names ss = do

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -3960,6 +3960,7 @@ primitives = Map.fromList $
     , "simplification rule set, and return a new set."
     , ""
     , "This function is deprecated: Use 'add_core_thms' instead."
+    , "Expected to be hidden by default in SAW 1.7."
     ]
 
   , prim "add_cryptol_eqs"     "[String] -> Simpset -> Simpset"
@@ -3969,6 +3970,7 @@ primitives = Map.fromList $
     , "simplification rule set, and return a new set."
     , ""
     , "This function is deprecated: Use 'add_core_thms' instead."
+    , "Expected to be hidden by default in SAW 1.7."
     ]
 
   , prim "add_prelude_defs"    "[String] -> Simpset -> Simpset"

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -3955,16 +3955,20 @@ primitives = Map.fromList $
 
   , prim "add_prelude_eqs"     "[String] -> Simpset -> Simpset"
     (funVal2 addPreludeEqs)
-    Current
+    WarnDeprecated
     [ "Add the named equality rules from the Prelude module to a"
     , "simplification rule set, and return a new set."
+    , ""
+    , "This function is deprecated: Use 'add_core_thms' instead."
     ]
 
   , prim "add_cryptol_eqs"     "[String] -> Simpset -> Simpset"
     (funVal2 addCryptolEqs)
-    Current
+    WarnDeprecated
     [ "Add the named equality rules from the Cryptol import module to a"
     , "simplification rule set, and return a new set."
+    , ""
+    , "This function is deprecated: Use 'add_core_thms' instead."
     ]
 
   , prim "add_prelude_defs"    "[String] -> Simpset -> Simpset"

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -3942,6 +3942,17 @@ primitives = Map.fromList $
     , "the Cryptol import module."
     ]
 
+  , prim "add_core_thms"       "[String] -> Simpset -> Simpset"
+    (funVal2 add_core_thms)
+    Current
+    [ "Add the named SAWCore equality rules to a simplification"
+    , "rule set, and return a new set."
+    , "Each string argument is parsed as a SAWCore expression,"
+    , "as with 'core_thm'."
+    , "Writing 'add_core_thms names ss' is equivalent to"
+    , "'addsimps (map core_thm names) ss'."
+    ]
+
   , prim "add_prelude_eqs"     "[String] -> Simpset -> Simpset"
     (funVal2 addPreludeEqs)
     Current


### PR DESCRIPTION
The new command `add_core_thms : [String] -> Simpset -> Simpset` can replace both `add_prelude_eqs` and `add_cryptol_eqs`. Both of the old functions are marked as deprecated. This fixes part of #3213.