### PR TITLE
allow SharedContext to store arbitrary data

### DIFF
--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
 
 {- |
 Module      : SAWCore.SharedTerm

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -58,7 +58,7 @@ module SAWCore.SharedTerm
   , prettyTermErrorPure
   , prettyTermError
   , ppTermError
-  , scGetPPOpts -- reexport from SAWCore.Term.Certified
+  , scGetPPOpts
   , scModifyPPOpts
   , scWithPPOpts
     -- * Checkpointing
@@ -301,20 +301,20 @@ import Data.Foldable (foldlM, foldrM)
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.IntSet as IntSet
-import qualified Data.IORef as IORef
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Ratio (numerator, denominator)
 import Data.Ref ( C )
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Data.Typeable
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Numeric.Natural (Natural)
 import qualified Prettyprinter as PP
 
 import qualified SAWSupport.IntRangeSet as IntRangeSet
-import qualified SAWSupport.Pretty as PPS (Doc, Opts, withOpts, render, renderText)
+import qualified SAWSupport.Pretty as PPS (Doc, Opts, defaultOpts, render, renderText)
 
 import SAWCore.Cache
 import SAWCore.Change
@@ -1007,16 +1007,24 @@ ppName sc opts nm =
 
 -- | Update the prettyprinter options.
 scModifyPPOpts :: SharedContext -> (PPS.Opts -> PPS.Opts) -> IO ()
-scModifyPPOpts sc f = scAlterData sc $ \mopts -> 
+scModifyPPOpts sc f = scAlterData @PPS.Opts sc $ \mopts -> 
   Just (f $ fromMaybe PPS.defaultOpts mopts)
+
+-- | Get the current prettyprinter options
+scGetPPOpts :: SharedContext -> IO PPS.Opts
+scGetPPOpts sc = do
+  mopts <- scGetData @PPS.Opts sc
+  case mopts of
+    Just opts -> return opts
+    Nothing -> return PPS.defaultOpts
 
 -- | Wrap an operation in different prettyprinter options.
 scWithPPOpts :: SharedContext -> (PPS.Opts -> PPS.Opts) -> IO a -> IO a
 scWithPPOpts sc alter action = do
-  old <- scGetData @PPS.Opts sc 
+  old <- scGetPPOpts sc 
   scModifyPPOpts sc alter
   a <- action
-  scAlterData sc (\_ -> old)
+  scModifyPPOpts sc (\_ -> old)
   return a
 
 --------------------------------------------------------------------------------

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -72,6 +72,10 @@ module SAWCore.SharedTerm
   , scFreshenGlobalIdent
   , scResolveName
   , scResolveQualName
+    -- * Metadata
+  , scAlterData
+  , scInsertData
+  , scGetData
     -- * Term builders
   , scTermF
   , scFlatTermF
@@ -1003,14 +1007,17 @@ ppName sc opts nm =
 
 -- | Update the prettyprinter options.
 scModifyPPOpts :: SharedContext -> (PPS.Opts -> PPS.Opts) -> IO ()
-scModifyPPOpts sc f =
-  IORef.modifyIORef (scGetPPOptsRef sc) f
+scModifyPPOpts sc f = scAlterData sc $ \mopts -> 
+  Just (f $ fromMaybe PPS.defaultOpts mopts)
 
 -- | Wrap an operation in different prettyprinter options.
 scWithPPOpts :: SharedContext -> (PPS.Opts -> PPS.Opts) -> IO a -> IO a
-scWithPPOpts sc alter action =
-  PPS.withOpts (scGetPPOptsRef sc) alter action
-
+scWithPPOpts sc alter action = do
+  old <- scGetData @PPS.Opts sc 
+  scModifyPPOpts sc alter
+  a <- action
+  scAlterData sc (\_ -> old)
+  return a
 
 --------------------------------------------------------------------------------
 -- Recursors
@@ -2370,3 +2377,16 @@ scTreeSizeAux = go
         Just sz' -> (sz + sz', seen)
         Nothing -> (sz + sz', Map.insert (termIndex t) sz' seen')
           where (sz', seen') = foldl' go (1, seen) (unwrapTermF t)
+
+scAlterData ::
+  Typeable a =>
+  SharedContext ->
+  (Maybe a -> Maybe a) ->
+  IO ()
+scAlterData sc f = execSCM sc (scmAlterData f)
+
+scInsertData :: Typeable a => SharedContext -> (a -> a -> a) -> a -> IO ()
+scInsertData sc f a = execSCM sc (scmInsertData f a)
+
+scGetData :: Typeable a => SharedContext -> IO (Maybe a)
+scGetData sc = execSCM sc scmGetData

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeApplications #-}
 
 {- |
 Module      : SAWCore.SharedTerm
@@ -74,9 +73,9 @@ module SAWCore.SharedTerm
   , scResolveName
   , scResolveQualName
     -- * Metadata
-  , scAlterData
-  , scInsertData
+  , IsMetadata(..)
   , scGetData
+  , scUpdateData
     -- * Term builders
   , scTermF
   , scFlatTermF
@@ -1006,18 +1005,22 @@ ppName :: SharedContext -> PPS.Opts -> Name -> IO Text
 ppName sc opts nm =
   PPS.renderText opts <$> prettyName sc opts nm
 
+newtype PrettyOpts = PrettyOpts PPS.Opts
+  deriving (Typeable)
+
+instance IsMetadata PrettyOpts where
+  initMetadata = return $ PrettyOpts PPS.defaultOpts
+
 -- | Update the prettyprinter options.
 scModifyPPOpts :: SharedContext -> (PPS.Opts -> PPS.Opts) -> IO ()
-scModifyPPOpts sc f = scAlterData @PPS.Opts sc $ \mopts -> 
-  Just (f $ fromMaybe PPS.defaultOpts mopts)
+scModifyPPOpts sc f = scUpdateData sc $ \(PrettyOpts opts) -> 
+  PrettyOpts $ f opts
 
 -- | Get the current prettyprinter options
 scGetPPOpts :: SharedContext -> IO PPS.Opts
 scGetPPOpts sc = do
-  mopts <- scGetData @PPS.Opts sc
-  case mopts of
-    Just opts -> return opts
-    Nothing -> return PPS.defaultOpts
+  PrettyOpts opts <- scGetData sc
+  return opts
 
 -- | Wrap an operation in different prettyprinter options.
 scWithPPOpts :: SharedContext -> (PPS.Opts -> PPS.Opts) -> IO a -> IO a
@@ -2387,15 +2390,9 @@ scTreeSizeAux = go
         Nothing -> (sz + sz', Map.insert (termIndex t) sz' seen')
           where (sz', seen') = foldl' go (1, seen) (unwrapTermF t)
 
-scAlterData ::
-  Typeable a =>
-  SharedContext ->
-  (Maybe a -> Maybe a) ->
-  IO ()
-scAlterData sc f = execSCM sc (scmAlterData f)
+scUpdateData ::
+  IsMetadata a => SharedContext -> (a -> a) -> IO ()
+scUpdateData sc f = execSCM sc (scmUpdateData f)
 
-scInsertData :: Typeable a => SharedContext -> (a -> a -> a) -> a -> IO ()
-scInsertData sc f a = execSCM sc (scmInsertData f a)
-
-scGetData :: Typeable a => SharedContext -> IO (Maybe a)
+scGetData :: IsMetadata a => SharedContext -> IO a
 scGetData sc = execSCM sc scmGetData

--- a/saw-core/src/SAWCore/Term/Certified.hs
+++ b/saw-core/src/SAWCore/Term/Certified.hs
@@ -32,6 +32,10 @@ module SAWCore.Term.Certified
   , closedTerm
   , termSortOrType
   , alphaEquiv
+  -- * Term metadata
+  , scmGetData
+  , scmAlterData
+  , scmInsertData
     -- * Term building monad
   , TermError(..)
   , SCM
@@ -77,7 +81,6 @@ module SAWCore.Term.Certified
   , scGetModuleMap
   , scGetNamingEnv
   , scGetPPOpts
-  , scGetPPOptsRef
   , scmRegisterName
   , scmFreshVarName
   , scmFreshInventedVar
@@ -125,6 +128,7 @@ import Data.Maybe
 import Data.Ref (C)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Data.Typeable
 import qualified Data.Vector as V
 import Numeric.Natural (Natural)
 import Prelude hiding (maximum)
@@ -133,6 +137,8 @@ import SAWSupport.EqRel (EqRel)
 import qualified SAWSupport.EqRel as EqRel
 import SAWSupport.IntRangeSet (IntRangeSet)
 import qualified SAWSupport.IntRangeSet as IntRangeSet
+import SAWSupport.TypedStore (TypedStore)
+import qualified SAWSupport.TypedStore as TypedStore
 import qualified SAWSupport.Pretty as PPS
 
 import SAWCore.Cache
@@ -332,14 +338,10 @@ data SharedContext = SharedContext
   , scNextVarIndex   :: IORef VarIndex
   , scNextTermIndex  :: IORef TermIndex
   , scValidTerms     :: IORef IntRangeSet
-  , scInventedVars   :: IORef (IntMap Term) -- ^ workaround until scopes are
-                                            -- supported (see #3066).
-                                            -- tracks variables that have
-                                            -- been given a global name and
-                                            -- are expected to appear free
-                                            -- at the top-level.
-  , scPPOpts         :: IORef PPS.Opts
+  , scMetadata       :: IORef TypedStore
   }
+
+
 
 -- | Internal function to get the next available 'TermIndex'. Not exported.
 scmFreshTermIndex :: SCM VarIndex
@@ -388,8 +390,7 @@ data SharedContextCheckpoint =
   , sccQualNameEnv :: Map QN.QualName VarIndex
   , sccGlobalEnv :: HashMap Ident Term
   , sccTermIndex :: TermIndex
-  , sccInventedVars :: IntMap Term
-  , sccPPOpts :: PPS.Opts
+  , sccMetadata :: TypedStore
   }
 
 checkpointSharedContext :: SharedContext -> IO SharedContextCheckpoint
@@ -399,16 +400,14 @@ checkpointSharedContext sc =
      uenv <- readIORef (scQualNameEnv sc)
      genv <- readIORef (scGlobalEnv sc)
      i <- readIORef (scNextTermIndex sc)
-     venv <- readIORef (scInventedVars sc)
-     ppopts <- readIORef (scPPOpts sc)
+     td <- readIORef (scMetadata sc)
      return SCC
             { sccModuleMap = mmap
             , sccNamingEnv = nenv
             , sccQualNameEnv = uenv
             , sccGlobalEnv = genv
             , sccTermIndex = i
-            , sccInventedVars = venv
-            , sccPPOpts = ppopts
+            , sccMetadata = td
             }
 
 restoreSharedContext :: SharedContextCheckpoint -> SharedContext -> IO ()
@@ -426,8 +425,7 @@ restoreSharedContext scc sc =
      writeIORef (scDisplayNameEnv sc) (sccNamingEnv scc)
      writeIORef (scQualNameEnv sc) (sccQualNameEnv scc)
      writeIORef (scGlobalEnv sc) (sccGlobalEnv scc)
-     writeIORef (scInventedVars sc) (sccInventedVars scc)
-     writeIORef (scPPOpts sc) (sccPPOpts scc)
+     writeIORef (scMetadata sc) (sccMetadata scc)
      -- Mark 'TermIndex'es created since the checkpoint as invalid
      j <- readIORef (scNextTermIndex sc)
      modifyIORef' (scValidTerms sc) (IntRangeSet.delete (i, j-1))
@@ -573,11 +571,30 @@ scmVariable x t =
      let mty = maybe (Right t) Left (asSort t)
      scmMakeTerm vt (Variable x t) mty
 
-scmGetInventedVarType :: VarIndex -> SCM (Maybe Term)
-scmGetInventedVarType i = do
+-- | Alter the global metadata with type 'a'.
+scmAlterData :: Typeable a => (Maybe a -> Maybe a) -> SCM ()
+scmAlterData f = do
   sc <- scmSharedContext
-  vars <- liftIO $ readIORef (scInventedVars sc)
-  return $ IntMap.lookup i vars
+  liftIO $ modifyIORef' (scMetadata sc) $ TypedStore.alter f
+
+-- | Add to the global metadata of type 'a', combining existing data
+--   with the given function (older value first), if present.
+scmInsertData :: Typeable a => (a -> a -> a) -> a -> SCM ()
+scmInsertData f a = scmAlterData $ \case
+  Just a' -> Just (f a' a)
+  Nothing -> Just a
+
+-- | Return the global metadata of type 'a'.
+scmGetData :: Typeable a => SCM (Maybe a)
+scmGetData = do
+  sc <- scmSharedContext
+  liftIO $ scGetData sc
+
+-- | Return the global metadata of type 'a' in IO.
+scGetData :: Typeable a => SharedContext -> IO (Maybe a)
+scGetData sc = do
+  m <- liftIO $ readIORef (scMetadata sc)
+  return $ TypedStore.lookup m
 
 -- | Check whether the given 'VarName' occurs free in the type of
 -- another variable in the context of the given 'Term', and fail if it
@@ -703,10 +720,20 @@ scmFreshInventedVar name ty = do
         _ -> QN.simpleName name
     qn' = qn { QN.index = Just (vnIndex vn), QN.namespace = Just QN.NamespaceFresh }
   scmRegisterNameWithIndex (vnIndex vn) popts qn'
-  sc <- scmSharedContext
-  liftIO $ modifyIORef' (scInventedVars sc) $
-    IntMap.insert (vnIndex vn) ty
+  scmInsertData (<>) $ InventedVars $ IntMap.singleton (vnIndex vn) ty
   return vn
+
+-- | workaround until scopes are supported (see #3066). tracks
+-- variables that have been given a global name and are expected to
+-- appear free at the top-level.
+-- This is a private type that we store as global metadata
+newtype InventedVars = InventedVars (IntMap Term)
+  deriving (Typeable, Semigroup)
+
+scmGetInventedVarType :: VarIndex -> SCM (Maybe Term)
+scmGetInventedVarType i = scmGetData >>= \case
+  Just (InventedVars m) -> return $ IntMap.lookup i m
+  Nothing -> return Nothing
 
 -- | Returns shared term associated with ident.
 -- Does not check module namespace.
@@ -744,13 +771,9 @@ scFreshenGlobalIdent sc ident =
 
 -- | Get the current prettyprinter options
 scGetPPOpts :: SharedContext -> IO PPS.Opts
-scGetPPOpts sc = readIORef (scPPOpts sc)
-
--- | Get the current prettyprinter options as an IORef. This is used
---    by @scWithPPOpts@ and @scModifyPPOpts@ in @SharedTerm@ and not
---    otherwise exported.
-scGetPPOptsRef :: SharedContext -> IORef PPS.Opts
-scGetPPOptsRef sc = scPPOpts sc
+scGetPPOpts sc = scGetData sc >>= \case
+  Just opts -> return opts
+  Nothing -> return PPS.defaultOpts
 
 -- | Get the current naming environment
 scGetNamingEnv :: SharedContext -> IO DisplayNameEnv
@@ -1890,8 +1913,7 @@ mkSharedContext =
      tr <- newIORef (i0 :: TermIndex)
      let j0 = i0 + (1 `shiftL` 48 - 1)
      ir <- newIORef (IntRangeSet.singleton (i0, j0))
-     dvr <- newIORef IntMap.empty
-     ppOptsRef <- newIORef PPS.defaultOpts
+     td <- newIORef TypedStore.empty
      pure $
        SharedContext
        { scModuleMap = mr
@@ -1902,8 +1924,7 @@ mkSharedContext =
        , scGlobalEnv = gr
        , scNextTermIndex = tr
        , scValidTerms = ir
-       , scInventedVars = dvr
-       , scPPOpts = ppOptsRef
+       , scMetadata = td
        }
 
 -- | Instantiate some of the named variables in the term.

--- a/saw-core/src/SAWCore/Term/Certified.hs
+++ b/saw-core/src/SAWCore/Term/Certified.hs
@@ -80,7 +80,6 @@ module SAWCore.Term.Certified
   , mkSharedContext
   , scGetModuleMap
   , scGetNamingEnv
-  , scGetPPOpts
   , scmRegisterName
   , scmFreshVarName
   , scmFreshInventedVar
@@ -139,7 +138,6 @@ import SAWSupport.IntRangeSet (IntRangeSet)
 import qualified SAWSupport.IntRangeSet as IntRangeSet
 import SAWSupport.TypedStore (TypedStore)
 import qualified SAWSupport.TypedStore as TypedStore
-import qualified SAWSupport.Pretty as PPS
 
 import SAWCore.Cache
 import SAWCore.Module
@@ -327,8 +325,10 @@ emptyAppCache = emptyTFM
 -- Invariant: All entries in 'scAppCache' must have 'TermIndex'es that
 -- are less than 'scNextTermIndex' and marked valid in 'scValidTerms'.
 --
--- The `PPS.Opts` (prettyprinter options) are kept here for all of SAW.
--- They are updated by upper-level code when the user changes settings.
+-- The 'scMetadata' field stores arbitrary metadata that is unrelated
+-- to the core functionality, but is otherwise convenient to keep
+-- in the shared context. The fields 'scInventedVars' and 'scPPOpts'
+-- have been removed, and are now stored as metadata instead.
 data SharedContext = SharedContext
   { scModuleMap      :: IORef ModuleMap
   , scAppCache       :: AppCacheRef
@@ -338,7 +338,7 @@ data SharedContext = SharedContext
   , scNextVarIndex   :: IORef VarIndex
   , scNextTermIndex  :: IORef TermIndex
   , scValidTerms     :: IORef IntRangeSet
-  , scMetadata       :: IORef TypedStore
+  , scMetadata       :: IORef (TypedStore IORef)
   }
 
 
@@ -390,7 +390,7 @@ data SharedContextCheckpoint =
   , sccQualNameEnv :: Map QN.QualName VarIndex
   , sccGlobalEnv :: HashMap Ident Term
   , sccTermIndex :: TermIndex
-  , sccMetadata :: TypedStore
+  , sccMetadata :: TypedStore Identity
   }
 
 checkpointSharedContext :: SharedContext -> IO SharedContextCheckpoint
@@ -400,7 +400,8 @@ checkpointSharedContext sc =
      uenv <- readIORef (scQualNameEnv sc)
      genv <- readIORef (scGlobalEnv sc)
      i <- readIORef (scNextTermIndex sc)
-     td <- readIORef (scMetadata sc)
+     td_refs <- readIORef (scMetadata sc)
+     td <- TypedStore.traverse (\ref -> Identity <$> readIORef ref) td_refs
      return SCC
             { sccModuleMap = mmap
             , sccNamingEnv = nenv
@@ -409,6 +410,25 @@ checkpointSharedContext sc =
             , sccTermIndex = i
             , sccMetadata = td
             }
+
+restoreMetadata :: 
+  TypedStore Identity -> TypedStore IORef -> IO (TypedStore IORef)
+restoreMetadata = TypedStore.mergeM overwrite keep_chk drop_now
+  where 
+    -- overwrite existing refs with checkpoint data
+    overwrite :: 
+      Identity a -> IORef a -> IO (Maybe (IORef a))
+    overwrite (Identity a) ref = 
+      writeIORef ref a >> return (Just ref)
+
+    -- allocate new refs for data only in the checkpoint 
+    keep_chk :: Identity a -> IO (Maybe (IORef a))
+    keep_chk (Identity a) = Just <$> newIORef a
+
+    -- remove any refs not present in the checkpoint, leaving
+    -- the contents of the ref unmodified
+    drop_now :: IORef a -> IO (Maybe (IORef a))
+    drop_now _ = return Nothing
 
 restoreSharedContext :: SharedContextCheckpoint -> SharedContext -> IO ()
 restoreSharedContext scc sc =
@@ -425,7 +445,9 @@ restoreSharedContext scc sc =
      writeIORef (scDisplayNameEnv sc) (sccNamingEnv scc)
      writeIORef (scQualNameEnv sc) (sccQualNameEnv scc)
      writeIORef (scGlobalEnv sc) (sccGlobalEnv scc)
-     writeIORef (scMetadata sc) (sccMetadata scc)
+     now <- readIORef (scMetadata sc)
+     restored <- restoreMetadata (sccMetadata scc) now
+     writeIORef (scMetadata sc) restored
      -- Mark 'TermIndex'es created since the checkpoint as invalid
      j <- readIORef (scNextTermIndex sc)
      modifyIORef' (scValidTerms sc) (IntRangeSet.delete (i, j-1))
@@ -572,10 +594,18 @@ scmVariable x t =
      scmMakeTerm vt (Variable x t) mty
 
 -- | Alter the global metadata with type 'a'.
+
+-- Each individual metadata type is stored as its own IORef, which
+-- simply allows for entries to be modified without requiring updates
+-- to the 'TypedStore' itself.
+
 scmAlterData :: Typeable a => (Maybe a -> Maybe a) -> SCM ()
 scmAlterData f = do
   sc <- scmSharedContext
-  liftIO $ modifyIORef' (scMetadata sc) $ TypedStore.alter f
+  ts <- liftIO $ readIORef (scMetadata sc)     
+  liftIO $ TypedStore.alterIO f ts >>= \case
+    Just ts' -> writeIORef (scMetadata sc) ts'
+    Nothing -> return ()
 
 -- | Add to the global metadata of type 'a', combining existing data
 --   with the given function (older value first), if present.
@@ -593,8 +623,8 @@ scmGetData = do
 -- | Return the global metadata of type 'a' in IO.
 scGetData :: Typeable a => SharedContext -> IO (Maybe a)
 scGetData sc = do
-  m <- liftIO $ readIORef (scMetadata sc)
-  return $ TypedStore.lookup m
+  d <- readIORef (scMetadata sc)
+  TypedStore.lookupIO d
 
 -- | Check whether the given 'VarName' occurs free in the type of
 -- another variable in the context of the given 'Term', and fail if it
@@ -769,11 +799,7 @@ scFreshenGlobalIdent sc ident =
                Text.append (identBaseName ident) .
                Text.pack . show) [(0::Integer) ..]
 
--- | Get the current prettyprinter options
-scGetPPOpts :: SharedContext -> IO PPS.Opts
-scGetPPOpts sc = scGetData sc >>= \case
-  Just opts -> return opts
-  Nothing -> return PPS.defaultOpts
+
 
 -- | Get the current naming environment
 scGetNamingEnv :: SharedContext -> IO DisplayNameEnv

--- a/saw-core/src/SAWCore/Term/Certified.hs
+++ b/saw-core/src/SAWCore/Term/Certified.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ExistentialQuantification #-}
 
 {- |
 Module      : SAWCore.Term.Certified
@@ -33,9 +34,9 @@ module SAWCore.Term.Certified
   , termSortOrType
   , alphaEquiv
   -- * Term metadata
+  , IsMetadata(..)
   , scmGetData
-  , scmAlterData
-  , scmInsertData
+  , scmUpdateData
     -- * Term building monad
   , TermError(..)
   , SCM
@@ -338,10 +339,21 @@ data SharedContext = SharedContext
   , scNextVarIndex   :: IORef VarIndex
   , scNextTermIndex  :: IORef TermIndex
   , scValidTerms     :: IORef IntRangeSet
-  , scMetadata       :: IORef (TypedStore IORef)
+  , scMetadata       :: IORef (TypedStore (Metadata IORef))
   }
 
+class Typeable a => IsMetadata a where
+  -- | Action to initialize this data on first access. Will only
+  --   run once, unless it is removed entirely after restoring
+  --   a checkpoint.
+  initMetadata :: IO a
 
+  -- | Action to run when restoring a 'SharedContext' checkpoint.
+  --   Checkpoint value first.
+  restoreMetadata :: a -> a -> IO a
+  restoreMetadata chk _ = return chk
+
+data Metadata f a = IsMetadata a => Metadata (f a)
 
 -- | Internal function to get the next available 'TermIndex'. Not exported.
 scmFreshTermIndex :: SCM VarIndex
@@ -390,7 +402,7 @@ data SharedContextCheckpoint =
   , sccQualNameEnv :: Map QN.QualName VarIndex
   , sccGlobalEnv :: HashMap Ident Term
   , sccTermIndex :: TermIndex
-  , sccMetadata :: TypedStore Identity
+  , sccMetadata :: TypedStore (Metadata Identity)
   }
 
 checkpointSharedContext :: SharedContext -> IO SharedContextCheckpoint
@@ -401,7 +413,8 @@ checkpointSharedContext sc =
      genv <- readIORef (scGlobalEnv sc)
      i <- readIORef (scNextTermIndex sc)
      td_refs <- readIORef (scMetadata sc)
-     td <- TypedStore.traverse (\ref -> Identity <$> readIORef ref) td_refs
+     td <- TypedStore.traverse 
+       (\(Metadata ref) -> (Metadata . Identity) <$> readIORef ref) td_refs
      return SCC
             { sccModuleMap = mmap
             , sccNamingEnv = nenv
@@ -411,24 +424,37 @@ checkpointSharedContext sc =
             , sccMetadata = td
             }
 
-restoreMetadata :: 
-  TypedStore Identity -> TypedStore IORef -> IO (TypedStore IORef)
-restoreMetadata = TypedStore.mergeM overwrite keep_chk drop_now
+restoreMetadataStore :: 
+  SharedContext ->
+  TypedStore (Metadata Identity) -> 
+  IO ()
+restoreMetadataStore sc chk = do
+  now <- readIORef (scMetadata sc)
+  restored <- TypedStore.mergeM restore keep_chk reinit_now chk now
+  writeIORef (scMetadata sc) restored
   where 
-    -- overwrite existing refs with checkpoint data
-    overwrite :: 
-      Identity a -> IORef a -> IO (Maybe (IORef a))
-    overwrite (Identity a) ref = 
-      writeIORef ref a >> return (Just ref)
+    -- restore existing refs with checkpoint data
+    restore :: 
+      Metadata Identity a -> Metadata IORef a -> IO (Maybe (Metadata IORef a))
+    restore (Metadata (Identity a_chk)) m@(Metadata ref) = do
+      a_now <- readIORef ref
+      a_restored <- restoreMetadata a_chk a_now
+      writeIORef ref a_restored
+      return $ Just m
 
-    -- allocate new refs for data only in the checkpoint 
-    keep_chk :: Identity a -> IO (Maybe (IORef a))
-    keep_chk (Identity a) = Just <$> newIORef a
+    -- allocate new refs for data only in the checkpoint
+    -- NOTE: in practice this should never happen, since the
+    -- API doesn't allow for deleting metadata entries
+    keep_chk :: Metadata Identity a -> IO (Maybe (Metadata IORef a))
+    keep_chk (Metadata (Identity a)) = (Just . Metadata) <$> newIORef a
 
-    -- remove any refs not present in the checkpoint, leaving
-    -- the contents of the ref unmodified
-    drop_now :: IORef a -> IO (Maybe (IORef a))
-    drop_now _ = return Nothing
+    -- for any refs not in the checkpoint, we re-initialize their
+    -- contents and return the original ref
+    reinit_now :: Metadata IORef a -> IO (Maybe (Metadata IORef a))
+    reinit_now m@(Metadata ref) = do
+      a_init <- initMetadata
+      writeIORef ref a_init
+      return $ Just m
 
 restoreSharedContext :: SharedContextCheckpoint -> SharedContext -> IO ()
 restoreSharedContext scc sc =
@@ -445,9 +471,6 @@ restoreSharedContext scc sc =
      writeIORef (scDisplayNameEnv sc) (sccNamingEnv scc)
      writeIORef (scQualNameEnv sc) (sccQualNameEnv scc)
      writeIORef (scGlobalEnv sc) (sccGlobalEnv scc)
-     now <- readIORef (scMetadata sc)
-     restored <- restoreMetadata (sccMetadata scc) now
-     writeIORef (scMetadata sc) restored
      -- Mark 'TermIndex'es created since the checkpoint as invalid
      j <- readIORef (scNextTermIndex sc)
      modifyIORef' (scValidTerms sc) (IntRangeSet.delete (i, j-1))
@@ -455,6 +478,8 @@ restoreSharedContext scc sc =
      modifyIORef' (scAppCache sc) (filterTFM (\t -> termIndex t < i))
      -- scNextVarIndex and scNextTermIndex are left untouched
 
+     -- Finally, restore metadata
+     restoreMetadataStore sc (sccMetadata scc)
 --------------------------------------------------------------------------------
 -- Fundamental term builders
 
@@ -593,38 +618,34 @@ scmVariable x t =
      let mty = maybe (Right t) Left (asSort t)
      scmMakeTerm vt (Variable x t) mty
 
--- | Alter the global metadata with type 'a'.
+-- | Update the global metadata of type 'a'.
 
 -- Each individual metadata type is stored as its own IORef, which
 -- simply allows for entries to be modified without requiring updates
 -- to the 'TypedStore' itself.
-
-scmAlterData :: Typeable a => (Maybe a -> Maybe a) -> SCM ()
-scmAlterData f = do
+scmUpdateData :: IsMetadata a => (a -> a) -> SCM ()
+scmUpdateData f = do
   sc <- scmSharedContext
-  ts <- liftIO $ readIORef (scMetadata sc)     
-  liftIO $ TypedStore.alterIO f ts >>= \case
-    Just ts' -> writeIORef (scMetadata sc) ts'
-    Nothing -> return ()
-
--- | Add to the global metadata of type 'a', combining existing data
---   with the given function (older value first), if present.
-scmInsertData :: Typeable a => (a -> a -> a) -> a -> SCM ()
-scmInsertData f a = scmAlterData $ \case
-  Just a' -> Just (f a' a)
-  Nothing -> Just a
+  ts <- liftIO $ readIORef (scMetadata sc)
+  liftIO $ case TypedStore.lookup ts of
+    Just (Metadata ref) -> modifyIORef' ref f
+    Nothing -> do
+      a <- initMetadata
+      ref <- Metadata <$> newIORef (f a)
+      modifyIORef' (scMetadata sc) (TypedStore.insert ref)
 
 -- | Return the global metadata of type 'a'.
-scmGetData :: Typeable a => SCM (Maybe a)
+scmGetData :: IsMetadata a => SCM a
 scmGetData = do
   sc <- scmSharedContext
-  liftIO $ scGetData sc
-
--- | Return the global metadata of type 'a' in IO.
-scGetData :: Typeable a => SharedContext -> IO (Maybe a)
-scGetData sc = do
-  d <- readIORef (scMetadata sc)
-  TypedStore.lookupIO d
+  ts <- liftIO $ readIORef (scMetadata sc)
+  liftIO $ case TypedStore.lookup ts of
+    Just (Metadata ref) -> readIORef ref
+    Nothing -> do
+      a <- initMetadata
+      ref <- Metadata <$> newIORef a
+      modifyIORef' (scMetadata sc) (TypedStore.insert ref)
+      return a
 
 -- | Check whether the given 'VarName' occurs free in the type of
 -- another variable in the context of the given 'Term', and fail if it
@@ -750,7 +771,8 @@ scmFreshInventedVar name ty = do
         _ -> QN.simpleName name
     qn' = qn { QN.index = Just (vnIndex vn), QN.namespace = Just QN.NamespaceFresh }
   scmRegisterNameWithIndex (vnIndex vn) popts qn'
-  scmInsertData (<>) $ InventedVars $ IntMap.singleton (vnIndex vn) ty
+  scmUpdateData $ \(InventedVars m) -> 
+    InventedVars (IntMap.insert (vnIndex vn) ty m)
   return vn
 
 -- | workaround until scopes are supported (see #3066). tracks
@@ -758,12 +780,15 @@ scmFreshInventedVar name ty = do
 -- appear free at the top-level.
 -- This is a private type that we store as global metadata
 newtype InventedVars = InventedVars (IntMap Term)
-  deriving (Typeable, Semigroup)
+  deriving (Typeable)
+
+instance IsMetadata InventedVars where
+  initMetadata = return $ InventedVars IntMap.empty
 
 scmGetInventedVarType :: VarIndex -> SCM (Maybe Term)
-scmGetInventedVarType i = scmGetData >>= \case
-  Just (InventedVars m) -> return $ IntMap.lookup i m
-  Nothing -> return Nothing
+scmGetInventedVarType i = do
+  InventedVars m <- scmGetData
+  return $ IntMap.lookup i m
 
 -- | Returns shared term associated with ident.
 -- Does not check module namespace.

--- a/saw-core/src/SAWCore/Typechecker.hs
+++ b/saw-core/src/SAWCore/Typechecker.hs
@@ -583,7 +583,7 @@ tcInsertModule sc (Un.Module (PosPair _ mnm) imports decls) = do
   decls_res <- runTCM (processDecls decls) sc (Just mnm)
   case decls_res of
     Left err -> do
-      ppopts <- SC.scGetPPOpts sc
+      ppopts <- scGetPPOpts sc
       fail $ ppTCError ppopts err
     Right _ -> return ()
 

--- a/saw-support/src/SAWSupport/Pretty.hs
+++ b/saw-support/src/SAWSupport/Pretty.hs
@@ -86,7 +86,6 @@ module SAWSupport.Pretty (
     MemoStyle(..),
     Opts(..),
     defaultOpts,
-    withOpts,
     limitMaxDepth,
     prettyStringDQ,
     ppStringLiteral,
@@ -111,8 +110,6 @@ import System.IO (stdout)
 import Numeric (showIntAtBase, showHex)
 import Numeric.Natural (Natural)
 import qualified Data.Char as Char
-import Data.IORef (IORef)
-import qualified Data.IORef as IORef
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as TextL
@@ -217,16 +214,6 @@ defaultOpts = Opts {
     ppMemoStyle = Incremental,
     ppMinSharing = 2
  }
-
-withOpts :: IORef Opts -> (Opts -> Opts) -> IO a -> IO a
-withOpts ref adjust action = do
-  -- why is there nothing like withIORef in the stdlib?
-  opts <- IORef.readIORef ref
-  let opts' = adjust opts
-  IORef.writeIORef ref opts'
-  result <- action
-  IORef.writeIORef ref opts
-  return result
 
 limitMaxDepth :: Int -> Opts -> Opts
 limitMaxDepth limit opts =

--- a/saw-support/src/SAWSupport/TypedStore.hs
+++ b/saw-support/src/SAWSupport/TypedStore.hs
@@ -1,5 +1,5 @@
 {- |
-Module      : SAWSupport.TypedMap
+Module      : SAWSupport.TypedStore
 Copyright   : Galois, Inc. 2012-2026
 License     : BSD3
 Maintainer  : saw@galois.com
@@ -49,6 +49,8 @@ import Data.Type.Equality
 import Data.Parameterized.Map (MapF)
 import qualified Data.Parameterized.Map as MapF
 
+import Data.Parameterized.TraversableF
+
 -- | Internal wrapper for 'TypeRep' that we provide an 'MapF.OrdF'
 --   instance for.
 newtype TypeRep' a = TypeRep' (TypeRep a)
@@ -87,7 +89,8 @@ alter :: forall a f.
   TypedStore f
 alter g ts = runIdentity $ alterM (\ma -> Identity (g ma)) ts
 
-
+-- | Alter the data of type 'f a' in the store, inserting or deleting
+-- based on the result of the monadic action 'g'.
 alterM :: forall a f m.
   Typeable a =>
   Monad m =>
@@ -111,13 +114,14 @@ alterM g (TypedStore tm) =
 insert :: forall a f. Typeable a => f a -> TypedStore f -> TypedStore f
 insert a = alter (\_ -> Just a)
 
+-- | Create a 'TypedStore' with a single entry of type 'f a'.
 singleton :: forall a f. (Typeable f, Typeable a) => f a -> TypedStore f
 singleton a = TypedStore (MapF.singleton (TypeRep' typeRep) a)
 
 size :: TypedStore f -> Int
 size (TypedStore ts) = MapF.size ts
 
--- | Delete the value of type 'a' from the store.
+-- | Delete the value of type 'f a' from the store, if present.
 delete :: forall a f proxy. Typeable a => proxy a -> TypedStore f -> TypedStore f
 delete _ tm = alter @a (\_ -> Nothing) tm
 
@@ -130,7 +134,6 @@ map f (TypedStore ts) = TypedStore $
 
 traverse :: forall f g m.
   Applicative m => 
-  Typeable g =>
   (forall a. (Typeable a) => f a -> m (g a)) -> 
   TypedStore f -> 
   m (TypedStore g)
@@ -209,7 +212,6 @@ toList :: forall f b.
 toList f (TypedStore ts) = 
   List.map (\(MapF.Pair rep x) -> withRep rep $ f x) $ MapF.toList ts
 
-
 lookupIO :: Typeable a => TypedStore IORef -> IO (Maybe a)
 lookupIO ts = do
   case lookup ts of
@@ -238,3 +240,11 @@ alterIO f ts = do
         return $ Just $ insert aref ts
       Nothing -> return Nothing
 
+instance FunctorF TypedStore where
+  fmapF = map
+
+instance FoldableF TypedStore where
+  foldrF f z (TypedStore ts) = foldrF f z ts
+
+instance TraversableF TypedStore where
+  traverseF = traverse

--- a/saw-support/src/SAWSupport/TypedStore.hs
+++ b/saw-support/src/SAWSupport/TypedStore.hs
@@ -39,6 +39,7 @@ module SAWSupport.TypedStore
   ) where
 
 import Prelude hiding (lookup, map, traverse)
+import Data.Coerce
 import qualified Data.List as List
 import Data.Functor.Identity (Identity(..))
 import Data.IORef (IORef,newIORef,readIORef,atomicModifyIORef')
@@ -46,25 +47,28 @@ import Data.IORef (IORef,newIORef,readIORef,atomicModifyIORef')
 import Type.Reflection
 import Data.Type.Equality
 
+import Data.Parameterized.Classes
 import Data.Parameterized.Map (MapF)
 import qualified Data.Parameterized.Map as MapF
+import Data.Parameterized.Pair
 
 import Data.Parameterized.TraversableF
 
--- | Internal wrapper for 'TypeRep' that we provide an 'MapF.OrdF'
+-- | Internal wrapper for 'TypeRep' that we provide an 'OrdF'
 --   instance for.
 newtype TypeRep' a = TypeRep' (TypeRep a)
-  deriving (TestEquality)
+  deriving (TestEquality, Show)
 
-instance MapF.OrdF TypeRep' where
+instance OrdF TypeRep' where
   compareF (TypeRep' tr1) (TypeRep' tr2) =
     case testEquality tr1 tr2 of
-      Just Refl -> MapF.EQF
+      Just Refl -> EQF
       Nothing -> case compare (SomeTypeRep tr1) (SomeTypeRep tr2) of
-        LT -> MapF.LTF
-        GT -> MapF.GTF
+        LT -> LTF
+        GT -> GTF
         EQ -> error "inconsistent TypeRep equality"
 
+instance ShowF TypeRep'
 
 withRep :: forall a b. TypeRep' a -> (Typeable a => b) -> b
 withRep (TypeRep' tr) f = withTypeable tr f
@@ -212,7 +216,7 @@ intersection f (TypedStore ts1) (TypedStore ts2) = TypedStore $
 toList :: forall f b.
   (forall a. (Typeable a) => f a -> b) -> TypedStore f -> [b]
 toList f (TypedStore ts) = 
-  List.map (\(MapF.Pair rep x) -> withRep rep $ f x) $ MapF.toList ts
+  List.map (\(Pair rep x) -> withRep rep $ f x) $ MapF.toList ts
 
 lookupIO :: forall a. Typeable a => TypedStore IORef -> IO (Maybe a)
 lookupIO ts =
@@ -250,3 +254,25 @@ instance FoldableF TypedStore where
 
 instance TraversableF TypedStore where
   traverseF = traverse
+
+instance EqF f => Eq (TypedStore f) where
+  (TypedStore ts1) == (TypedStore ts2) = ts1 == ts2
+
+newtype Pair' f g = Pair' (Pair f g)
+  deriving (Eq)
+
+instance (EqF g, OrdF f, OrdF g) => Ord (Pair' f g) where
+  compare (Pair' (Pair f1 g1)) (Pair' (Pair f2 g2)) =
+    toOrdering (compareF f1 f2) <> toOrdering (compareF g1 g2)
+
+instance (EqF f, OrdF f) => Ord (TypedStore f) where
+  compare (TypedStore ts1) (TypedStore ts2) = 
+    compare 
+      (coerce (MapF.toList ts1) :: [Pair' TypeRep' f]) 
+      (coerce (MapF.toList ts2) :: [Pair' TypeRep' f])
+
+instance (EqF f, HashableF f) => Hashable (TypedStore f) where
+  hashWithSalt i = foldrF (\x y -> hashWithSaltF y x) i
+
+instance ShowF f => Show (TypedStore f) where
+  show (TypedStore ts) = show ts

--- a/saw-support/src/SAWSupport/TypedStore.hs
+++ b/saw-support/src/SAWSupport/TypedStore.hs
@@ -153,7 +153,6 @@ traverse_ f (TypedStore ts) =
   MapF.traverseWithKey_ (\rep x -> withRep rep $ f x) ts
 
 merge :: forall f g h.
-  Typeable h =>
   -- keys in both
   (forall a. (Typeable a) => f a -> g a -> Maybe (h a)) ->
   -- keys only in left
@@ -172,7 +171,6 @@ merge f g1 g2 (TypedStore ts1) (TypedStore ts2) =
 
 mergeM :: forall f g h m.
   Applicative m =>
-  Typeable h =>
   -- keys in both
   (forall a. (Typeable a) => f a -> g a -> m (Maybe (h a))) ->
   -- keys only in left

--- a/saw-support/src/SAWSupport/TypedStore.hs
+++ b/saw-support/src/SAWSupport/TypedStore.hs
@@ -24,18 +24,25 @@ module SAWSupport.TypedStore
   , size
   , lookup
   , alter
+  , alterM
   , delete
   , map
   , traverse
+  , traverse_
   , toList
   , merge
+  , mergeM
   , union
   , intersection
+  , alterIO
+  , lookupIO
   ) where
 
 import Prelude hiding (lookup, map, traverse)
 import qualified Data.List as List
 import Data.Functor.Identity (Identity(..))
+import Data.IORef (IORef,newIORef,readIORef,atomicModifyIORef')
+
 import Type.Reflection
 import Data.Type.Equality
 
@@ -47,9 +54,6 @@ import qualified Data.Parameterized.Map as MapF
 newtype TypeRep' a = TypeRep' (TypeRep a)
   deriving (TestEquality)
 
-withRep :: TypeRep' a -> (Typeable a => b) -> b
-withRep (TypeRep' tr) f = withTypeable tr f
-
 instance MapF.OrdF TypeRep' where
   compareF (TypeRep' tr1) (TypeRep' tr2) =
     case testEquality tr1 tr2 of
@@ -59,118 +63,178 @@ instance MapF.OrdF TypeRep' where
         GT -> MapF.GTF
         EQ -> error "inconsistent TypeRep equality"
 
-newtype Wrapped t = Wrapped { unwrap :: t }
+
+withRep :: forall a b. TypeRep' a -> (Typeable a => b) -> b
+withRep (TypeRep' tr) f = withTypeable tr f
 
 -- | A store of arbitrary 'Typeable' data, indexed by type.
-newtype TypedStore = TypedStore (MapF TypeRep' Wrapped)
+newtype TypedStore f = TypedStore (MapF TypeRep' f)
 
 -- | An empty 'TypedStore'.
-empty :: TypedStore
+empty :: TypedStore f
 empty = TypedStore MapF.empty
 
--- | Lookup the value of type 'a' from the store.
-lookup :: forall a. Typeable a => TypedStore -> Maybe a
-lookup (TypedStore tm) = fmap unwrap $ MapF.lookup (TypeRep' typeRep) tm
+-- | Lookup the value of type 'f a' from the store.
+lookup :: forall a f. Typeable a => TypedStore f -> Maybe (f a)
+lookup (TypedStore tm) = MapF.lookup (TypeRep' typeRep) tm
 
--- | Alter the data of type 'a' in the store, inserting or
---   deleting based on the result of 'f'.
-alter :: forall a.
+-- | Alter the data of type 'f a' in the store, inserting or
+--   deleting based on the result of 'g'.
+alter :: forall a f.
   Typeable a =>
-  (Maybe a -> Maybe a) ->
-  TypedStore ->
-  TypedStore
-alter f (TypedStore tm) = TypedStore (MapF.updatedValue tm')
+  (Maybe (f a) -> Maybe (f a)) ->
+  TypedStore f ->
+  TypedStore f
+alter g ts = runIdentity $ alterM (\ma -> Identity (g ma)) ts
+
+
+alterM :: forall a f m.
+  Typeable a =>
+  Monad m =>
+  (Maybe (f a) -> m (Maybe (f a))) ->
+  TypedStore f ->
+  m (TypedStore f)
+alterM g (TypedStore tm) = 
+  (TypedStore . MapF.updatedValue) <$> tm'
   where
-    rep = TypeRep' (TypeRep @a)
+    rep = TypeRep' @a TypeRep
 
-    go :: Wrapped a -> Identity (MapF.UpdateRequest (Wrapped a))
-    go (Wrapped a) = case f (Just a) of
+    go :: f a -> m (MapF.UpdateRequest (f a))
+    go a = g (Just a) >>= \case
       Nothing -> pure $ MapF.Delete
-      Just a' -> pure $ MapF.Set (Wrapped a')
+      Just a' -> pure $ MapF.Set a'
 
-    tm' = runIdentity $
-      MapF.updateAtKey rep (pure $ fmap Wrapped $ f Nothing) go tm
+    tm' = MapF.updateAtKey rep (g Nothing) go tm
 
-
--- | Insert a value of type 'a' in the store, overwriting existing
+-- | Insert a value of type 'f a' in the store, overwriting existing
 --   data.
-insert :: forall a. Typeable a => a -> TypedStore -> TypedStore
+insert :: forall a f. Typeable a => f a -> TypedStore f -> TypedStore f
 insert a = alter (\_ -> Just a)
 
-singleton :: Typeable a => a -> TypedStore
-singleton a = TypedStore (MapF.singleton (TypeRep' typeRep) (Wrapped a))
+singleton :: forall a f. (Typeable f, Typeable a) => f a -> TypedStore f
+singleton a = TypedStore (MapF.singleton (TypeRep' typeRep) a)
 
-size :: TypedStore -> Int
+size :: TypedStore f -> Int
 size (TypedStore ts) = MapF.size ts
 
 -- | Delete the value of type 'a' from the store.
-delete :: forall a. Typeable a => TypedStore -> TypedStore
-delete tm = alter @a (\_ -> Nothing) tm
+delete :: forall a f proxy. Typeable a => proxy a -> TypedStore f -> TypedStore f
+delete _ tm = alter @a (\_ -> Nothing) tm
 
-map :: (forall a. Typeable a => a -> a) -> TypedStore -> TypedStore
+map :: forall f g.
+  (forall a. (Typeable a) => f a -> g a) -> 
+  TypedStore f -> 
+  TypedStore g
 map f (TypedStore ts) = TypedStore $ 
-  MapF.mapWithKey (\rep (Wrapped x) -> withRep rep $ Wrapped (f x)) ts
+  MapF.mapWithKey (\rep x -> withRep rep $ f x) ts
 
-traverse :: 
+traverse :: forall f g m.
   Applicative m => 
-  (forall a. Typeable a => a -> m a) -> 
-  TypedStore -> 
-  m TypedStore
+  Typeable g =>
+  (forall a. (Typeable a) => f a -> m (g a)) -> 
+  TypedStore f -> 
+  m (TypedStore g)
 traverse f (TypedStore ts) = TypedStore <$>
-  MapF.traverseWithKey (\rep (Wrapped x) -> withRep rep $ Wrapped <$> f x) ts
+  MapF.traverseWithKey (\rep x -> withRep rep $ f x) ts
 
-liftWrap2 :: 
-  (Typeable a => a -> a -> Maybe a) ->
-  TypeRep' a -> Wrapped a -> Wrapped a -> Maybe (Wrapped a)
-liftWrap2 f rep (Wrapped l) (Wrapped r) = withRep rep $
-  case f l r of
-    Just a -> Just (Wrapped a)
-    Nothing -> Nothing
+traverse_ :: forall f m.
+  Applicative m => 
+  (forall a. (Typeable a) => f a -> m ()) -> 
+  TypedStore f -> 
+  m ()
+traverse_ f (TypedStore ts) =
+  MapF.traverseWithKey_ (\rep x -> withRep rep $ f x) ts
 
-merge :: 
+merge :: forall f g h.
+  Typeable h =>
   -- keys in both
-  (forall a. Typeable a => a -> a -> Maybe a) ->
+  (forall a. (Typeable a) => f a -> g a -> Maybe (h a)) ->
   -- keys only in left
-  (forall a. Typeable a => a -> Maybe a) ->
+  (forall a. (Typeable a) => f a -> Maybe (h a)) ->
   -- keys only in right
-  (forall a. Typeable a => a -> Maybe a) ->
-  TypedStore ->
-  TypedStore ->
-  TypedStore
+  (forall a. (Typeable a) => g a -> Maybe (h a)) ->
+  TypedStore f ->
+  TypedStore g ->
+  TypedStore h
 merge f g1 g2 (TypedStore ts1) (TypedStore ts2) =
-  TypedStore (MapF.mergeWithKey (liftWrap2 f) (do_filter g1) (do_filter g2) ts1 ts2)
-    where
-      do_filter :: 
-        (forall a. Typeable a => a -> Maybe a) -> 
-        MapF TypeRep' Wrapped -> 
-        MapF TypeRep' Wrapped
-      do_filter g = MapF.mapMaybeWithKey $ 
-        \rep (Wrapped a) -> withRep rep $
-          case g a of
-            Just b -> Just (Wrapped b)
-            Nothing -> Nothing
+  TypedStore $ MapF.mergeWithKey 
+    (\rep x y -> withRep rep $ f x y)
+    (MapF.mapMaybeWithKey (\rep x -> withRep rep $ g1 x))
+    (MapF.mapMaybeWithKey (\rep x -> withRep rep $ g2 x))
+    ts1 ts2
+
+mergeM :: forall f g h m.
+  Applicative m =>
+  Typeable h =>
+  -- keys in both
+  (forall a. (Typeable a) => f a -> g a -> m (Maybe (h a))) ->
+  -- keys only in left
+  (forall a. (Typeable a) => f a -> m (Maybe (h a))) ->
+  -- keys only in right
+  (forall a. (Typeable a) => g a -> m (Maybe (h a))) ->
+  TypedStore f ->
+  TypedStore g ->
+  m (TypedStore h)
+mergeM f g1 g2 (TypedStore ts1) (TypedStore ts2) =
+  TypedStore <$> MapF.mergeWithKeyM 
+    (\rep x y -> withRep rep $ f x y)
+    (MapF.traverseMaybeWithKey (\rep x -> withRep rep $ g1 x))
+    (MapF.traverseMaybeWithKey (\rep x -> withRep rep $ g2 x))
+    ts1 ts2
 
 -- | Combine two 'TypedStore's, using the given function to merge
 --   entries of the same type.
-union :: 
-  (forall a. Typeable a => a -> a -> Maybe a) ->
-  TypedStore ->
-  TypedStore ->
-  TypedStore
-union f (TypedStore ts1) (TypedStore ts2) =
-  TypedStore (MapF.mergeWithKey (liftWrap2 f) id id ts1 ts2)
+union :: forall f.
+  (forall a. (Typeable a) => f a -> f a -> Maybe (f a)) ->
+  TypedStore f ->
+  TypedStore f ->
+  TypedStore f
+union f (TypedStore ts1) (TypedStore ts2) = TypedStore $
+  MapF.mergeWithKey (\rep x y -> withRep rep $ f x y) id id ts1 ts2
 
 -- | Intersect two 'TypedStore's, using the given function to merge
 --   entries of the same type, and discarding types which only are
 --   only present in one store.
-intersection :: 
-  (forall a. Typeable a => a -> a -> Maybe a) ->
-  TypedStore ->
-  TypedStore ->
-  TypedStore
-intersection f (TypedStore ts1) (TypedStore ts2) =
-  TypedStore (MapF.mergeWithKey (liftWrap2 f) (const MapF.empty) (const MapF.empty) ts1 ts2)
+intersection :: forall f.
+  (forall a. (Typeable a) => f a -> f a -> Maybe (f a)) ->
+  TypedStore f ->
+  TypedStore f ->
+  TypedStore f
+intersection f (TypedStore ts1) (TypedStore ts2) = TypedStore $
+  MapF.mergeWithKey (\rep x y -> withRep rep $ f x y) 
+    (const MapF.empty) (const MapF.empty) ts1 ts2
 
-toList :: (forall a. Typeable a => a -> b) -> TypedStore -> [b]
+toList :: forall f b.
+  (forall a. (Typeable a) => f a -> b) -> TypedStore f -> [b]
 toList f (TypedStore ts) = 
-  List.map (\(MapF.Pair rep (Wrapped x)) -> withRep rep $ f x) $ MapF.toList ts
+  List.map (\(MapF.Pair rep x) -> withRep rep $ f x) $ MapF.toList ts
+
+
+lookupIO :: Typeable a => TypedStore IORef -> IO (Maybe a)
+lookupIO ts = do
+  case lookup ts of
+    Just aref -> Just <$> readIORef aref
+    Nothing -> return Nothing
+
+-- | Modify the contents of a 'TypedStore' of IORefs. Returns 'Nothing'
+--   if the 'TypedStore' itself is unchanged.
+--   NOTE: When an entry is deleted, the contents of the IORef are
+--   unmodified, the reference is simply removed in the resulting
+--   'TypedStore'.
+alterIO :: 
+  Typeable a => 
+  (Maybe a -> Maybe a) -> 
+  TypedStore IORef -> 
+  IO (Maybe (TypedStore IORef))
+alterIO f ts = do
+  case lookup ts of
+    Just aref -> atomicModifyIORef' aref $ \a -> 
+      case f (Just a) of
+        Just a' -> (a', Nothing)
+        Nothing -> (a, Just $ delete aref ts)
+    Nothing -> case f Nothing of
+      Just a -> do
+        aref <- newIORef (Just a)
+        return $ Just $ insert aref ts
+      Nothing -> return Nothing
+

--- a/saw-support/src/SAWSupport/TypedStore.hs
+++ b/saw-support/src/SAWSupport/TypedStore.hs
@@ -1,0 +1,176 @@
+{- |
+Module      : SAWSupport.TypedMap
+Copyright   : Galois, Inc. 2012-2026
+License     : BSD3
+Maintainer  : saw@galois.com
+Stability   : experimental
+Portability : non-portable (language extensions)
+
+A store of arbitrary data, indexed by type.
+-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE RankNTypes #-}
+
+module SAWSupport.TypedStore
+  ( TypedStore
+  , empty
+  , insert
+  , singleton
+  , size
+  , lookup
+  , alter
+  , delete
+  , map
+  , traverse
+  , toList
+  , merge
+  , union
+  , intersection
+  ) where
+
+import Prelude hiding (lookup, map, traverse)
+import qualified Data.List as List
+import Data.Functor.Identity (Identity(..))
+import Type.Reflection
+import Data.Type.Equality
+
+import Data.Parameterized.Map (MapF)
+import qualified Data.Parameterized.Map as MapF
+
+-- | Internal wrapper for 'TypeRep' that we provide an 'MapF.OrdF'
+--   instance for.
+newtype TypeRep' a = TypeRep' (TypeRep a)
+  deriving (TestEquality)
+
+withRep :: TypeRep' a -> (Typeable a => b) -> b
+withRep (TypeRep' tr) f = withTypeable tr f
+
+instance MapF.OrdF TypeRep' where
+  compareF (TypeRep' tr1) (TypeRep' tr2) =
+    case testEquality tr1 tr2 of
+      Just Refl -> MapF.EQF
+      Nothing -> case compare (SomeTypeRep tr1) (SomeTypeRep tr2) of
+        LT -> MapF.LTF
+        GT -> MapF.GTF
+        EQ -> error "inconsistent TypeRep equality"
+
+newtype Wrapped t = Wrapped { unwrap :: t }
+
+-- | A store of arbitrary 'Typeable' data, indexed by type.
+newtype TypedStore = TypedStore (MapF TypeRep' Wrapped)
+
+-- | An empty 'TypedStore'.
+empty :: TypedStore
+empty = TypedStore MapF.empty
+
+-- | Lookup the value of type 'a' from the store.
+lookup :: forall a. Typeable a => TypedStore -> Maybe a
+lookup (TypedStore tm) = fmap unwrap $ MapF.lookup (TypeRep' typeRep) tm
+
+-- | Alter the data of type 'a' in the store, inserting or
+--   deleting based on the result of 'f'.
+alter :: forall a.
+  Typeable a =>
+  (Maybe a -> Maybe a) ->
+  TypedStore ->
+  TypedStore
+alter f (TypedStore tm) = TypedStore (MapF.updatedValue tm')
+  where
+    rep = TypeRep' (TypeRep @a)
+
+    go :: Wrapped a -> Identity (MapF.UpdateRequest (Wrapped a))
+    go (Wrapped a) = case f (Just a) of
+      Nothing -> pure $ MapF.Delete
+      Just a' -> pure $ MapF.Set (Wrapped a')
+
+    tm' = runIdentity $
+      MapF.updateAtKey rep (pure $ fmap Wrapped $ f Nothing) go tm
+
+
+-- | Insert a value of type 'a' in the store, overwriting existing
+--   data.
+insert :: forall a. Typeable a => a -> TypedStore -> TypedStore
+insert a = alter (\_ -> Just a)
+
+singleton :: Typeable a => a -> TypedStore
+singleton a = TypedStore (MapF.singleton (TypeRep' typeRep) (Wrapped a))
+
+size :: TypedStore -> Int
+size (TypedStore ts) = MapF.size ts
+
+-- | Delete the value of type 'a' from the store.
+delete :: forall a. Typeable a => TypedStore -> TypedStore
+delete tm = alter @a (\_ -> Nothing) tm
+
+map :: (forall a. Typeable a => a -> a) -> TypedStore -> TypedStore
+map f (TypedStore ts) = TypedStore $ 
+  MapF.mapWithKey (\rep (Wrapped x) -> withRep rep $ Wrapped (f x)) ts
+
+traverse :: 
+  Applicative m => 
+  (forall a. Typeable a => a -> m a) -> 
+  TypedStore -> 
+  m TypedStore
+traverse f (TypedStore ts) = TypedStore <$>
+  MapF.traverseWithKey (\rep (Wrapped x) -> withRep rep $ Wrapped <$> f x) ts
+
+liftWrap2 :: 
+  (Typeable a => a -> a -> Maybe a) ->
+  TypeRep' a -> Wrapped a -> Wrapped a -> Maybe (Wrapped a)
+liftWrap2 f rep (Wrapped l) (Wrapped r) = withRep rep $
+  case f l r of
+    Just a -> Just (Wrapped a)
+    Nothing -> Nothing
+
+merge :: 
+  -- keys in both
+  (forall a. Typeable a => a -> a -> Maybe a) ->
+  -- keys only in left
+  (forall a. Typeable a => a -> Maybe a) ->
+  -- keys only in right
+  (forall a. Typeable a => a -> Maybe a) ->
+  TypedStore ->
+  TypedStore ->
+  TypedStore
+merge f g1 g2 (TypedStore ts1) (TypedStore ts2) =
+  TypedStore (MapF.mergeWithKey (liftWrap2 f) (do_filter g1) (do_filter g2) ts1 ts2)
+    where
+      do_filter :: 
+        (forall a. Typeable a => a -> Maybe a) -> 
+        MapF TypeRep' Wrapped -> 
+        MapF TypeRep' Wrapped
+      do_filter g = MapF.mapMaybeWithKey $ 
+        \rep (Wrapped a) -> withRep rep $
+          case g a of
+            Just b -> Just (Wrapped b)
+            Nothing -> Nothing
+
+-- | Combine two 'TypedStore's, using the given function to merge
+--   entries of the same type.
+union :: 
+  (forall a. Typeable a => a -> a -> Maybe a) ->
+  TypedStore ->
+  TypedStore ->
+  TypedStore
+union f (TypedStore ts1) (TypedStore ts2) =
+  TypedStore (MapF.mergeWithKey (liftWrap2 f) id id ts1 ts2)
+
+-- | Intersect two 'TypedStore's, using the given function to merge
+--   entries of the same type, and discarding types which only are
+--   only present in one store.
+intersection :: 
+  (forall a. Typeable a => a -> a -> Maybe a) ->
+  TypedStore ->
+  TypedStore ->
+  TypedStore
+intersection f (TypedStore ts1) (TypedStore ts2) =
+  TypedStore (MapF.mergeWithKey (liftWrap2 f) (const MapF.empty) (const MapF.empty) ts1 ts2)
+
+toList :: (forall a. Typeable a => a -> b) -> TypedStore -> [b]
+toList f (TypedStore ts) = 
+  List.map (\(MapF.Pair rep (Wrapped x)) -> withRep rep $ f x) $ MapF.toList ts

--- a/saw-support/src/SAWSupport/TypedStore.hs
+++ b/saw-support/src/SAWSupport/TypedStore.hs
@@ -34,15 +34,12 @@ module SAWSupport.TypedStore
   , mergeM
   , union
   , intersection
-  , alterIO
-  , lookupIO
   ) where
 
 import Prelude hiding (lookup, map, traverse)
 import Data.Coerce
 import qualified Data.List as List
 import Data.Functor.Identity (Identity(..))
-import Data.IORef (IORef,newIORef,readIORef,atomicModifyIORef')
 
 import Type.Reflection
 import Data.Type.Equality
@@ -217,34 +214,6 @@ toList :: forall f b.
   (forall a. (Typeable a) => f a -> b) -> TypedStore f -> [b]
 toList f (TypedStore ts) = 
   List.map (\(Pair rep x) -> withRep rep $ f x) $ MapF.toList ts
-
-lookupIO :: forall a. Typeable a => TypedStore IORef -> IO (Maybe a)
-lookupIO ts =
-  case lookup @a ts of
-    Just aref -> Just <$> readIORef aref
-    Nothing -> return Nothing
-
--- | Modify the contents of a 'TypedStore' of IORefs. Returns 'Nothing'
---   if the 'TypedStore' itself is unchanged.
---   NOTE: When an entry is deleted, the contents of the IORef are
---   unmodified, the reference is simply removed in the resulting
---   'TypedStore'.
-alterIO :: forall a.
-  Typeable a => 
-  (Maybe a -> Maybe a) -> 
-  TypedStore IORef -> 
-  IO (Maybe (TypedStore IORef))
-alterIO f ts = do
-  case lookup @a ts of
-    Just aref -> atomicModifyIORef' aref $ \a -> 
-      case f (Just a) of
-        Just a' -> (a', Nothing)
-        Nothing -> (a, Just $ delete @a aref ts)
-    Nothing -> case f Nothing of
-      Just a -> do
-        aref <- newIORef a
-        return $ Just $ insert @a aref ts
-      Nothing -> return Nothing
 
 instance FunctorF TypedStore where
   fmapF = map

--- a/saw-support/src/SAWSupport/TypedStore.hs
+++ b/saw-support/src/SAWSupport/TypedStore.hs
@@ -78,7 +78,9 @@ empty = TypedStore MapF.empty
 
 -- | Lookup the value of type 'f a' from the store.
 lookup :: forall a f. Typeable a => TypedStore f -> Maybe (f a)
-lookup (TypedStore tm) = MapF.lookup (TypeRep' typeRep) tm
+lookup (TypedStore tm) = MapF.lookup rep tm
+  where
+    rep = TypeRep' @a TypeRep
 
 -- | Alter the data of type 'f a' in the store, inserting or
 --   deleting based on the result of 'g'.
@@ -116,7 +118,9 @@ insert a = alter (\_ -> Just a)
 
 -- | Create a 'TypedStore' with a single entry of type 'f a'.
 singleton :: forall a f. (Typeable f, Typeable a) => f a -> TypedStore f
-singleton a = TypedStore (MapF.singleton (TypeRep' typeRep) a)
+singleton a = TypedStore (MapF.singleton rep a)
+  where
+    rep = TypeRep' @a TypeRep
 
 size :: TypedStore f -> Int
 size (TypedStore ts) = MapF.size ts
@@ -212,9 +216,9 @@ toList :: forall f b.
 toList f (TypedStore ts) = 
   List.map (\(MapF.Pair rep x) -> withRep rep $ f x) $ MapF.toList ts
 
-lookupIO :: Typeable a => TypedStore IORef -> IO (Maybe a)
-lookupIO ts = do
-  case lookup ts of
+lookupIO :: forall a. Typeable a => TypedStore IORef -> IO (Maybe a)
+lookupIO ts =
+  case lookup @a ts of
     Just aref -> Just <$> readIORef aref
     Nothing -> return Nothing
 
@@ -223,21 +227,21 @@ lookupIO ts = do
 --   NOTE: When an entry is deleted, the contents of the IORef are
 --   unmodified, the reference is simply removed in the resulting
 --   'TypedStore'.
-alterIO :: 
+alterIO :: forall a.
   Typeable a => 
   (Maybe a -> Maybe a) -> 
   TypedStore IORef -> 
   IO (Maybe (TypedStore IORef))
 alterIO f ts = do
-  case lookup ts of
+  case lookup @a ts of
     Just aref -> atomicModifyIORef' aref $ \a -> 
       case f (Just a) of
         Just a' -> (a', Nothing)
-        Nothing -> (a, Just $ delete aref ts)
+        Nothing -> (a, Just $ delete @a aref ts)
     Nothing -> case f Nothing of
       Just a -> do
-        aref <- newIORef (Just a)
-        return $ Just $ insert aref ts
+        aref <- newIORef a
+        return $ Just $ insert @a aref ts
       Nothing -> return Nothing
 
 instance FunctorF TypedStore where

--- a/saw.cabal
+++ b/saw.cabal
@@ -76,6 +76,7 @@ library saw-support
     containers,
     hashable,
     panic,
+    parameterized-utils,
     prettyprinter >= 1.7.0,
     prettyprinter-ansi-terminal >= 1.1.2,
     unordered-containers,
@@ -98,6 +99,7 @@ library saw-support
     SAWSupport.Pretty
     SAWSupport.ScopedMap
     SAWSupport.Trie
+    SAWSupport.TypedStore
   other-modules:
     SAWSupport.Panic
 


### PR DESCRIPTION
The original motivation for this change came from wanting the ability to keep track of hints for naming memoization variables, which turns into tracking arbitrary metadata for terms, and ultimately resulted in simply wanting arbitrary metadata that is tracked by the 'SharedContext'.

This adds a `TypedStore` datatype which is essentially a map from types to values of that type, using the `Typeable` class for reflection. In general, a `TypedStore f` can store exactly one value of `f a` for any type `a`. The intended usage is for external code to declare fresh 'newtype's for any data it wishes to track in the context. 

This approach has a few advantages:
* it allows for extensions to keep data "private" by simply not exposing the type of the data.
* types can be stored in the context regardless of their place in the import hierarchy
* checkpointing is implicitly handled for all metadata, avoiding issues where external data could become de-synced if the context was rolled back

Using this, the fields `scPPOpts` and `scInventedVars` were pulled out of the top-level of `SharedContext` and instead tracked as metadata. This was largely done to demonstrate the process, but also avoids the monotonic creep of `SharedContext` fields.