### PR TITLE
Add has_env built-in to SAW

### DIFF
--- a/intTests/test1646/test15.log.good
+++ b/intTests/test1646/test15.log.good
@@ -139,6 +139,7 @@ get_opt : Int -> String
 goal_eval : ProofScript ()
 goal_eval_unint : [String] -> ProofScript ()
 goal_num : ProofScript Int
+has_env : String -> Bool
 head : {a} [a] -> a
 hoist_ifs : Term -> TopLevel Term
 int_to_term : Int -> Term

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -200,6 +200,7 @@ module SAWCentral.Builtins (
     get_opt,
     get_nopts,
     get_env,
+    has_env,
     cryptol_prims,
     cryptol_load,
     cryptol_extract,
@@ -2174,6 +2175,13 @@ get_env name = do
   case mbValue of
     Nothing -> fail $ "Environment variable not found: " ++ Text.unpack name
     Just v -> return $ Text.pack v
+
+has_env :: Text -> TopLevel Bool
+has_env name = do
+  mbValue <- io (Env.lookupEnv (Text.unpack name))
+  case mbValue of
+    Nothing -> return False
+    Just{} -> return True
 
 cryptol_prims :: TopLevel CSC.ExtCryptolModule
 cryptol_prims =

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -3103,6 +3103,13 @@ primitives = Map.fromList $
     , "string."
     ]
 
+  , prim "has_env"            "String -> Bool"
+    (funVal1 has_env)
+    Current
+    [ "Check if an environment variable (from the process environment)"
+    , "is assigned a value."
+    ]
+
   , prim "exit"                "Int -> TopLevel ()"
     (pureVal exitPrim)
     Current


### PR DESCRIPTION
This enables us to write scripts that use optional environment variables as get_env fails when called with an undefined environment variable name.