### PR TITLE
Add `map` primitive to SAWScript.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ This release supports [version
 
 ## New Features
 
+* SAW now includes `map : {a, b} (a -> b) -> [a] -> [b]` as a primitive.
+
 * Add new SAWScript commands `timeout_handle` and `timeout` for adding
   time limits to scripts.
 

--- a/intTests/test1646/test15.log.good
+++ b/intTests/test1646/test15.log.good
@@ -257,6 +257,7 @@ llvm_verify :
    ProofScript () ->
    TopLevel LLVMSpec
 load_aig : String -> TopLevel AIG
+map : {a, b} (a -> b) -> [a] -> [b]
 mathsat : ProofScript ()
 mir_adt : MIRAdt -> MIRType
 mir_alloc : MIRType -> MIRSetup MIRValue

--- a/intTests/test_sawscript_builtins/lists.saw
+++ b/intTests/test_sawscript_builtins/lists.saw
@@ -56,10 +56,9 @@ print "*** for (two) ***";
 for [1, 2] print;
 print "*** end for ***";
 
-// implement fold and map (uses the Haskell argument orderings)
+// implement fold (uses the Haskell argument orderings)
 rec foldl f z xs = if null xs then z else foldl f (f z (head xs)) (tail xs);
 rec foldr f z xs = if null xs then z else f (head xs) (foldr f z (tail xs));
-let map f xs = foldl (\acc x -> concat acc [f x]) [] xs;
 
 print "**** map ****";
 let inc x = eval_size {| x + 1 |};

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -1913,6 +1913,13 @@ proofScriptSubshell () = do
         popScope
     return $ toValue "proof_subshell" ()
 
+-- The "map" builtin.
+mapValue :: Value -> [Value] -> TopLevel Value
+mapValue f xs =
+  do let pos = SS.PosInsideBuiltin
+     let info = "(value was in a \"map\")"
+     toValue "map" <$> traverse (applyValue pos info f) xs
+
 -- The "for" builtin.
 --
 -- XXX: this is the only thing in the tree that uses VBindOnce.
@@ -3026,6 +3033,12 @@ primitives = Map.fromList $
     (funVal2 (nthPrim :: [Value] -> Int -> TopLevel Value))
     Current
     [ "Look up the value at the given list position." ]
+
+  , prim "map"                 "{a, b} (a -> b) -> [a] -> [b]"
+    (funVal2 mapValue)
+    Current
+    [ "Apply the given function element-wise to a list of values."
+    ]
 
   , prim "for"                 "{m, a, b} [a] -> (a -> m b) -> m [b]"
     (funVal2 forValue)


### PR DESCRIPTION
Fixes #2083.