### PR TITLE
Add the test case from #3000

### DIFF
--- a/intTests/test3000/Functors.cry
+++ b/intTests/test3000/Functors.cry
@@ -1,0 +1,35 @@
+module Functors where
+  interface submodule Size where
+    type n : #
+
+  interface submodule Func where
+    type Ty : *
+    f : Ty -> Ty
+
+  submodule DefineFunc where
+    import interface submodule Size
+
+    fun : [n] -> [n]
+    fun x = x
+
+  submodule Empty where
+    import interface submodule Func
+
+  submodule Wrapper where
+    import interface submodule Size
+
+    submodule Definition where
+      import submodule DefineFunc { interface Size }
+
+      type Ty = [n]
+      f = fun
+
+    submodule MyEmpty = submodule Empty { submodule Definition }
+
+  submodule Four where
+    type n = 4
+  submodule P4 = submodule Wrapper { submodule Four }
+
+  submodule Eight where
+    type n = 8
+  submodule P8 = submodule Wrapper { submodule Eight }

--- a/intTests/test3000/test.saw
+++ b/intTests/test3000/test.saw
@@ -1,0 +1,1 @@
+import Functors;

--- a/intTests/test3000/test.sh
+++ b/intTests/test3000/test.sh
@@ -1,0 +1,1 @@
+${SAW:-saw} test.saw


### PR DESCRIPTION
It no longer fails, probably since the Cryptol renamer changes. Closes #3000.