### PR TITLE
Isabelle fixes

### DIFF
--- a/otherTests/saw-core-isabelle/ArithMap.log.good
+++ b/otherTests/saw-core-isabelle/ArithMap.log.good
@@ -1,0 +1,33 @@
+Loading file "ArithMap.saw"
+Loading file "saw/isa_test.saw"
+Successfully translated theory ArithMap
+Translation successful. Generating theory files...
+Generating ArithMap.thy
+Successfully wrote '../isabelle/ArithMap.thy'
+theory "ArithMap"
+imports "Cryptol.Cryptol"
+begin
+
+context includes cryptol_translation_syntax begin
+cryptol_definition map2 :: "{'n,'a,'b} ((fin 'n,Eq 'a,Eq 'b) =?> (('a \<Rightarrow> ('a \<Rightarrow> 'b)) \<Rightarrow> ((['n]'a) \<Rightarrow> ((['n]'a) \<Rightarrow> (['n]'b)))))" where
+"map2 f x y \<equiv> map`{'n,('a) \<times> ('a),'b} (\<lambda>(i__p0 :: ('a) \<times> ('a)). (
+  let
+    b = ((\<lambda>(_,x). x) i__p0 :: 'a);
+    a = ((\<lambda>(x,_). x) i__p0 :: 'a)
+  in (f`{} a b))) (zip`{'n,'a,'a} x y)"
+
+cryptol_definition map2_minus :: "{'n} ((fin 'n) =?> ((['n]['n]) \<Rightarrow> ((['n]['n]) \<Rightarrow> Bit)))" where
+"map2_minus x y \<equiv> (map2`{'n,['n],['n]} (\<lblot>-`{['n]}\<rblot>) x y) ==`{['n]['n]} (x -`{['n]['n]} y)"
+
+cryptol_definition map2_plus :: "{'n} ((fin 'n) =?> ((['n]['n]) \<Rightarrow> ((['n]['n]) \<Rightarrow> Bit)))" where
+"map2_plus x y \<equiv> (map2`{'n,['n],['n]} (\<lblot>+`{['n]}\<rblot>) x y) ==`{['n]['n]} (x +`{['n]['n]} y)"
+
+cryptol_definition map2_times :: "{'n} ((fin 'n) =?> ((['n]['n]) \<Rightarrow> ((['n]['n]) \<Rightarrow> Bit)))" where
+"map2_times x y \<equiv> (map2`{'n,['n],['n]} (\<lblot>*`{['n]}\<rblot>) x y) ==`{['n]['n]} (x *`{['n]['n]} y)"
+
+cryptol_definition map_uminus :: "{'n} ((fin 'n) =?> ((['n]['n]) \<Rightarrow> Bit))" where
+"map_uminus x \<equiv> (map`{'n,['n],['n]} (\<lambda>(a :: ['n]). (negate`{['n]} a)) x) ==`{['n]['n]} (negate`{['n]['n]} x)"
+
+end
+end
+

--- a/otherTests/saw-core-isabelle/ArithMap.saw
+++ b/otherTests/saw-core-isabelle/ArithMap.saw
@@ -1,0 +1,2 @@
+let modname = "ArithMap";
+include "./saw/isa_test.saw";

--- a/otherTests/saw-core-isabelle/Enums.log.good
+++ b/otherTests/saw-core-isabelle/Enums.log.good
@@ -23,7 +23,7 @@ instance ..
 end
 
 context includes cryptol_translation_syntax begin
-lemma MyEnum_same_type[simp]: 
+lemma MyEnum_same_type[simp]:
   "same_type TYPE((('a::coercible_atom),'b) MyEnum) TYPE((('a1::coercible_atom),'b1) MyEnum) = ((same_type TYPE('a) TYPE('a1)) \<and> (LEN('b) = LEN('b1)))"
   by (simp add: same_type_def strip_type_MyEnum_def strip_type_seq_def)
 end
@@ -34,7 +34,7 @@ definition strip_MyEnum :: "('a,'b) MyEnum => stripped" where
   "strip_MyEnum \<equiv> case_MyEnum (strip ((0::nat),())) (curry strip (1::nat)) ((curry o curry o curry)(curry strip (2::nat)))"
 
 definition unstrip_MyEnum :: "stripped => ('a,'b) MyEnum" where
-  "unstrip_MyEnum \<equiv> (\<lambda> r. let (a :: nat, b :: stripped) = unstrip r in 
+  "unstrip_MyEnum \<equiv> (\<lambda> r. let (a :: nat, b :: stripped) = unstrip r in
      (case a of 0 \<Rightarrow> \<lambda> _. MyNone | Suc (0) \<Rightarrow> MySome o unstrip | Suc (Suc (0)) \<Rightarrow> (uncurry o uncurry o uncurry) MyCtr2 o unstrip) b)"
 
 instance

--- a/otherTests/saw-core-isabelle/Tests.thy
+++ b/otherTests/saw-core-isabelle/Tests.thy
@@ -3,6 +3,7 @@ theory Tests
           Sequences_Proofs Comprehension_Proofs RecordDecls_Proofs Words_Proofs OOB_Proofs
           Recursion_Proofs TypeArith_Proofs Quickcheck_Tests "isabelle/tac_prove0" "isabelle/Enums"
           "isabelle/Nested" "isabelle/Names" "isabelle/Enums" "isabelle/Foreign" "isabelle/Inf"
+          "isabelle/ArithMap"
 begin
 
 lemma "\<And>x y z. tac_prove0.goal x y z"
@@ -16,5 +17,29 @@ lemma "\<And>a b c x y. Enums.myEnum_eq_valid a b c x y"
 lemma "\<And>a b x y. Enums.opt_valid a b x y"
   unfolding Enums.opt_valid_def
   by (auto split: option.splits)
+
+lemma "\<And>n x y. ArithMap.map2_plus n x y"
+  unfolding ArithMap.map2_plus_def ArithMap.map2_def
+  apply simp
+  apply transfer'
+  by auto
+
+lemma "\<And>n x y. ArithMap.map2_times n x y"
+  unfolding ArithMap.map2_times_def ArithMap.map2_def
+  apply simp
+  apply transfer'
+  by auto
+
+lemma "\<And>n x y. ArithMap.map2_minus n x y"
+  unfolding ArithMap.map2_minus_def ArithMap.map2_def
+  apply simp
+  apply transfer'
+  by auto
+
+lemma "\<And>n x. ArithMap.map_uminus n x"
+  unfolding ArithMap.map_uminus_def
+  apply simp
+  apply transfer'
+  by auto
 
 end

--- a/otherTests/saw-core-isabelle/cryptol/ArithMap.cry
+++ b/otherTests/saw-core-isabelle/cryptol/ArithMap.cry
@@ -1,0 +1,16 @@
+module ArithMap where
+
+map2 : {n,a,b} (fin n) => (a -> a -> b) -> [n]a -> [n]a -> [n]b
+map2 f x y = map (\(a,b) -> f a b) (zip x y)
+
+map2_plus : {n} (fin n) => [n][n] -> [n][n] -> Bit
+map2_plus x y = map2 (+) x y == (x + y)
+
+map2_times : {n} (fin n) => [n][n] -> [n][n] -> Bit
+map2_times x y = map2 (*) x y == (x * y)
+
+map2_minus : {n} (fin n) => [n][n] -> [n][n] -> Bit
+map2_minus x y = map2 (-) x y == (x - y)
+
+map_uminus : {n} (fin n) => [n][n] -> Bit
+map_uminus x = map (\a -> -a) x == -x

--- a/otherTests/saw-core-isabelle/isabelle/ArithMap.thy
+++ b/otherTests/saw-core-isabelle/isabelle/ArithMap.thy
@@ -1,0 +1,26 @@
+theory "ArithMap"
+imports "Cryptol.Cryptol"
+begin
+
+context includes cryptol_translation_syntax begin
+cryptol_definition map2 :: "{'n,'a,'b} ((fin 'n,Eq 'a,Eq 'b) =?> (('a \<Rightarrow> ('a \<Rightarrow> 'b)) \<Rightarrow> ((['n]'a) \<Rightarrow> ((['n]'a) \<Rightarrow> (['n]'b)))))" where
+"map2 f x y \<equiv> map`{'n,('a) \<times> ('a),'b} (\<lambda>(i__p0 :: ('a) \<times> ('a)). (
+  let
+    b = ((\<lambda>(_,x). x) i__p0 :: 'a);
+    a = ((\<lambda>(x,_). x) i__p0 :: 'a)
+  in (f`{} a b))) (zip`{'n,'a,'a} x y)"
+
+cryptol_definition map2_minus :: "{'n} ((fin 'n) =?> ((['n]['n]) \<Rightarrow> ((['n]['n]) \<Rightarrow> Bit)))" where
+"map2_minus x y \<equiv> (map2`{'n,['n],['n]} (\<lblot>-`{['n]}\<rblot>) x y) ==`{['n]['n]} (x -`{['n]['n]} y)"
+
+cryptol_definition map2_plus :: "{'n} ((fin 'n) =?> ((['n]['n]) \<Rightarrow> ((['n]['n]) \<Rightarrow> Bit)))" where
+"map2_plus x y \<equiv> (map2`{'n,['n],['n]} (\<lblot>+`{['n]}\<rblot>) x y) ==`{['n]['n]} (x +`{['n]['n]} y)"
+
+cryptol_definition map2_times :: "{'n} ((fin 'n) =?> ((['n]['n]) \<Rightarrow> ((['n]['n]) \<Rightarrow> Bit)))" where
+"map2_times x y \<equiv> (map2`{'n,['n],['n]} (\<lblot>*`{['n]}\<rblot>) x y) ==`{['n]['n]} (x *`{['n]['n]} y)"
+
+cryptol_definition map_uminus :: "{'n} ((fin 'n) =?> ((['n]['n]) \<Rightarrow> Bit))" where
+"map_uminus x \<equiv> (map`{'n,['n],['n]} (\<lambda>(a :: ['n]). (negate`{['n]} a)) x) ==`{['n]['n]} (negate`{['n]['n]} x)"
+
+end
+end

--- a/saw-core-isabelle/isabelle/templates/Coercible_Datatype.thy_template
+++ b/saw-core-isabelle/isabelle/templates/Coercible_Datatype.thy_template
@@ -10,7 +10,7 @@ instance ..
 end
 
 context includes cryptol_translation_syntax begin
-lemma $1_same_type[simp]: 
+lemma $1_same_type[simp]:
   "same_type TYPE(($11) $1) TYPE(($12) $1) = ($13)"
   by (simp add: same_type_def strip_type_$1_def strip_type_seq_def)
 end
@@ -21,7 +21,7 @@ definition strip_$1 :: "($2) $1 => stripped" where
   "strip_$1 \<equiv> case_$1 $7"
 
 definition unstrip_$1 :: "stripped => ($2) $1" where
-  "unstrip_$1 \<equiv> (\<lambda> r. let (a :: nat, b :: stripped) = unstrip r in 
+  "unstrip_$1 \<equiv> (\<lambda> r. let (a :: nat, b :: stripped) = unstrip r in
      (case a of $8) b)"
 
 instance

--- a/saw-core-isabelle/isabelle/theories/Cryptol_Syntax.thy
+++ b/saw-core-isabelle/isabelle/theories/Cryptol_Syntax.thy
@@ -318,7 +318,7 @@ qualified abbreviation seq_concat_map :: "{'n,'a,'m,'b} ('a \<Rightarrow> ['n]'b
 qualified abbreviation  complement :: "{'a::logic} (('a) \<Rightarrow> 'a)" where
   "complement _ x \<equiv> logic_class.not x"
 
-qualified abbreviation negate :: "{'a :: ring} 'a \<Rightarrow> 'a" where
+qualified abbreviation negate :: "{'a :: uminus} 'a \<Rightarrow> 'a" where
   "negate _ x \<equiv> uminus x"
 
 qualified abbreviation fromZ :: "{'n} 'n Z \<Rightarrow> int" where

--- a/saw-core-isabelle/isabelle/theories/Seq.thy
+++ b/saw-core-isabelle/isabelle/theories/Seq.thy
@@ -2734,8 +2734,82 @@ lemma list_to_seq_pad_Nil:
 
 ML \<open>val seq_syntax = Attrib.setup_config_bool \<^binding>\<open>seq_syntax\<close> (K false);\<close>
 
+nonterminal seq_patterns
+
+hide_const (open) case_seq
+(* this is analgous to case_list, except we only need to examine the length parameter
+   to determine which case to follow.*)
+definition case_seq :: "'b \<Rightarrow> ('a \<Rightarrow> ('n-1,'a) seq \<Rightarrow> 'b) \<Rightarrow> ('n,'a) seq \<Rightarrow> 'b" where
+  "case_seq b f xs \<equiv> if LEN('n) > 0 then f (nth_seq xs 0) (drop_seq xs) else b"
+
+lemma seq_split: "P (case_seq f1 f2 seq) =
+  ((size seq = 0 \<longrightarrow> P f1) \<and>
+   ((size seq > 0) \<longrightarrow> P (f2 (nth_seq seq 0) (drop_seq seq))))"
+  by (simp add: case_seq_def)
+
+lemma seq_split_asm: "P (case_seq f1 f2 seq) =
+  (\<not> (size seq = 0 \<and> \<not> P f1 \<or>
+       (size seq > 0 \<and> \<not> P (f2 (nth_seq seq 0) (drop_seq seq)))))"
+  by (metis seq_split)
+
+definition case_seq_cons :: "('a \<Rightarrow> ('n-1,'a) seq \<Rightarrow> 'b) \<Rightarrow> ('n,'a) seq \<Rightarrow> 'b" where
+  "case_seq_cons f \<equiv> case_seq undefined f"
+
+definition case_seq_nil :: "'b \<Rightarrow> ('n,'a) seq \<Rightarrow> 'b" where
+  "case_seq_nil b \<equiv> case_seq b (\<lambda>_ _. undefined)"
+
+lemma case_seq_tail[simp]:
+  "LEN('n) > 0 \<Longrightarrow> case_seq b (f :: 'a \<Rightarrow> ('n-1,'a) seq \<Rightarrow> 'b) = case_seq_cons f"
+  by (simp add: case_seq_def[abs_def] case_seq_cons_def)
+
+lemma case_seq_head[simp]:
+  "LEN('n) = 0 \<Longrightarrow> case_seq b (f :: 'a \<Rightarrow> ('n-1,'a) seq \<Rightarrow> 'b) = case_seq_nil b"
+  by (simp add: case_seq_def[abs_def] case_seq_nil_def)
+
+lemmas seq_splits_1 = seq_split seq_split_asm
+
+lemmas seq_splits = seq_splits_1
+  seq_splits_1[of _ undefined, simplified case_seq_cons_def[symmetric]]
+  seq_splits_1[of _ _ "\<lambda>_ _. undefined", simplified case_seq_nil_def[symmetric]]
+
+lemma case_seq_cons_simp[simp]: "Suc (length xs) = LEN('n) \<Longrightarrow>
+ case_seq_cons f (list_to_seq (x#xs) :: ('n,'a) seq) = f x (list_to_seq xs)"
+  unfolding case_seq_cons_def case_seq_def
+  apply simp
+  apply transfer
+  by simp
+
+lemma case_seq_nil_simp[simp]: "LEN('n) = 0 \<Longrightarrow>
+ case_seq_nil b (list_to_seq [] :: ('n,'a) seq) = b"
+  unfolding case_seq_nil_def case_seq_def
+  by simp
+
+(* we need an alternate case constant to install the case syntax, so that we can
+   declare list_to_seq as its only constructor *)
+definition case_seq_list :: "('a list \<Rightarrow> 'b) \<Rightarrow> ('n,'a) seq \<Rightarrow> 'b" where
+  "case_seq_list f xs \<equiv> f (seq_to_list xs)"
+
+lemma case_seq_list_case_list[simp]:
+  "case_seq_list (case_list b (\<lambda>x xs. f x xs)) = (case_seq b (\<lambda>x xs. case_seq_list (f x) xs))"
+  unfolding case_seq_list_def case_seq_def
+  apply (rule ext)
+  apply transfer
+  by auto (metis drop0 drop_Suc_nth list.simps(5))
+
 bundle seq_syntax begin
 declare [[seq_syntax]]
+declare [[case_translation case_seq_list list_to_seq]]
+
+syntax
+  "_seq_pattern"  :: "seq_patterns \<Rightarrow> pttrn"         (\<open>(\<open>open_block notation=\<open>pattern list\<close>\<close>'\<lbrakk>_'\<rbrakk>)\<close>)
+  ""              :: "pttrn \<Rightarrow> seq_patterns"                  (\<open>_\<close>)
+  "_seq_patterns" :: "pttrn \<Rightarrow> seq_patterns \<Rightarrow> seq_patterns"      (\<open>_,/ _\<close>)
+syntax_consts
+  "_seq_pattern" "_seq_patterns" \<rightleftharpoons> case_seq
+translations
+  "\<lambda>\<lbrakk>x, y, zs\<rbrakk>. b" \<rightleftharpoons> "CONST case_seq_cons (\<lambda>x \<lbrakk>y, zs\<rbrakk>. b)"
+  "\<lambda>\<lbrakk>x, y\<rbrakk>. b" \<rightleftharpoons> "CONST case_seq_cons (\<lambda>x \<lbrakk>y\<rbrakk>. b)"
+  "\<lambda>\<lbrakk>x\<rbrakk>. b" \<rightleftharpoons> "CONST case_seq_cons (\<lambda>x. CONST case_seq_nil b)"
 
 no_syntax "_bracket" :: "types \<Rightarrow> type \<Rightarrow> type" ("(\<open>notation=\<open>infix \<Rightarrow>\<close>\<close>[_]/ \<Rightarrow> _)" [0,0] 0)
 
@@ -2856,8 +2930,53 @@ in
 end
 \<close>
 
+lemma nth_drop:
+  "LEN('n) > (Suc n) \<Longrightarrow> nth_seq (drop_seq z :: ('n-1,'a) seq) n = nth_seq (z :: ('n,'a) seq) (Suc n)"
+  apply transfer
+  by simp
+
+lemma Suc_inc:
+  "Suc (numeral n) = numeral (Num.inc n)"
+  "Suc 1 = 2"
+  by (simp add: add_One)+
+
+(* prefer to generate numeral indexes *)
+
+lemmas nth_drop_simps[simp] =
+  nth_drop[where n="Suc (Suc n)" for n]
+  nth_drop[where n="numeral n" for n, simplified Suc_inc]
+  nth_drop[where n="0", simplified One_nat_def[symmetric]]
+  nth_drop[where n="1", simplified Suc_inc, simplified One_nat_def]
+
 experiment begin
 context includes seq_syntax begin
+
+lemma "size z = 4 \<Longrightarrow> (let \<lbrakk>x,y,a,b\<rbrakk> = z in (y,x,b,a)) = (nth_seq z 1,nth_seq z 0,nth_seq z 3, nth_seq z 2)"
+  by (auto split: seq_splits)
+
+lemma "size z \<noteq> 4 \<Longrightarrow> (let \<lbrakk>x,y,a,b\<rbrakk> = z in (y,x,b,a)) = undefined"
+  by (auto split: seq_splits)
+
+(* don't require splits when the argument sequence is explicit *)
+lemma "(let \<lbrakk>x,y,z,w\<rbrakk> = \<lbrakk>a,b,c,d\<rbrakk> in \<lbrakk>w,z,w,y,x\<rbrakk>) = \<lbrakk>d,c,d,b,a\<rbrakk>"
+  by simp
+
+lemma "((\<lambda>\<lbrakk>x, y, z, w\<rbrakk>. (x, y, z, w)) \<lbrakk>a, b, c, d\<rbrakk>) = (a,b,c,d)"
+  by simp
+
+lemma ZZ:
+  assumes A: "mz = Some \<lbrakk>x, y, z, w\<rbrakk>"
+  shows "(case mz of Some \<lbrakk>a,b,c,d\<rbrakk> \<Rightarrow> (a = x \<and> b = y \<and> c = z \<and> d = w) | _ \<Rightarrow> False)"
+proof -
+  have B: "case mz of None \<Rightarrow> False | Some aa \<Rightarrow>
+    (\<lambda>\<lbrakk>a, b, c, d\<rbrakk>. a = x \<and> b = y \<and> c = z \<and> d = w) aa"
+    by (simp add: A)
+  show ?thesis
+    (* the case syntax expands to all possible argument lists, but these can be simplified
+       away as unreachable if the sequence length is known *)
+    apply (simp cong: option.case_cong)
+    by (rule B)
+qed
 
 lemma "\<lbrakk>x,y,z\<rbrakk> = rev_seq \<lbrakk>z,y,x\<rbrakk>"
   apply transfer
@@ -2877,6 +2996,8 @@ typ "['a]['b] \<Rightarrow> 'c"
 end
 
 thm X
+(* no case syntax outside the bundle *)
+thm ZZ
 end
 
 end

--- a/saw-core-isabelle/isabelle/theories/Seq.thy
+++ b/saw-core-isabelle/isabelle/theories/Seq.thy
@@ -1061,6 +1061,11 @@ lemma replicate_seq_eq: "((replicate_seq x :: ('n,'a) seq) = s) = (\<forall>i. i
 abbreviation (input) map2_seq :: "('a \<Rightarrow> 'b \<Rightarrow> 'c) \<Rightarrow> ('n,'a) seq \<Rightarrow> ('n,'b) seq \<Rightarrow> ('n,'c) seq" where
   "map2_seq f a b \<equiv> map_seq (\<lambda>(a',b'). f a' b') (zip_seq a b)"
 
+lemma map2_seq_transfer[transfer_rule]:
+  "(pcr_seq (=) ===> pcr_seq (=) ===> pcr_seq (=))
+     (map2 f) (map2_seq f :: ('a,'b) seq \<Rightarrow> ('a,'c) seq \<Rightarrow> ('a,'d) seq)"
+  by transfer_prover
+
 lemma map2_eqI: 
   "length a = length b \<Longrightarrow> 
    length b = length c \<Longrightarrow>

--- a/saw-core-isabelle/isabelle/theories/Seq_Code.thy
+++ b/saw-core-isabelle/isabelle/theories/Seq_Code.thy
@@ -1223,10 +1223,14 @@ lemma sext_seq_code[code abstract]: "seq_to_seqE (sext_seq xs) = sext_seqE (seq_
   apply transfer
   by (auto simp: to_seqI_def)
 
-lemma zip_seq_code[code abstract]: "seq_to_seqE (zip_seq x y) = 
+lemma zip_seq_code1: "seq_to_seqE (zip_seq x y) =
   list_to_seqE (zip (seq_to_list x) (seq_to_list y))"
   apply transfer
   by (auto simp: to_seqI_def)
+
+lemma zip_seq_code[code abstract]:
+  "seq_to_seqE (zip_seq x y) = list_to_seqE (zip (seqE_to_list (seq_to_seqE x)) (seqE_to_list (seq_to_seqE y)))"
+  by (metis zip_seq_code1 seqE_to_list_seq)
 
 lemma word_reverse_zero: "word_reverse 0 = 0"
   unfolding word_reverse_def
@@ -1248,8 +1252,42 @@ lemma set_seq_code[code]: "set_seq y = set (seqE_to_list (seq_to_seqE y))"
   apply transfer
   by simp
 
-experiment  begin
+declare plus_seq0[code_unfold]
+declare times_seq0[code_unfold]
+declare minus_seq0[code_unfold]
+declare divide_seq0[code_unfold]
+declare uminus_seq0[code_unfold]
+
+lemma plus_seq_code_map[code_unfold]:
+  "((x :: ('a, 'b::{not_bool,plus}) seq) + y) = map2_seq (+) x y"
+  unfolding plus_seq_def
+  by simp
+
+lemma times_seq_code_map[code_unfold]:
+  "((x :: ('a, 'b::{not_bool,times}) seq) * y) = map2_seq (*) x y"
+  unfolding times_seq_def
+  by simp
+
+lemma minus_seq_code_map[code_unfold]:
+  "((x :: ('a, 'b::{not_bool,minus}) seq) - y) = map2_seq (-) x y"
+  unfolding minus_seq_def
+  by simp
+
+lemma divide_seq_code_map[code_unfold]:
+  "((x :: ('a, 'b::{not_bool,divide}) seq) div y) = map2_seq (div) x y"
+  unfolding divide_seq_def
+  by simp
+
+lemma uminus_seq_code_map[code_unfold]:
+  "(-(x :: ('a, 'b::{not_bool,uminus}) seq)) = map_seq uminus x"
+  unfolding uminus_seq_def
+  by simp
+
+experiment begin
 context includes rotate_shift_syntax and seq_syntax begin
+value "((list_to_seq [1,2]) :: (2,int) seq) + ((list_to_seq [3,4]) :: (2,int) seq)"
+value "let f = \<lambda>(x::integer) y. x + y in (f 1 2, f 3 4)"
+value "((1 :: (32,bool) seq) + 2)"
 
 value " ((list_to_seq [True,False,True,True]) :: (4,bool) seq)"
 value "(0 ^ 10000000) :: (32, bool) seq"
@@ -1292,6 +1330,12 @@ lemma
   "set_seq (0 :: (32,bool) seq) = {0}"
   "set_seq (-1 :: (32,bool) seq) = {1}"
   "set_seq (1 :: (32,bool) seq) = {0,1}"
+  "(1 :: (32,bool) seq) + 2 = 3"
+  "\<lbrakk>1::int,2,3\<rbrakk> + \<lbrakk>4,5,6\<rbrakk> = \<lbrakk>5,7,9\<rbrakk>"
+  "\<lbrakk>1::int,2,3\<rbrakk> * \<lbrakk>4,5,6\<rbrakk> = \<lbrakk>4,10,18\<rbrakk>"
+  "\<lbrakk>1::int,2,3\<rbrakk> - \<lbrakk>4,5,6\<rbrakk> = \<lbrakk>-3,-3,-3\<rbrakk>"
+  "\<lbrakk>4::int,8,16\<rbrakk> div \<lbrakk>2,4,8\<rbrakk> = \<lbrakk>2,2,2\<rbrakk>"
+  "-\<lbrakk>1::int,2,3\<rbrakk> = \<lbrakk>-1,-2,-3\<rbrakk>"
   by eval+
 
 value "(from_nat (log2_nat (to_nat (32 :: (32,bool) seq))) :: (32,bool) seq)"

--- a/saw-core-isabelle/isabelle/theories/Seq_Lib.thy
+++ b/saw-core-isabelle/isabelle/theories/Seq_Lib.thy
@@ -321,9 +321,10 @@ lemma or[seq_to_word]:
   "seq_to_word (map2_seq (\<or>) x z) =  (seq_to_word x) OR (seq_to_word z)"
   by (simp add: word_seq_convs)
 
-lemma xor[simplified, seq_to_word]:
-  "seq_to_word (map2_seq (\<noteq>) x z) =  (seq_to_word x) xor (seq_to_word z)"
-  by (simp add: word_seq_convs)
+lemma xor[seq_to_word]:
+  "seq_to_word (map2_seq (\<noteq>) x z) = (seq_to_word x) xor (seq_to_word z)"
+  "seq_to_word (map2_seq (\<lambda>a' b'. a' = (\<not> b')) x z) = (seq_to_word x) xor (seq_to_word z)"
+  by (auto simp add: word_seq_convs)
 
 lemma signed_mod[seq_to_word]: 
   "seq_to_word (x smod z) = seq_to_word x smod seq_to_word z"

--- a/saw-core-isabelle/isabelle/theories/WordSeq.thy
+++ b/saw-core-isabelle/isabelle/theories/WordSeq.thy
@@ -1153,12 +1153,16 @@ lemma or_seq_conv[word_seq_convs]:
 
 lemma xor_seq_conv[word_seq_convs]:
  "(\<lambda>x y. map2_seq ((\<noteq>) :: bool \<Rightarrow> bool \<Rightarrow> bool) x y) = (\<lambda>x y. word_to_seq (seq_to_word x XOR seq_to_word y))"
-  supply [simp del] = not_iff
-  apply (rule ext)+
-  apply (simp add: zip_seq_as_bl_zip)
-  apply transfer
-  by (simp add: word_rotate.blwl_syms)
-
+ "(\<lambda>x y. map2_seq (\<lambda>a' b'. a' = (\<not> b')) x y) = (\<lambda>x y. word_to_seq (seq_to_word x XOR seq_to_word y))"
+  apply (constrain 'a="'aa::len")
+  subgoal H
+    supply [simp del] = not_iff
+    apply (rule ext)+
+    apply (simp add: zip_seq_as_bl_zip)
+    apply transfer
+    by (simp add: word_rotate.blwl_syms)
+  apply (rule H)
+  by (rule H[simplified])
 
 end
 

--- a/saw-core-isabelle/isabelle/theories/WordSeq.thy
+++ b/saw-core-isabelle/isabelle/theories/WordSeq.thy
@@ -652,24 +652,39 @@ lemma signed_shift_conv2[word_seq_convs]:
   apply (subst signed_shift_conv1[symmetric])
   by simp
 
-
 (* Using native mod_ring division is only defined if the cardinality is prime, which
    is more restrictive than word division, so we need to perform the division
    as integers. *)
-instantiation seq :: (_,bool) divide begin
 context includes seq_zint.seq.lifting begin
-lift_definition divide_seq :: "('a, 'b::bool) seq \<Rightarrow> ('a, 'b) seq \<Rightarrow> ('a, 'b) seq" is 
+lift_definition divide_seq_zint :: "('a, 'b::bool) seq \<Rightarrow> ('a, 'b) seq \<Rightarrow> ('a, 'b) seq" is
   "\<lambda>x y. of_int_mod_ring (to_int_mod_ring x div to_int_mod_ring y)" .
 end
+
+unconstraining divide_seq_zint and divide begin
+definition divide_seq' :: "('a,'b) seq \<Rightarrow> ('a,'b) seq \<Rightarrow> ('a,'b) seq" where
+  "divide_seq' \<equiv> \<lambda>xs ys.
+    if is_bool TYPE('b) then divide_seq_zint xs ys
+    else map2_seq (div) xs ys"
+end
+
+instantiation seq :: (_, _) divide begin
+definition [simplified divide_seq'_def]: "divide_seq \<equiv> divide_seq'"
 instance ..
 end
 
 lemma div_seq_transfer[transfer_rule]:
  "(eq_word_seq ===> eq_word_seq ===> eq_word_seq) (div) (div)"
+  unfolding divide_seq_def
   apply (rule rel_funI)+
   apply (simp add: eq_word_seq_def2)
   apply transfer
   by (simp add: take_bit_of_to_mod_ring)
+
+lemma div_seq_not_bool_transfer[transfer_rule]:
+  "(pcr_seq (=) ===> pcr_seq (=) ===> pcr_seq (=)) (map2 (div))
+     ((div) :: ('a,'b::{divide,not_bool}) seq \<Rightarrow> ('a,'b) seq \<Rightarrow> ('a,'b) seq)"
+  unfolding divide_seq_def
+  by (simp add: map2_seq_transfer)
 
 lemma seq_to_word_div[word_seq_convs]: 
   "seq_to_word (x div y) = (seq_to_word x) div (seq_to_word y)"

--- a/saw-core-isabelle/isabelle/theories/ZIntSeq.thy
+++ b/saw-core-isabelle/isabelle/theories/ZIntSeq.thy
@@ -287,36 +287,127 @@ lemma bs_to_zint_inj: "seq_to_zint y = seq_to_zint x \<Longrightarrow> x = y"
 lemma bs_to_zint_inj'[simp]: "inj seq_to_zint"
   by (simp add: bs_to_zint_inj injI)
 
+term is_bool
+
 lemma zero_transfer_seq[transfer_rule]: 
   "eq_zint_seq 0 (0 :: ('a,'b::bool) seq)"
   apply (simp add: eq_zint_seq_def)
   apply transfer
   using bin_to_bl_zero by force
 
-
-instantiation seq :: (_, bool) comm_ring begin
-interpretation seq_zint .
-
-lift_definition plus_seq :: 
+context includes seq_zint.seq.lifting begin
+lift_definition plus_seq_zint ::
   "('a,'b::bool) seq \<Rightarrow> ('a,'b) seq \<Rightarrow> ('a,'b) seq" is "(+)" .
-
-lift_definition minus_seq :: 
+lift_definition minus_seq_zint ::
   "('a,'b::bool) seq \<Rightarrow> ('a,'b) seq \<Rightarrow> ('a,'b) seq" is "(-)" .
-
-lift_definition times_seq :: 
+lift_definition times_seq_zint ::
   "('a,'b::bool) seq \<Rightarrow> ('a,'b) seq \<Rightarrow> ('a,'b) seq" is "(*)" .
+lift_definition uminus_seq_zint ::
+  "('a,'b::bool) seq \<Rightarrow> ('a,'b) seq" is "uminus" .
+end
 
-lift_definition uminus_seq :: "('a,'b::bool) seq \<Rightarrow> ('a,'b) seq" is "\<lambda>x. -x" .
+unconstraining plus_seq_zint and plus begin
+definition plus_seq' :: "('a,'b) seq \<Rightarrow> ('a,'b) seq \<Rightarrow> ('a,'b) seq" where
+  "plus_seq' \<equiv> \<lambda>xs ys.
+    if is_bool TYPE('b) then plus_seq_zint xs ys
+    else map2_seq (+) xs ys"
+end
 
-instance
+instantiation seq :: (_, _) plus begin
+definition [simplified plus_seq'_def]: "plus_seq \<equiv> plus_seq'"
+instance ..
+end
+
+unconstraining times_seq_zint and times begin
+definition times_seq' :: "('a,'b) seq \<Rightarrow> ('a,'b) seq \<Rightarrow> ('a,'b) seq" where
+  "times_seq' \<equiv> \<lambda>xs ys.
+    if is_bool TYPE('b) then times_seq_zint xs ys
+    else map2_seq (*) xs ys"
+end
+
+instantiation seq :: (_, _) times begin
+definition [simplified times_seq'_def]: "times_seq \<equiv> times_seq'"
+instance ..
+end
+
+unconstraining minus_seq_zint and minus begin
+definition minus_seq' :: "('a,'b) seq \<Rightarrow> ('a,'b) seq \<Rightarrow> ('a,'b) seq" where
+  "minus_seq' \<equiv> \<lambda>xs ys.
+    if is_bool TYPE('b) then minus_seq_zint xs ys
+    else map2_seq (-) xs ys"
+end
+
+instantiation seq :: (_, _) minus begin
+definition [simplified minus_seq'_def]: "minus_seq \<equiv> minus_seq'"
+instance ..
+end
+
+unconstraining uminus_seq_zint and uminus begin
+definition uminus_seq' :: "('a,'b) seq \<Rightarrow> ('a,'b) seq" where
+  "uminus_seq' \<equiv> \<lambda>xs.
+    if is_bool TYPE('b) then uminus_seq_zint xs
+    else map_seq uminus xs"
+end
+
+instantiation seq :: (_, _) uminus begin
+definition [simplified uminus_seq'_def]: "uminus_seq \<equiv> uminus_seq'"
+instance ..
+end
+
+lemma plus_seq_bool_transfer[transfer_rule]:
+  "(eq_zint_seq ===> eq_zint_seq ===> eq_zint_seq) (+) (+)"
+  unfolding plus_seq_def
+  apply simp
+  by (rule plus_seq_zint.transfer)
+
+lemma times_seq_bool_transfer[transfer_rule]:
+  "(eq_zint_seq ===> eq_zint_seq ===> eq_zint_seq) (*) (*)"
+  unfolding times_seq_def
+  apply simp
+  by (rule times_seq_zint.transfer)
+
+lemma minus_seq_bool_transfer[transfer_rule]:
+  "(eq_zint_seq ===> eq_zint_seq ===> eq_zint_seq) (-) (-)"
+  unfolding minus_seq_def
+  apply simp
+  by (rule minus_seq_zint.transfer)
+
+lemma uminus_seq_bool_transfer[transfer_rule]:
+  "(eq_zint_seq ===> eq_zint_seq) uminus uminus"
+  unfolding uminus_seq_def
+  apply simp
+  by (rule uminus_seq_zint.transfer)
+
+lemma plus_seq_not_bool_transfer[transfer_rule]:
+  "(pcr_seq (=) ===> pcr_seq (=) ===> pcr_seq (=)) (map2 (+))
+     ((+) :: ('a,'b::{plus,not_bool}) seq \<Rightarrow> ('a,'b) seq \<Rightarrow> ('a,'b) seq)"
+  unfolding plus_seq_def
+  by (simp add: map2_seq_transfer)
+
+lemma times_seq_not_bool_transfer[transfer_rule]:
+  "(pcr_seq (=) ===> pcr_seq (=) ===> pcr_seq (=)) (map2 (*))
+     ((*) :: ('a,'b::{times,not_bool}) seq \<Rightarrow> ('a,'b) seq \<Rightarrow> ('a,'b) seq)"
+  unfolding times_seq_def
+  by (simp add: map2_seq_transfer)
+
+lemma minus_seq_not_bool_transfer[transfer_rule]:
+  "(pcr_seq (=) ===> pcr_seq (=) ===> pcr_seq (=)) (map2 (-))
+     ((-) :: ('a,'b::{minus,not_bool}) seq \<Rightarrow> ('a,'b) seq \<Rightarrow> ('a,'b) seq)"
+  unfolding minus_seq_def
+  by (simp add: map2_seq_transfer)
+
+lemma uminus_seq_not_bool_transfer[transfer_rule]:
+  "(pcr_seq (=) ===> pcr_seq (=)) (map uminus)
+     (uminus :: ('a,'b::{uminus,not_bool}) seq \<Rightarrow> ('a,'b) seq)"
+  unfolding uminus_seq_def
+  apply simp
+  by transfer_prover
+
+instance seq :: (_, bool) comm_ring
   apply (standard;transfer;simp?)
     apply (simp add: mult.assoc)
    apply (simp add: mult.commute)
   by (simp add: distrib_left mult.commute)
-end
-
-
-
 
 instantiation seq :: (_, bool) one begin
 context includes  seq_zint.seq.lifting begin
@@ -341,7 +432,7 @@ instance
 end
 
 lemma zint_to_bs_distrib[simp]: "zint_to_seq (x + y) = (zint_to_seq x) + (zint_to_seq y)"
-  by (simp add: plus_seq.abs_eq)
+  by (simp add: plus_seq_def plus_seq_zint.abs_eq)
 
 lemma zint_to_bs_1[simp]: "zint_to_seq 1 = 1"
   by (simp add: one_seq.abs_eq)

--- a/saw-core-isabelle/src/Language/Isabelle/Name.hs
+++ b/saw-core-isabelle/src/Language/Isabelle/Name.hs
@@ -100,7 +100,7 @@ qualifiedIdent t = case nameOf t of
   nm@SimpleName{} -> cleanName nm
 
 keywords :: [String]
-keywords = ["mod", "div", "xor", "undefined"]
+keywords = ["mod", "div", "xor", "undefined", "in"]
 
 stripSuffix :: Eq a => [a] -> [a] -> Maybe [a]
 stripSuffix suf l = case stripPrefix suf (reverse l) of

--- a/saw-core-isabelle/src/SAWCoreIsabelle/Translate.hs
+++ b/saw-core-isabelle/src/SAWCoreIsabelle/Translate.hs
@@ -342,7 +342,9 @@ translateDecl d = withDeclBinding' d $ \b mbody -> case mbody of
 -- | Returns Undefined if translation fails
 translateDecl' :: Cry.Decl -> IsaM (Binding.Binding, Expr)
 translateDecl' d = withDeclBinding d $ \b body -> (tryError $ translateExpr body) >>= \case
-  Left err -> return $ (b, Expr.Undefined (Binding.bindType b) (Error.showErr err))
+  Left err -> do
+    warn err
+    return $ (b, Expr.Undefined (Binding.bindType b) (Error.showErr err))
   Right body' -> return $ (b, body')
 
 nameToVar :: Name.Name -> IsaM Expr


### PR DESCRIPTION
* adds support for +,-,/,* over non-boolean-valued sequences (where a + b is `map (+) (zip a b)`). The translator would already output expressions of this form that would otherwise fail to type check.
* ensures warnings are emitted whenever stub `undefined` constants are included. These result in translation failure unless `--keep-going` flag is given
* adds support for pattern-binding syntax with sequences (no change to translator output yet)