### PR TITLE
dependencies: update `crucible`

### DIFF
--- a/crucible-mir-comp/src/Mir/Compositional/Override.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Override.hs
@@ -153,7 +153,8 @@ printSpec ms = ovrWithBackend $ \bak ->
         ag (zip [0..] byteVals)
     let agRef = newConstMirRef sym MirAggregateRepr ag'
     zero <- liftIO (W4.bvLit sym knownRepr (BV.zero knownRepr))
-    ptr <- subindexMirRefSim sym byteRepr agRef zero byteSize
+    ptr <- ovrWithBackend $ \_bak ->
+        modifyRefMuxSim (mirRef_agElemLeaf zero byteSize byteRepr) agRef
     return $ Empty :> RV ptr :> RV len
 
 -- | Enable a MethodSpec.  This installs an override, so for the remainder of
@@ -352,7 +353,8 @@ runSpec sc myCS mh ms = ovrWithBackend $ \bak -> do
         ag <- liftIO $ mirAggregate_uninitIO bak allocSize_sym
         writeMirRefSim MirAggregateRepr agRef ag
         zero <- liftIO $ W4.bvLit sym knownRepr $ BV.zero knownRepr
-        ref <- subindexMirRefSim sym (allocSpec ^. maType) agRef zero elemSize
+        ref <- ovrWithBackend $ \_bak ->
+            modifyRefMuxSim (mirRef_agElemLeaf zero elemSize (allocSpec ^. maType)) agRef
         return ( alloc
                , Some $ MirPointer (allocSpec ^. maType)
                                    (allocSpec ^. maPtrKind)

--- a/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
@@ -915,8 +915,9 @@ resolveSetupVal mcc env tyenv nameEnv val =
                   Right x -> return x
                 i_sym <- usizeBvLit sym i
                 let elemSize = tySize col elemTy
+                elemOff <- W4.bvMul sym i_sym =<< usizeBvLit sym (fromIntegral elemSize)
                 MIRVal (RefShape elemPtrTy elemTy mutbl elemTpr) <$>
-                  Mir.subindexMirRefIO bak iTypes elemTpr xsVal i_sym elemSize
+                  Mir.mirRef_agElemIO bak iTypes elemOff elemSize elemTpr xsVal
               else do
                 let sc = sawCoreSharedContext sym
                 ppopts <- liftIO $ scGetPPOpts sc
@@ -1129,7 +1130,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
             Right x -> return x
           zeroBV <- usizeBvLit sym 0
           let elemSize = tySize col elemTy
-          refVal <- Mir.subindexMirRefIO bak iTypes elemTpr arrRefVal zeroBV elemSize
+          refVal <- Mir.mirRef_agElemIO bak iTypes zeroBV elemSize elemTpr arrRefVal
           let sliceShp = SliceShape (Mir.TyRef sliceTy mut) elemTy mut elemTpr
           pure $ SetupSliceFromArrayRef sliceShp refVal len
         _ -> do
@@ -1655,7 +1656,7 @@ doAlloc cc globals (Some ma) =
      globals' <- Mir.writeMirRefIO bak globals iTypes Mir.MirAggregateRepr ref ag
 
      zero <- W4.bvLit sym W4.knownRepr $ BV.mkBV W4.knownRepr 0
-     ptr <- Mir.subindexMirRefIO bak iTypes tpr ref zero elemSize
+     ptr <- Mir.mirRef_agElemIO bak iTypes zero elemSize tpr ref
      let mirPtr = Some MirPointer
            { _mpType = tpr
            , _mpKind = ma^.maPtrKind


### PR DESCRIPTION
Accommodates https://github.com/GaloisInc/crucible/pull/1841.

Note that this doesn't replace `subindexMirRefSim` with some `mirRef_agElemSim` operation, but instead with what the implementation of `mirRef_agElemSim` would be, since `crucible-mir` doesn't define such an operation.

Marked as draft pending https://github.com/GaloisInc/crucible/pull/1841 being merged, but otherwise ready for review.