### PR TITLE
Add a message about SAWScript functions applied to too few args

### DIFF
--- a/intTests/test_type_errors/err016.log.good
+++ b/intTests/test_type_errors/err016.log.good
@@ -1,6 +1,6 @@
 Loading file "err016.saw"
 err016.saw:12:13-12:14: Type mismatch.
-    Mismatch of types.
+    Mismatch of types. Perhaps a function was not given enough arguments?
     err016.saw:12:11-12:12: The type Int arises from the type of this term
     err016.saw:12:13-12:14: The type Int -> t.1 arises from the context of the term
 

--- a/intTests/test_type_errors/err037.log.good
+++ b/intTests/test_type_errors/err037.log.good
@@ -1,6 +1,6 @@
 Loading file "err037.saw"
 err037.saw:9:18-9:33: Type mismatch.
-    Mismatch of types.
+    Mismatch of types. Perhaps a function was not given enough arguments?
     err037.saw:9:10-9:15: The type [Int] arises from this type annotation
     err037.saw:7:15-7:35: The type [Int] -> [Int] arises from the context of the term
 

--- a/intTests/test_type_errors/err038.log.good
+++ b/intTests/test_type_errors/err038.log.good
@@ -1,6 +1,6 @@
 Loading file "err038.saw"
 err038.saw:10:16-10:17: Type mismatch.
-    Mismatch of types.
+    Mismatch of types. Perhaps a function was not given enough arguments?
     <type of concat>:1:5-1:8: The type [t.0] arises from this type annotation
     err038.saw:7:15-7:35: The type [Int] -> [Int] arises from the context of the term
 

--- a/saw-script/src/SAWScript/Typechecker.hs
+++ b/saw-script/src/SAWScript/Typechecker.hs
@@ -944,6 +944,10 @@ mgu ppopts t1 t2 = case (t1, t2) of
       -- Same named variable
       return emptySubst
 
+  (_, TyFunc{}) ->
+      -- If we expected a scalar and found a function, speculate that
+      -- someone forgot a function argument earlier.
+      failMGU ppopts "Mismatch of types. Perhaps a function was not given enough arguments?" t1 t2
   (_, _) ->
       -- Did not work
       failMGU ppopts "Mismatch of types." t1 t2
@@ -2020,7 +2024,7 @@ inferBlock cname blockpos ctx ty (stmts, lastexpr) = do
 -- assorted messiness and technical debt. Eventually we'll get it into
 -- a state where we can always just typecheck immediately after
 -- parsing (including incrementally from the repl) but we're some
--- distance from that. In the meantime the first step is to get it to
+-- distance from that.) In the meantime the first step is to get it to
 -- typecheck one statement at a time without special-casing any of
 -- them, and this is how it does that.
 --


### PR DESCRIPTION
This is now reasonably detectable after the optional arguments changes, and vaguely corresponds to the change embedded in that branch that warns about functions applied to too many args.

Closes #1765.

There is a problem here, though, which is that it's not cool for err016 to start printing "Perhaps a function was not given enough arguments?" given that it's a case of being given too _many_ arguments.

This is a delicate case: function of the form `t -> t`, so if you apply an extra arg we infer that `t` must itself have the form `a -> a`, and then when you pass a scalar there it is in fact not applied to enough arguments... but that's confusing and misleading.

The best available way to fix this involves doing unifications in a different order when processing function arguments; however, after the optional arguments changes that's no longer feasible. The error message the way things are is accurate enough apart from the new "Perhaps..." bit, but ideally we should either figure out how to suppress that or find a different approach for function arguments that doesn't tickle it.

Doing any of that requires cleaning out the typechecker again, though. It has not exactly bitrotted since I last cleaned it out, or at least not much... but that cleanup was one of the first things I did cleaning up SAW and accordingly wasn't very aggressive; I know a lot more about both the context and the pertinent Haskell idioms now.

Anyway, we could merge this change now or hold off on it until that pending cleanup is ready and there's an actual solution for err016 available. The misleading message in err016 is not fatal, just not super desirable, and it's not a case that comes up that often in real life, so we could reasonably do it either way...