### PR TITLE
Add inhabited-type hypotheses to `Theorem` type

### DIFF
--- a/intTests/test3270/Makefile
+++ b/intTests/test3270/Makefile
@@ -1,0 +1,5 @@
+all: ;
+clean:
+	sh ./test.sh clean
+
+.PHONY: all clean

--- a/intTests/test3270/test.log.good
+++ b/intTests/test3270/test.log.good
@@ -1,0 +1,28 @@
+Loading file "test.saw"
+An example of a correct proof that locally uses a false assumption
+Theorem (let { x`1 = EqTrue False; } in x`1 -> x`1)
+An example of a correct proof that locally uses a variable of an empty type
+Theorem ((x : Void)
+-> EqTrue False)
+An ill-formed proof that improperly uses a local false assumption
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in prove_core
+   test.saw:26:3-33:17 in (callback)
+   (builtin) in fails
+   test.saw:25:1-33:17 (at top level)
+Theorem depends on undischarged hypotheses:
+EqTrue False
+
+
+An ill-formed proof that improperly uses a variable of an empty type
+== Anticipated failure message ==
+Stack trace:
+   (builtin) in prove_print
+   test.saw:40:3-48:14 in (callback)
+   (builtin) in fails
+   test.saw:39:1-48:14 (at top level)
+Theorem depends on undischarged hypotheses:
+Void
+
+

--- a/intTests/test3270/test.saw
+++ b/intTests/test3270/test.saw
@@ -1,0 +1,49 @@
+enable_experimental;
+
+print "An example of a correct proof that locally uses a false assumption";
+thm1 <-
+  prove_core
+  do {
+    true_eq_false <- goal_intro "x";
+    goal_exact true_eq_false;
+  }
+  "EqTrue False -> EqTrue False";
+print thm1;
+
+print "An example of a correct proof that locally uses a variable of an empty type";
+thm2 <-
+  prove_core
+  do {
+    x <- goal_intro "x";
+    rule3 <- return (run (specialize_theorem (core_thm "elimVoid (EqTrue False)") [x]));
+    goal_apply rule3;
+  }
+  "(x : Void) -> EqTrue False";
+print thm2;
+
+print "An ill-formed proof that improperly uses a local false assumption";
+fails (
+  prove_core
+  do {
+    goal_apply (core_thm "\\ (x : EqTrue False -> TrueProp) (y : EqTrue False) -> y");
+    true_eq_false <- goal_intro "x";
+    goal_exact (parse_core "TrueI");
+    goal_exact true_eq_false;
+  }
+  "EqTrue False"
+);
+
+print "An ill-formed proof that improperly uses a variable of an empty type";
+let rule1 = core_thm "\\ (P Q : Prop) (x : P) (y : Q) -> y";
+rule2 <- specialize_theorem rule1 [parse_core "(x : Void) -> TrueProp"];
+fails (
+  prove_print
+  do {
+    goal_apply rule2;
+    x <- goal_intro "x";
+    trivial;
+    rule3 <- return (run (specialize_theorem (core_thm "elimVoid (EqTrue False)") [x]));
+    goal_apply rule3;
+  }
+  {{ False }}
+);

--- a/intTests/test3270/test.sh
+++ b/intTests/test3270/test.sh
@@ -1,0 +1,1 @@
+exec ${TEST_SHELL:-bash} ../support/test-and-diff.sh "$@"

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -1616,14 +1616,14 @@ term_eval unints (TypedTerm schema t0) =
 addsimp :: Theorem -> SV.SAWSimpset -> TopLevel SV.SAWSimpset
 addsimp thm ss =
   do sc <- getSharedContext
-     io (propToRewriteRule sc (thmProp thm) (Just (thmNonce thm))) >>= \case
+     io (propToRewriteRule sc (thmProp thm) (Just (Set.singleton (thmNonce thm)))) >>= \case
        Nothing -> fail "addsimp: theorem not an equation"
        Just rule -> pure (addRule rule ss)
 
 addsimp_shallow :: Theorem -> SV.SAWSimpset -> TopLevel SV.SAWSimpset
 addsimp_shallow thm ss =
   do sc <- getSharedContext
-     io (propToRewriteRule sc (thmProp thm) (Just (thmNonce thm))) >>= \case
+     io (propToRewriteRule sc (thmProp thm) (Just (Set.singleton (thmNonce thm)))) >>= \case
        Nothing -> fail "addsimp: theorem not an equation"
        Just rule -> pure (addRule (shallowRule rule) ss)
 

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -1616,14 +1616,16 @@ term_eval unints (TypedTerm schema t0) =
 addsimp :: Theorem -> SV.SAWSimpset -> TopLevel SV.SAWSimpset
 addsimp thm ss =
   do sc <- getSharedContext
-     io (propToRewriteRule sc (thmProp thm) (Just (Set.singleton (thmNonce thm)))) >>= \case
+     let ann = TheoremAnnotation (Set.singleton (thmNonce thm)) (thmHyps thm) (thmSummary thm)
+     io (propToRewriteRule sc (thmProp thm) (Just ann)) >>= \case
        Nothing -> fail "addsimp: theorem not an equation"
        Just rule -> pure (addRule rule ss)
 
 addsimp_shallow :: Theorem -> SV.SAWSimpset -> TopLevel SV.SAWSimpset
 addsimp_shallow thm ss =
   do sc <- getSharedContext
-     io (propToRewriteRule sc (thmProp thm) (Just (Set.singleton (thmNonce thm)))) >>= \case
+     let ann = TheoremAnnotation (Set.singleton (thmNonce thm)) (thmHyps thm) (thmSummary thm)
+     io (propToRewriteRule sc (thmProp thm) (Just ann)) >>= \case
        Nothing -> fail "addsimp: theorem not an equation"
        Just rule -> pure (addRule (shallowRule rule) ss)
 

--- a/saw-central/src/SAWCentral/Crucible/Common/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/ResolveSetupValue.hs
@@ -30,7 +30,7 @@ import SAWCoreWhat4.ReturnTrip
 
 import SAWCentral.Crucible.Common
 
-import SAWCentral.Proof (TheoremNonce)
+import SAWCentral.Proof (TheoremAnnotation)
 import SAWCore.Rewriter (Simpset, rewriteSharedTerm)
 import SAWCoreWhat4.What4(w4EvalAny, valueToSymExpr)
 
@@ -41,7 +41,7 @@ import qualified CryptolSAWCore.Pretty as CryPP
 
 -- | Optional rewrites to do when resolving a term
 data ResolveRewrite = ResolveRewrite {
-  rrBasicSS :: Maybe (Simpset (Set TheoremNonce)),
+  rrBasicSS :: Maybe (Simpset TheoremAnnotation),
   -- ^ Rewrite terms using these rewrites
 
   rrWhat4Eval :: Bool

--- a/saw-central/src/SAWCentral/Crucible/Common/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/Common/ResolveSetupValue.hs
@@ -41,7 +41,7 @@ import qualified CryptolSAWCore.Pretty as CryPP
 
 -- | Optional rewrites to do when resolving a term
 data ResolveRewrite = ResolveRewrite {
-  rrBasicSS :: Maybe (Simpset TheoremNonce),
+  rrBasicSS :: Maybe (Simpset (Set TheoremNonce)),
   -- ^ Rewrite terms using these rewrites
 
   rrWhat4Eval :: Bool

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Setup/Value.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Setup/Value.hs
@@ -294,7 +294,7 @@ data LLVMCrucibleContext arch =
   , _ccLLVMSimContext  :: Crucible.SimContext (SAWCruciblePersonality Sym) Sym CL.LLVM
   , _ccLLVMGlobals     :: Crucible.SymGlobalState Sym
   , _ccCryptolEnv      :: Cry.CryptolEnv
-  , _ccBasicSS         :: Simpset TheoremNonce
+  , _ccBasicSS         :: Simpset (Set TheoremNonce)
   , _ccUninterp        :: !(Set VarIndex)
   }
 

--- a/saw-central/src/SAWCentral/Crucible/LLVM/Setup/Value.hs
+++ b/saw-central/src/SAWCentral/Crucible/LLVM/Setup/Value.hs
@@ -107,7 +107,7 @@ import qualified SAWCentral.Crucible.Common.Setup.Value as Setup
 import qualified SAWCentral.Crucible.LLVM.CrucibleLLVM as CL
 import           SAWCentral.Crucible.LLVM.Setup.LLVMCombine ( llvmModuleCombine )
 
-import           SAWCentral.Proof (TheoremNonce)
+import           SAWCentral.Proof (TheoremAnnotation)
 
 import           SAWCore.Rewriter (Simpset)
 import           SAWCore.SharedTerm
@@ -294,7 +294,7 @@ data LLVMCrucibleContext arch =
   , _ccLLVMSimContext  :: Crucible.SimContext (SAWCruciblePersonality Sym) Sym CL.LLVM
   , _ccLLVMGlobals     :: Crucible.SymGlobalState Sym
   , _ccCryptolEnv      :: Cry.CryptolEnv
-  , _ccBasicSS         :: Simpset (Set TheoremNonce)
+  , _ccBasicSS         :: Simpset TheoremAnnotation
   , _ccUninterp        :: !(Set VarIndex)
   }
 

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -80,6 +80,7 @@ module SAWCentral.Proof
   , thmSummary
   , TheoremNonce
   , TheoremSummary(..)
+  , TheoremAnnotation(..)
   , prettyTheorem
 
   , admitTheorem
@@ -1018,6 +1019,18 @@ instance Semigroup TheoremSummary where
   _ <> TestedTheorem y = TestedTheorem y
   ProvedTheorem s1 <> ProvedTheorem s2 = ProvedTheorem (s1<>s2)
 
+-- | When a 'Theorem' is converted to a rewrite rule, it is tagged
+-- with a 'TheoremAnnotation' that records dependencies that will be
+-- collected and combined as rewrite rules are applied.
+data TheoremAnnotation =
+  TheoremAnnotation (Set TheoremNonce) Hypotheses TheoremSummary
+
+instance Semigroup TheoremAnnotation where
+  TheoremAnnotation d1 h1 s1 <> TheoremAnnotation d2 h2 s2 =
+    TheoremAnnotation (d1 <> d2) (h1 <> h2) (s1 <> s2)
+
+instance Monoid TheoremAnnotation where
+  mempty = TheoremAnnotation mempty mempty mempty
 
 -- | This datatype records evidence for the truth of a proposition.
 data Evidence
@@ -1084,7 +1097,7 @@ data Evidence
     --   simpset; then the provided evidence is used to check the
     --   modified sequent. The list of integers indicate local
     --   hypotheses that should also be treated as rewrite rules.
-  | RewriteEvidence ![Integer] !(Simpset (Set TheoremNonce)) !Evidence
+  | RewriteEvidence ![Integer] !(Simpset TheoremAnnotation) !Evidence
 
     -- | This type of evidence is used to modify a sequent via unfolding
     --   constant definitions.  The sequent is modified by unfolding
@@ -1762,9 +1775,9 @@ checkEvidence sc what4PushMuxOps = \e p -> do
 
       RewriteEvidence hs ss e' ->
         do ss' <- localHypSimpset sc sqt hs ss
-           (d1, sqt') <- simplifySequent sc ss' sqt
-           (d2, sy, hyps) <- check nenv e' sqt'
-           return (Set.union d1 d2, sy, hyps)
+           (TheoremAnnotation d1 h1 s1, sqt') <- simplifySequent sc ss' sqt
+           (d2, s2, h2) <- check nenv e' sqt'
+           return (d1 <> d2, s1 <> s2, h1 <> h2)
 
       HoistIfsEvidence e' ->
         do sqt' <- traverseSequentWithFocus (hoistIfsInProp sc) sqt

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -1931,6 +1931,9 @@ finishProof sc db conclProp
                    then NormalizeSequentEvidence concl e
                    else e
          (deps, sy, hyps) <- checkEvidence sc what4PushMuxOps e' conclProp
+         ppHyps <- traverse (ppTerm sc) (HashSet.toList hyps)
+         unless (HashSet.null hyps) $
+           fail $ unlines $ ["Theorem depends on undischarged hypotheses:"] ++ ppHyps
          n <- freshNonce globalNonceGenerator
          end <- getCurrentTime
          let theorem =

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -68,6 +68,7 @@ module SAWCentral.Proof
 
   , Theorem
   , thmProp
+  , thmHyps
   , thmStats
   , thmEvidence
   , thmLocation
@@ -79,6 +80,7 @@ module SAWCentral.Proof
   , thmSummary
   , TheoremNonce
   , TheoremSummary(..)
+  , prettyTheorem
 
   , admitTheorem
   , solverTheorem
@@ -137,6 +139,8 @@ import           Control.Monad.IO.Class (MonadIO(..))
 import           Control.Monad.Except (ExceptT, MonadError(..), runExceptT)
 import           Control.Monad.Trans.Class (MonadTrans(..))
 import qualified Data.Foldable as Fold
+import           Data.HashSet (HashSet)
+import qualified Data.HashSet as HashSet
 import qualified Data.IntMap as IntMap
 import qualified Data.IntSet as IntSet
 import           Data.List (genericDrop, genericLength, genericSplitAt)
@@ -526,6 +530,18 @@ ppProp opts nenv p = PPS.render opts (prettyProp opts nenv p)
 prettyProp :: PPS.Opts -> DisplayNameEnv -> Prop -> PPS.Doc
 prettyProp opts nenv (Prop tm) = prettyTermWithEnv opts nenv tm
 
+-- | Pretty print the given theorem as a @PPS.Doc@.
+prettyTheorem :: PPS.Opts -> DisplayNameEnv -> Theorem -> PPS.Doc
+prettyTheorem opts nenv thm
+  | HashSet.null (thmHyps thm) = prettyProp opts nenv (thmProp thm)
+  | otherwise =
+    group $ vsep $
+    [ group $
+      encloseSep (flatAlt "{ " "{") (flatAlt " }" "}") ", " $
+      map (prettyTermWithEnv opts nenv) (HashSet.toList (thmHyps thm))
+    , "|-" <+> prettyProp opts nenv (thmProp thm)
+    ]
+
 -- TODO, I'd like to add metadata here
 type SequentBranch = Prop
 
@@ -888,6 +904,23 @@ checkProp sc (Prop t) =
           ty' <- ppTerm sc ty
           fail $ unlines ["Term is not a prop!", t', ty']
 
+-- | Type 'Hypotheses' represents a side condition on a theorem:
+-- It is a set of types that are all assumed to be inhabited.
+type Hypotheses = HashSet Term
+
+termHypotheses :: Term -> Hypotheses
+termHypotheses t = HashSet.fromList (IntMap.elems (varTypes t))
+
+propHypotheses :: Prop -> Hypotheses
+propHypotheses p = termHypotheses (unProp p)
+
+rawSequentHypotheses :: RawSequent Prop -> Hypotheses
+rawSequentHypotheses (RawSequent hs gs) =
+  Fold.foldMap propHypotheses (hs ++ gs)
+
+sequentHypotheses :: Sequent -> Hypotheses
+sequentHypotheses sqt = rawSequentHypotheses (sequentToRawSequent sqt)
+
 type TheoremNonce = Nonce GlobalNonceGenerator Theorem
 
 -- | A theorem is a proposition which has been wrapped in a
@@ -896,6 +929,7 @@ type TheoremNonce = Nonce GlobalNonceGenerator Theorem
 data Theorem =
   Theorem
   { _thmProp :: Prop
+  , _thmHyps :: Hypotheses -- ^ Types assumed to be inhabited.
   , _thmStats :: SolverStats
   , _thmEvidence :: Evidence
   , _thmLocation :: Pos
@@ -959,11 +993,14 @@ reachableTheorems db roots = Set.foldl' (loop (theoremMap db)) mempty roots
 validateTheorem :: SharedContext -> Bool -> TheoremDB -> Theorem -> IO ()
 
 validateTheorem sc what4PushMuxOps db Theorem{ _thmProp = p, _thmEvidence = e, _thmDepends = thmDep } =
-   do let hyps = Map.keysSet (theoremMap db)
-      (deps,_) <- checkEvidence sc what4PushMuxOps e p
-      unless (Set.isSubsetOf deps thmDep && Set.isSubsetOf thmDep hyps)
+   do let knownThms = Map.keysSet (theoremMap db)
+      (deps, _, hyps) <- checkEvidence sc what4PushMuxOps e p
+      unless (Set.isSubsetOf deps thmDep && Set.isSubsetOf thmDep knownThms)
              (fail $ unlines ["Theorem failed to declare its dependencies correctly"
                              , show deps, show thmDep ])
+      ppHyps <- traverse (ppTerm sc) (HashSet.toList hyps)
+      unless (HashSet.null hyps) $
+        fail $ unlines $ ["Theorem depends on undischarged hypotheses:"] ++ ppHyps
 
 data TheoremSummary
   = AdmittedTheorem Text
@@ -1100,6 +1137,10 @@ data Evidence
 thmProp :: Theorem -> Prop
 thmProp Theorem{ _thmProp = p } = p
 
+-- | The hypotheses assumed by a given theorem.
+thmHyps :: Theorem -> Hypotheses
+thmHyps Theorem{ _thmHyps = hyps } = hyps
+
 -- | Retrieve any solver stats from the proved theorem.
 thmStats :: Theorem -> SolverStats
 thmStats Theorem{ _thmStats = stats } = stats
@@ -1171,6 +1212,7 @@ proofByTerm sc db prf loc rsn =
      let thm =
           Theorem
           { _thmProp      = p
+          , _thmHyps      = termHypotheses prf
           , _thmStats     = mempty
           , _thmEvidence  = ProofTerm prf
           , _thmLocation  = loc
@@ -1200,11 +1242,12 @@ constructTheorem ::
   NominalDiffTime ->
   IO (Theorem, TheoremDB)
 constructTheorem sc what4PushMuxOps db p e loc ploc rsn elapsed =
-  do (deps,sy) <- checkEvidence sc what4PushMuxOps e p
+  do (deps, sy, hyps) <- checkEvidence sc what4PushMuxOps e p
      n  <- freshNonce globalNonceGenerator
      let thm =
           Theorem
           { _thmProp  = p
+          , _thmHyps = hyps
           , _thmStats = mempty
           , _thmEvidence = e
           , _thmLocation = loc
@@ -1264,6 +1307,7 @@ admitTheorem db msg p loc rsn =
      let thm =
           Theorem
           { _thmProp        = p
+          , _thmHyps        = propHypotheses p
           , _thmStats       = solverStats "ADMITTED" (propSize p)
           , _thmEvidence    = Admitted msg loc (propToSequent p)
           , _thmLocation    = loc
@@ -1291,6 +1335,7 @@ solverTheorem db p stats loc rsn elapsed =
      let thm =
           Theorem
           { _thmProp      = p
+          , _thmHyps      = propHypotheses p
           , _thmStats     = stats
           , _thmEvidence  = SolverEvidence stats (propToSequent p)
           , _thmLocation  = loc
@@ -1546,14 +1591,17 @@ normalizeConclBoolCommit sc b =
 
 
 -- | Verify that the given evidence in fact supports the given proposition.
---   Returns the identifiers of all the theorems depended on while checking evidence.
-checkEvidence :: SharedContext -> Bool -> Evidence -> Prop -> IO (Set TheoremNonce, TheoremSummary)
+--   Returns the identifiers of all the theorems depended on while checking evidence
+--   Also return the context of all types assumed to be inhabited.
+checkEvidence ::
+  SharedContext -> Bool -> Evidence -> Prop ->
+  IO (Set TheoremNonce, TheoremSummary, Hypotheses)
 checkEvidence sc what4PushMuxOps = \e p -> do
                               nenv <- scGetNamingEnv sc
                               check nenv e (propToSequent p)
 
   where
-    checkApply _nenv _mkSqt (Prop p) [] = return (mempty, mempty, p)
+    checkApply _nenv _mkSqt (Prop p) [] = return (mempty, mempty, p, termHypotheses p)
 
     -- Check a theorem applied to "Evidence".
     -- The given prop must be an implication
@@ -1562,9 +1610,9 @@ checkEvidence sc what4PushMuxOps = \e p -> do
     checkApply nenv mkSqt (Prop p) (Right e:es)
       | Just (lnm, tp, body) <- asPi p
       , IntSet.notMember (vnIndex lnm) (freeVars body)
-      = do (d1,sy1) <- check nenv e . mkSqt =<< termToProp sc tp
-           (d2,sy2,p') <- checkApply nenv mkSqt (Prop body) es
-           return (Set.union d1 d2, sy1 <> sy2, p')
+      = do (d1, sy1, hyps1) <- check nenv e . mkSqt =<< termToProp sc tp
+           (d2, sy2, p', hyps2) <- checkApply nenv mkSqt (Prop body) es
+           return (Set.union d1 d2, sy1 <> sy2, p', hyps1 <> hyps2)
       | otherwise = do
            p' <- ppTerm sc p
            fail $ unlines [
@@ -1575,14 +1623,15 @@ checkEvidence sc what4PushMuxOps = \e p -> do
     -- Check a theorem applied to a term. This explicitly instantiates
     -- a Pi binder with the given term.
     checkApply nenv mkSqt (Prop p) (Left tm:es) =
-      do p' <- reducePi sc p tm
-         checkApply nenv mkSqt (Prop p') es
+      do p1 <- reducePi sc p tm
+         (deps, sy, p2, hyps) <- checkApply nenv mkSqt (Prop p1) es
+         pure (deps, sy, p2, hyps <> termHypotheses tm)
 
     check ::
       DisplayNameEnv ->
       Evidence ->
       Sequent ->
-      IO (Set TheoremNonce, TheoremSummary)
+      IO (Set TheoremNonce, TheoremSummary, HashSet Term)
     check nenv e sqt = case e of
       ProofTerm tm ->
         case sequentState sqt of
@@ -1597,7 +1646,7 @@ checkEvidence sc what4PushMuxOps = \e p -> do
                        ptm',
                        tm'
                     ]
-               return (mempty, ProvedTheorem mempty)
+               return (mempty, ProvedTheorem mempty, termHypotheses tm)
           _ -> fail "Sequent must be conclusion-focused for proof term evidence"
 
       SolverEvidence stats sqt' ->
@@ -1609,7 +1658,7 @@ checkEvidence sc what4PushMuxOps = \e p -> do
                , prettySequent ppopts nenv sqt
                , prettySequent ppopts nenv sqt'
                ]
-           return (mempty, ProvedTheorem stats)
+           return (mempty, ProvedTheorem stats, sequentHypotheses sqt')
 
       Admitted msg pos sqt' ->
         do ok <- sequentSubsumes sc sqt' sqt
@@ -1622,7 +1671,7 @@ checkEvidence sc what4PushMuxOps = \e p -> do
                , prettySequent ppopts nenv sqt
                , prettySequent ppopts nenv sqt'
                ]
-           return (mempty, AdmittedTheorem msg)
+           return (mempty, AdmittedTheorem msg, sequentHypotheses sqt')
 
       QuickcheckEvidence n sqt' ->
         do ok <- sequentSubsumes sc sqt' sqt
@@ -1633,7 +1682,7 @@ checkEvidence sc what4PushMuxOps = \e p -> do
                , prettySequent ppopts nenv sqt
                , prettySequent ppopts nenv sqt'
                ]
-           return (mempty, TestedTheorem n)
+           return (mempty, TestedTheorem n, sequentHypotheses sqt')
 
       SplitEvidence e1 e2 ->
         splitSequent sc sqt >>= \case
@@ -1653,7 +1702,7 @@ checkEvidence sc what4PushMuxOps = \e p -> do
           ConclFocusedSequent hs (FB gs1 g gs2) ->
             case genericDrop n hs of
               (h:_) ->
-                do (d,sy,p') <- checkApply nenv (\g' -> ConclFocusedSequent hs (FB gs1 g' gs2)) h es
+                do (d, sy, p', hyps) <- checkApply nenv (\g' -> ConclFocusedSequent hs (FB gs1 g' gs2)) h es
                    ok <- scConvertible sc (unProp g) p'
                    unless ok $ do
                        g' <- ppTerm sc (unProp g)
@@ -1663,7 +1712,7 @@ checkEvidence sc what4PushMuxOps = \e p -> do
                            g',
                            p''
                         ]
-                   return (d, sy)
+                   return (d, sy, hyps)
 
               _ -> do
                   ppopts <- scGetPPOpts sc
@@ -1681,7 +1730,7 @@ checkEvidence sc what4PushMuxOps = \e p -> do
       ApplyEvidence thm es ->
         case sequentState sqt of
           ConclFocus p mkSqt ->
-            do (d,sy,p') <- checkApply nenv mkSqt (thmProp thm) es
+            do (d, sy, p', hyps) <- checkApply nenv mkSqt (thmProp thm) es
                ok <- scConvertible sc (unProp p) p'
                unless ok $ do
                    sp <- ppTerm sc (unProp p)
@@ -1691,7 +1740,7 @@ checkEvidence sc what4PushMuxOps = \e p -> do
                        sp,
                        sp'
                     ]
-               return (Set.insert (thmNonce thm) d, sy)
+               return (Set.insert (thmNonce thm) d, sy, thmHyps thm <> hyps)
           _ -> do
               ppopts <- scGetPPOpts sc
               fail $ PPS.render ppopts $ PP.vsep
@@ -1713,9 +1762,9 @@ checkEvidence sc what4PushMuxOps = \e p -> do
 
       RewriteEvidence hs ss e' ->
         do ss' <- localHypSimpset sc sqt hs ss
-           (d1,sqt') <- simplifySequent sc ss' sqt
-           (d2,sy) <- check nenv e' sqt'
-           return (Set.union d1 d2, sy)
+           (d1, sqt') <- simplifySequent sc ss' sqt
+           (d2, sy, hyps) <- check nenv e' sqt'
+           return (Set.union d1 d2, sy, hyps)
 
       HoistIfsEvidence e' ->
         do sqt' <- traverseSequentWithFocus (hoistIfsInProp sc) sqt
@@ -1766,7 +1815,7 @@ checkEvidence sc what4PushMuxOps = \e p -> do
                    "Sequent is not an instance of the sequent calculus axiom",
                    prettySequent ppopts nenv sqt
                 ]
-           return (mempty, ProvedTheorem mempty)
+           return (mempty, ProvedTheorem mempty, mempty)
 
       CutEvidence p ehyp egl ->
         do d1 <- check nenv ehyp (addHypothesis p sqt)
@@ -1806,7 +1855,9 @@ checkEvidence sc what4PushMuxOps = \e p -> do
                         ]
                    x' <- scVariable sc x xty
                    body' <- scInstantiate sc (IntMap.singleton (vnIndex nm) x') body
-                   check nenv e' (mkSqt (Prop body'))
+                   (deps, sy, hyps) <- check nenv e' (mkSqt (Prop body'))
+                   let hyps' = HashSet.delete xty hyps
+                   pure (deps, sy, hyps')
 
 passthroughEvidence :: [Evidence] -> IO Evidence
 passthroughEvidence [e] = pure e
@@ -1866,12 +1917,13 @@ finishProof sc db conclProp
          let e' = if useSequentGoals
                    then NormalizeSequentEvidence concl e
                    else e
-         (deps,sy) <- checkEvidence sc what4PushMuxOps e' conclProp
+         (deps, sy, hyps) <- checkEvidence sc what4PushMuxOps e' conclProp
          n <- freshNonce globalNonceGenerator
          end <- getCurrentTime
          let theorem =
                    Theorem
                    { _thmProp = conclProp
+                   , _thmHyps = hyps
                    , _thmStats = stats
                    , _thmEvidence = e'
                    , _thmLocation = loc

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -397,18 +397,18 @@ unfoldFixOnceProp sc unints (Prop tm) =
      return (Prop tm')
 
 -- | Rewrite the proposition using the provided Simpset
-simplifyProp :: Ord a => SharedContext -> Simpset a -> Prop -> IO (Set a, Prop)
+simplifyProp :: Monoid a => SharedContext -> Simpset a -> Prop -> IO (a, Prop)
 simplifyProp sc ss (Prop tm) =
   do (a, tm') <- rewriteSharedTerm sc ss tm
      return (a, Prop tm')
 
 -- | Rewrite the propositions using the provided Simpset
-simplifyProps :: Ord a => SharedContext -> Simpset a -> [Prop] -> IO (Set a, [Prop])
+simplifyProps :: Monoid a => SharedContext -> Simpset a -> [Prop] -> IO (a, [Prop])
 simplifyProps _sc _ss [] = return (mempty, [])
 simplifyProps sc ss (p:ps) =
   do (a, p')  <- simplifyProp sc ss p
      (b, ps') <- simplifyProps sc ss ps
-     return (Set.union a b, p' : ps')
+     return (a <> b, p' : ps')
 
 -- | Add hypotheses from the given sequent as rewrite rules
 --   to the given simpset.
@@ -429,11 +429,11 @@ localHypSimpset sc sqt hs ss0 = Fold.foldlM processHyp ss0 nhyps
     hset = Set.fromList hs
 
 -- | Rewrite in the sequent using the provided Simpset
-simplifySequent :: Ord a => SharedContext -> Simpset a -> Sequent -> IO (Set a, Sequent)
+simplifySequent :: Monoid a => SharedContext -> Simpset a -> Sequent -> IO (a, Sequent)
 simplifySequent sc ss (UnfocusedSequent hs gs) =
   do (a, hs') <- simplifyProps sc ss hs
      (b, gs') <- simplifyProps sc ss gs
-     return (Set.union a b, UnfocusedSequent hs' gs')
+     return (a <> b, UnfocusedSequent hs' gs')
 simplifySequent sc ss (ConclFocusedSequent hs (FB gs1 g gs2)) =
   do (a, g') <- simplifyProp sc ss g
      return (a, ConclFocusedSequent hs (FB gs1 g' gs2))
@@ -1047,7 +1047,7 @@ data Evidence
     --   simpset; then the provided evidence is used to check the
     --   modified sequent. The list of integers indicate local
     --   hypotheses that should also be treated as rewrite rules.
-  | RewriteEvidence ![Integer] !(Simpset TheoremNonce) !Evidence
+  | RewriteEvidence ![Integer] !(Simpset (Set TheoremNonce)) !Evidence
 
     -- | This type of evidence is used to modify a sequent via unfolding
     --   constant definitions.  The sequent is modified by unfolding

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -1931,8 +1931,11 @@ finishProof sc db conclProp
                    then NormalizeSequentEvidence concl e
                    else e
          (deps, sy, hyps) <- checkEvidence sc what4PushMuxOps e' conclProp
-         ppHyps <- traverse (ppTerm sc) (HashSet.toList hyps)
-         unless (HashSet.null hyps) $
+         -- Fail if hyps includes any types that do not correspond to a
+         -- free variable in the conclusion
+         let extraHyps = HashSet.difference hyps (propHypotheses conclProp)
+         ppHyps <- traverse (ppTerm sc) (HashSet.toList extraHyps)
+         unless (HashSet.null extraHyps) $
            fail $ unlines $ ["Theorem depends on undischarged hypotheses:"] ++ ppHyps
          n <- freshNonce globalNonceGenerator
          end <- getCurrentTime

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -737,7 +737,7 @@ prettyValue sc = visit (0 :: Int)
       VTheorem thm -> do
         nenv <- scGetNamingEnv sc
         ppopts <- scGetPPOpts sc
-        pure $ "Theorem" <+> PP.parens (prettyProp ppopts nenv (thmProp thm))
+        pure $ "Theorem" <+> PP.parens (prettyTheorem ppopts nenv thm)
       VBisimTheorem _ -> pure "<<Bisimulation theorem>>"
       VLLVMCrucibleSetup{} -> pure "<<LLVM Setup>>"
       VLLVMCrucibleSetupValue x -> CMS.prettySetupValue sc $ CMSLLVM.getAllLLVM x

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -621,7 +621,7 @@ data Value
   | VYosysSequential YosysSequential
   | VYosysTheorem YosysTheorem
 
-type SAWSimpset = Simpset (Set TheoremNonce)
+type SAWSimpset = Simpset TheoremAnnotation
 
 data AIGNetwork where
   AIGNetwork :: (Typeable l, Typeable g, AIG.IsAIG l g) => AIG.Network l g -> AIGNetwork

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -621,7 +621,7 @@ data Value
   | VYosysSequential YosysSequential
   | VYosysTheorem YosysTheorem
 
-type SAWSimpset = Simpset TheoremNonce
+type SAWSimpset = Simpset (Set TheoremNonce)
 
 data AIGNetwork where
   AIGNetwork :: (Typeable l, Typeable g, AIG.IsAIG l g) => AIG.Network l g -> AIGNetwork

--- a/saw-central/src/SAWCentral/VerificationSummary.hs
+++ b/saw-central/src/SAWCentral/VerificationSummary.hs
@@ -191,13 +191,13 @@ prettyVerificationSummary ppOpts nenv vs@(VerificationSummary jspecs lspecs thms
              , subitem (verifStatus s)
              ]
       prettyTheorems ts =
-        sectionWithItems "Theorems Proved or Assumed" (item . prettyTheorem) ts
-      prettyTheorem t =
+        sectionWithItems "Theorems Proved or Assumed" (item . prettyThm) ts
+      prettyThm t =
         vsep [ case thmSummary t of
                  ProvedTheorem{}   -> "Theorem:"
                  TestedTheorem n   -> "Theorem (randomly tested on" <+> viaShow n <+> "samples):"
                  AdmittedTheorem{} -> "Axiom:"
-             , code (indent 2 (prettyProp ppOpts nenv (thmProp t)))
+             , code (indent 2 (prettyTheorem ppOpts nenv t))
              , ""
              ]
       prettySolvers ss =

--- a/saw-core/src/SAWCore/Rewriter.hs
+++ b/saw-core/src/SAWCore/Rewriter.hs
@@ -60,7 +60,6 @@ import qualified Data.List as List
 import Data.List.Extra (nubOrd)
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Set (Set)
 import qualified Data.Set as Set
 import Control.Monad.Trans.Writer.Strict
 import Numeric.Natural
@@ -720,9 +719,9 @@ data Convertibility = AllRules | ConvertibleRulesOnly
 -- The second is for rewriting with 'ConvertibleRulesOnly'.
 type RewriterCaches = (IntCache IO Term, IntCache IO Term)
 
--- | Rewriter for shared terms.  The annotations of any used rules are collected
---   and returned in the result set.
-rewriteSharedTerm :: forall a. Ord a => SharedContext -> Simpset a -> Term -> IO (Set a, Term)
+-- | Rewriter for shared terms.
+-- The annotations of any used rules are combined and returned in the result set.
+rewriteSharedTerm :: forall a. Monoid a => SharedContext -> Simpset a -> Term -> IO (a, Term)
 rewriteSharedTerm sc ss1 t0 =
     do cache1 <- newIntCache
        cache2 <- newIntCache
@@ -737,7 +736,7 @@ rewriteSharedTerm sc ss1 t0 =
     ss2 = Net.filter (either convertible conversionIsSafe) ss1
 
     rewriteAll ::
-      (?caches :: RewriterCaches, ?annSet :: IORef (Set a)) =>
+      (?caches :: RewriterCaches, ?annSet :: IORef a) =>
       Convertibility -> Term  -> IO Term
     rewriteAll convertibleFlag t =
       useIntCache cache (termIndex t) $
@@ -754,7 +753,7 @@ rewriteSharedTerm sc ss1 t0 =
             ConvertibleRulesOnly -> snd ?caches
 
     rewriteTermF ::
-      (?caches :: RewriterCaches, ?annSet :: IORef (Set a)) =>
+      (?caches :: RewriterCaches, ?annSet :: IORef a) =>
       Convertibility -> TermF Term -> IO (TermF Term)
     rewriteTermF convertibleFlag tf =
         case tf of
@@ -794,7 +793,7 @@ rewriteSharedTerm sc ss1 t0 =
                pure (Pi x t1' t2'')
 
     rewriteFTermF ::
-      (?caches :: RewriterCaches, ?annSet :: IORef (Set a)) =>
+      (?caches :: RewriterCaches, ?annSet :: IORef a) =>
       Convertibility -> FlatTermF Term -> IO (FlatTermF Term)
     rewriteFTermF convertibleFlag ftf =
         case ftf of
@@ -804,7 +803,7 @@ rewriteSharedTerm sc ss1 t0 =
           StringLit{}      -> return ftf
 
     rewriteTop ::
-      (?caches :: RewriterCaches, ?annSet :: IORef (Set a)) =>
+      (?caches :: RewriterCaches, ?annSet :: IORef a) =>
       Convertibility -> Term -> IO Term
     rewriteTop convertibleFlag t =
       do mt <- reduceSharedTerm sc t
@@ -818,12 +817,12 @@ rewriteSharedTerm sc ss1 t0 =
              in apply convertibleFlag rules t
            Just t' -> rewriteAll convertibleFlag t'
 
-    recordAnn :: (?annSet :: IORef (Set a)) => Maybe a -> IO ()
+    recordAnn :: (?annSet :: IORef a) => Maybe a -> IO ()
     recordAnn Nothing  = return ()
-    recordAnn (Just a) = modifyIORef' ?annSet (Set.insert a)
+    recordAnn (Just a) = modifyIORef' ?annSet (mappend a)
 
     apply ::
-      (?caches :: RewriterCaches, ?annSet :: IORef (Set a)) =>
+      (?caches :: RewriterCaches, ?annSet :: IORef a) =>
       Convertibility -> [Either (RewriteRule a) Conversion] -> Term -> IO Term
     apply _ [] t = return t
     apply convertibleFlag (Left (RewriteRule {ctxt, lhs, rhs, permutative, shallow, annotation}) : rules) t = do
@@ -868,12 +867,13 @@ rewriteSharedTerm sc ss1 t0 =
 
 -- FIXME: is there some way to have sensable term replacement in the presence of loose variables
 --  and/or under binders?
-replaceTerm :: Ord a =>
+replaceTerm ::
+  Monoid a =>
   SharedContext ->
   Simpset a    {- ^ A simpset of rewrite rules to apply along with the replacement -} ->
   (Term, Term) {- ^ (pat,repl) is a tuple of a pattern term to replace and a replacement term -} ->
   Term         {- ^ the term in which to perform the replacement -} ->
-  IO (Set a, Term)
+  IO (a, Term)
 replaceTerm sc ss (pat, repl) t = do
     let rule = ruleOfTerms pat repl
     let ss' = addRule rule ss
@@ -928,13 +928,13 @@ hoistIfs sc t = do
    splitConds sc ss (nubOrd $ map fst conds) t'
 
 
-splitConds :: Ord a => SharedContext -> Simpset a -> [Term] -> Term -> IO Term
+splitConds :: Monoid a => SharedContext -> Simpset a -> [Term] -> Term -> IO Term
 splitConds sc ss = go
  where
    go [] t = return t
    go (c:cs) t = go cs =<< splitCond sc ss c t
 
-splitCond :: Ord a => SharedContext -> Simpset a -> Term -> Term -> IO Term
+splitCond :: Monoid a => SharedContext -> Simpset a -> Term -> Term -> IO Term
 splitCond sc ss c t = do
    ty <- scTypeOf sc t
    trueTerm  <- scBool sc True
@@ -951,7 +951,8 @@ type HoistIfs s = (Term, [(Term, Map VarName Term)])
 orderTerms :: SharedContext -> [Term] -> IO [Term]
 orderTerms _sc xs = return $ List.sort xs
 
-doHoistIfs :: Ord a =>
+doHoistIfs ::
+  Monoid a =>
   SharedContext ->
   Simpset a ->
   IntCache IO (HoistIfs s) ->


### PR DESCRIPTION
The "hypotheses" of a theorem are simply a set of SAWCore types (represented as `Term`s) that the theorem assumes to be inhabited.

When a `Theorem` value is printed, any hypotheses are shown in curly brackets with a turnstile:
```
Theorem ({hyp1, hyp2} |- conclusion)
```
Theorem hypotheses can originate in a few ways:
* Free variables occurring within explicit proof terms
* Local variables and assumptions from `goal_intro`
* Open terms used with `specialize_theorem`

Theorem hypotheses are discharged by the `IntroEvidence` rule, which effectively performs Pi-introduction on theorems:
```
      {P} U Hyps |- Q
    -------------------
       Hyps |- P -> Q
```
Other theorem-building operations propagate hypotheses from all input theorems.

When complete, this PR should fix the soundness bug in #3270.