### PR TITLE
CI release fixes going forward (1.6 and beyond)

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -281,6 +281,47 @@ files_since() {
   echo "$files"
 }
 
+# Print either true or false if the argument $1 (the event tag from a
+# GH Actions run in ci.yml) is a branch event from a stable branch
+# matching the current SAW version. Branch events have the form
+# "refs/heads/branch-name". Stable branches begin with "release-".
+#
+# The intended version matching logic is as follows:
+#    branch    version
+#    1.6        1.6	yes
+#    1.6	1.6.1	yes
+#    1.6.1	1.6	no
+#    1.6.1	1.6.1	yes
+#    1.6.1	1.6.2	no
+#
+# The idea is that if the branch has a point release version, the version
+# must match it; however, if it doesn't, the version may still be a point
+# release.
+is_stable_branch_event() {
+    local ver=$(saw_ver)
+    local majver=$(echo "$ver" | sed 's,^\([^.]*\.[^.]*\)\..*,\1,')
+    local branchver=$(echo "$1" | sed 's,^refs/heads/release-,,')
+    case "$1" in
+        refs/heads/release-*.*.*)
+            if [ "$branchver" = "$ver" ]; then
+                echo true
+            else
+                echo false
+            fi
+        ;;
+        refs/heads/release-*.*)
+            if [ "$branchver" = "$majver" ]; then
+                echo true
+            else
+                echo false
+            fi
+        ;;
+        *)
+            echo false
+        ;;
+    esac
+}
+
 COMMAND="$1"
 shift
 

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -298,9 +298,15 @@ files_since() {
 # must match it; however, if it doesn't, the version may still be a point
 # release.
 is_stable_branch_event() {
-    local ver=$(saw_ver)
-    local majver=$(echo "$ver" | sed 's,^\([^.]*\.[^.]*\)\..*,\1,')
+    # Prune the git bits from the branch version, assuming it matches
+    # (if it doesn't, we'll not use this output)
     local branchver=$(echo "$1" | sed 's,^refs/heads/release-,,')
+
+    # Get the SAW version from saw.cabal, and drop all but the first two
+    # components of the version number to get the base version.
+    local ver=$(saw_ver)
+    local basever=$(echo "$ver" | sed 's,^\([^.]*\.[^.]*\)\..*,\1,')
+
     case "$1" in
         refs/heads/release-*.*.*)
             if [ "$branchver" = "$ver" ]; then
@@ -310,7 +316,7 @@ is_stable_branch_event() {
             fi
         ;;
         refs/heads/release-*.*)
-            if [ "$branchver" = "$majver" ]; then
+            if [ "$branchver" = "$basever" ]; then
                 echo true
             else
                 echo false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       event-tag: ${{ steps.config.outputs.tag }}
       event-schedule: ${{ steps.config.outputs.schedule }}
       publish: ${{ steps.config.outputs.publish }}
-      release: ${{ steps.config.outputs.release }}
+      is-stable-branch: ${{ steps.config.outputs.is-stable-branch }}
       retention-days: ${{ steps.config.outputs.retention-days }}
     steps:
       - uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
           EVENT_TAG: ${{ startsWith(github.event.ref, 'refs/tags/') }}
           EVENT_SCHEDULE: ${{ github.event_name == 'schedule' }}
           EVENT_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
-          RELEASE: ${{ startsWith(github.event.ref, 'refs/heads/release-') }}
+          IS_STABLE: ${{ startsWith(github.event.ref, 'refs/heads/release-') }}
         run: |
           set -x
           .github/ci.sh output name saw-$(.github/ci.sh saw_ver)
@@ -75,8 +75,8 @@ jobs:
           .github/ci.sh output tag $EVENT_TAG
           .github/ci.sh output schedule $EVENT_SCHEDULE
           .github/ci.sh output publish $({ $EVENT_TAG || $EVENT_SCHEDULE; } && echo true || echo false)
-          .github/ci.sh output release $([[ "refs/heads/release-$(.github/ci.sh saw_ver)" == "${{ github.event.ref }}" ]] && echo true || echo false)
-          .github/ci.sh output retention-days $($RELEASE && echo 90 || echo 5)
+          .github/ci.sh output is-stable-branch $([[ "refs/heads/release-$(.github/ci.sh saw_ver)" == "${{ github.event.ref }}" ]] && echo true || echo false)
+          .github/ci.sh output retention-days $($IS_STABLE && echo 90 || echo 5)
 
   build:
     runs-on: ${{ matrix.os }}
@@ -180,8 +180,6 @@ jobs:
           ENABLE_HPC: ${{ matrix.hpc }}
 
       - shell: bash
-        env:
-          RELEASE: ${{ needs.config.outputs.release }}
         run: .github/ci.sh build_cryptol
 
       - if: matrix.haddock == true
@@ -414,10 +412,11 @@ jobs:
     # `master`, branches matching `release-**`, and release tags, per
     # the `on:` stanza at the top of the file.
     #
-    # We want to upload docs for `master` and for releases, and not
-    # otherwise, so filter this further:
+    # We want to upload docs for `master` and for tagged releases, and
+    # not otherwise, so filter this further:
     #    - restricting to `push` actions eliminates pull requests
-    #    - requiring needs.config.outputs.release be false skips `release-**` branches
+    #    - requiring needs.config.outputs.is-stable-branch be false skips
+    #      miscellaneous builds on stable (`release-**`) branches
     # so what's left is `master` and release tags.
     #
     # Then also check the repository owner to avoid running in forks.
@@ -425,16 +424,16 @@ jobs:
     # GITHUB_TOKEN, needed when actually deploying the documentation
     # to the `gh-pages` branch.
     #
-    # Note that even though tags will normally be _on_ release
-    # branches, tag events generate a github.ref of the form
-    # `refs/tags/...` which won't set needs.config.outputs.release, so
-    # we aren't accidentally skipping release tags. We think,
-    # according to the docs, that if you push to a release branch that
-    # will trigger a branch run, and then tagging it will trigger a
-    # separate tag run.
+    # Note that even though tags will normally be _on_ stable
+    # branches, tag events generate a completely different github.ref
+    # of the form `refs/tags/...` which won't set
+    # needs.config.outputs.is-stable-branch, so we aren't accidentally
+    # skipping release tags. According to the docs, pushing to a
+    # stable branch will trigger a branch run, and then tagging it
+    # will trigger a separate tag run, and it seems to so work.
     #
     if: github.event_name == 'push' &&
-        needs.config.outputs.release == 'false' &&
+        needs.config.outputs.is-stable-branch == 'false' &&
         github.repository_owner == 'GaloisInc' &&
         github.actor != 'dependabot[bot]'
     strategy:
@@ -899,7 +898,7 @@ jobs:
     # will be available. As noted above, scheduled runs also happen in
     # forks. It would be nice to run all of it but the final push step,
     # but we appear to need docker login to build.
-    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.config.outputs.release == 'true') &&
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.config.outputs.is-stable-branch == 'true') &&
         github.repository_owner == 'GaloisInc' &&
         github.actor != 'dependabot[bot]'
     strategy:
@@ -1008,7 +1007,7 @@ jobs:
           docker tag ${{ matrix.image }}:$COMMON_TAG ${{ matrix.image }}:nightly
           docker push ${{ matrix.image }}:nightly
 
-      - if: needs.config.outputs.release == 'true'
+      - if: needs.config.outputs.is-stable-branch == 'true'
         name: ${{ matrix.image }}:${{ matrix.image-tag }}
         run: |
           docker tag ${{ matrix.image }}:$COMMON_TAG ${{ matrix.image }}:${{ matrix.image-tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           .github/ci.sh output tag $EVENT_TAG
           .github/ci.sh output schedule $EVENT_SCHEDULE
           .github/ci.sh output publish $({ $EVENT_TAG || $EVENT_SCHEDULE; } && echo true || echo false)
-          .github/ci.sh output is-stable-branch $([[ "refs/heads/release-$(.github/ci.sh saw_ver)" == "${{ github.event.ref }}" ]] && echo true || echo false)
+          .github/ci.sh output is-stable-branch $(.github/ci.sh is_stable_branch_event "$EVENT_TAG")
           .github/ci.sh output retention-days $($IS_STABLE && echo 90 || echo 5)
 
   build:


### PR DESCRIPTION
Make the following CI fixes:
- rename the "release" config variable to "is-stable-branch", which is much less confusing
- be more flexible about matching stable branches

Arises from some discussions associated with the 1.5 stable branch and the possibility of a 1.5.1 point release; however, we're not intending to backport to the 1.5 branch.
