### PR TITLE
MIR: accommodate `MirAggregate` flattening

### DIFF
--- a/crucible-mir-comp/src/Mir/Compositional/Builder.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Builder.hs
@@ -244,8 +244,9 @@ addArg tpr argRef msb =
             Just x -> x
             Nothing -> error $ "arg index out of range: " ++ show idx
     let shp0 = tyToShapeEq col ty tpr
+    let sz = tySize col ty
 
-    rv0 <- lift $ readMirRefSim tpr argRef
+    rv0 <- lift $ readMirRefSim tpr (M.Width sz) argRef
     sv0 <- regToSetup bak Pre (\_tpr expr -> SAW.mkTypedTerm sc =<< eval expr) shp0 rv0
 
     void $ forNewRefs Pre $ \fr -> do
@@ -258,7 +259,7 @@ addArg tpr argRef msb =
             -- Record a points-to entry
             iSym <- liftIO $ W4.bvLit sym knownNat $ BV.mkBV knownNat $ fromIntegral i
             ref' <- lift $ mirRef_offsetSim (fr ^. frRef) iSym elemSize
-            rv <- lift $ readMirRefSim (fr ^. frType) ref'
+            rv <- lift $ readMirRefSim (fr ^. frType) (M.Width elemSize) ref'
             let shp = tyToShapeEq col (fr ^. frMirType) (fr ^. frType)
             sv <- regToSetup bak Pre (\_tpr expr -> SAW.mkTypedTerm sc =<< eval expr) shp rv
 
@@ -266,7 +267,7 @@ addArg tpr argRef msb =
             rv' <- case fr ^. frAllocSpec . maMutbl of
                 M.Mut -> lift $ clobberSymbolic sym loc "clobberArg" shp rv
                 M.Immut -> lift $ clobberImmutSymbolic sym loc "clobberArg" shp rv
-            lift $ writeMirRefSim (fr ^. frType) ref' rv'
+            lift $ writeMirRefSim (fr ^. frType) ref' (M.Width elemSize) rv'
             -- Gather fresh vars created by the clobber operation
             sv' <- regToSetup bak Post (\_tpr expr -> SAW.mkTypedTerm sc =<< eval expr) shp rv'
 
@@ -299,8 +300,9 @@ setReturn tpr argRef msb =
             Just x -> x
             Nothing -> M.TyTuple []
     let shp0 = tyToShapeEq col ty tpr
+    let sz = tySize col ty
 
-    rv0 <- lift $ readMirRefSim tpr argRef
+    rv0 <- lift $ readMirRefSim tpr (M.Width sz) argRef
     sv0 <- regToSetup bak Post (\_tpr expr -> SAW.mkTypedTerm sc =<< eval expr) shp0 rv0
 
     void $ forNewRefs Post $ \fr -> do
@@ -313,7 +315,7 @@ setReturn tpr argRef msb =
             -- Record a points-to entry
             iSym <- liftIO $ W4.bvLit sym knownNat $ BV.mkBV knownNat $ fromIntegral i
             ref' <- lift $ mirRef_offsetSim (fr ^. frRef) iSym elemSize
-            rv <- lift $ readMirRefSim (fr ^. frType) ref'
+            rv <- lift $ readMirRefSim (fr ^. frType) (M.Width elemSize) ref'
             let shp = tyToShapeEq col (fr ^. frMirType) (fr ^. frType)
             regToSetup bak Post (\_tpr expr -> SAW.mkTypedTerm sc =<< eval expr) shp rv
 
@@ -811,7 +813,7 @@ refToAlloc bak p pkind mutbl ty tpr ref len = do
     lookupAlloc [] = return Nothing
     lookupAlloc (Some fr : frs) = case testEquality tpr (fr ^. frType) of
         Just Refl -> do
-            eq <- mirRef_eqIO bak ref (fr ^. frRef)
+            eq <- mirRef_eqMA bak ref (fr ^. frRef)
             case W4.asConstantPred eq of
                 Just True -> return $ Just $ fr ^. frAlloc
                 Just False -> lookupAlloc frs

--- a/crucible-mir-comp/src/Mir/Compositional/Convert.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Convert.hs
@@ -145,11 +145,12 @@ termToExpr sym varMap term = do
 -- `(A, (B, C))` vs `(A, B, C)` (these are the same type in saw-core).
 termToReg :: forall sym t fs tp.
     (IsSymInterface sym, sym ~ MirSym t fs, HasCallStack) =>
+    M.Collection ->
     sym ->
     SAW.Term ->
     TypeShape tp ->
     IO (RegValue sym tp)
-termToReg sym term shp0 = do
+termToReg col sym term shp0 = do
     varMap <- readIORef (SAW.saw_elt_cache_r (mirSAWCoreState (sym ^. W4.userState)))
     sv <- termToSValue sym varMap term
     go shp0 sv
@@ -167,9 +168,10 @@ termToReg sym term shp0 = do
                                             ("a vector containing " <> show x)
             buildBitVector w bits
         (TupleShape _ [], SAW.VCtorApp 0 _ []) -> mirAggregate_zstIO
-        (TupleShape _ elems, _) -> do
+        (TupleShape ty elems, _) -> do
+            let tupleSz = tySize col ty
             svs <- reverse <$> tupleToListRev (length elems) [] sv
-            buildMirAggregate sym elems svs $ \_ _ shp' sv' -> go shp' sv'
+            buildMirAggregate sym tupleSz elems svs $ \_ _ shp' sv' -> go shp' sv'
         (ArrayShape _ _ sz shp' len, SAW.VVector thunks) -> do
             svs <- mapM SAW.force $ toList thunks
             when (length svs /= fromIntegral len) $

--- a/crucible-mir-comp/src/Mir/Compositional/Convert.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Convert.hs
@@ -346,7 +346,8 @@ regToTermWithAdapt sym sc name ada0 shp0 rv0 = go ada0 shp0 rv0
             tyTerm <- shapeToTerm' sc a shp'
             liftIO $ SAW.scVector sc tyTerm terms
         (AdaptDerefRef col elAda, RefShape _ty elT M.Immut tpr, mirPtr) ->
-             do r <- readMirRefSim tpr mirPtr
+             do let elSize = tySize col elT
+                r <- readMirRefSim tpr (M.Width elSize) mirPtr
                 let elShp = tyToShapeEq col elT tpr
                 go elAda elShp r
         (AdaptDerefSlice col n elAda, SliceShape _ty elT M.Immut tpr, Ctx.Empty Ctx.:> RV mirPtr Ctx.:> RV lenExpr) ->
@@ -369,7 +370,7 @@ regToTermWithAdapt sym sc name ada0 shp0 rv0 = go ada0 shp0 rv0
                       do
                         iExpr   <- liftIO (W4.bvLit sym knownNat (BV.mkBV knownNat i))
                         elemPtr <- mirRef_offsetWrapSim mirPtr iExpr elSize
-                        r       <- readMirRefSim tpr elemPtr
+                        r       <- readMirRefSim tpr (M.Width elSize) elemPtr
                         go elAda elShp r
                   elTyTerm <- shapeToTerm' sc elAda elShp
                   liftIO (SAW.scVector sc elTyTerm vals)

--- a/crucible-mir-comp/src/Mir/Compositional/Override.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Override.hs
@@ -373,7 +373,7 @@ runSpec sc myCS mh ms = ovrWithBackend $ \bak -> do
     w4VarMap <- liftIO $ readIORef w4VarMapRef
     let termSub = os ^. MS.termSub
     retVal <- case ms ^. MS.csRetValue of
-        Just sv -> liftIO $ setupToReg sym termSub w4VarMap allocMap retShp sv
+        Just sv -> liftIO $ setupToReg sym col termSub w4VarMap allocMap retShp sv
         Nothing ->
           -- We know that the returned value is (), so assert that the type
           -- representation is MirAggregateRepr (which is how all tuples are
@@ -408,7 +408,7 @@ runSpec sc myCS mh ms = ovrWithBackend $ \bak -> do
         forM_ (zip svs [0 .. len - 1]) $ \(sv, i) -> do
             iSym <- liftIO $ W4.bvLit sym knownNat $ BV.mkBV knownNat $ fromIntegral i
             ref' <- mirRef_offsetSim (ptr ^. mpRef) iSym elemSize
-            rv <- liftIO $ setupToReg sym termSub w4VarMap allocMap shp sv
+            rv <- liftIO $ setupToReg sym col termSub w4VarMap allocMap shp sv
             writeMirRefSim (ptr ^. mpType) ref' (M.Width elemSize) rv
 
     -- Clobber all globals.  We don't yet support mentioning globals in specs.
@@ -568,6 +568,7 @@ matchArg sym ppopts eval col allocSpecs md shp0 rv0 sv0 = go shp0 rv0 sv0
 setupToReg :: forall sym t fs tp0.
     (IsSymInterface sym, sym ~ MirSym t fs, HasCallStack) =>
     sym ->
+    M.Collection ->
     -- | `termSub`: maps `VarIndex`es in the MethodSpec's namespace to `Term`s
     -- in the context's namespace.
     IntMap SAW.Term ->
@@ -578,7 +579,7 @@ setupToReg :: forall sym t fs tp0.
     TypeShape tp0 ->
     MS.SetupValue MIR ->
     IO (RegValue sym tp0)
-setupToReg sym termSub myRegMap allocMap shp0 sv0 = go shp0 sv0
+setupToReg sym col termSub myRegMap allocMap shp0 sv0 = go shp0 sv0
   where
     go :: forall tp. TypeShape tp -> MS.SetupValue MIR -> IO (RegValue sym tp)
     go (PrimShape _ btpr) (MS.SetupTerm tt) = do
@@ -590,12 +591,14 @@ setupToReg sym termSub myRegMap allocMap shp0 sv0 = go shp0 sv0
             Nothing -> error $ "setupToReg: expected " ++ show btpr ++ ", but got " ++
                 show (W4.exprType expr)
         return expr
-    go (TupleShape _ elems) (MS.SetupTuple _ svs) =
-        buildMirAggregate sym elems svs $ \_off _sz shp sv -> go shp sv
+    go (TupleShape tupleTy elems) (MS.SetupTuple _ svs) = do
+        let tupleSz = tySize col tupleTy
+        buildMirAggregate sym tupleSz elems svs $ \_off _sz shp sv -> go shp sv
     go (ArrayShape _ _ sz shp len) (MS.SetupArray _ svs) = do
         buildMirAggregateArray sym sz shp len svs $ \_off sv -> go shp sv
-    go (StructShape _ elems) (MS.SetupStruct _ svs) =
-        buildMirAggregate sym elems svs $ \_off _sz shp sv -> go shp sv
+    go (StructShape structTy elems) (MS.SetupStruct _ svs) = do
+        let structSz = tySize col structTy
+        buildMirAggregate sym structSz elems svs $ \_off _sz shp sv -> go shp sv
     go (TransparentShape _ shp) sv = go shp sv
     go (RefShape _ _ _ tpr) (MS.SetupVar alloc) = case Map.lookup alloc allocMap of
         Just (Some ptr) -> case testEquality tpr (ptr ^. mpType) of

--- a/crucible-mir-comp/src/Mir/Compositional/Override.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Override.hs
@@ -155,7 +155,7 @@ printSpec ms = ovrWithBackend $ \bak ->
     let agRef = newConstMirRef sym MirAggregateRepr ag'
     zero <- liftIO (W4.bvLit sym knownRepr (BV.zero knownRepr))
     ptr <- ovrWithBackend $ \_bak ->
-        modifyRefMuxSim (mirRef_agElemLeaf zero byteSize byteRepr) agRef
+        modifyRefMuxSim (mirRef_agOffsetLeaf bak zero) agRef
     return $ Empty :> RV ptr :> RV len
 
 -- | Enable a MethodSpec.  This installs an override, so for the remainder of
@@ -280,7 +280,7 @@ runSpec sc myCS mh ms = ovrWithBackend $ \bak -> do
                 iSym <- liftIO $ W4.bvLit sym knownNat $ BV.mkBV knownNat $ fromIntegral i
                 let elemSize = tySize col ty
                 ref' <- lift $ mirRef_offsetSim (ptr ^. mpRef) iSym elemSize
-                rv <- lift $ readMirRefSim (ptr ^. mpType) ref'
+                rv <- lift $ readMirRefSim (ptr ^. mpType) (M.Width elemSize) ref'
                 let shp = tyToShapeEq col ty (ptr ^. mpType)
                 matchArg sym ppopts eval col (ms ^. MS.csPreState . MS.csAllocs) md shp rv sv
 
@@ -352,10 +352,10 @@ runSpec sc myCS mh ms = ovrWithBackend $ \bak -> do
         elemSize_sym <- liftIO $ usizeBvLit sym (fromIntegral elemSize)
         allocSize_sym <- liftIO (W4.bvMul sym len_sym elemSize_sym)
         ag <- liftIO $ mirAggregate_uninitIO bak allocSize_sym
-        writeMirRefSim MirAggregateRepr agRef ag
+        writeMirRefSim MirAggregateRepr agRef M.All ag
         zero <- liftIO $ W4.bvLit sym knownRepr $ BV.zero knownRepr
         ref <- ovrWithBackend $ \_bak ->
-            modifyRefMuxSim (mirRef_agElemLeaf zero elemSize (allocSpec ^. maType)) agRef
+            modifyRefMuxSim (mirRef_agOffsetLeaf bak zero) agRef
         return ( alloc
                , Some $ MirPointer (allocSpec ^. maType)
                                    (allocSpec ^. maPtrKind)
@@ -409,7 +409,7 @@ runSpec sc myCS mh ms = ovrWithBackend $ \bak -> do
             iSym <- liftIO $ W4.bvLit sym knownNat $ BV.mkBV knownNat $ fromIntegral i
             ref' <- mirRef_offsetSim (ptr ^. mpRef) iSym elemSize
             rv <- liftIO $ setupToReg sym termSub w4VarMap allocMap shp sv
-            writeMirRefSim (ptr ^. mpType) ref' rv
+            writeMirRefSim (ptr ^. mpType) ref' (M.Width elemSize) rv
 
     -- Clobber all globals.  We don't yet support mentioning globals in specs.
     -- However, we also don't prevent the subject function from modifying
@@ -553,7 +553,7 @@ matchArg sym ppopts eval col allocSpecs md shp0 rv0 sv0 = go shp0 rv0 sv0
             Just (Some ptr)
               | Just Refl <- testEquality tpr (ptr ^. mpType) -> do
                 eq <- lift $ ovrWithBackend $ \bak ->
-                        liftIO $ mirRef_eqIO bak ref' (ptr ^. mpRef)
+                        liftIO $ mirRef_eqMA bak ref' (ptr ^. mpRef)
                 let loc = mkProgramLoc "matchArg" InternalPos
                 MS.addAssert eq md $
                     SimError loc (AssertFailureSimError ("mismatch on " ++ show alloc) "")

--- a/crucible-mir-comp/src/Mir/Compositional/Override.hs
+++ b/crucible-mir-comp/src/Mir/Compositional/Override.hs
@@ -652,7 +652,7 @@ checkDisjoint bak refs = go refs
     go [] = return ()
     go ((alloc, Some ptr) : rest) = do
         forM_ rest $ \(alloc', Some ptr') -> do
-            disjoint <- W4.notPred sym =<< mirRef_overlapsIO bak (ptr ^. mpRef) (ptr' ^. mpRef)
+            disjoint <- W4.notPred sym =<< mirRef_overlapsMA bak (ptr ^. mpRef) (ptr' ^. mpRef)
             assert bak disjoint $ GenericSimError $
                 "references " ++ show alloc ++ " and " ++ show alloc' ++ " must not overlap"
         go rest

--- a/crux-mir-comp/src/Mir/Cryptol.hs
+++ b/crux-mir-comp/src/Mir/Cryptol.hs
@@ -139,7 +139,7 @@ cryptolOverrides _symOnline cs name cfg
 
         sym <- getSymInterface
         RegMap (Empty :> RegEntry _ rv) <- getOverrideArgs
-        liftIO $ munge sym shp rv
+        liftIO $ munge (cs ^. collection) sym shp rv
 
   | otherwise = Nothing
   where
@@ -254,7 +254,7 @@ loadCryptolFunc col sig modulePath name = do
 
     let fnName = "cryptol_" <> modulePath <> "_" <> name
     return $ LoadedCryptolFunc argShps retShp $
-        cryptolRun (Text.unpack fnName) args retShp (SAW.ttTerm tt)
+        cryptolRun col (Text.unpack fnName) args retShp (SAW.ttTerm tt)
 
   where
     listToCtx :: forall k0 (f0 :: k0 -> Kind.Type). [Some f0] -> Some (Assignment f0)
@@ -276,12 +276,13 @@ loadCryptolFunc col sig modulePath name = do
 cryptolRun ::
     forall sym p t fs rtp r args ret .
     (IsSymInterface sym, sym ~ MirSym t fs) =>
+    M.Collection ->
     String ->
     CryFunArgs args ->
     TypeShape ret ->
     SAW.Term ->
     OverrideSim (p sym) sym MIR rtp args r (RegValue sym ret)
-cryptolRun name (CryFunArgs (CryFunArgs' tpArgs ctrs normArgs)) retShp funcTerm = do
+cryptolRun col name (CryFunArgs (CryFunArgs' tpArgs ctrs normArgs)) retShp funcTerm = do
     let tpArgsSize      = Ctx.size tpArgs
         normArgsSize    = Ctx.size normArgs
 
@@ -331,17 +332,17 @@ cryptolRun name (CryFunArgs (CryFunArgs' tpArgs ctrs normArgs)) retShp funcTerm 
 
     let allTerms = tpTerms ++ argTerms
     appTerm  <- liftIO (SAW.scApplyAll sc funcTerm allTerms)
-    liftIO $ termToReg sym appTerm retShp
+    liftIO $ termToReg col sym appTerm retShp
 
 munge :: forall sym t fs tp0.
     (IsSymInterface sym, sym ~ MirSym t fs) =>
-    sym -> TypeShape tp0 -> RegValue sym tp0 -> IO (RegValue sym tp0)
-munge sym shp0 rv0 = do
+    M.Collection -> sym -> TypeShape tp0 -> RegValue sym tp0 -> IO (RegValue sym tp0)
+munge col sym shp0 rv0 = do
 
     let eval :: forall tp. W4.Expr t tp -> IO SAW.Term
         eval = exprToTerm sym
         uneval :: TypeShape (BaseToType btp) -> SAW.Term -> IO (W4.Expr t btp)
-        uneval shp t = termToReg sym t shp
+        uneval shp t = termToReg col sym t shp
 
     let go :: forall tp. TypeShape tp -> RegValue sym tp -> IO (RegValue sym tp)
         go shp@(PrimShape _ _) expr = eval expr >>= uneval shp

--- a/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Builtins.hs
@@ -2133,7 +2133,8 @@ setupArg sc cc ecRef mty0 tp0 =
           IO (Crucible.RegValue Sym tp')
         termToMirRegValue shp scTp t =
           case shp of
-            TupleShape _ elems -> do
+            TupleShape ty elems -> do
+              let sz = tySize col ty
               eltScTps <-
                 case asTupleType scTp of
                   Just eltScTps -> pure eltScTps
@@ -2144,7 +2145,7 @@ setupArg sc cc ecRef mty0 tp0 =
                       [ "TupleShape with non-tuple type:"
                       , Text.pack $ scTp'
                       ]
-              buildMirAggregate sym elems (zip [0..] eltScTps) $
+              buildMirAggregate sym sz elems (zip [0..] eltScTps) $
                 \_off _sz shp' (idx, eltScTp) -> do
                   t' <- scTupleSelector sc t idx
                   termToMirRegValue shp' eltScTp t'

--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -2149,7 +2149,7 @@ valueToSC sym fail_ tval (MIRVal shp val) =
       -- TypeShape might differ from the actual length of the RegValue, so we
       -- need to check both.
       | toInteger len == n
-      , length (Mir.mirAggregate_entries sym val) == fromIntegral len
+      , length (Mir.mirAggregate_entries sym val) >= fromIntegral len
       -> do terms <- accessMirAggregateArray sym elemSz elemShp len val $
               \_off val' -> valueToSC sym fail_ cryty (MIRVal elemShp val')
             t <- shapeToTerm sc elemShp

--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -72,7 +72,7 @@ import qualified Mir.DefId as Mir
 import qualified Mir.FancyMuxTree as Mir
 import qualified Mir.Generator as Mir
 import qualified Mir.Intrinsics as Mir
-import Mir.Intrinsics (MIR)
+import Mir.Intrinsics (MIR, wordLit)
 import qualified Mir.Mir as Mir
 import qualified Mir.TransTy as Mir
 import qualified What4.Expr as W4
@@ -1352,16 +1352,11 @@ matchArg opts sc cc cs prepost md = go False []
                         let elemSize = tySize col elemTy
                         -- get the reference to the containing aggregate and the
                         -- index of the current reference within it
-                        Ctx.Empty Ctx.:> Crucible.RV arrRef
-                                  Ctx.:> Crucible.RV i'_sym <-
-                          tryMirOperation $ Mir.mirRef_peelIndexMA bak iTypes elemRef elemSize
-                        -- the index should be concrete
-                        case fromInteger . BV.asUnsigned <$> W4.asBV i'_sym of
-                          Just i'
-                            -- make sure the expected and actual indices match
-                            | i == i' ->
-                              go inCast [] (MIRVal arrRefShp arrRef) z
-                          _ -> fail_
+                        let elemOff = fromIntegral i * elemSize
+                        originOff <- liftIO $ wordLit sym (negate elemOff)
+                        arrRef <- tryMirOperation $ do
+                          Mir.mirRef_agOffsetMA bak iTypes originOff elemRef
+                        go inCast [] (MIRVal arrRefShp arrRef) z
                     _ -> fail_
                 _ -> fail_
 
@@ -1429,10 +1424,11 @@ matchArg opts sc cc cs prepost md = go False []
                           TransparentShape _ _ ->
                             go inCast [] (MIRVal structRefShp fieldRef) z
                           StructShape _ elems -> do
-                            AgElemShape off sz _shp <-
+                            AgElemShape off _sz _shp <-
                               return $ agElemShapeAtIndex structTy elems iInt
                             structRef <- tryMirOperation $ do
-                              Mir.mirRef_peelAgElemMA bak iTypes off fieldRef
+                              originOff <- liftIO $ wordLit sym (negate off)
+                              Mir.mirRef_agOffsetMA bak iTypes originOff fieldRef
                             go inCast [] (MIRVal structRefShp structRef) z
                           _ -> fail_
                     _ -> fail_

--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -183,7 +183,7 @@ assignVar cc md var sref@(Some ref) =
   do old <- OM (setupValueSub . at var <<.= Just sref)
      let loc = MS.conditionLoc md
      F.for_ old $ \(Some ref') ->
-       do p <- liftIO (Mir.mirRef_eqIO bak (ref^.mpRef) (ref'^.mpRef))
+       do p <- liftIO (Mir.mirRef_eqMA bak (ref^.mpRef) (ref'^.mpRef))
           addAssert p md (Crucible.SimError loc (Crucible.AssertFailureSimError "equality of aliased references" ""))
 
 -- | When a specification is used as a composition override, this function
@@ -428,19 +428,18 @@ cmpPathConcretely _ (Mir.ArrayIndex_RefPath _ _ _) _ = PC.LTF
 cmpPathConcretely _ _ (Mir.ArrayIndex_RefPath _ _ _) = PC.GTF
 
 -- AgElem_RefPath
-cmpPathConcretely sym (Mir.AgElem_RefPath off1 sz1 tpr1 p1) (Mir.AgElem_RefPath off2 sz2 tpr2 p2) =
+cmpPathConcretely sym (Mir.AgElem_RefPath off1 tpr1 p1) (Mir.AgElem_RefPath off2 tpr2 p2) =
   PC.compareF off1 off2 <<>>
-  PC.fromOrdering (compare sz1 sz2) <<>>
   PC.compareF tpr1 tpr2 <<>>
   cmpPathConcretely sym p1 p2 <<>>
   PC.EQF
 
-cmpPathConcretely sym (Mir.AggregateAsChunks_RefPath off1 sz1 cnt1 p1) (Mir.AggregateAsChunks_RefPath off2 sz2 cnt2 p2) =
-  PC.fromOrdering (compare off1 off2 <> compare sz1 sz2 <> compare cnt1 cnt2) <<>>
+cmpPathConcretely sym (Mir.AgOffset_RefPath off1 p1) (Mir.AgOffset_RefPath off2 p2) =
+  PC.compareF off1 off2 <<>>
   cmpPathConcretely sym p1 p2 <<>>
   PC.EQF
-cmpPathConcretely _ (Mir.AggregateAsChunks_RefPath _ _ _ _) _ = PC.LTF
-cmpPathConcretely _ _ (Mir.AggregateAsChunks_RefPath _ _ _ _) = PC.GTF
+cmpPathConcretely _ (Mir.AgOffset_RefPath _ _) _ = PC.LTF
+cmpPathConcretely _ _ (Mir.AgOffset_RefPath _ _) = PC.GTF
 
 -- | Compare two 'W4.SymBV' values that are known to be concrete. If they are
 -- not concrete, this function will panic.
@@ -1114,8 +1113,9 @@ learnPointsTo opts sc cc spec prepost pointsTo@(MirPointsTo md reference target)
            [ "CrucibleMirCompPointsToTarget not implemented in SAW"
            ]
        MirPointsToSingleTarget referent -> do
+         let pointeeSize = tySize col referenceInnerMirTy
          v <- tryMirOperation
-           (Mir.readMirRefMA bak globals iTypes referenceInnerTpr referenceVal)
+           (Mir.readMirRefMA bak globals iTypes referenceInnerTpr (Mir.Width pointeeSize) referenceVal)
            Nothing
          matchArg opts sc cc spec prepost md (MIRVal innerShp v) referent
        MirPointsToMultiTarget referentArray -> do
@@ -1132,7 +1132,7 @@ learnPointsTo opts sc cc spec prepost pointsTo@(MirPointsTo md reference target)
                  tryMirOperation
                    (do
                      referenceVal' <- Mir.mirRef_offsetMA bak iTypes referenceVal i_sym elemSz
-                     Mir.readMirRefMA bak globals iTypes referenceInnerTpr referenceVal')
+                     Mir.readMirRefMA bak globals iTypes referenceInnerTpr (Mir.Width elemSz) referenceVal')
                    (Just ("When trying to read element at offset"
                           <+> PP.pretty i <+> "from pointer:"))
              let arrShp = ArrayShape referentArrayMirTy
@@ -1432,7 +1432,7 @@ matchArg opts sc cc cs prepost md = go False []
                             AgElemShape off sz _shp <-
                               return $ agElemShapeAtIndex structTy elems iInt
                             structRef <- tryMirOperation $ do
-                              Mir.mirRef_peelAgElemMA bak iTypes off sz fieldRef
+                              Mir.mirRef_peelAgElemMA bak iTypes off fieldRef
                             go inCast [] (MIRVal structRefShp structRef) z
                           _ -> fail_
                     _ -> fail_
@@ -1621,7 +1621,7 @@ matchArg opts sc cc cs prepost md = go False []
             Nothing -> fail_
             Just Refl -> do
               pred_ <- liftIO $
-                Mir.mirRef_eqIO bak x y
+                Mir.mirRef_eqMA bak x y
               addAssert pred_ md =<< notEq
         (_, MIRVal actualShp _, MS.SetupGlobalInitializer () name) -> do
           ppopts <- omGetPPOpts

--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -183,7 +183,15 @@ assignVar cc md var sref@(Some ref) =
   do old <- OM (setupValueSub . at var <<.= Just sref)
      let loc = MS.conditionLoc md
      F.for_ old $ \(Some ref') ->
-       do p <- liftIO (Mir.mirRef_eqMA bak (ref^.mpRef) (ref'^.mpRef))
+       do let eq = Mir.mirRef_eqMA bak (ref^.mpRef) (ref'^.mpRef)
+          let maEnv = MatchAssertEnv
+                { maeConditionMetadata = md
+                , maeFailureReason = \_ -> pure BadEqualityComparison
+                }
+          -- We run `mirRef_eqMA` in `MatchAssertM` here because we'd like its
+          -- failure to propagate neatly during override matching, and running
+          -- it in `IO` instead will cause it to fail messily.
+          p <- runMatchAssert eq maEnv
           addAssert p md (Crucible.SimError loc (Crucible.AssertFailureSimError "equality of aliased references" ""))
 
 -- | When a specification is used as a composition override, this function

--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -156,6 +156,18 @@ instance IsSymBackend Sym bak => Mir.MonadAssert Sym bak (MatchAssertM w) where
 runMatchAssert :: MatchAssertM w a -> MatchAssertEnv w -> OverrideMatcher MIR w a
 runMatchAssert (MatchAssertM m) = runReaderT m
 
+runMatchAssertSimple ::
+  MS.ConditionMetadata ->
+  (Crucible.SimErrorReason -> OverrideMatcher MIR w (OverrideFailureReason MIR)) ->
+  MatchAssertM w a ->
+  OverrideMatcher MIR w a
+runMatchAssertSimple md reason f =
+  runMatchAssert f $
+    MatchAssertEnv
+      { maeConditionMetadata = md
+      , maeFailureReason = reason
+      }
+
 assertTermEqualities ::
   SharedContext ->
   MIRCrucibleContext ->
@@ -183,15 +195,8 @@ assignVar cc md var sref@(Some ref) =
   do old <- OM (setupValueSub . at var <<.= Just sref)
      let loc = MS.conditionLoc md
      F.for_ old $ \(Some ref') ->
-       do let eq = Mir.mirRef_eqMA bak (ref^.mpRef) (ref'^.mpRef)
-          let maEnv = MatchAssertEnv
-                { maeConditionMetadata = md
-                , maeFailureReason = \_ -> pure BadEqualityComparison
-                }
-          -- We run `mirRef_eqMA` in `MatchAssertM` here because we'd like its
-          -- failure to propagate neatly during override matching, and running
-          -- it in `IO` instead will cause it to fail messily.
-          p <- runMatchAssert eq maEnv
+       do p <- runMatchAssertSimple md (\_ -> pure BadEqualityComparison) $
+            Mir.mirRef_eqMA bak (ref^.mpRef) (ref'^.mpRef)
           addAssert p md (Crucible.SimError loc (Crucible.AssertFailureSimError "equality of aliased references" ""))
 
 -- | When a specification is used as a composition override, this function
@@ -620,9 +625,10 @@ enforceDisjointness cc loc ss =
               }
      -- Ensure that all regions are disjoint from each other.
      sequence_
-        [ do c <- liftIO $
-                    W4.notPred sym =<< Mir.mirRef_overlapsIO bak (p^.mpRef) (q^.mpRef)
-             addAssert c md a
+        [ do overlap <- runMatchAssertSimple md (\_ -> pure BadEqualityComparison) $
+                    Mir.mirRef_overlapsMA bak (p^.mpRef) (q^.mpRef)
+             notOverlap <- liftIO $ W4.notPred sym overlap
+             addAssert notOverlap md a
 
         | let a = Crucible.SimError loc $
                     Crucible.AssertFailureSimError "Memory regions not disjoint" ""
@@ -644,13 +650,13 @@ enforcePointerValidity cc ss =
   let mems = Map.intersectionWith (,) (view MS.csAllocs ss) sub
   F.for_ mems $ \(Some alloc, Some ptr) -> do
     -- For now, pointer is valid iff its constructor is MirReference
-    c <- liftIO $
+    let md = alloc^.maConditionMetadata
+    c <- runMatchAssertSimple md (\_ -> pure BadPointerCast) $
       Mir.readRefMuxMA bak (cc^.mccIntrinsicTypes) Crucible.BoolRepr
         (\case
           Mir.MirReference{} -> pure $ W4.truePred sym
           Mir.MirReference_Integer{} -> pure $ W4.falsePred sym)
         (ptr^.mpRef)
-    let md = alloc^.maConditionMetadata
     addAssert c md $
       Crucible.SimError (MS.conditionLoc md) $
         Crucible.AssertFailureSimError "Pointer not valid" ""
@@ -1562,7 +1568,7 @@ matchArg opts sc cc cs prepost md = go False []
              -- See Note [Matching slices in overrides] for why we do this.
              let arrElemSize = tySize col actualElemTy
              Ctx.Empty Ctx.:> Crucible.RV actualArrRef Ctx.:> Crucible.RV actualStartSym <-
-               liftIO $ Mir.mirRef_peelIndexMA bak iTypes actualSliceRef arrElemSize
+               tryMirOperation $ Mir.mirRef_peelIndexMA bak iTypes actualSliceRef arrElemSize
 
              let -- Match the expected array reference value against the actual
                  -- array reference value.
@@ -1624,7 +1630,7 @@ matchArg opts sc cc cs prepost md = go False []
           case W4.testEquality xTpr (Crucible.globalType yGlobalVar) of
             Nothing -> fail_
             Just Refl -> do
-              pred_ <- liftIO $
+              pred_ <- tryMirOperation $
                 Mir.mirRef_eqMA bak x y
               addAssert pred_ md =<< notEq
         (_, MIRVal actualShp _, MS.SetupGlobalInitializer () name) -> do

--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -2168,11 +2168,11 @@ valueToSC sym fail_ tval (MIRVal shp val) =
               \_off _sz shp' val' tval' -> valueToSC sym fail_ tval' (MIRVal shp' val')
             liftIO (scTupleReduced sc terms)
     (Cryptol.TVSeq n cryty, ArrayShape _ _ elemSz elemShp len)
-      -- When matching against the backing array of a slice, the length in the
-      -- TypeShape might differ from the actual length of the RegValue, so we
-      -- need to check both.
+      -- The lengths of the cryptol type, the MIR type/shape, and the aggregate
+      -- value should all match up.
       | toInteger len == n
-      , length (Mir.mirAggregate_entries sym val) >= fromIntegral len
+      , entriesPerElem <- length (expandAgElem $ AgElemShape 0 elemSz elemShp)
+      , length (Mir.mirAggregate_entries sym val) == fromIntegral len * entriesPerElem
       -> do terms <- accessMirAggregateArray sym elemSz elemShp len val $
               \_off val' -> valueToSC sym fail_ cryty (MIRVal elemShp val')
             t <- shapeToTerm sc elemShp

--- a/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/Override.hs
@@ -123,6 +123,15 @@ type SetupCondition = MS.SetupCondition MIR
 -- various functions in this module as arguments. So instead we put a 'ReaderT'
 -- on top, which can then be supplied with the right inputs at the call site of
 -- the "Mir.Intrinsics" operation.
+--
+-- Many operations on 'MirReferenceMux' (a.k.a. @RegValue sym MirReferenceRepr@)
+-- can fail if the input is an empty 'FancyMuxTree' (or, for operations with
+-- two inputs, if there is no condition under which both 'FancyMuxTree's have
+-- values).  This specifically applies to operations that return types other
+-- than 'MirReferenceMux', since these operations typically don't have good
+-- default values to return when the input 'FancyMuxTree' is empty.  Operations
+-- that take and return 'MirReferenceMux' can instead return an empty output
+-- when the input is empty.
 newtype MatchAssertM w a =
   MatchAssertM (ReaderT (MatchAssertEnv w) (OverrideMatcher' Sym MIR w IO) a)
   deriving (Functor, Applicative, Monad, MonadIO)

--- a/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
@@ -249,12 +249,13 @@ prettyMIRVal sym (MIRVal shp val) =
 buildMirAggregateWithVal ::
   (HasCallStack, Monad m, MonadFail m) =>
   Sym ->
+  Word ->
   [AgElemShape] ->
   [MIRVal] ->
   (forall tp. Word -> Word -> TypeShape tp -> RegValue Sym tp -> m (RegValue Sym tp)) ->
   m (Mir.MirAggregate Sym)
-buildMirAggregateWithVal sym elems vals f =
-  buildMirAggregate sym elems vals $
+buildMirAggregateWithVal sym totalSize elems vals f =
+  buildMirAggregate sym totalSize elems vals $
     \off sz shp (MIRVal shp' rv) ->
       case W4.testEquality shp shp' of
         Just Refl -> f off sz shp rv
@@ -662,12 +663,13 @@ resolveSetupVal mcc env tyenv nameEnv val =
 
           -- Finally, construct a MIRVal of the appropriate shape.
           let mirTy = mirAdtToTy adt
+          let structSz = tySize col mirTy
           Some (structShp :: TypeShape tp) <- pure $ tyToShape col mirTy
           (elems :: [AgElemShape], Refl :: tp :~: Mir.MirAggregateType) <- case structShp of
             StructShape _ elems -> return (elems, Refl)
             _ -> panic "resolveSetupVal"
               ["TyAdt Struct produced non-StructShape", Text.pack $ show structShp]
-          ag <- buildMirAggregateWithVal sym elems flds' $ \_off _sz _shp rv -> return rv
+          ag <- buildMirAggregateWithVal sym structSz elems flds' $ \_off _sz _shp rv -> return rv
           pure $ MIRVal structShp ag
         Mir.Adt nm (Mir.Enum _) _ _ _ _ _ ->
           panic "resolveSetupVal" [
@@ -832,12 +834,13 @@ resolveSetupVal mcc env tyenv nameEnv val =
       flds' <- traverse (resolveSetupVal mcc env tyenv nameEnv) flds
       let fldMirTys = map (\(MIRVal shp _) -> shapeMirTy shp) flds'
       let mirTy = Mir.TyTuple fldMirTys
+      let tupleSz = tySize col mirTy
       Some (tupleShp :: TypeShape tp) <- pure $ tyToShape col mirTy
       (elems :: [AgElemShape], Refl :: tp :~: Mir.MirAggregateType) <- case tupleShp of
         TupleShape _ elems -> return (elems, Refl)
         _ -> panic "resolveSetupVal"
           ["TyTuple produced non-TupleShape", Text.pack $ show tupleShp]
-      ag <- buildMirAggregateWithVal sym elems flds' $ \_off _sz _shp rv -> return rv
+      ag <- buildMirAggregateWithVal sym tupleSz elems flds' $ \_off _sz _shp rv -> return rv
       pure $ MIRVal tupleShp ag
     MS.SetupSlice slice ->
       case slice of
@@ -1268,12 +1271,13 @@ resolveSAWTerm mcc tp tm =
       vals <- zipWithM (resolveSAWTerm mcc) tps tms
       let mirTys = map (\(MIRVal shp _) -> shapeMirTy shp) vals
       let mirTupleTy = Mir.TyTuple mirTys
+      let tupleSz = tySize col mirTupleTy
       Some (tupleShp :: TypeShape tp) <- pure $ tyToShape col mirTupleTy
       (elems :: [AgElemShape], Refl :: tp :~: Mir.MirAggregateType) <- case tupleShp of
         TupleShape _ elems -> return (elems, Refl)
         _ -> panic "resolveSAWTerm"
           ["TyTuple produced non-TupleShape", Text.pack $ show tupleShp]
-      ag <- buildMirAggregateWithVal sym elems vals $ \_off _sz _shp rv -> return rv
+      ag <- buildMirAggregateWithVal sym tupleSz elems vals $ \_off _sz _shp rv -> return rv
       pure $ MIRVal tupleShp ag
     Cryptol.TVRec _flds ->
       fail "resolveSAWTerm: unsupported record type"

--- a/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
@@ -65,8 +65,6 @@ import qualified Data.Foldable as F
 import qualified Data.Foldable.WithIndex as FWI
 import qualified Data.Functor.Product as Functor
 import           Data.Kind (Type)
-import           Data.IntMap (IntMap)
-import qualified Data.IntMap as IntMap
 import qualified Data.List.Extra as List (firstJust, unsnoc)
 import           Data.List.NonEmpty (NonEmpty(..))
 import           Data.Map (Map)
@@ -210,8 +208,8 @@ prettyMIRVal sym (MIRVal shp val) =
       [AgElemShape] ->
       Mir.MirAggregate Sym ->
       PP.Doc ann
-    prettyAggregate elems (Mir.MirAggregate _sz m) =
-      PP.braces $ commaList (map (prettyAgElem m) elems)
+    prettyAggregate elems ag =
+      PP.braces $ commaList (map (prettyAgElem ag) elems)
 
     prettyAggregateArray ::
       Word ->
@@ -219,12 +217,12 @@ prettyMIRVal sym (MIRVal shp val) =
       Word ->
       Mir.MirAggregate Sym ->
       PP.Doc ann
-    prettyAggregateArray elemSz elemShp len (Mir.MirAggregate _sz m) =
+    prettyAggregateArray elemSz elemShp len ag =
       let elems = arrayAgElemShapes elemSz elemShp len in
-      PP.brackets $ commaList (map (prettyAgElem m) elems)
+      PP.brackets $ commaList (map (prettyAgElem ag) elems)
 
     prettyAgElem ::
-      IntMap (Mir.MirAggregateEntry Sym) ->
+      Mir.MirAggregate Sym ->
       AgElemShape ->
       PP.Doc ann
     prettyAgElem m e@(AgElemShape off _sz _shp') =
@@ -232,17 +230,16 @@ prettyMIRVal sym (MIRVal shp val) =
       PP.viaShow off PP.<+> "->" PP.<+> valDoc
 
     prettyAgElemValue ::
-      IntMap (Mir.MirAggregateEntry Sym) ->
+      Mir.MirAggregate Sym ->
       AgElemShape ->
       PP.Doc ann
-    prettyAgElemValue m (AgElemShape off _sz shp') =
-      case IntMap.lookup (fromIntegral off) m of
-        Just (Mir.MirAggregateEntry _sz tpr rv)
-          | Just Refl <- W4.testEquality tpr (shapeType shp') ->
+    prettyAgElemValue ag (AgElemShape off sz shp') = do
+      let tpr = shapeType shp'
+      case Mir.mirAggregate_lookup sym (fromIntegral off) sz tpr ag of
+        Right rv ->
               prettyMIRVal sym $ MIRVal shp' $
               readMaybeType sym "elem" tpr rv
-          | otherwise -> "<type mismatch>"
-        Nothing -> "<unset>"
+        Left _err -> "<err>"
 
 
 -- | Wrapper around `buildMirAggregate` for the case where the additional
@@ -1373,11 +1370,11 @@ indexMirArray ::
   TypeShape elemTp {- ^ 'TypeShape' of the array elements -} ->
   Mir.MirAggregate Sym {- ^ 'RegValue' of the 'MIRVal' -} ->
   Maybe MIRVal
-indexMirArray sym i elemSz elemShp (Mir.MirAggregate _totalSize m) = do
+indexMirArray sym i elemSz elemShp ag = do
   let off = fromIntegral i * elemSz
-  Mir.MirAggregateEntry sz' tpr' rvPart <- IntMap.lookup (fromIntegral off) m
-  Refl <- W4.testEquality (shapeType elemShp) tpr'
-  guard (elemSz == sz')
+  rvPart <- case Mir.mirAggregate_lookup sym off elemSz (shapeType elemShp) ag of
+    Left _err -> Nothing
+    Right rvP -> Just rvP
   rv <- readPartExprMaybe sym rvPart
   return $ MIRVal elemShp rv
 
@@ -1402,23 +1399,13 @@ accessMirStructFieldVal sym col fieldName (MIRVal structShp structRV) = do
   case structShp of
     StructShape structTy elems -> do
       (_, iInt) <- findStructField ppopts col (MirFieldAccessByVal, structTy) structTy fieldName
-      AgElemShape off _sz shp <- return $ agElemShapeAtIndex structTy elems iInt
-      let Mir.MirAggregate _ m = structRV
+      AgElemShape off sz shp <- return $ agElemShapeAtIndex structTy elems iInt
       pure $
-        case IntMap.lookup (fromIntegral off) m of
-          Nothing -> Nothing
-          Just (Mir.MirAggregateEntry _ tpr fieldRV)
-            | Just Refl <- W4.testEquality tpr (shapeType shp) ->
-              MIRVal shp <$> readPartExprMaybe sym fieldRV
-            | otherwise -> panic "accessMirStructFieldVal"
-              [ "Ill-typed aggregate entry"
-              , "Found: " <> Text.pack (show tpr)
-              , "Expected: " <> Text.pack (show shp)
-              , "Struct: " <> Text.pack (show structTy)
-              , "Field name: " <> Text.pack (show fieldName)
-              , "Index: " <> Text.pack (show iInt)
-              , "Field shapes: " <> Text.pack (show elems)
-              ]
+        case Mir.mirAggregate_lookup sym off sz (shapeType shp) structRV of
+          Left _err ->
+            Nothing
+          Right fieldRV ->
+            MIRVal shp <$> readPartExprMaybe sym fieldRV
     TransparentShape structTy innerShp -> do
       -- We still need to call findStructField, to check that the field exists
       -- and is the primary field
@@ -1735,26 +1722,15 @@ doPointsTo mspec cc env globals (MirPointsTo _ reference target) =
         case referentArrShp of
           -- mir_points_to_multi should check that the RHS type is TyArray, so
           -- this case should always match.
-          ArrayShape _ _ elemSize referentElemShp _ -> do
+          ArrayShape _ _ _ referentElemShp _ -> do
             Refl <- testReferentShp referentElemShp
-            let write globals' i referentVal = do
-                  i_sym <- usizeBvLit sym i
-                  referenceVal' <- Mir.mirRef_offsetMA bak iTypes referenceVal i_sym elemSize
-                  Mir.writeMirRefIO bak globals' iTypes referenceInnerTy
-                    referenceVal' (Mir.Width elemSize) referentVal
-            let writeEntry globals' (off, Mir.MirAggregateEntry _sz tpr rvPart) = do
-                  Refl <- case W4.testEquality tpr (shapeType referentElemShp) of
-                    Just r -> pure r
-                    Nothing ->
-                      panic "doPointsTo" [
-                          "Unexpected type mismatch between referent outer and entry types",
-                          "Outer type: " <> Text.pack (show (shapeType referentElemShp)),
-                          "Entry type: " <> Text.pack (show tpr),
-                          "At offset " <> Text.pack (show off)
-                      ]
+            let writeEntry globals' (off, Mir.MirAggregateEntry sz tpr rvPart) = do
                   let rv = readMaybeType sym "array element" tpr rvPart
-                  let off' = off `div` elemSize
-                  write globals' (fromIntegral off') rv
+                  let off' = off `div` sz
+                  i_sym <- usizeBvLit sym (fromIntegral off')
+                  referenceVal' <- Mir.mirRef_offsetMA bak iTypes referenceVal i_sym sz
+                  Mir.writeMirRefIO bak globals' iTypes tpr
+                    referenceVal' (Mir.Width sz) rv
             foldM writeEntry globals (Mir.mirAggregate_entries sym referentArrVal)
           _ -> panic "doPointsTo"
             [ "Unexpected non-array shape resolved from MirPointsToMultiTarget:"

--- a/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/ResolveSetupValue.hs
@@ -916,7 +916,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
                 let elemSize = tySize col elemTy
                 elemOff <- W4.bvMul sym i_sym =<< usizeBvLit sym (fromIntegral elemSize)
                 MIRVal (RefShape elemPtrTy elemTy mutbl elemTpr) <$>
-                  Mir.mirRef_agElemIO bak iTypes elemOff elemSize elemTpr xsVal
+                  Mir.mirRef_agOffsetMA bak iTypes elemOff xsVal
               else do
                 let sc = sawCoreSharedContext sym
                 ppopts <- liftIO $ scGetPPOpts sc
@@ -957,10 +957,10 @@ resolveSetupVal mcc env tyenv nameEnv val =
                       fieldPtrTy = ptrKindToTy (tyToPtrKind structPtrTy) fieldValTy mutbl
               case tyToShapeEq col structValTy structRepr of
                 StructShape _ elems -> do
-                  AgElemShape off sz shp <- return $ agElemShapeAtIndex structValTy elems iInt
+                  AgElemShape off _sz shp <- return $ agElemShapeAtIndex structValTy elems iInt
                   offRV <- usizeBvLit sym (fromIntegral off)
                   fieldMIRVal (shapeType shp) <$>
-                    Mir.mirRef_agElemIO bak iTypes offRV sz (shapeType shp) structPtrRV
+                    Mir.mirRef_agOffsetMA bak iTypes offRV structPtrRV
                 TransparentShape _ _ ->
                   -- structRepr is the field's TypeRepr
                   pure $ fieldMIRVal structRepr structPtrRV
@@ -1128,8 +1128,7 @@ resolveSetupVal mcc env tyenv nameEnv val =
             Left err -> panic "resolveSetupSliceFromArrayRef" ["Unsupported type", Text.pack err]
             Right x -> return x
           zeroBV <- usizeBvLit sym 0
-          let elemSize = tySize col elemTy
-          refVal <- Mir.mirRef_agElemIO bak iTypes zeroBV elemSize elemTpr arrRefVal
+          refVal <- Mir.mirRef_agOffsetMA bak iTypes zeroBV arrRefVal
           let sliceShp = SliceShape (Mir.TyRef sliceTy mut) elemTy mut elemTpr
           pure $ SetupSliceFromArrayRef sliceShp refVal len
         _ -> do
@@ -1477,7 +1476,7 @@ equalValsPred cc mv1 mv2 =
       goTy shp v1 v2
     goTy (RefShape _ _ _ _) ref1 ref2 =
       mccWithBackend cc $ \bak ->
-        liftIO $ Mir.mirRef_eqIO bak ref1 ref2
+        liftIO $ Mir.mirRef_eqMA bak ref1 ref2
     goTy (SliceShape _ ty mut tpr)
          (Ctx.Empty Ctx.:> RV ref1 Ctx.:> RV len1)
          (Ctx.Empty Ctx.:> RV ref2 Ctx.:> RV len2) = do
@@ -1652,10 +1651,10 @@ doAlloc cc globals (Some ma) =
      elemSize_sym <- usizeBvLit sym $ fromIntegral elemSize
      allocSize_sym <- W4.bvMul sym len_sym elemSize_sym
      ag <- Mir.mirAggregate_uninitIO bak allocSize_sym
-     globals' <- Mir.writeMirRefIO bak globals iTypes Mir.MirAggregateRepr ref ag
+     globals' <- Mir.writeMirRefIO bak globals iTypes Mir.MirAggregateRepr ref Mir.All ag
 
      zero <- W4.bvLit sym W4.knownRepr $ BV.mkBV W4.knownRepr 0
-     ptr <- Mir.mirRef_agElemIO bak iTypes zero elemSize tpr ref
+     ptr <- Mir.mirRef_agOffsetMA bak iTypes zero ref
      let mirPtr = Some MirPointer
            { _mpType = tpr
            , _mpKind = ma^.maPtrKind
@@ -1695,7 +1694,7 @@ doPointsTo mspec cc env globals (MirPointsTo _ reference target) =
     -- By the time we reach here, we have already checked (in mir_points_to)
     -- that we are in fact dealing with a reference value, so the call to
     -- `testRefShape` below should always succeed.
-    IsRefShape _ _ _ (referenceInnerTy :: TypeRepr referenceInnerTp) <-
+    IsRefShape _ referenceInnerMirTy _ (referenceInnerTy :: TypeRepr referenceInnerTp) <-
       case testRefShape referenceShp of
         Just irs -> pure irs
         Nothing ->
@@ -1727,8 +1726,9 @@ doPointsTo mspec cc env globals (MirPointsTo _ reference target) =
         MIRVal referentShp referentVal <-
           resolveSetupVal cc env tyenv nameEnv referent
         Refl <- testReferentShp referentShp
+        let pointeeSize = tySize col referenceInnerMirTy
         Mir.writeMirRefIO bak globals iTypes referenceInnerTy
-          referenceVal referentVal
+          referenceVal (Mir.Width pointeeSize) referentVal
       MirPointsToMultiTarget referentArray -> do
         MIRVal referentArrShp referentArrVal <-
           resolveSetupVal cc env tyenv nameEnv referentArray
@@ -1741,7 +1741,7 @@ doPointsTo mspec cc env globals (MirPointsTo _ reference target) =
                   i_sym <- usizeBvLit sym i
                   referenceVal' <- Mir.mirRef_offsetMA bak iTypes referenceVal i_sym elemSize
                   Mir.writeMirRefIO bak globals' iTypes referenceInnerTy
-                    referenceVal' referentVal
+                    referenceVal' (Mir.Width elemSize) referentVal
             let writeEntry globals' (off, Mir.MirAggregateEntry _sz tpr rvPart) = do
                   Refl <- case W4.testEquality tpr (shapeType referentElemShp) of
                     Just r -> pure r
@@ -1764,6 +1764,7 @@ doPointsTo mspec cc env globals (MirPointsTo _ reference target) =
     iTypes = cc ^. mccIntrinsicTypes
     tyenv = MS.csAllocations mspec
     nameEnv = mspec ^. MS.csPreState . MS.csVarTypeNames
+    col = cc ^. mccRustModule ^. Mir.rmCS ^. Mir.collection
 
 -- | Construct an 'Mir.TyAdt' from an 'Mir.Adt'.
 mirAdtToTy :: Mir.Adt -> Mir.Ty

--- a/saw-central/src/SAWCentral/Crucible/MIR/TypeShape.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/TypeShape.hs
@@ -567,13 +567,13 @@ buildMirAggregate ::
   forall a m sym.
   (HasCallStack, IsSymInterface sym, Monad m, MonadFail m) =>
   sym ->
+  Word ->
   [AgElemShape] ->
   [a] ->
   (forall tp. Word -> Word -> TypeShape tp -> a -> m (RegValue sym tp)) ->
   m (MirAggregate sym)
-buildMirAggregate sym elems xs f = do
+buildMirAggregate sym totalSize elems xs f = do
   agCheckLengthsEq "buildMirAggregate" elems xs
-  let totalSize = maximum (0 : [off + sz | AgElemShape off sz _ <- elems])
   let emptyAg = MirAggregate totalSize mempty
   foldM insert emptyAg (zip elems xs)
   where
@@ -752,7 +752,7 @@ buildMirAggregateArray ::
 buildMirAggregateArray sym elemSz elemShp len xs f = do
   agArrayCheckLengthsEq "buildMirAggregateArray" len xs
   let elems = arrayAgElemShapes elemSz elemShp len
-  buildMirAggregate sym elems xs $
+  buildMirAggregate sym (elemSz * len) elems xs $
     \off _sz shp x -> do
       Refl <- case testEquality (shapeType shp) (shapeType elemShp) of
         Just pf -> return pf

--- a/saw-central/src/SAWCentral/Crucible/MIR/TypeShape.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/TypeShape.hs
@@ -57,14 +57,11 @@ module SAWCentral.Crucible.MIR.TypeShape
   ) where
 
 import Control.Lens ((^.), (^..), each)
-import Control.Monad (when, forM, zipWithM)
+import Control.Monad (when, forM, zipWithM, foldM)
 import Control.Monad.IO.Class (MonadIO(..))
-import Data.IntMap (IntMap)
-import qualified Data.IntMap as IntMap
-import qualified Data.IntSet as IntSet
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Maybe (isJust, catMaybes)
+import Data.Maybe (isJust)
 import qualified Data.Text as Text
 import Data.Parameterized.Classes (ShowF)
 import Data.Parameterized.Context (pattern Empty, pattern (:>), Assignment)
@@ -560,22 +557,6 @@ agCheckLengthsEqF fail_ loc elems xs =
   when (length elems /= length xs) $
     fail_ $ loc ++ ": got " ++ show (length elems) ++ " elems, but " ++ show (length xs) ++ " xs"
 
-agCheckKeysEq :: MonadFail m => String -> [AgElemShape] -> IntMap (MirAggregateEntry sym) -> m ()
-agCheckKeysEq loc elems m =
-  agCheckKeysEqF fail loc elems m
-
-agCheckKeysEqF :: Monad m =>
-  (forall a. String -> m a) -> String -> [AgElemShape] -> IntMap (MirAggregateEntry sym) -> m ()
-agCheckKeysEqF fail_ loc elems m = do
-  let mKeys = IntMap.keysSet m
-  let elemsKeys = IntSet.fromList [fromIntegral off | AgElemShape off sz _ <- elems, sz /= 0]
-  when (mKeys /= elemsKeys) $
-    if mKeys `IntSet.isSubsetOf` elemsKeys
-      then fail_ $ loc ++ ": missing or uninitialized fields at offsets "
-        ++ show (elemsKeys IntSet.\\ mKeys)
-      else fail_ $ loc ++ ": expected aggregate to have fields at offsets "
-        ++ show elemsKeys ++ ", but got fields at offsets " ++ show mKeys
-
 -- | Build a `MirAggregate` with one entry for each provided `AgElemShape`.
 -- The callback receives the offset, size, and type of the entry, along with
 -- the corresponding value from @xs@ (which must have as many items as there
@@ -583,6 +564,7 @@ agCheckKeysEqF fail_ loc elems m = do
 -- the entry. For zero-sized entries, the callback will not get called and the
 -- resulting `MirAggregate` will not contain that entry.
 buildMirAggregate ::
+  forall a m sym.
   (HasCallStack, IsSymInterface sym, Monad m, MonadFail m) =>
   sym ->
   [AgElemShape] ->
@@ -592,15 +574,21 @@ buildMirAggregate ::
 buildMirAggregate sym elems xs f = do
   agCheckLengthsEq "buildMirAggregate" elems xs
   let totalSize = maximum (0 : [off + sz | AgElemShape off sz _ <- elems])
-  maybeEntries <- forM (zip elems xs) $ \(AgElemShape off sz shp, x) ->
-    case sz of
-      -- Omit zero-sized elements
-      0 -> return Nothing
-      _ -> do
-        rv <- f off sz shp x
-        let rvPart = W4.justPartExpr sym rv
-        return $ Just (fromIntegral off, MirAggregateEntry sz (shapeType shp) rvPart)
-  return $ MirAggregate totalSize (IntMap.fromList (catMaybes maybeEntries))
+  let emptyAg = MirAggregate totalSize mempty
+  foldM insert emptyAg (zip elems xs)
+  where
+    insert :: MirAggregate sym -> (AgElemShape, a) -> m (MirAggregate sym)
+    insert ag (AgElemShape off sz shp, x)
+      | sz == 0 =
+          pure ag
+      | otherwise = do
+          rv <- f off sz shp x
+          let rvPart = W4.justPartExpr sym rv
+          let entry = MirAggregateEntry sz (shapeType shp) rvPart
+          case mirAggregate_insert off entry ag of
+            Left err -> fail err
+            Right ag' -> pure ag'
+
 
 -- | Modify the value of each entry in a `MirAggregate`.  The callback gets the
 -- offset, size, type, and value of the entry, and its result is stored as the
@@ -613,53 +601,23 @@ traverseMirAggregate ::
   MirAggregate sym ->
   (forall tp. Word -> Word -> TypeShape tp -> RegValue sym tp -> m (RegValue sym tp)) ->
   m (MirAggregate sym)
-traverseMirAggregate sym elems (MirAggregate totalSize m) f = do
-  agCheckKeysEq "traverseMirAggregate" elems m
-  m' <-
-    -- Hack: we include a special case for when the list of AgElemShapes and
-    -- the MirAggregate are both empty, skipping the call to mergeEntries
-    -- entirely if this is the case. This is because mergeEntries calls
-    -- IntMap.mergeWithKey under the hood, and prior to containers-0.8, the
-    -- implementation of IntMap.mergeWithKey had a bug where merging two empty
-    -- IntMaps would invoke the third callback argument instead of just
-    -- returning an empty map. (See
-    -- https://github.com/haskell/containers/issues/979.) Note that
-    -- mergeEntries uses the third callback argument to panic, however, and we
-    -- definitely don't want to panic if the IntMaps are both empty!
-    --
-    -- Because SAW still supports GHC versions that bundle versions of
-    -- containers that are older than 0.8 (and therefore do not contain a fix
-    -- for the issue above), we include this special case as a workaround. Once
-    -- SAW drops support for pre-0.8 versions of containers, we can remove this
-    -- special case.
-    if null elems && IntMap.null m
-      then pure IntMap.empty
-      else mergeEntries
-  return $ MirAggregate totalSize m'
- where
-  -- Merge the existing MirAggregate's entries together with the new entries
-  -- from the list of AgElemShapes.
-  --
-  -- Precondition: both the list of AgElemShapes and the MirAggregate are
-  -- non-empty (see the comments above near mergeEntries' call site).
-  mergeEntries :: m (IntMap (MirAggregateEntry sym))
-  mergeEntries = sequence $ IntMap.mergeWithKey
-    (\_off' (AgElemShape off _sz' shp) (MirAggregateEntry sz tpr rvPart) -> Just $ do
-        Refl <- case testEquality tpr (shapeType shp) of
-            Just pf -> return pf
-            Nothing -> fail $ "traverseMirAggregate: ill-typed field value at offset "
-              ++ show off ++ ": expected " ++ show (shapeType shp) ++ ", but got " ++ show tpr
-        let rv = readMaybeType sym "elem" tpr rvPart
-        rv' <- f off sz shp rv
-        let rvPart' = W4.justPartExpr sym rv'
-        return $ MirAggregateEntry sz tpr rvPart')
-    (\m' ->
-      if all (\(AgElemShape _ sz' _) -> sz' == 0) (IntMap.elems m')
-        then mempty
-        else panic "traverseMirAggregate" ["mismatched keys in aggregate"])
-    (\_ -> panic "traverseMirAggregate" ["mismatched keys in aggregate"])
-    (IntMap.fromList [(fromIntegral off, e) | e@(AgElemShape off _ _) <- elems])
-    m
+traverseMirAggregate sym elems aggregate f = foldM modify aggregate elems
+  where
+    modify :: MirAggregate sym -> AgElemShape -> m (MirAggregate sym)
+    modify ag (AgElemShape off sz elemShp)
+      | sz == 0 =
+          pure ag
+      | otherwise = do
+          let elemTpr = shapeType elemShp
+          rvPart <- case mirAggregate_lookup sym off sz elemTpr ag of
+            Left err -> fail err
+            Right partial -> pure partial
+          let rv = readMaybeType sym "elem" elemTpr rvPart
+          rv' <- f off sz elemShp rv
+          let rvPart' = W4.justPartExpr sym rv'
+          case mirAggregate_insert off (MirAggregateEntry sz elemTpr rvPart') ag of
+            Left err -> fail err
+            Right ag' -> pure ag'
 
 -- | Extract values from a `MirAggregate`, one for each entry.  The callback
 -- gets the offset, size, type, and value of the entry.  Callback results are
@@ -701,30 +659,23 @@ accessMirAggregateF' ::
   MirAggregate sym ->
   (forall tp. Word -> Word -> TypeShape tp -> RegValue sym tp -> a -> m b) ->
   m [b]
-accessMirAggregateF' sym fail_ elems xs (MirAggregate _totalSize m) f = do
+accessMirAggregateF' sym fail_ elems xs ag f = do
   agCheckLengthsEqF fail_ "accessMirAggregate'" elems xs
-  agCheckKeysEqF fail_ "accessMirAggregate'" elems m
   forM (zip elems xs) $ \(AgElemShape off sz shp, x) -> do
-    case IntMap.lookup (fromIntegral off) m of
+    let tpr = shapeType shp
+    case mirAggregate_lookup sym off sz tpr ag of
       _ | sz == 0 -> do
-        Refl <- case testEquality MirAggregateRepr (shapeType shp) of
+        Refl <- case testEquality MirAggregateRepr tpr of
           Just pf -> return pf
           Nothing -> fail_ $ "accessMirAggregate: ill-typed zero-sized field shape at offset "
-            ++ show off ++ ": expected MirAggregateRepr, but got " ++ show (shapeType shp)
+            ++ show off ++ ": expected MirAggregateRepr, but got " ++ show tpr
         rv <- liftIO mirAggregate_zstIO
         f off sz shp rv x
-      Just (MirAggregateEntry _sz' tpr rvPart) -> do
-        Refl <- case testEquality tpr (shapeType shp) of
-          Just pf -> return pf
-          Nothing -> fail_ $ "accessMirAggregate: ill-typed field value at offset "
-            ++ show off ++ ": expected " ++ show (shapeType shp) ++ ", but got " ++ show tpr
+      Left err ->
+        fail_ err
+      Right rvPart -> do
         let rv = readMaybeType sym "elem" tpr rvPart
         f off sz shp rv x
-      -- Should be impossible, since we checked above that the key sets
-      -- match.
-      Nothing -> panic "accessMirAggregate"
-        [Text.pack $ "missing MirAggregateEntry at offset " ++ show off,
-        Text.pack $ show elems]
 
 -- | Zip together two `MirAggregate`s and extract values from them.  The callback
 -- gets the offset, size, type, and the value at that offset in each aggregate.
@@ -737,38 +688,27 @@ zipMirAggregates ::
   MirAggregate sym ->
   (forall tp. Word -> Word -> TypeShape tp -> RegValue sym tp -> RegValue sym tp -> m b) ->
   m [b]
-zipMirAggregates sym elems (MirAggregate _totalSize1 m1) (MirAggregate _totalSize2 m2) f = do
-  agCheckKeysEq "zipMirAggregates" elems m1
-  agCheckKeysEq "zipMirAggregates" elems m2
+zipMirAggregates sym elems a1 a2 f = do
   -- We don't require the `totalSize`s of the two aggregates to match.
   -- `buildMirAggregate` sets the `totalSize` to the end of the last field, but
   -- other methods of building aggregates use the actual layout from rustc,
   -- which may have extra padding at the end.
   forM elems $ \(AgElemShape off sz shp) -> do
-    MirAggregateEntry _sz1 tpr1 rvPart1 <-
-      case IntMap.lookup (fromIntegral off) m1 of
-        Just e -> return e
-        Nothing -> panic "zipMirAggregates"
-          [Text.pack $ "missing MirAggregateEntry at offset " ++ show off
-            ++ " (in first input)"]
-    MirAggregateEntry _sz2 tpr2 rvPart2 <-
-      case IntMap.lookup (fromIntegral off) m2 of
-        Just e -> return e
-        Nothing -> panic "zipMirAggregates"
-          [Text.pack $ "missing MirAggregateEntry at offset " ++ show off
-            ++ " (in second input)"]
-    Refl <- case testEquality tpr1 (shapeType shp) of
-      Just pf -> return pf
-      Nothing -> fail $ "zipMirAggregates: ill-typed field value at offset "
-        ++ show off ++ ": expected " ++ show (shapeType shp) ++ ", but got " ++ show tpr1
-        ++ " (in first aggregate)"
-    Refl <- case testEquality tpr2 (shapeType shp) of
-      Just pf -> return pf
-      Nothing -> fail $ "zipMirAggregates: ill-typed field value at offset "
-        ++ show off ++ ": expected " ++ show (shapeType shp) ++ ", but got " ++ show tpr2
-        ++ " (in second aggregate)"
-    let rv1 = readMaybeType sym "elem" tpr1 rvPart1
-    let rv2 = readMaybeType sym "elem" tpr2 rvPart2
+    let tpr = shapeType shp
+    rvPart1 <-
+      case mirAggregate_lookup sym (fromIntegral off) sz tpr a1 of
+        Right e -> pure e
+        Left err -> panic "zipMirAggregates"
+          [Text.pack $ "failed MirAggregate lookup at offset " ++ show off
+            ++ " (in first input)", Text.pack err]
+    rvPart2 <-
+      case mirAggregate_lookup sym (fromIntegral off) sz tpr a2 of
+        Right e -> pure e
+        Left err -> panic "zipMirAggregates"
+          [Text.pack $ "failed MirAggregate lookup at offset " ++ show off
+            ++ " (in second input)", Text.pack err]
+    let rv1 = readMaybeType sym "elem" tpr rvPart1
+    let rv2 = readMaybeType sym "elem" tpr rvPart2
     f off sz shp rv1 rv2
 
 

--- a/saw-central/src/SAWCentral/Crucible/MIR/TypeShape.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/TypeShape.hs
@@ -59,6 +59,7 @@ module SAWCentral.Crucible.MIR.TypeShape
 import Control.Lens ((^.), (^..), each)
 import Control.Monad (when, forM, zipWithM, foldM)
 import Control.Monad.IO.Class (MonadIO(..))
+import qualified Data.IntSet as IntSet
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe (isJust)
@@ -557,6 +558,45 @@ agCheckLengthsEqF fail_ loc elems xs =
   when (length elems /= length xs) $
     fail_ $ loc ++ ": got " ++ show (length elems) ++ " elems, but " ++ show (length xs) ++ " xs"
 
+-- | Expand a list of `AgElemShape`s recursively.  Given the `AgElemShape`s
+-- from the top-level `TypeShape`, this returns the complete list of
+-- `AgElemShape`s that will appear in a flattened aggregate of that type.
+expandAgElems :: [AgElemShape] -> [AgElemShape]
+expandAgElems as = goList 0 as
+  where
+    go :: Word -> AgElemShape -> [AgElemShape]
+    go base (AgElemShape off sz shp) =
+      case goShape (base + off) shp of
+        Just x -> x
+        Nothing -> [AgElemShape (base + off) sz shp]
+
+    goShape :: Word -> TypeShape tp -> Maybe [AgElemShape]
+    goShape base (TupleShape _ as') = Just $ goList base as'
+    goShape base (ArrayShape _ _ sz shp len) =
+      Just $ concat [go base (AgElemShape (i * sz) sz shp) | i <- init [0 .. len]]
+    goShape base (StructShape _ as') = Just $ goList base as'
+    goShape base (TransparentShape _ shp) = goShape base shp
+    goShape _ _ = Nothing
+
+    goList base as' = concatMap (go base) as'
+
+agCheckKeysEq :: MonadFail m => String -> [AgElemShape] -> MirAggregate sym -> m ()
+agCheckKeysEq loc elems m =
+  agCheckKeysEqF fail loc elems m
+
+agCheckKeysEqF :: Monad m =>
+  (forall a. String -> m a) -> String -> [AgElemShape] -> MirAggregate sym -> m ()
+agCheckKeysEqF fail_ loc elems ag = do
+  let mKeys = mirAggregate_keysSet ag
+  let elemsKeys =
+        IntSet.fromList [fromIntegral off | AgElemShape off sz _ <- expandAgElems elems, sz /= 0]
+  when (mKeys /= elemsKeys) $
+    if mKeys `IntSet.isSubsetOf` elemsKeys
+      then fail_ $ loc ++ ": missing or uninitialized fields at offsets "
+        ++ show (elemsKeys IntSet.\\ mKeys)
+      else fail_ $ loc ++ ": expected aggregate to have fields at offsets "
+        ++ show elemsKeys ++ ", but got fields at offsets " ++ show mKeys
+
 -- | Build a `MirAggregate` with one entry for each provided `AgElemShape`.
 -- The callback receives the offset, size, and type of the entry, along with
 -- the corresponding value from @xs@ (which must have as many items as there
@@ -601,7 +641,9 @@ traverseMirAggregate ::
   MirAggregate sym ->
   (forall tp. Word -> Word -> TypeShape tp -> RegValue sym tp -> m (RegValue sym tp)) ->
   m (MirAggregate sym)
-traverseMirAggregate sym elems aggregate f = foldM modify aggregate elems
+traverseMirAggregate sym elems aggregate f = do
+  agCheckKeysEq "traverseMirAggregate" elems aggregate
+  foldM modify aggregate elems
   where
     modify :: MirAggregate sym -> AgElemShape -> m (MirAggregate sym)
     modify ag (AgElemShape off sz elemShp)
@@ -661,6 +703,7 @@ accessMirAggregateF' ::
   m [b]
 accessMirAggregateF' sym fail_ elems xs ag f = do
   agCheckLengthsEqF fail_ "accessMirAggregate'" elems xs
+  agCheckKeysEqF fail_ "accessMirAggregate'" elems ag
   forM (zip elems xs) $ \(AgElemShape off sz shp, x) -> do
     let tpr = shapeType shp
     case mirAggregate_lookup sym off sz tpr ag of
@@ -689,6 +732,8 @@ zipMirAggregates ::
   (forall tp. Word -> Word -> TypeShape tp -> RegValue sym tp -> RegValue sym tp -> m b) ->
   m [b]
 zipMirAggregates sym elems a1 a2 f = do
+  agCheckKeysEq "zipMirAggregates" elems a1
+  agCheckKeysEq "zipMirAggregates" elems a2
   -- We don't require the `totalSize`s of the two aggregates to match.
   -- `buildMirAggregate` sets the `totalSize` to the end of the last field, but
   -- other methods of building aggregates use the actual layout from rustc,

--- a/saw-central/src/SAWCentral/Crucible/MIR/TypeShape.hs
+++ b/saw-central/src/SAWCentral/Crucible/MIR/TypeShape.hs
@@ -36,6 +36,8 @@ module SAWCentral.Crucible.MIR.TypeShape
   , testRefShape
   , sliceShapeParts
   -- `MirAggregate` / `AgElemShape` helpers
+  , expandAgElem
+  , expandAgElems
   , buildMirAggregate
   , traverseMirAggregate
   , accessMirAggregate
@@ -557,6 +559,9 @@ agCheckLengthsEqF :: (HasCallStack, Monad m) =>
 agCheckLengthsEqF fail_ loc elems xs =
   when (length elems /= length xs) $
     fail_ $ loc ++ ": got " ++ show (length elems) ++ " elems, but " ++ show (length xs) ++ " xs"
+
+expandAgElem :: AgElemShape -> [AgElemShape]
+expandAgElem a = expandAgElems [a]
 
 -- | Expand a list of `AgElemShape`s recursively.  Given the `AgElemShape`s
 -- from the top-level `TypeShape`, this returns the complete list of


### PR DESCRIPTION
Pulls in https://github.com/GaloisInc/crucible/pull/1842 and adapts to its aggregate layout changes.

In draft form while that PR pends, but otherwise ready for review.