### PR TITLE
Fix the `css` build post-#3215

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -86,7 +86,7 @@ tgt_build() {
     cabal build $JOBSOPT \
                 exe:cryptol exe:cryptol-remote-api exe:cryptol-eval-server \
                 exe:saw exe:saw-remote-api \
-                exe:crux-mir-comp exe:extcore-info exe:verif-viewer \
+                exe:crux-mir-comp exe:css exe:extcore-info exe:verif-viewer \
                 test-suite:integration-tests test-suite:saw-core-tests \
                 test-suite:crux-mir-comp-tests \
                 test-suite:cryptol-saw-core-tests \

--- a/saw-tools/css/Main.hs
+++ b/saw-tools/css/Main.hs
@@ -101,7 +101,7 @@ cssMain css [inputModule,name] | cssMode css == NormalMode = do
     let ?fileReader = BS.readFile
     cryenv <- C.initCryptolEnv sc
     cryenv' <- C.importCryptolModule sc cryenv (Left inputModule)
-                    Nothing C.PublicAndPrivate Nothing
+                    Nothing False C.PublicAndPrivate Nothing
     processSymbol sc cryenv' out name
 
 cssMain css _ | cssMode css == VersionMode = do


### PR DESCRIPTION
Also add `css` to `build.sh` to ensure that future changes do not cause the `css` build to regress.

Fixes https://github.com/GaloisInc/saw-script/issues/3243.