### PR TITLE
Make `prove` and `prove_print` accept terms of type `Prop`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ This release supports [version
 
 ## New Features
 
+* The SAW proof commands `prove` and `prove_print` now accept SAWCore
+  terms of type `Prop`, in addition to predicates returning `Bool`.
+  Previously this required a special proof command `prove_extcore`,
+  which is now deprecated in favor of `prove_print`.
+
 * The REPL once again accepts pure expressions as well as monadic
   statements.
   These are _not_ accepted in monadic contexts in SAWScript files, as

--- a/intTests/test_sawcore_qualify/test.log.good
+++ b/intTests/test_sawcore_qualify/test.log.good
@@ -219,11 +219,11 @@ let { x@free : Bool;
 == Anticipated failure message ==
 Stack trace:
    (builtin) in z3
-   test.saw:148:22-148:24 in (callback)
-   (builtin) in prove_extcore
-   test.saw:148:8-148:29 in (callback)
+   test.saw:148:20-148:22 in (callback)
+   (builtin) in prove_print
+   test.saw:148:8-148:27 in (callback)
    (builtin) in fails
-   test.saw:148:1-148:29 (at top level)
+   test.saw:148:1-148:27 (at top level)
 prove: 1 unsolved subgoal(s)
 Invalid: [
    x = True

--- a/intTests/test_sawcore_qualify/test.saw
+++ b/intTests/test_sawcore_qualify/test.saw
@@ -145,7 +145,7 @@ let x_free_eq = parse_core "let { x@free : Bool; } in \\(x : Bool) -> EqTrue (bo
 let test = beta_reduce_term (term_apply x_free_eq [x_free]);
 print_term test;
 
-fails (prove_extcore z3 test);
+fails (prove_print z3 test);
 
 // if "fresh_symbolic" is given an invalid identifer, it is implicitly
 // quoted when creating the formal name

--- a/intTests/test_search/search03.log.good
+++ b/intTests/test_search/search03.log.good
@@ -82,7 +82,9 @@ print_goal_size : ProofScript ()
 print_goal_summary : ProofScript ()
 prove : ProofScript () -> Term -> TopLevel ProofResult
 prove_core : ProofScript () -> String -> TopLevel Theorem
-prove_extcore : ProofScript () -> Term -> TopLevel Theorem
+prove_extcore :
+   ProofScript () -> Term -> TopLevel Theorem
+   (DEPRECATED AND WILL WARN)
 prove_print : ProofScript () -> Term -> TopLevel Theorem
 quickcheck : Int -> ProofScript ()
 rme : ProofScript ()
@@ -220,7 +222,9 @@ print_goal_size : ProofScript ()
 print_goal_summary : ProofScript ()
 prove : ProofScript () -> Term -> TopLevel ProofResult
 prove_core : ProofScript () -> String -> TopLevel Theorem
-prove_extcore : ProofScript () -> Term -> TopLevel Theorem
+prove_extcore :
+   ProofScript () -> Term -> TopLevel Theorem
+   (DEPRECATED AND WILL WARN)
 prove_print : ProofScript () -> Term -> TopLevel Theorem
 quickcheck : Int -> ProofScript ()
 rme : ProofScript ()

--- a/intTests/test_term_labels/test.log.good
+++ b/intTests/test_term_labels/test.log.good
@@ -6,7 +6,7 @@ Loading file "test.saw"
        }
  in Eq Nat (addNat x (addNat y z_lbl))
       (addNat (addNat x y) z_lbl)
-WARNING: admitting goal prove_extcore
+WARNING: admitting goal prove_print
 \(a : Nat) ->
   \(b : Nat) ->
     \(c : Nat) ->
@@ -32,7 +32,7 @@ WARNING: admitting goal prove_extcore
     -> let { z_lbl`2 = z;
            }
      in Eq Nat (addNat (addNat x y) z_lbl`2) w
-WARNING: admitting goal prove_extcore
+WARNING: admitting goal prove_print
 Goal prove_core (goal number 0): prove.subgoal0
 at test.saw:203:1-203:138
 

--- a/intTests/test_term_labels/test.saw
+++ b/intTests/test_term_labels/test.saw
@@ -176,7 +176,7 @@ let assoc_term = parse_core "(x y z : Nat) -> let { z_lbl = z; } in Eq Nat (addN
 
 print_term assoc_term;
 
-assoc_rule <- prove_extcore (admit "test") assoc_term;
+assoc_rule <- prove_print (admit "test") assoc_term;
 
 let abc_test = parse_core "\\(a b c : Nat) -> let { a_lbl = a; c_lbl = c; } in addNat a_lbl (addNat b c_lbl)";
 
@@ -189,7 +189,7 @@ let assoc_intro_term =
   parse_core "(x y z w : Nat) -> let { z_lbl = z; } in (Eq Nat (addNat x (addNat y z_lbl)) w) -> Eq Nat (addNat (addNat x y) z_lbl) w";
 
 print_term assoc_intro_term;
-assoc_intro_rule <- prove_extcore (admit "test") assoc_intro_term;
+assoc_intro_rule <- prove_print (admit "test") assoc_intro_term;
 
 let tac = do {
   goal_intro "a";

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -1423,7 +1423,7 @@ provePrim ::
   TopLevel ProofResult
 provePrim script t = do
   sc <- getSharedContext
-  prop <- io $ predicateToProp sc Universal (ttTerm t)
+  prop <- io $ termToProp sc (ttTerm t)
   pos <- SV.getPosition
   let goal = ProofGoal
              { goalNum  = 0
@@ -1481,7 +1481,7 @@ provePrintPrim ::
   TopLevel Theorem
 provePrintPrim script t = do
   sc <- getSharedContext
-  proveHelper "prove_print" script (ttTerm t) $ io . predicateToProp sc Universal
+  proveHelper "prove_print" script (ttTerm t) $ io . termToProp sc
 
 provePropPrim ::
   ProofScript () ->

--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -2125,28 +2125,9 @@ parse_core_mod mnm input = do
 
 prove_core :: ProofScript () -> Text -> TopLevel Theorem
 prove_core script input =
-  do sc <- getSharedContext
-     t <- parseCore input
-     p <- io (termToProp sc t)
-     pos <- SV.getPosition
-     opts <- SV.getPPOpts
-     let goal = ProofGoal
-                { goalNum = 0
-                , goalType = "prove"
-                , goalName = "prove_core"
-                , goalLoc  = show pos
-                , goalDesc = ""
-                , goalSequent = propToSequent p
-                , goalTags = mempty
-                }
-     res <- SV.runProofScript script p goal Nothing "prove_core" True False
-     let failProof pst =
-            fail $ "prove_core: " ++ show (length (psGoals pst)) ++ " unsolved subgoal(s)\n"
-                                  ++ Text.unpack (ppProofResult opts res)
-     case res of
-       ValidProof _ thm -> SV.returnTheoremProof thm
-       InvalidProof _ _ pst -> failProof pst
-       UnfinishedProof pst  -> failProof pst
+  do t <- parseCore input
+     sc <- getSharedContext
+     proveHelper "prove_core" script t (io . termToProp sc)
 
 core_axiom :: Text -> TopLevel Theorem
 core_axiom input =

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -196,25 +196,28 @@ newtype Prop = Prop Term
 unProp :: Prop -> Term
 unProp (Prop tm) = tm
 
--- | Turn a saw-core term into a proposition under the type-as-propositions
---   regime.  The given term must be a type, which means that its own type
---   is a sort.
+-- | Turn a SAWCore term into a proposition.
+-- If it already has type @Prop@, then it is returned as is.
+-- If it has a function type of any arity with a return type of
+-- @Bool@, then convert the function arguments to universal
+-- quantifiers.
 termToProp :: SharedContext -> Term -> IO Prop
 termToProp sc tm =
-   do ty <- scWhnf sc =<< scTypeOf sc tm
-      case asSort ty of
-        Just s | s == propSort -> return (Prop tm)
-        _ -> do
-          tm' <- ppTerm sc tm
-          ty' <- ppTerm sc ty
-          case asLambda tm of
-            Just _ -> do
-              fail $ unlines [ "termToProp: Term is not a proposition."
-                             , "Note: the given term is a lambda; try using Pi terms instead."
-                             , tm', ty'
-                             ]
-            Nothing ->
-              fail $ unlines [ "termToProp: Term is not a proposition", tm', ty' ]
+  do ty <- scWhnf sc =<< scTypeOf sc tm
+     case asSort ty of
+       Just s | s == propSort -> pure (Prop tm)
+       -- If the term is not a Prop, then we check whether it is a
+       -- function that returns a Bool.
+       _ ->
+         case asBoolType (snd (asPiList ty)) of
+           Nothing ->
+             do ty' <- ppTerm sc ty
+                fail $ unlines $
+                  [ "Expected type Prop or function type returning Bool."
+                  , "Found type: " ++ ty'
+                  ]
+           Just () ->
+             predicateToProp sc Universal tm
 
 -- | Turn a saw-core term into a proposition under the type-as-propositions
 --   regime.  The given term must be a type, which means that its own type

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -3896,11 +3896,15 @@ primitives = Map.fromList $
 
   , prim "prove_extcore"         "ProofScript () -> Term -> TopLevel Theorem"
     (pureVal provePropPrim)
-    Current
+    WarnDeprecated
     [ "Use the given proof script to attempt to prove that a term"
     , "representing a proposition is valid. This is useful for proving"
     , "goals obtained with 'offline_extcore' or 'parse_core'. Returns a"
     , "Theorem if successful, and fails if unsuccessful."
+    , ""
+    , "This function is deprecated: Use 'prove_print' instead."
+    , "Expected to be hidden by default in SAW 1.7."
+
     ]
 
   , prim "prove_core"         "ProofScript () -> String -> TopLevel Theorem"

--- a/saw-script/src/SAWScript/Interpreter.hs
+++ b/saw-script/src/SAWScript/Interpreter.hs
@@ -3910,6 +3910,8 @@ primitives = Map.fromList $
     , "valid (true for all inputs). The term is specified as a String"
     , "containing SAWCore concrete syntax. Returns a Theorem if"
     , "successful, and fails if unsuccessful."
+    , ""
+    , "'prove_core t s' is equivalent to 'prove_print t (parse_core s)'."
     ]
 
   , prim "core_axiom"         "String -> Theorem"


### PR DESCRIPTION
We also mark `prove_extcore` as deprecated in favor of `prove_print`, with which it is now identical.

Fixes #3211.