### PR TITLE
Fix build failures with GHC 9.10 and 9.12

### DIFF
--- a/cryptol-saw-core/src/CryptolSAWCore/FileReader.hs
+++ b/cryptol-saw-core/src/CryptolSAWCore/FileReader.hs
@@ -9,12 +9,10 @@ module CryptolSAWCore.FileReader
 import Control.Monad.IO.Class
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
-import Data.Typeable
 
 import SAWCore.SharedTerm (SharedContext, IsMetadata(..), scGetData, scWithData)
 
 newtype FileReader = FileReader (FilePath -> IO ByteString)
-  deriving Typeable
 
 instance IsMetadata FileReader where
   initMetadata = return $ FileReader BS.readFile

--- a/saw-core/src/SAWCore/SharedTerm.hs
+++ b/saw-core/src/SAWCore/SharedTerm.hs
@@ -311,7 +311,6 @@ import Data.Ratio (numerator, denominator)
 import Data.Ref ( C )
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Data.Typeable
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Numeric.Natural (Natural)
@@ -1016,7 +1015,6 @@ ppName sc opts nm =
   PPS.renderText opts <$> prettyName sc opts nm
 
 newtype PrettyOpts = PrettyOpts PPS.Opts
-  deriving (Typeable)
 
 instance IsMetadata PrettyOpts where
   initMetadata = return $ PrettyOpts PPS.defaultOpts

--- a/saw-core/src/SAWCore/Simulator.hs
+++ b/saw-core/src/SAWCore/Simulator.hs
@@ -24,7 +24,10 @@ module SAWCore.Simulator
   , defaultPrimHandler
   ) where
 
-import Prelude hiding (mapM)
+-- FUTURE: hiding Foldable and then importing it explicitly can be
+-- dropped once we no longer support building with GHC 9.8 or earlier
+-- (base 4.19 and earlier).
+import Prelude hiding (mapM, Foldable(..))
 
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Maybe

--- a/saw-core/src/SAWCore/Term/Certified.hs
+++ b/saw-core/src/SAWCore/Term/Certified.hs
@@ -866,7 +866,6 @@ scmFreshInventedVar name ty = do
 -- appear free at the top-level.
 -- This is a private type that we store as global metadata
 newtype InventedVars = InventedVars (IntMap Term)
-  deriving (Typeable)
 
 instance IsMetadata InventedVars where
   initMetadata = return $ InventedVars IntMap.empty

--- a/saw-server/src/SAWServer/LLVMCrucibleSetup.hs
+++ b/saw-server/src/SAWServer/LLVMCrucibleSetup.hs
@@ -118,6 +118,13 @@ compileLLVMContract fileReader bic ghostEnv cenv0 c =
       do t <- llvm_fresh_var dn (llvmType ty)
          return (n, t)
 
+    -- ghc 9.12.2 requires the following type signature to avoid a
+    -- type error that's almost certainly a GHC bug
+    setupState ::
+        [(ServerName, CMS.AllLLVM MS.SetupValue)] ->
+        (Map ServerName ServerSetupVal, CryptolEnv) ->
+        [ContractVar JSONLLVMType] ->
+        LLVMCrucibleSetupM (Map ServerName ServerSetupVal, CryptolEnv)
     setupState allocs (env, cenv) vars =
       do freshTerms <- mapM setupFresh vars
          let sc = biSharedContext bic


### PR DESCRIPTION
Also bump the Crucible submodule to bring in its GHC 9.12 support.

Most of the failures on the SAW side are regressions :-(

Note: this is the first four commits from #2973, which should be neither controversial nor problematic.