### PR TITLE
Make `CrucibleMethodSpec` an ordinary typedef instead of a reserved word

### DIFF
--- a/intTests/test_type_errors/err027.log.good
+++ b/intTests/test_type_errors/err027.log.good
@@ -1,7 +1,6 @@
 Loading file "err027.saw"
 err027.saw:7:10-7:11: Error: Syntax error: unexpected `]'
 Some legal inputs at this point: 'ProofScript' 'TopLevel'
-   'CrucibleSetup' 'CrucibleMethodSpec' 'LLVMSpec' 'JVMMethodSpec'
-   'JVMSpec' 'MIRSpec' 'Bool' 'Int' 'String' 'Term' 'Type' 'AIG'
-   'CFG' '[' '(' '{' name
+   'CrucibleSetup' 'LLVMSpec' 'JVMMethodSpec' 'JVMSpec' 'MIRSpec'
+   'Bool' 'Int' 'String' 'Term' 'Type' 'AIG' 'CFG' '[' '(' '{' name
 FAILED

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -2612,6 +2612,9 @@ primTypes = foldl doadd Map.empty
   , abstype "YosysSequential" Experimental
   , abstype "YosysTheorem" Experimental
   , conctype "SetupValue" "LLVMValue" Current -- XXX: deprecate in 1.6
+  , conctype "CrucibleMethodSpec" "LLVMSpec" Current -- XXX: deprecate in 1.6
+  -- "CrucibleSetup" should be here as well, but is kind * -> * and
+  -- doesn't currently work as a typedef. XXX: deprecate it too in 1.6
   , abstype "__DEPRECATED__" HideDeprecated
   ]
   where

--- a/saw-script/src/SAWScript/Lexer.x
+++ b/saw-script/src/SAWScript/Lexer.x
@@ -48,7 +48,7 @@ $codechar  = [$graphic $whitechar \n]
              |rebindable
              |ProofScript|TopLevel|CrucibleSetup
              |Int|String|Term|Type|Bool|AIG|CFG
-             |CrucibleMethodSpec|LLVMSpec|JVMMethodSpec|JVMSpec|MIRSpec
+             |LLVMSpec|JVMMethodSpec|JVMSpec|MIRSpec
 
 @punct       = "," | ";" | "(" | ")" | ":" | "::" | "[" | "]" | "<-" | "->"
              | "=" | "{" | "}" | "." | "\"

--- a/saw-script/src/SAWScript/Parser.y
+++ b/saw-script/src/SAWScript/Parser.y
@@ -63,7 +63,6 @@ import qualified Cryptol.Utils.Ident as P (mkIdent, packModName)
   'ProofScript'  { TReserved _ "ProofScript"    }
   'TopLevel'     { TReserved _ "TopLevel"       }
   'CrucibleSetup'{ TReserved _ "CrucibleSetup"  }
-  'CrucibleMethodSpec' { TReserved _ "CrucibleMethodSpec" }
   'LLVMSpec'     { TReserved _ "LLVMSpec"       }
   'JVMMethodSpec'{ TReserved _ "JVMMethodSpec"  }
   'JVMSpec'      { TReserved _ "JVMSpec"        }
@@ -244,7 +243,6 @@ BaseType :: { Type }
  | 'Type'                               { tType (getPos $1)                }
  | 'AIG'                                { tAIG (getPos $1)                 }
  | 'CFG'                                { tCFG (getPos $1)                 }
- | 'CrucibleMethodSpec'                 { tLLVMSpec (getPos $1)            }
  | 'LLVMSpec'                           { tLLVMSpec (getPos $1)            }
  | 'JVMMethodSpec'                      { tJVMSpec (getPos $1)             }
  | 'JVMSpec'                            { tJVMSpec (getPos $1)             }


### PR DESCRIPTION
Among other things, this will make it easier to deprecate when the time comes (which is soon)