### PR TITLE
Fix assorted typos in docs and source comments

### DIFF
--- a/doc/developer/extcore.md
+++ b/doc/developer/extcore.md
@@ -135,7 +135,7 @@ The previous section gave an example of a bit vector operation. The
 SAWCore prelude contains a number of built-in operations on both bit
 vectors and booleans.
 
-Th `bvNat` function constructs a constant bit vector, of a given size,
+The `bvNat` function constructs a constant bit vector, of a given size,
 from the given natural number. Conversely, the `bvToNat` function
 takes a bit vector length, a vector of this length, and returns the
 corresponding natural number.
@@ -150,7 +150,7 @@ operand. All signed bit vector operations take a natural number one
 smaller than the size of their remaining arguments (to ensure that
 their arguments have non-zero size). The `bvAppend` operator takes two
 natural numbers, corresponding to the lengths of its two bit vector
-arguments, and returns a bit vector with length correponding to the
+arguments, and returns a bit vector with length corresponding to the
 sum of the lengths of its arguments.
 
 The complete collection of bit vector operations appears in the
@@ -262,7 +262,7 @@ they rarely occur in terms exported for analysis by third-party tools.
 
 This section summarizes the built-in types, boolean functions, and bit
 vector functions defined in the SAWCore prelude. These types and
-functions will apppear in `extcore` files in the form
+functions will appear in `extcore` files in the form
 `Prelude.<name>`, but are listed below in the form `<name>`, without
 the `Prelude` prefix, for brevity and readability.
 

--- a/doc/developer/reorg-2025.md
+++ b/doc/developer/reorg-2025.md
@@ -363,7 +363,7 @@ In `src`, moved to `saw-script/src`:
 | SAWScript.Import                                | (unchanged)
 | SAWScript.Interpreter                           | (unchanged)
 | SAWScript.Lexer                                 | (unchanged)
-| SAWScript.MGU                                   | SAWSCript.Typechecker
+| SAWScript.MGU                                   | SAWScript.Typechecker
 | SAWScript.Parser                                | (unchanged)
 | SAWScript.Panic                                 | (unchanged)
 | SAWScript.Search                                | (unchanged)

--- a/doc/saw-user-manual/the-sawscript-language.md
+++ b/doc/saw-user-manual/the-sawscript-language.md
@@ -253,7 +253,7 @@ There are also the following derived types:
   (The unit type has one value, also written `()`; a value of type `()`
   contains no information.
   It is like `void` in C and Java.)
-  There are no monoples (tuples of arity 1).
+  There are no monuples (tuples of arity 1).
 - Lists.
   List types are written with a type name in square brackets: `[Int]` is a
   list of integers.
@@ -492,7 +492,7 @@ One can also write `let {{ ... }};`, in which the double-braces can
 contain not just an expression but any Cryptol declaration or
 let-binding.
 This is a convenient way to insert Cryptol type declarations; it also
-allows using Cryptol binding patterns that cannot readly be expressed
+allows using Cryptol binding patterns that cannot readily be expressed
 directly in SAWScript.
 
 (monad-bind)=

--- a/doc/saw-user-manual/the-sawscript-language.md
+++ b/doc/saw-user-manual/the-sawscript-language.md
@@ -253,7 +253,7 @@ There are also the following derived types:
   (The unit type has one value, also written `()`; a value of type `()`
   contains no information.
   It is like `void` in C and Java.)
-  There are no monuples (tuples of arity 1).
+  There are no monoples (tuples of arity 1).
 - Lists.
   List types are written with a type name in square brackets: `[Int]` is a
   list of integers.

--- a/doc/saw-user-manual/verifying-code.md
+++ b/doc/saw-user-manual/verifying-code.md
@@ -318,7 +318,7 @@ llvm_verify bc "add" [] true add_spec z3;
 ```
 
 This loads the compiler output, giving us an LLVM module handle `bc`,
-and them runs the verification by calling `llvm_verify`.
+and then runs the verification by calling `llvm_verify`.
 
 (Note that `jvm_verify` and `mir_verify` are essentially the same,
 except that they work with JVM and MIR code modules and specs.)
@@ -1176,7 +1176,7 @@ that call this one.
 
 ## The JVM Backend and JVM Specifications
 
-In the JVM backend, types appear as values of SAWSCript type
+In the JVM backend, types appear as values of SAWScript type
 `JavaType` (not `JVMType`, by historical accident), and values have
 the type `JVMValue`.
 JVM code modules are class files and thus have the type `JavaClass`.

--- a/saw-central/src/SAWCentral/Proof.hs
+++ b/saw-central/src/SAWCentral/Proof.hs
@@ -492,7 +492,7 @@ betaReduceProp sc (Prop tm) =
   do tm' <- betaNormalize sc tm
      return (Prop tm')
 
--- | Return the contant false proposition.
+-- | Return the constant false proposition.
 falseProp :: SharedContext -> IO Prop
 falseProp sc = Prop <$> (scEqTrue sc =<< scBool sc False)
 

--- a/saw-central/src/SAWCentral/Value.hs
+++ b/saw-central/src/SAWCentral/Value.hs
@@ -507,7 +507,7 @@ type RefChain = [(SS.Pos, SS.Name)]
 --   applied to the builtin. This is purely for printing in stack
 --   traces. FUTURE: VLambda should have this as well, but it doesn't
 --   make sense to make such a list separate from the variable
---   environment handling, and that needs a through mucking-out of its
+--   environment handling, and that needs a thorough mucking-out of its
 --   own first. UPDATE: that's been done, this can be fixed now.
 --
 --   The flow for the position of last reference is as follows:
@@ -532,7 +532,7 @@ type RefChain = [(SS.Pos, SS.Name)]
 --      (e) The same goes for statements in do-blocks, using the
 --          position of the BindStmt, or for the last expression in a
 --          do-block, the position of the expression.
---      (f) When the Haskell-level monadic action in a plan monadic
+--      (f) When the Haskell-level monadic action in a plain monadic
 --          value is extracted with fromValue, we use the position to
 --          call setPosition to update the interpreter's last
 --          execution position.


### PR DESCRIPTION
Corrects ten single-word typos across the documentation and two source-comment files. No functional changes; every edit is within a comment or prose.

| File | Correction |
| --- | --- |
| `saw-central/src/SAWCentral/Proof.hs` | `contant` → `constant` |
| `saw-central/src/SAWCentral/Value.hs` | `through` → `thorough`; `plan` → `plain` |
| `doc/saw-user-manual/verifying-code.md` | `them runs` → `then runs`; `SAWSCript` → `SAWScript` |
| `doc/saw-user-manual/the-sawscript-language.md` | `readly` → `readily` |
| `doc/developer/extcore.md` | `Th` → `The`; `correponding` → `corresponding`; `apppear` → `appear` |
| `doc/developer/reorg-2025.md` | `SAWSCript` → `SAWScript` |
