### PR TITLE
Improve pretty printer for counterexamples

### DIFF
--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -1979,7 +1979,7 @@ prettyCEX opts cex =
           let x' = PP.pretty $ vnName x
               v' = prettyFirstOrderValue opts v
           in
-          x' <+> "=" <+> v'
+          PP.nest 2 (x' <+> "=" <> PP.group (PP.line <> v'))
     in
     PP.vsep $ map once cex
 

--- a/saw-core/src/SAWCore/FiniteValue.hs
+++ b/saw-core/src/SAWCore/FiniteValue.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 {- |
 Module      : SAWCore.FiniteValue
@@ -231,7 +232,7 @@ instance Show FirstOrderValue where
       FOVVec _ vs -> showString "[" . commaSep (map shows vs) . showString "]"
       FOVArray _kty d vs ->
         let vs' = map showEntry $ Map.toAscList vs
-            d' = showEntry ("<default>", d)
+            d' = showEntry ("<default>" :: String, d)
         in
         showString "[" . commaSep (vs' ++ [d']) . showString "]"
       FOVOpaqueArray _kty _vty ->
@@ -249,29 +250,28 @@ prettyFiniteValue opts fv = prettyFirstOrderValue opts (toFirstOrderValue fv)
 
 prettyFirstOrderValue :: PPS.Opts -> FirstOrderValue -> PPS.Doc
 prettyFirstOrderValue opts = loop
- where
- loop fv = case fv of
-   FOVBit b
-     | b         -> pretty "True"
-     | otherwise -> pretty "False"
-   FOVInt i      -> pretty i
-   FOVIntMod _ i -> pretty i
-   FOVRational r ->
-     pretty (numerator r) <+> pretty "%" <+> pretty (denominator r)
-   FOVWord _w i  -> prettyInteger opts i
-   FOVVec _ xs   -> brackets (sep (punctuate comma (map loop xs)))
-   FOVArray _kty d vs ->
-      let ppEntry' k' v = k' <+> pretty ":=" <+> loop v
-          ppEntry (k, v) = ppEntry' (loop k) v
-          d' = ppEntry' (pretty "<default>") d
-          vs' = map ppEntry $ Map.toAscList vs
-      in
-      brackets (nest 4 (sep (punctuate comma (vs' ++ [d']))))
-   FOVOpaqueArray _kty _vty ->
-      pretty "[ opaque array, sorry ]"
-   FOVTuple xs   -> parens (nest 4 (sep (punctuate comma (map loop xs))))
-   FOVRec xs     -> braces (sep (punctuate comma (map ppField (Map.toList xs))))
-      where ppField (f,x) = pretty f <+> pretty '=' <+> loop x
+  where
+    loop fv =
+      case fv of
+        FOVBit b
+          | b         -> "True"
+          | otherwise -> "False"
+        FOVInt i      -> pretty i
+        FOVIntMod _ i -> pretty i
+        FOVRational r -> pretty (numerator r) <+> "%" <+> pretty (denominator r)
+        FOVWord _w i  -> prettyInteger opts i
+        FOVVec _ xs   -> brackets (align (sep (punctuate comma (map loop xs))))
+        FOVArray _kty d vs ->
+          let ppEntry' k' v = nest 2 (k' <+> ":=" <> group (line <> loop v))
+              ppEntry (k, v) = ppEntry' (loop k) v
+              d' = ppEntry' "<default>" d
+              vs' = map ppEntry $ Map.toAscList vs
+          in brackets (align (sep (punctuate comma (vs' ++ [d']))))
+        FOVOpaqueArray _kty _vty ->
+          "[ opaque array, sorry ]"
+        FOVTuple xs   -> parens (align (sep (punctuate comma (map loop xs))))
+        FOVRec xs     -> braces (align (sep (punctuate comma (map ppField (Map.toList xs)))))
+          where ppField (f, x) = nest 2 (pretty f <+> "=" <> group (line <> loop x))
 
 -- | The options for JSON-serializing 'FirstOrderType's and 'FirstOrderValue's:
 -- remove the @FOT@/@FOV@ prefixes and encode the different constructors as


### PR DESCRIPTION
Reimplement pretty printers for `FirstOrderValue` and `CEX` types. Now it properly indents counterexample values, and aligns fields of records and elements of lists and tuples.

Fixes #3294.

Here's an example of the improved output:
```
sawscript> prove_print z3 {{ \ (x : {a : Bool, b : Bool, c : Bool, d : Bool, e : Bool, f : Bool, g : ([8][8],[8][8],[8][8]), h : [8][8][8]}) y -> x == y }};

Stack trace:
   (builtin) in z3
   <stdin>:1:13-1:15 in (callback)
   (builtin) in prove_print
   <stdin>:1:1-1:145 (at top level)
prove: 1 unsolved subgoal(s)
Invalid: [
   x =
     {a = True,
      b = True,
      c = True,
      d = True,
      e = True,
      f = True,
      g =
        ([255, 255, 255, 255, 255, 255, 255, 255],
         [255, 255, 255, 255, 255, 255, 255, 255],
         [255, 255, 255, 255, 255, 255, 255, 255]),
      h =
        [[255, 255, 255, 255, 255, 255, 255, 255],
         [255, 255, 255, 255, 255, 255, 255, 255],
         [255, 255, 255, 255, 255, 255, 255, 255],
         [255, 255, 255, 255, 255, 255, 255, 255],
         [255, 255, 255, 255, 255, 255, 255, 255],
         [255, 255, 255, 255, 255, 255, 255, 255],
         [255, 255, 255, 255, 255, 255, 255, 255],
         [255, 255, 255, 255, 255, 255, 255, 255]]}
   y =
     {a = False,
      b = False,
      c = False,
      d = False,
      e = False,
      f = False,
      g =
        ([0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0]),
      h =
        [[0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0]]}
]
```