### PR TITLE
Bump `mir-json`/`crucible` submodule, update line numbers in `crux-mir-comp` expected output

### DIFF
--- a/crux-mir-comp/test/symb_eval/comp/alias_array_bad.good
+++ b/crux-mir-comp/test/symb_eval/comp/alias_array_bad.good
@@ -11,11 +11,11 @@ failures:
 [Crux]     internal: alias_array_bad/<DISAMB>::f[0]
 [Crux]     test/symb_eval/comp/alias_array_bad.rs:45:5: 45:17: alias_array_bad/<DISAMB>::use_f[0]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/alias_array_bad.rs:46:5: 46:37: error: in alias_array_bad/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/alias_array_bad.rs:46:5: 46:37: error: in alias_array_bad/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/alias_array_bad.rs:46:5:
 [Crux]   	0 < b[0].get()
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/alias_array_bad.rs:47:5: 47:38: error: in alias_array_bad/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/alias_array_bad.rs:47:5: 47:38: error: in alias_array_bad/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/alias_array_bad.rs:47:5:
 [Crux]   	b[0].get() < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/alias_array_bad2.good
+++ b/crux-mir-comp/test/symb_eval/comp/alias_array_bad2.good
@@ -11,7 +11,7 @@ failures:
 [Crux]     internal: alias_array_bad2/<DISAMB>::f[0]
 [Crux]     test/symb_eval/comp/alias_array_bad2.rs:45:5: 45:17: alias_array_bad2/<DISAMB>::use_f[0]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/alias_array_bad2.rs:47:5: 47:38: error: in alias_array_bad2/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/alias_array_bad2.rs:47:5: 47:38: error: in alias_array_bad2/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/alias_array_bad2.rs:47:5:
 [Crux]   	b[0].get() < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/alias_array_ok.good
+++ b/crux-mir-comp/test/symb_eval/comp/alias_array_ok.good
@@ -5,7 +5,7 @@ failures:
 
 ---- alias_array_ok/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/alias_array_ok.rs:48:5: 48:38: error: in alias_array_ok/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/alias_array_ok.rs:48:5: 48:38: error: in alias_array_ok/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/alias_array_ok.rs:48:5:
 [Crux]   	b[0].get() < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/alias_bad.good
+++ b/crux-mir-comp/test/symb_eval/comp/alias_bad.good
@@ -11,11 +11,11 @@ failures:
 [Crux]     internal: alias_bad/<DISAMB>::f[0]
 [Crux]     test/symb_eval/comp/alias_bad.rs:45:5: 45:14: alias_bad/<DISAMB>::use_f[0]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/alias_bad.rs:46:5: 46:34: error: in alias_bad/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/alias_bad.rs:46:5: 46:34: error: in alias_bad/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/alias_bad.rs:46:5:
 [Crux]   	0 < b.get()
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/alias_bad.rs:47:5: 47:35: error: in alias_bad/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/alias_bad.rs:47:5: 47:35: error: in alias_bad/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/alias_bad.rs:47:5:
 [Crux]   	b.get() < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/alias_ok.good
+++ b/crux-mir-comp/test/symb_eval/comp/alias_ok.good
@@ -5,7 +5,7 @@ failures:
 
 ---- alias_ok/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/alias_ok.rs:49:5: 49:35: error: in alias_ok/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/alias_ok.rs:49:5: 49:35: error: in alias_ok/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/alias_ok.rs:49:5:
 [Crux]   	b.get() < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/clobber_globals.good
+++ b/crux-mir-comp/test/symb_eval/comp/clobber_globals.good
@@ -5,13 +5,13 @@ failures:
 
 ---- clobber_globals/<DISAMB>::f_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/clobber_globals.rs:15:5: 16:71: error: in clobber_globals/<DISAMB>::f_test[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/clobber_globals.rs:15:5: 16:71: error: in clobber_globals/<DISAMB>::f_test[0]
 [Crux]   MIR assertion at test/symb_eval/comp/clobber_globals.rs:15:5:
 [Crux]   	expected failure; ATOMIC was clobbered by clobber_globals()
 
 ---- clobber_globals/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/clobber_globals.rs:37:5: 38:62: error: in clobber_globals/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/clobber_globals.rs:37:5: 38:62: error: in clobber_globals/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/clobber_globals.rs:37:5:
 [Crux]   	expected failure; ATOMIC was clobbered by f's spec
 

--- a/crux-mir-comp/test/symb_eval/comp/override_test_indep.good
+++ b/crux-mir-comp/test/symb_eval/comp/override_test_indep.good
@@ -7,7 +7,7 @@ failures:
 
 ---- override_test_indep/<DISAMB>::use_f2[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/override_test_indep.rs:57:5: 57:29: error: in override_test_indep/<DISAMB>::use_f2[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/override_test_indep.rs:57:5: 57:29: error: in override_test_indep/<DISAMB>::use_f2[0]
 [Crux]   MIR assertion at test/symb_eval/comp/override_test_indep.rs:57:5:
 [Crux]   	d < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/ptr_offset.good
+++ b/crux-mir-comp/test/symb_eval/comp/ptr_offset.good
@@ -5,7 +5,7 @@ failures:
 
 ---- ptr_offset/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/ptr_offset.rs:64:5: 64:30: error: in ptr_offset/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/ptr_offset.rs:64:5: 64:30: error: in ptr_offset/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/ptr_offset.rs:64:5:
 [Crux]   	b2 < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/ptr_offset_rev.good
+++ b/crux-mir-comp/test/symb_eval/comp/ptr_offset_rev.good
@@ -5,7 +5,7 @@ failures:
 
 ---- ptr_offset_rev/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/ptr_offset_rev.rs:64:5: 64:30: error: in ptr_offset_rev/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/ptr_offset_rev.rs:64:5: 64:30: error: in ptr_offset_rev/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/ptr_offset_rev.rs:64:5:
 [Crux]   	b2 < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/spec_array.good
+++ b/crux-mir-comp/test/symb_eval/comp/spec_array.good
@@ -5,7 +5,7 @@ failures:
 
 ---- spec_array/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/spec_array.rs:43:5: 43:29: error: in spec_array/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/spec_array.rs:43:5: 43:29: error: in spec_array/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/spec_array.rs:43:5:
 [Crux]   	d < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/spec_box.good
+++ b/crux-mir-comp/test/symb_eval/comp/spec_box.good
@@ -5,7 +5,7 @@ failures:
 
 ---- spec_box/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/spec_box.rs:58:5: 58:29: error: in spec_box/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/spec_box.rs:58:5: 58:29: error: in spec_box/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/spec_box.rs:58:5:
 [Crux]   	d < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/spec_immut_cell.good
+++ b/crux-mir-comp/test/symb_eval/comp/spec_immut_cell.good
@@ -5,7 +5,7 @@ failures:
 
 ---- spec_immut_cell/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/spec_immut_cell.rs:68:5: 68:35: error: in spec_immut_cell/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/spec_immut_cell.rs:68:5: 68:35: error: in spec_immut_cell/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/spec_immut_cell.rs:68:5:
 [Crux]   	d.get() < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/spec_mut.good
+++ b/crux-mir-comp/test/symb_eval/comp/spec_mut.good
@@ -5,7 +5,7 @@ failures:
 
 ---- spec_mut/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/spec_mut.rs:61:5: 61:29: error: in spec_mut/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/spec_mut.rs:61:5: 61:29: error: in spec_mut/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/spec_mut.rs:61:5:
 [Crux]   	d < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/spec_mut_slice.good
+++ b/crux-mir-comp/test/symb_eval/comp/spec_mut_slice.good
@@ -5,7 +5,7 @@ failures:
 
 ---- spec_mut_slice/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/spec_mut_slice.rs:48:5: 48:29: error: in spec_mut_slice/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/spec_mut_slice.rs:48:5: 48:29: error: in spec_mut_slice/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/spec_mut_slice.rs:48:5:
 [Crux]   	d < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/spec_struct.good
+++ b/crux-mir-comp/test/symb_eval/comp/spec_struct.good
@@ -5,7 +5,7 @@ failures:
 
 ---- spec_struct/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/spec_struct.rs:51:5: 51:29: error: in spec_struct/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/spec_struct.rs:51:5: 51:29: error: in spec_struct/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/spec_struct.rs:51:5:
 [Crux]   	d < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/spec_tuple.good
+++ b/crux-mir-comp/test/symb_eval/comp/spec_tuple.good
@@ -5,7 +5,7 @@ failures:
 
 ---- spec_tuple/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/spec_tuple.rs:55:5: 55:29: error: in spec_tuple/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/spec_tuple.rs:55:5: 55:29: error: in spec_tuple/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/spec_tuple.rs:55:5:
 [Crux]   	d < 10
 

--- a/crux-mir-comp/test/symb_eval/comp/subst_output.good
+++ b/crux-mir-comp/test/symb_eval/comp/subst_output.good
@@ -4,7 +4,7 @@ failures:
 
 ---- subst_output/<DISAMB>::use_f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/comp/subst_output.rs:32:5: 32:30: error: in subst_output/<DISAMB>::use_f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/comp/subst_output.rs:32:5: 32:30: error: in subst_output/<DISAMB>::use_f[0]
 [Crux]   MIR assertion at test/symb_eval/comp/subst_output.rs:32:5:
 [Crux]   	b0 == a
 

--- a/crux-mir-comp/test/symb_eval/cryptol/slice_arg_err.good
+++ b/crux-mir-comp/test/symb_eval/cryptol/slice_arg_err.good
@@ -4,14 +4,14 @@ failures:
 
 ---- slice_arg_err/<DISAMB>::bar[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/cryptol.rs:61:13: 61:34 !test/symb_eval/cryptol/slice_arg_err.rs:3:1: 6:2: error: in slice_arg_err/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/cryptol.rs:59:13: 59:34 !test/symb_eval/cryptol/slice_arg_err.rs:3:1: 6:2: error: in slice_arg_err/<DISAMB>::f[0]
 [Crux]   Slice length mismatch:
 [Crux]     Expected: 3
 [Crux]     Actual  : 2
 [Crux] 
 [Crux]   Context:
 [Crux]     internal: slice_arg_err/<DISAMB>::f[0]
-[Crux]     ./libs/crucible/cryptol.rs:61:13: 61:34 !test/symb_eval/cryptol/slice_arg_err.rs:3:1: 6:2: slice_arg_err/<DISAMB>::f[0]
+[Crux]     ./libs/crucible/cryptol.rs:59:13: 59:34 !test/symb_eval/cryptol/slice_arg_err.rs:3:1: 6:2: slice_arg_err/<DISAMB>::f[0]
 [Crux]     test/symb_eval/cryptol/slice_arg_err.rs:8:22: 8:31: slice_arg_err/<DISAMB>::g[0]
 [Crux]     test/symb_eval/cryptol/slice_arg_err.rs:14:14: 14:18: slice_arg_err/<DISAMB>::bar[0]
 


### PR DESCRIPTION
This bumps the following submodules:

* `mir-json`: https://github.com/GaloisInc/mir-json/pull/303 and https://github.com/GaloisInc/mir-json/pull/300
* `crucible`: https://github.com/GaloisInc/crucible/pull/1871

Among other changes, the `mir-json` changes shift around the line numbers of definitions in the `crucible` crate, so several `crux-mir-comp` test cases' expected error messages have been updated to reflect the new line numbers.