### PR TITLE
Add function to `SAWCore.SharedTerm` library for building a constant `Term` from a `QualName`

### DIFF
--- a/saw-central/src/SAWCentral/Builtins.hs
+++ b/saw-central/src/SAWCentral/Builtins.hs
@@ -772,7 +772,7 @@ resolveNameIO sc cenv nm =
               ImportedName qn _ ->
                 do resolvedName <- scResolveQualName sc qn
                    case resolvedName of
-                     Just vi -> pure (vi : scnms)
+                     Just n -> pure (nameIndex n : scnms)
                      Nothing -> pure scnms
               _ -> pure scnms
        Nothing -> pure scnms
@@ -801,7 +801,7 @@ normalize_term_opaque opaque tt =
      -- Also exclude defined SAWCore constants that are implemented as primitives
      let primQualNames = map moduleIdentToQualName (Map.keys constMap)
      primIdxs <- io $ traverse (scResolveQualName sc) primQualNames
-     let opaqueSet = Set.fromList (catMaybes primIdxs ++ idxs)
+     let opaqueSet = Set.fromList (map nameIndex (catMaybes primIdxs) ++ idxs)
      let unfold nm = Set.notMember (nameIndex nm) opaqueSet
      tm' <- io $ scNormalize sc unfold (ttTerm tt)
      pure tt{ ttTerm = tm' }
@@ -814,7 +814,7 @@ goal_normalize opaque =
        -- Also exclude defined SAWCore constants that are implemented as primitives
        let primQualNames = map moduleIdentToQualName (Map.keys constMap)
        primIdxs <- io $ traverse (scResolveQualName sc) primQualNames
-       let opaqueSet = Set.fromList (catMaybes primIdxs ++ idxs)
+       let opaqueSet = Set.fromList (map nameIndex (catMaybes primIdxs) ++ idxs)
        sqt' <- io $ traverseSequentWithFocus (normalizeProp sc opaqueSet) (goalSequent goal)
        return (sqt', NormalizePropEvidence opaqueSet)
 

--- a/saw-central/src/SAWCentral/Yosys/Theorem.hs
+++ b/saw-central/src/SAWCentral/Yosys/Theorem.hs
@@ -158,15 +158,15 @@ applyOverride ::
   SC.Term ->
   IO SC.Term
 applyOverride sc thm t = do
-  tidx <-
+  tnm <-
     do result <- SC.scResolveQualName sc $ thm ^. theoremQualName
        case result of
          Nothing -> yosysError . YosysErrorOverrideNameNotFound . QN.ppQualName $ thm ^. theoremQualName
-         Just i -> pure i
+         Just nm -> pure nm
   -- unfold everything except for theoremQualName and prelude constants
   let isPreludeName (SC.ModuleIdentifier ident) = SC.identModule ident == SC.preludeModuleName
       isPreludeName _ = False
-  let unfold nm = SC.nameIndex nm /= tidx && not (isPreludeName (SC.nameInfo nm))
+  let unfold nm = nm /= tnm && not (isPreludeName (SC.nameInfo nm))
   unfolded <- SC.scUnfoldConstants sc unfold t
   cache <- SC.newIntCache
   let
@@ -174,8 +174,8 @@ applyOverride sc thm t = do
     go s =
       SC.useIntCache cache (SC.termIndex s) $
       case SC.unwrapTermF s of
-        SC.Constant (SC.Name idx _)
-          | idx == tidx -> theoremReplacement sc thm
+        SC.Constant nm
+          | nm == tnm -> theoremReplacement sc thm
           | otherwise -> pure s
         _ -> SC.scTermF sc =<< traverse go (SC.unwrapTermF s)
   go unfolded

--- a/saw-core-what4/src/SAWCoreWhat4/Uninterp.hs
+++ b/saw-core-what4/src/SAWCoreWhat4/Uninterp.hs
@@ -156,6 +156,7 @@ import Numeric.Natural (Natural)
 import SAWCore.SharedTerm
 import SAWCore.Simulator.Value
 import SAWCore.Module (ResolvedName(..), ctorName, dtCtors, lookupVarIndexInMap)
+import SAWCore.Name (nameIndex)
 import SAWCore.Term.Functor (FieldName)
 
 -- what4
@@ -787,14 +788,14 @@ mkArgTerm sc ty val =
          pure (ArgTermRecord fname x1 x2)
 
     (VDataType nmi ps _, VCtorApp n _ vv) ->
-      do mvi <- scResolveQualName sc (toQualName nmi)
-         vi <-
-           case mvi of
-             Just vi -> pure vi
+      do mnm <- scResolveQualName sc (toQualName nmi)
+         nm <-
+           case mnm of
+             Just nm -> pure nm
              Nothing -> panic "mkArgTerm" ["Data type name not found: " <> toAbsoluteName nmi]
          mm <- scGetModuleMap sc
          dt <-
-           case lookupVarIndexInMap vi mm of
+           case lookupVarIndexInMap (nameIndex nm) mm of
              Just (ResolvedDataType dt) -> pure dt
              _ -> panic "mkArgTerm" ["Data type not found: " <> toAbsoluteName nmi]
          let ctor = dtCtors dt !! n

--- a/saw-core/src/SAWCore/ExternalFormat.hs
+++ b/saw-core/src/SAWCore/ExternalFormat.hs
@@ -188,11 +188,11 @@ scReadExternal sc input =
          case nmi of
            ModuleIdentifier ident ->
              lift (scResolveQualName sc (moduleIdentToQualName ident)) >>= \case
-               Just vi' -> pure (Name vi' nmi)
+               Just nm  -> pure nm
                Nothing  -> lift $ fail $ "scReadExternal: missing module identifier: " ++ show ident
            ImportedName qn _aliases ->
              lift (scResolveQualName sc qn) >>= \case
-               Just vi' -> pure (Name vi' nmi)
+               Just nm -> pure nm
                Nothing -> case Map.lookup vi vs of
                  Just vi' -> pure $ Name vi' nmi
                  Nothing ->

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -105,6 +105,7 @@ module SAWCore.SharedTerm
   , scConst
   , scConstApply
   , scGlobalDef
+  , scGlobalConst
   , scGlobalApply
     -- ** Sorts
   , scSort
@@ -444,6 +445,8 @@ prettyTermErrorPure opts ne err =
       [ "No such constant:" PP.<+> prettyNameWithEnv opts ne nm ]
     IdentNotFound ident ->
       [ "No such global:" PP.<+> PP.pretty (show ident) ]
+    QualNameNotFound qn ->
+      [ "No such global name:" PP.<+> PP.pretty (QN.ppQualName qn) ]
     NotPairType t ->
       [ "Tuple field projection with non-tuple"
       , withFrees [t] $
@@ -729,6 +732,10 @@ scFreshVarName sc x = execSCM sc (scmFreshVarName x)
 -- | Create a 'Term' for the global constant with the given 'Ident'.
 scGlobalDef :: SharedContext -> Ident -> IO Term
 scGlobalDef sc ident = execSCM sc (scmGlobalDef ident)
+
+-- | Create a 'Term' for the global constant with the given 'QN.QualName'.
+scGlobalConst :: SharedContext -> QN.QualName -> IO Term
+scGlobalConst sc qn = execSCM sc (scmGlobalConst qn)
 
 -- | Create a recursor for the data type of the given 'Name', which
 -- eliminates to the given 'Sort'.

--- a/saw-core/src/SAWCore/Term/Certified.hs
+++ b/saw-core/src/SAWCore/Term/Certified.hs
@@ -56,6 +56,7 @@ module SAWCore.Term.Certified
   , scmPiList
   , scmConst
   , scmGlobalDef
+  , scmGlobalConst
   , scmVariable
   , scmUnitValue
   , scmUnitType
@@ -200,6 +201,7 @@ data TermError
   | NotPairType Term
   | NameNotFound Name
   | IdentNotFound Ident
+  | QualNameNotFound QN.QualName
   | NotRecord Term
   | FieldNotFound Term FieldName
   | VectorNotSubtype Term Term -- expected type, element
@@ -883,6 +885,16 @@ scmGlobalDef ident =
      case HMap.lookup ident m of
        Nothing -> scmError (IdentNotFound ident)
        Just t -> pure t
+
+-- | Return the constant 'Term' named by the given 'QN.QualName'.
+-- Raise an error if the 'QN.QualName' is not found in the context.
+scmGlobalConst :: QN.QualName -> SCM Term
+scmGlobalConst qn =
+  do sc <- scmSharedContext
+     m <- liftIO $ readIORef (scQualNameEnv sc)
+     case Map.lookup qn m of
+       Nothing -> scmError (QualNameNotFound qn)
+       Just nm -> scmConst nm
 
 -- | Internal function to register an 'Ident' with a 'Term' (which
 -- must be a 'Constant' term with the same 'Ident') in the

--- a/saw-core/src/SAWCore/Term/Certified.hs
+++ b/saw-core/src/SAWCore/Term/Certified.hs
@@ -344,7 +344,7 @@ data SharedContext = SharedContext
   { scModuleMap      :: IORef ModuleMap
   , scAppCache       :: AppCacheRef
   , scDisplayNameEnv :: IORef DisplayNameEnv
-  , scQualNameEnv    :: IORef (Map QN.QualName VarIndex)
+  , scQualNameEnv    :: IORef (Map QN.QualName Name)
   , scGlobalEnv      :: IORef (HashMap Ident Term)
   , scNextVarIndex   :: IORef VarIndex
   , scNextTermIndex  :: IORef TermIndex
@@ -409,7 +409,7 @@ data SharedContextCheckpoint =
   SCC
   { sccModuleMap :: ModuleMap
   , sccNamingEnv :: DisplayNameEnv
-  , sccQualNameEnv :: Map QN.QualName VarIndex
+  , sccQualNameEnv :: Map QN.QualName Name
   , sccGlobalEnv :: HashMap Ident Term
   , sccTermIndex :: TermIndex
   , sccMetadata :: TypedStore (Metadata Identity)
@@ -790,16 +790,20 @@ scmFreshVarIndex =
      liftIO $ atomicModifyIORef' (scNextVarIndex sc) (\i -> (i + 1, i))
 
 -- | Internal function to register a name with a caller-provided
--- 'VarIndex'. Valid alises are generated based on the provided 'QN.POpts'.
---  Not exported.
-scmRegisterNameWithIndex :: VarIndex -> QN.POpts -> QN.QualName -> SCM ()
-scmRegisterNameWithIndex i opts qn =
+-- 'VarIndex'.
+-- Valid aliases are generated based on the provided 'QN.POpts'.
+-- Not exported.
+scmRegisterNameInfoWithIndex :: VarIndex -> QN.POpts -> NameInfo -> SCM Name
+scmRegisterNameInfoWithIndex i opts nmi =
   do sc <- scmSharedContext
+     let qn = toQualName nmi
      qns <- liftIO $ readIORef (scQualNameEnv sc)
      when (Map.member qn qns) $ scmError (DuplicateQualName qn)
-     liftIO $ writeIORef (scQualNameEnv sc) (Map.insert qn i qns)
+     let nm = Name i nmi
+     liftIO $ writeIORef (scQualNameEnv sc) (Map.insert qn nm qns)
      let aliases = QN.aliasesOpts opts qn
      liftIO $ modifyIORef' (scDisplayNameEnv sc) $ extendDisplayNameEnv i aliases
+     pure nm
 
 -- | Generate a 'Name' with a fresh 'VarIndex' for the given
 -- 'NameInfo' and register everything together in the naming
@@ -807,10 +811,9 @@ scmRegisterNameWithIndex i opts qn =
 scmRegisterName :: NameInfo -> SCM Name
 scmRegisterName nmi =
   do i <- scmFreshVarIndex
-     scmRegisterNameWithIndex i QN.allAliasesPOpts (toQualName nmi)
-     pure (Name i nmi)
+     scmRegisterNameInfoWithIndex i QN.allAliasesPOpts nmi
 
-scResolveQualName :: SharedContext -> QN.QualName -> IO (Maybe VarIndex)
+scResolveQualName :: SharedContext -> QN.QualName -> IO (Maybe Name)
 scResolveQualName sc qn =
   do env <- readIORef (scQualNameEnv sc)
      pure $! Map.lookup qn env
@@ -820,8 +823,8 @@ scmFreshName :: Text -> SCM Name
 scmFreshName x =
   do i <- scmFreshVarIndex
      let qn = scFreshQualName x i
-     scmRegisterNameWithIndex i QN.allAliasesPOpts qn
-     pure (Name i (mkImportedName qn))
+     let nmi = mkImportedName qn
+     scmRegisterNameInfoWithIndex i QN.allAliasesPOpts nmi
 
 -- | Create a 'VarName' with the given identifier (which may be "_").
 scmFreshVarName :: Text -> SCM VarName
@@ -850,8 +853,9 @@ scmFreshInventedVar name ty = do
         Right qn_@(QN.QualName _ _ _ Nothing Nothing) -> qn_
         _ -> QN.simpleName name
     qn' = qn { QN.index = Just (vnIndex vn), QN.namespace = Just QN.NamespaceFresh }
-  scmRegisterNameWithIndex (vnIndex vn) popts qn'
-  scmUpdateData $ \(InventedVars m) -> 
+    nmi = mkImportedName qn'
+  _nm <- scmRegisterNameInfoWithIndex (vnIndex vn) popts nmi
+  scmUpdateData $ \(InventedVars m) ->
     InventedVars (IntMap.insert (vnIndex vn) ty m)
   return vn
 


### PR DESCRIPTION
```
scGlobalConst :: SharedContext -> QN.QualName -> IO Term
```

To implement it, I augmented one of the tables in the `SharedContext` to reduce the number of lookups required to obtain the `Name` from the `QualName`.

Fixes #3369.

This will be useful for future enhancements to the Cryptol importer.