### PR TITLE
Postprocess the test_sawcore_qualify output

### DIFF
--- a/intTests/test_sawcore_qualify/.gitignore
+++ b/intTests/test_sawcore_qualify/.gitignore
@@ -1,3 +1,5 @@
 *.rawlog
 *.log
 *.diff
+
+D.extcore

--- a/intTests/test_sawcore_qualify/Makefile
+++ b/intTests/test_sawcore_qualify/Makefile
@@ -1,5 +1,6 @@
 all: ;
 clean:
 	sh ./test.sh clean
+	rm -f D.sawcore
 
 .PHONY: all clean

--- a/intTests/test_sawcore_qualify/test.log.good
+++ b/intTests/test_sawcore_qualify/test.log.good
@@ -20,11 +20,11 @@ While typechecking term:
 Ambiguous name: x
 Possible matches:
 A::B:|:C::x@cryptol
-x`5950@fresh
+x<1>@fresh
 
 |:C::x
 |:C::x
-x`5950
+x<2>
 == Anticipated failure message ==
 Stack trace:
    (builtin) in parse_core
@@ -64,7 +64,7 @@ x@core
 x@core
 A::x@cryptol
 |:C::x
-x`5950
+x<3>
 == Anticipated failure message ==
 Stack trace:
    (builtin) in parse_core
@@ -79,7 +79,7 @@ While typechecking term:
 Ambiguous name: x
 Possible matches:
 A::B:|:C::x@cryptol
-x`5950@fresh
+x<4>@fresh
 A::x@cryptol
 A::x@core
 B::x@core
@@ -157,8 +157,8 @@ While typechecking term:
 .:1:0:
 Ambiguous name: x@fresh
 Possible matches:
-x`5950@fresh
-x`5983@fresh
+x<5>@fresh
+x<6>@fresh
 
 z
 z
@@ -206,7 +206,7 @@ Stack trace:
    test.saw:142:1-142:25 (at top level)
 Definition body contains free variables
 Name:
-  y`5992
+  y<7>
 For term:
   let { x@free : Bool; } in x@free
 With type:
@@ -297,3 +297,25 @@ let { n : Nat;
       let { x`1 = Vec m Nat; } in (x1 : x`1) -> x`1 -> Prop
 
 Success
+Postprocess found 7 serial numbers:
+   <1> == <2>: same
+   <1> == <3>: same
+   <1> == <4>: same
+   <1> == <5>: same
+   <1> == <6>: different
+   <1> == <7>: different
+   <2> == <3>: same
+   <2> == <4>: same
+   <2> == <5>: same
+   <2> == <6>: different
+   <2> == <7>: different
+   <3> == <4>: same
+   <3> == <5>: same
+   <3> == <6>: different
+   <3> == <7>: different
+   <4> == <5>: same
+   <4> == <6>: different
+   <4> == <7>: different
+   <5> == <6>: different
+   <5> == <7>: different
+   <6> == <7>: different

--- a/intTests/test_sawcore_qualify/test.postprocess.sh
+++ b/intTests/test_sawcore_qualify/test.postprocess.sh
@@ -1,0 +1,46 @@
+# postprocessor for test.saw
+# usage: ... | sh test.postprocess.sh | ... per test-and-diff.mk
+#
+# The output specifically exposes the SAWCore term serial numbers, and
+# so it generates several identifiers of the form [xy]`NNNN; these are
+# unstable (they change anytime anything rearranges any of the
+# bindings in the SAWCore prelude or SAWCore Cryptol module) so
+# substitute fixed strings for them. Then also check that the ones
+# that are supposed to be the same actually are.
+#
+# It also assumes any `[0-9][0-9][0-9]+ is something we should
+# substitute. For the time being at least, that's true. It's
+# important not to match ones with only 1 digit, and for safety
+# we also don't match ones with 2; those are display numbers, not
+# the internal serial numbers.
+#
+
+awk '
+   BEGIN {
+       counter = 0;
+   }
+   {
+       while ($0 ~ "`[0-9][0-9][0-9]+") {
+           # Extract the serial number.
+           # Vanilla awk does not support substituting submatches,
+           # so just substituting away the rest of the string does
+           # not really work. Do something else instead.
+           pos = match($0, "`[0-9][0-9][0-9]+");
+           serial = substr($0, pos, RLENGTH);
+
+           names[++counter] = serial;
+           newname = sprintf("<%d>", counter);
+           sub("`[0-9][0-9][0-9]+", newname, $0);
+       }
+       print;
+   }
+   END {
+       printf "Postprocess found %d serial numbers:\n", counter;
+       for (i=1;i<=counter;i++) {
+           for (j=i+1;j<=counter;j++) {
+               r = (names[i] == names[j]) ? "same" : "different";
+               printf "   <%d> == <%d>: %s\n", i, j, r;
+           }
+       }
+   }
+'


### PR DESCRIPTION
Hide away the SAWCore term serial numbers so we don't have to keep updating the test reference output.
